### PR TITLE
Pin Spring AI to version 1.0.0-M4 Issue #290

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/SelfToolCallbackPublisher.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/SelfToolCallbackPublisher.kt
@@ -18,8 +18,8 @@ package com.embabel.agent.api.common
 import com.embabel.agent.core.*
 import com.embabel.common.core.types.AssetCoordinates
 import com.embabel.common.core.types.Semver
-import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.ToolCallbacks
 
 /**
  * Convenient interface a class can implement to publish @Tool

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/springAiUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/springAiUtils.kt
@@ -15,8 +15,8 @@
  */
 package com.embabel.agent.core.support
 
-import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.ToolCallbacks
 
 /**
  * ToolCallbacks.from complains if no tools.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/toolgroups/web/search/brave/BraveSearchTools.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/toolgroups/web/search/brave/BraveSearchTools.kt
@@ -16,8 +16,8 @@
 package com.embabel.agent.toolgroups.web.search.brave
 
 import com.embabel.agent.toolgroups.web.search.WebSearchRequest
-import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.ToolCallbacks
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.annotation.ToolParam
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/experimental/d/ToolGroupExposerKtTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/experimental/d/ToolGroupExposerKtTest.kt
@@ -20,7 +20,7 @@ import com.embabel.agent.experimental.dsl.exposeAsInterface
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.ai.support.ToolCallbacks
+import org.springframework.ai.tool.ToolCallbacks
 import org.springframework.ai.tool.annotation.Tool
 import kotlin.test.assertEquals
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -43,7 +43,7 @@ import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.DefaultChatOptions
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.ai.model.tool.ToolCallingChatOptions
-import org.springframework.ai.support.ToolCallbacks
+import org.springframework.ai.tool.ToolCallbacks
 import kotlin.test.assertEquals
 
 /**

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt
@@ -26,7 +26,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.springframework.ai.support.ToolCallbacks
+import org.springframework.ai.tool.ToolCallbacks
 import org.springframework.ai.tool.annotation.Tool
 
 class SimpleTools {


### PR DESCRIPTION
This pull request updates the import path for `ToolCallbacks` across multiple files to reflect its relocation from `org.springframework.ai.support` to `org.springframework.ai.tool`. These changes ensure consistency and prevent potential issues caused by outdated imports.

### Updated import paths for `ToolCallbacks`:

* [`embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/SelfToolCallbackPublisher.kt`](diffhunk://#diff-e1eaa32858078ebe430893a94231df42bcbb8b778e1841747878da16af6ee6b6L21-R22): Updated the import path for `ToolCallbacks` to `org.springframework.ai.tool.ToolCallbacks`.
* [`embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/springAiUtils.kt`](diffhunk://#diff-d5a68f3145511ab6db9943d6dd5064d671ee9be83a354caf0848269ac7ec476aL18-R19): Adjusted the import path for `ToolCallbacks` to the new location.
* [`embabel-agent-api/src/main/kotlin/com/embabel/agent/toolgroups/web/search/brave/BraveSearchTools.kt`](diffhunk://#diff-d3ee13d4c4d156abb2f562377294f0d85a9044a974763d03143f0bddc38365baL19-R20): Corrected the import path for `ToolCallbacks` to match its new package.
* [`embabel-agent-api/src/test/kotlin/com/embabel/agent/experimental/d/ToolGroupExposerKtTest.kt`](diffhunk://#diff-e4e268c6f399b945bece9104a5d94a4e93d21658e1c716ac6aa2c0b3a1e95560L23-R23): Updated the test file to use the relocated `ToolCallbacks` import path.
* [`embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt`](diffhunk://#diff-bf29d55ce0e64fc95e602952f20dcc99f6b82aedb04dcc3baf0c82b96cbb7300L46-R46): Adjusted the import path for `ToolCallbacks` in the test file.
* [`embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt`](diffhunk://#diff-62dcaa4550cad628af5d444a1912216451a6740a8466acbb3dc5a7175248fad2L29-R29): Updated the import path for `ToolCallbacks` in another test file.