### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Developers must carefully read all code they commit and improve generated code i
 
 - Get the bits
 - Set up your environment
+- Set up Maven Settings with GitHub Token
 - Run the application
 
 ### Getting the bits
@@ -292,6 +293,48 @@ the following tools from the catalog:
 - Fetch
 - Puppeteer
 - Wikipedia
+
+### **IMPORTANT**: Setup GitHub Access Token (required to build Embabel Agent API)
+
+Embabel Agent API project uses dependencies from GitHub Packages Maven Repository. To build successfully, you need to configure Maven with a GitHub Personal Access Token.
+
+#### 1. Generate a GitHub Read-Only Token
+
+1. Go to [GitHub Settings → Developer Settings → Personal Access Tokens → Tokens (classic)](https://github.com/settings/tokens)
+2. Click **Generate new token** → **Generate new token (classic)**
+3. Name your token (e.g., "Maven GitHub Packages Read")
+4. Select only the `read:packages` scope
+5. Click **Generate token**
+6. **IMPORTANT**: Copy your token immediately - you won't see it again!
+
+#### 2. Configure Maven Settings
+
+Add this to your `~/.m2/settings.xml` file:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_GITHUB_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Replace:
+- `YOUR_GITHUB_USERNAME` with your GitHub username
+- `YOUR_GITHUB_TOKEN` with the token you generated
+
+If you don't have a `settings.xml` file:
+- Windows: Create at `%USERPROFILE%\.m2\settings.xml`
+- Mac/Linux: Create at `~/.m2/settings.xml`
+
+##### References
+
+- [GitHub Packages Documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry)
+- [Maven Settings Reference](https://maven.apache.org/settings.html)
 
 ### Running
 


### PR DESCRIPTION
This pull request updates the `README.md` file to include instructions for setting up a GitHub Personal Access Token for Maven. These changes aim to ensure developers can successfully build the project by configuring access to dependencies hosted on GitHub Packages.

### Documentation Updates:

* Added a new section titled "**IMPORTANT**: Setup GitHub Access Token (required to build Embabel Agent API)" with step-by-step instructions for generating a GitHub Personal Access Token and configuring Maven's `settings.xml` file. This includes detailed guidance on token creation, scope selection (`read:packages`), and file setup for different operating systems.
* Updated the "Set up your environment" section to include "Set up Maven Settings with GitHub Token" as a prerequisite for running the application.Add section on how to setup GitHub Access Token