### PR TITLE
Add Support for Micrometer and Zipkin Trace

### DIFF
--- a/embabel-agent-api/docker-compose.yml
+++ b/embabel-agent-api/docker-compose.yml
@@ -1,18 +1,16 @@
 services:
-
   llama3.2:
-    provider:
-      type: model
-      options:
-        model: ai/llama3.2
-
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    environment:
+      - OLLAMA_MODELS=llama3.2
   qwen3:
-    provider:
-      type: model
-      options:
-        model: ai/qwen3
-
-
+    image: ollama/ollama:latest  
+    ports:
+      - "11435:11434"
+    environment:
+      - OLLAMA_MODELS=qwen2.5
   neo4j:
     image: neo4j:5.26
     ports:
@@ -22,14 +20,10 @@ services:
     environment:
       - NEO4J_AUTH=${NEO4J_USERNAME:-neo4j}/${NEO4J_PASSWORD:-brahmsian}
       - NEO4J_PLUGINS=["apoc"]
-
-
   zipkin:
     image: 'openzipkin/zipkin:latest'
     ports:
       - "9411:9411"
-
-
   # the environment variables that will be automatically set in this process are
   # LLAMA3.2_URL - this is the http base url - add /chat/completions to this for doing completions
   # LLAMA3.2_MODEL - this is the name of the model that should be passed in the request
@@ -40,4 +34,3 @@ services:
 #    depends_on:
 #      - llama3.2
 #      - mcp-gateway
-

--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -146,6 +146,23 @@
             <artifactId>moby-names-generator</artifactId>
         </dependency>
 
+        <!-- ================ Observability ================ -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-brave</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-reporter-brave</artifactId>
+        </dependency>
+        <!-- ================ Observability ================ -->
+
         <!-- Unit and Integration Testing -->
         <!-- Most common testing dependencies are in the embabel-agent-parent -->
         <!-- If something is missing, add it here -->

--- a/embabel-agent-api/scripts/shell.cmd
+++ b/embabel-agent-api/scripts/shell.cmd
@@ -10,7 +10,7 @@ if errorlevel 1 (
 
 cd ..
 
-set SPRING_PROFILES_ACTIVE=shell,severance
+set SPRING_PROFILES_ACTIVE=shell,severance,observability
 
 cmd /c mvn spring-boot:run
 

--- a/embabel-agent-api/scripts/shell.ps1
+++ b/embabel-agent-api/scripts/shell.ps1
@@ -16,7 +16,7 @@ try {
     Set-Location ..
     
     # Set Spring profiles
-    $env:SPRING_PROFILES_ACTIVE = "shell,severance"
+    $env:SPRING_PROFILES_ACTIVE = "shell,severance,observability"
     
     # Run Maven in subprocess
     cmd /c "mvn spring-boot:run"

--- a/embabel-agent-api/scripts/shell.sh
+++ b/embabel-agent-api/scripts/shell.sh
@@ -3,5 +3,5 @@
 ./support/check_env.sh
 
 cd ..
-export SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop
+export SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop,observabilty
 mvn spring-boot:run

--- a/embabel-agent-api/scripts/shell_docker.cmd
+++ b/embabel-agent-api/scripts/shell_docker.cmd
@@ -10,7 +10,7 @@ if errorlevel 1 (
 
 cd ..
 
-set SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop
+set SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop,observability
 
 cmd /c mvn spring-boot:run
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/OpenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/OpenAiModels.kt
@@ -22,6 +22,7 @@ import com.embabel.common.ai.model.PerTokenPricingModel
 import com.embabel.common.ai.model.config.OpenAiConfiguration
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import com.embabel.common.util.loggerFor
+import io.micrometer.observation.ObservationRegistry
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.document.MetadataMode
 import org.springframework.ai.openai.OpenAiChatModel
@@ -43,6 +44,7 @@ import java.time.LocalDate
 class OpenAiModels(
     @Value("\${OPENAI_API_KEY}")
     private val apiKey: String,
+    private val observationRegistry: ObservationRegistry,
 ) {
     init {
         loggerFor<OpenAiConfiguration>().info("OpenAI AI models are available")
@@ -124,6 +126,7 @@ class OpenAiModels(
             .openAiApi(openAiApi)
             .defaultOptions(
                 OpenAiChatOptions.builder().model(model).build()
+            ).observationRegistry(observationRegistry
             ).build()
     }
 

--- a/embabel-agent-api/src/main/resources/application-observability.yml
+++ b/embabel-agent-api/src/main/resources/application-observability.yml
@@ -1,0 +1,31 @@
+spring:
+  ai:
+    chat:
+      observations:
+        enabled: true
+        include-completion: true
+        include-prompt: true
+        include-error-logging: true
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+    enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    env:
+      show-values: always
+      show-details: always
+    health:
+      show-details: always
+  observations:
+    enabled: true
+    web:
+      response:
+        enabled: true
+  zipkin:
+    tracing:
+      endpoint: http://localhost:9411/api/v2/spans


### PR DESCRIPTION
This pull request introduces observability enhancements to the `embabel-agent-api` project and updates the configuration for model services in the `docker-compose.yml` file. Key changes include adding observability dependencies, enabling observability features in Spring profiles and configurations, and replacing the model service provider setup with a Docker-based configuration.

### Observability Enhancements:

* **Added dependencies for observability tools**: Included `spring-boot-starter-actuator`, `micrometer-tracing-bridge-brave`, and `zipkin-reporter-brave` in `pom.xml` to enable tracing and metrics collection.
* **Enabled observability in Spring profiles**: Updated `SPRING_PROFILES_ACTIVE` in `shell.cmd`, `shell.ps1`, `shell.sh`, and `shell_docker.cmd` scripts to include the `observability` profile. [[1]](diffhunk://#diff-013696b1a8a589dadb335f9b6401bd2c317f21e690de6683997d0366d4b2ca1fL13-R13) [[2]](diffhunk://#diff-75b012cbe3adb7f86618ed2205e1d0d2b0bdbd97ebaa6383d8c19da07975c689L19-R19) [[3]](diffhunk://#diff-825a9b4e3d4d68ae5da7447a4a034cbc75759db759cc365fbc4f22168672abb2L6-R6) [[4]](diffhunk://#diff-909956e839d89cf630c60fe03c1619a66228aec3dba62281a35c3a62dd7006c4L13-R13)
* **Configured observability settings**: Added `application-observability.yml` with configurations for tracing, endpoint exposure, and Zipkin integration.
* **Integrated observation registry**: Updated `OpenAiModels` class to use `ObservationRegistry` for monitoring AI model interactions. [[1]](diffhunk://#diff-a22688a84f51dfdcb0bee1dc2ca90a06c797eff7fd51ce4cf0c2edfdc70cd90dR25) [[2]](diffhunk://#diff-a22688a84f51dfdcb0bee1dc2ca90a06c797eff7fd51ce4cf0c2edfdc70cd90dR47) [[3]](diffhunk://#diff-a22688a84f51dfdcb0bee1dc2ca90a06c797eff7fd51ce4cf0c2edfdc70cd90dR129)

### Model Service Configuration Updates:

* **Replaced model service providers with Docker images**: Updated `docker-compose.yml` to configure `llama3.2` and `qwen3` services using the `ollama/ollama:latest` Docker image, replacing the previous provider-based setup.
* **Cleaned up unused configurations**: Removed unnecessary lines and comments in `docker-compose.yml` for better readability. [[1]](diffhunk://#diff-cac2c97e36c419a5c2a0b0a49d1f4615933ff77ed3e0b1ddd66cf4d3a3518208L25-L32) [[2]](diffhunk://#diff-cac2c97e36c419a5c2a0b0a49d1f4615933ff77ed3e0b1ddd66cf4d3a3518208L43)