### PR TITLE
Update pom.xml

### DIFF
--- a/embabel-agent-docs/pom.xml
+++ b/embabel-agent-docs/pom.xml
@@ -63,6 +63,7 @@
                         <imagesdir>images</imagesdir>
                         <stylesheet>embabel-agent-docs.css</stylesheet>
                         <stylesDir>${project.basedir}/src/main/resources/themes</stylesDir>
+                        <plantuml-config>graphviz_dot=none</plantuml-config>
                         <embabel-agent-version>${agent-api.version}</embabel-agent-version>
                     </attributes>
                 </configuration>


### PR DESCRIPTION
This pull request introduces a configuration update to the `embabel-agent-docs/pom.xml` file. The change adds a new property to the PlantUML configuration to disable the use of Graphviz for diagram rendering.

Configuration update:

* [`embabel-agent-docs/pom.xml`](diffhunk://#diff-34fc9a9e21813f022b8bce564bce6db92c9629e96fafe52444e8322845978f21R66): Added `<plantuml-config>graphviz_dot=none</plantuml-config>` to the attributes section, specifying that Graphviz should not be used for PlantUML diagrams.