### PR TITLE
Bump up log level to default for PostProcessorRegistrationDelegate.

### DIFF
--- a/embabel-agent-api/src/main/resources/application.yml
+++ b/embabel-agent-api/src/main/resources/application.yml
@@ -65,7 +65,7 @@ logging:
   level:
 
     # Temporary hack until we resolve BeanPostProcessor warnings
-    org.springframework.context.support.PostProcessorRegistrationDelegate: ERROR
+    # org.springframework.context.support.PostProcessorRegistrationDelegate: ERROR
 
     # We deliberately suppress verbose error messages from the Spring AI converter
     # that can be distracting in the console


### PR DESCRIPTION
This pull request includes a small change to the `application.yml` file. It comments out the log level configuration for `org.springframework.context.support.PostProcessorRegistrationDelegate`, effectively disabling the suppression of its error-level logs.