### PR TITLE
Polishing.

### DIFF
--- a/embabel-agent-api/.mvn/wrapper/maven-wrapper.properties
+++ b/embabel-agent-api/.mvn/wrapper/maven-wrapper.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-wrapperVersion=3.3.2
+wrapperVersion=3.9.6
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip

--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -15,7 +15,6 @@
     
     <properties>
         <embabel-common.version>1.0.0-SNAPSHOT</embabel-common.version>
-        <mockk.version>1.13.3</mockk.version>
     </properties>
 
     <dependencies>
@@ -139,12 +138,6 @@
         <dependency>
             <groupId>info.schnatterer.moby-names-generator</groupId>
             <artifactId>moby-names-generator</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.mockk</groupId>
-            <artifactId>mockk-jvm</artifactId>
-            <version>${mockk.version}</version>
         </dependency>
 
         <!-- Unit and Integration Testing -->


### PR DESCRIPTION
This pull request updates the Maven wrapper version and removes the `mockk` dependency from the project. Below are the key changes:

### Build Tool Update:
* Updated the Maven wrapper version from `3.3.2` to `3.9.6` in `embabel-agent-api/.mvn/wrapper/maven-wrapper.properties` to use a more recent version of Maven.

### Dependency Cleanup:
* Removed the `mockk` version property from `embabel-agent-api/pom.xml` as it is no longer needed.
* Removed the `mockk-jvm` dependency from `embabel-agent-api/pom.xml`, likely as part of a cleanup or migration away from this library.