### PR TITLE
Fix path to Embabel Logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
 ![IntelliJ IDEA](https://img.shields.io/badge/IntelliJIDEA-000000.svg?style=for-the-badge&logo=intellij-idea&logoColor=white)
 
-<img align="left" src="https://github.com/embabel/agent-api/blob/main/images/315px-Meister_der_Weltenchronik_001.jpg?raw=true" width="180">
+<img align="left" src="https://github.com/embabel/embabel-agent/embabel-agent-api/images/315px-Meister_der_Weltenchronik_001.jpg?raw=true" width="180">
 
 &nbsp;&nbsp;&nbsp;&nbsp;
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)
 ![IntelliJ IDEA](https://img.shields.io/badge/IntelliJIDEA-000000.svg?style=for-the-badge&logo=intellij-idea&logoColor=white)
 
-<img align="left" src="https://github.com/embabel/embabel-agent/embabel-agent-api/images/315px-Meister_der_Weltenchronik_001.jpg?raw=true" width="180">
+<img align="left" src="https://github.com/embabel/embabel-agent/blob/fix-readme/embabel-agent-api/images/315px-Meister_der_Weltenchronik_001.jpg?raw=true" width="180">
 
 &nbsp;&nbsp;&nbsp;&nbsp;
 


### PR DESCRIPTION
This pull request updates the `README.md` file to fix a broken image link by pointing it to the correct repository and path.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18): Updated the image source URL to `https://github.com/embabel/embabel-agent/blob/fix-readme/embabel-agent-api/images/315px-Meister_der_Weltenchronik_001.jpg?raw=true` to replace the outdated link and ensure the image displays correctly.