### PR TITLE
Issue #307 Agent Shell  hangs under Windows with Docker Desktop Profile

### DIFF
--- a/embabel-agent-api/src/main/resources/application-shell.yml
+++ b/embabel-agent-api/src/main/resources/application-shell.yml
@@ -2,6 +2,11 @@ spring:
   main:
     web-application-type: none
   shell:
+    command:
+      exit:
+        enabled: false
+      quit:
+        enabled: false
     history:
       enabled: true
     interactive:


### PR DESCRIPTION
This pull request introduces an "exit" command to the `ShellCommands` class, allowing users to gracefully shut down the application. It also includes related changes to support this functionality, such as dependency injection for the application context and configuration updates to disable default exit commands.

### New "exit" Command Implementation:

* Added a new `exit` method in `ShellCommands` to handle application shutdown. The method logs the shutdown process, clears active processes, and uses `SpringApplication.exit` for a graceful termination. It also provides user feedback and handles exceptions during shutdown. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/shell/ShellCommands.ktR358-R378](diffhunk://#diff-e7d9a3061518898b203311eab7e906599c468a84e70a7d487f4cdf78c75a8a14R358-R378))

### Dependency Injection:

* Injected `ConfigurableApplicationContext` into the `ShellCommands` class to enable access to the application context for performing the shutdown. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/shell/ShellCommands.ktR51](diffhunk://#diff-e7d9a3061518898b203311eab7e906599c468a84e70a7d487f4cdf78c75a8a14R51))

### Import Additions:

* Added necessary imports for `SpringApplication`, `ConfigurableApplicationContext`, `CompletableFuture`, and `exitProcess` to support the new functionality. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/shell/ShellCommands.ktR30-R37](diffhunk://#diff-e7d9a3061518898b203311eab7e906599c468a84e70a7d487f4cdf78c75a8a14R30-R37))

### Configuration Updates:

* Updated `application-shell.yml` to disable default exit-related commands (`exit` and `quit`) provided by Spring Shell, ensuring only the custom `exit` command is used. (`embabel-agent-api/src/main/resources/application-shell.yml`, [embabel-agent-api/src/main/resources/application-shell.ymlR5-R9](diffhunk://#diff-b23fe2fa33960efc39fb2d1ceec489dad4f3ef47e08432588a8b14ec27d29432R5-R9))