### PR TITLE
Artifactory

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Configure Maven Settings
         uses: s4u/maven-settings-action@v2.8.0
         with:
-          servers: ${{secrets.GITREPO_WRITE_PACKAGE}}
+          servers: ${{secrets.EMBABEL_ARTIFACTORY}}
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -30,10 +30,6 @@ jobs:
         run: |
           mkdir -p /home/runner
           echo "testcontainers.reuse.enable=true" > /home/runner/.testcontainers.properties
-      - name: Configure Maven Settings
-        uses: s4u/maven-settings-action@v2.8.0
-        with:
-          servers: ${{secrets.GITREPO_SERVER}}
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -216,13 +216,6 @@
 
     <repositories>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
             <name>Central Portal Snapshots</name>
             <id>central-portal-snapshots</id>
             <url>https://central.sonatype.com/repository/maven-snapshots/</url>

--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -12,8 +12,10 @@
     <packaging>jar</packaging>
     <name>Embabel Agent API</name>
     <description>Fluent DSL and Kotlin DSL for Agentic Flows</description>
+    
     <properties>
         <embabel-common.version>1.0.0-SNAPSHOT</embabel-common.version>
+        <mockk.version>1.13.3</mockk.version>
     </properties>
 
     <dependencies>
@@ -55,6 +57,11 @@
         </dependency>
 
         <!-- Kotlin Dependencies -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
@@ -132,6 +139,12 @@
         <dependency>
             <groupId>info.schnatterer.moby-names-generator</groupId>
             <artifactId>moby-names-generator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.mockk</groupId>
+            <artifactId>mockk-jvm</artifactId>
+            <version>${mockk.version}</version>
         </dependency>
 
         <!-- Unit and Integration Testing -->

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -64,8 +64,8 @@
 
     <repositories>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -74,8 +74,8 @@
 
     <distributionManagement>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-agent</url>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
         </repository>
     </distributionManagement>
     

--- a/embabel-agent-eval/pom.xml
+++ b/embabel-agent-eval/pom.xml
@@ -29,6 +29,16 @@
             <artifactId>spring-data-neo4j</artifactId>
         </dependency>
 
+        <dependency>
+           <groupId>org.jetbrains.kotlin</groupId>
+           <artifactId>kotlin-compiler</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-scripting-compiler</artifactId>
+        </dependency>
+
        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-scripting-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <packaging>pom</packaging>
     <name>Embabel Agent Parent</name>
     <description>Parent POM for Embabel Agent Modules</description>
+
     <properties>
         <embabel-common.version>1.0.0-SNAPSHOT</embabel-common.version>
     </properties>
@@ -106,21 +107,16 @@
         </plugins>
     </build>
 
-    <repositories>
+    
+   <repositories>
         <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-build</url>
+            <id>embabel-snapshots</id>
+            <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
         </repository>
     </repositories>
 
-    <distributionManagement>
-        <repository>
-            <id>github</id>
-            <url>https://maven.pkg.github.com/embabel/embabel-agent</url>
-        </repository>
-    </distributionManagement>
 
 </project>


### PR DESCRIPTION
This pull request updates Maven repository configurations across multiple files to transition from using GitHub Packages to Embabel's Artifactory for managing dependencies and snapshots. It also includes some minor structural adjustments in the `pom.xml` files.

### Repository Configuration Updates:

* [`.github/workflows/deploy-snapshots.yml`](diffhunk://#diff-441fb097201dd492df86898768fa710e824a03b73403c88c6e4b84404bc76528L24-R24): Updated the Maven server configuration to use `secrets.EMBABEL_ARTIFACTORY` instead of `secrets.GITREPO_WRITE_PACKAGE`.
* [`.github/workflows/maven.yml`](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L33-L36): Removed the Maven server configuration step that previously referenced `secrets.GITREPO_SERVER`.
* [`embabel-agent-api/pom.xml`](diffhunk://#diff-c161fccae45bca8f24d2ba5c90f64d55eb224d566485532dbf0d4abf7109d034L218-L224): Removed the GitHub repository configuration for Maven dependencies.
* [`embabel-agent-dependencies/pom.xml`](diffhunk://#diff-afe07651950d7d2835eb6cc02163f9241976a101f42ab11fe2d932fc246750f9L67-R68): Updated repository and distribution management configurations to use Embabel's Artifactory (`embabel-snapshots`) instead of GitHub Packages. [[1]](diffhunk://#diff-afe07651950d7d2835eb6cc02163f9241976a101f42ab11fe2d932fc246750f9L67-R68) [[2]](diffhunk://#diff-afe07651950d7d2835eb6cc02163f9241976a101f42ab11fe2d932fc246750f9L77-R78)
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R110-L124): Replaced GitHub repository configurations with Embabel's Artifactory for Maven dependencies and removed the distribution management section.

### Minor Structural Adjustments:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R16): Added a blank line for better readability between the project description and properties section.