### PR TITLE
Remove reference to sonatype repository

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -227,18 +227,4 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <name>Central Portal Snapshots</name>
-            <id>central-portal-snapshots</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
 </project>


### PR DESCRIPTION
This pull request removes an unused Maven repository configuration from the `embabel-agent-api/pom.xml` file.

* [`embabel-agent-api/pom.xml`](diffhunk://#diff-c161fccae45bca8f24d2ba5c90f64d55eb224d566485532dbf0d4abf7109d034L230-L243): Deleted the `repositories` section that included the "Central Portal Snapshots" repository, as it is no longer needed.