### PR TITLE
Fix Issue #218

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -124,6 +124,36 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <source>src/main/java</source>
+                                <source>src/main/kotlin</source>
+                                <source>target/generated-sources/annotations</source>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <source>src/test/java</source>
+                                <source>src/test/kotlin</source>
+                                <source>target/generated-test-sources/test-annotations</source>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/embabel-agent-api/src/test/kotlin/com/embabel/ux/form/FormBinderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/ux/form/FormBinderTest.kt
@@ -16,6 +16,7 @@
 package com.embabel.ux.form
 
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -268,49 +269,50 @@ class FormBinderTest {
         }
     }
 
-//    @Nested
-//    @DisplayName("Java Binding Tests")
-//    inner class JavaBindingTests {
-//
-//        @Test
-//        fun `bind record`() {
-//            // Given
-//            val submission = createSimpleSubmission()
-//
-//            // When
-//            val user: JavaPersonRecord = submission.bindTo()
-//
-//            // Then
-//            assertEquals("John Doe", user.name)
-//            assertEquals(30, user.age)
-//        }
-//
-//        @Test
-//        fun `bind bean`() {
-//            // Given
-//            val submission = createSimpleSubmission()
-//
-//            // When
-//            val user: JavaPersonBean = submission.bindTo()
-//
-//            // Then
-//            assertEquals("John Doe", user.name)
-//            assertEquals(30, user.age)
-//        }
-//
-//        @Test
-//        fun `bind immutable class`() {
-//            // Given
-//            val submission = createSimpleSubmission()
-//
-//            // When
-//            val user: JavaPersonImmutable = submission.bindTo()
-//
-//            // Then
-//            assertEquals("John Doe", user.getName())
-//            assertEquals(30, user.getAge())
-//        }
-//    }
+    @Nested
+    @DisplayName("Java Binding Tests")
+    @Disabled("Disabled until Java binding is implemented in FormBinder")
+    inner class JavaBindingTests {
+
+        @Test
+        fun `bind record`() {
+            // Given
+            val submission = createSimpleSubmission()
+
+            // When
+            val user: JavaPersonRecord = submission.bindTo()
+
+            // Then
+            assertEquals("John Doe", user.name)
+            assertEquals(30, user.age)
+        }
+
+        @Test
+        fun `bind bean`() {
+            // Given
+            val submission = createSimpleSubmission()
+
+            // When
+            val user: JavaPersonBean = submission.bindTo()
+
+            // Then
+            assertEquals("John Doe", user.name)
+            assertEquals(30, user.age)
+        }
+
+        @Test
+        fun `bind immutable class`() {
+            // Given
+            val submission = createSimpleSubmission()
+
+            // When
+            val user: JavaPersonImmutable = submission.bindTo()
+
+            // Then
+            assertEquals("John Doe", user.getName())
+            assertEquals(30, user.getAge())
+        }
+    }
 
     @Nested
     @DisplayName("Error Handling Tests")


### PR DESCRIPTION
This pull request introduces updates to the Maven build configuration and test suite for the `embabel-agent-api` module. Key changes include enabling Kotlin compilation in the Maven build process and re-enabling previously commented-out Java binding tests with a `@Disabled` annotation for future implementation.

### Build Configuration Updates:
* Added Kotlin compilation support to the Maven build process by configuring the `kotlin-maven-plugin`. This includes specifying source directories for both main and test phases. (`embabel-agent-api/pom.xml`, [embabel-agent-api/pom.xmlR127-R156](diffhunk://#diff-c161fccae45bca8f24d2ba5c90f64d55eb224d566485532dbf0d4abf7109d034R127-R156))

### Test Suite Updates:
* Imported the `@Disabled` annotation from JUnit to manage test execution. (`embabel-agent-api/src/test/kotlin/com/embabel/ux/form/FormBinderTest.kt`, [embabel-agent-api/src/test/kotlin/com/embabel/ux/form/FormBinderTest.ktR19](diffhunk://#diff-b8d28c47670369b31423b6265a26e2a5d8f61a622a7481340f137fdf0ba62645R19))
* Re-enabled the `JavaBindingTests` nested test class by uncommenting it and marking it with the `@Disabled` annotation to indicate it is not yet ready for execution. This includes tests for binding records, beans, and immutable classes. (`embabel-agent-api/src/test/kotlin/com/embabel/ux/form/FormBinderTest.kt`, [embabel-agent-api/src/test/kotlin/com/embabel/ux/form/FormBinderTest.ktL271-R315](diffhunk://#diff-b8d28c47670369b31423b6265a26e2a5d8f61a622a7481340f137fdf0ba62645L271-R315))