### PR TITLE
More descriptive names and more comments.

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/PostProcessBeansListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/PostProcessBeansListener.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.config
 
-import com.embabel.agent.spi.support.AgentScanningBeanPostProcessor
+import com.embabel.agent.spi.support.AgentScanningPostProcessorDelegate
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationListener
 import org.springframework.context.event.ContextRefreshedEvent
@@ -27,8 +27,8 @@ import org.springframework.context.annotation.Profile
 
 /**
  *  After all beans got initialized we deploy Agent Platform
- *  Refer to [AgentScanningBeanPostProcessor]
- *  Note, Profile "!test" gets aligned with [AgentScanningBeanPostProcessor]
+ *  Refer to [AgentScanningPostProcessorDelegate]
+ *  Note, Profile "!test" gets aligned with [AgentScanningPostProcessorDelegate]
  */
 @Profile("!test & !dev & !prod & !shell  & !neo & !default")
 @Component
@@ -42,7 +42,7 @@ class PostProcessBeansListener(@Autowired val context: ApplicationContext) :
         logger.info("🚀 Application context has been refreshed and all beans are initialized.")
 
         // get AgentScanningBeanPostProcessor
-        val agentScanningBeanPostProcessor = context.getBean(AgentScanningBeanPostProcessor::class.java)
+        val agentScanningBeanPostProcessor = context.getBean(AgentScanningPostProcessorDelegate::class.java)
 
         // Get all beans from the application context
         val allBeans = context.getBeansOfType(Any::class.java)  // Fetch all beans, or filter by your criteria


### PR DESCRIPTION
This pull request refactors and renames several classes and components related to the agent scanning functionality, aiming to improve clarity and consistency in naming. The most significant changes include renaming `AgentScanningBeanPostProcessor` to `AgentScanningPostProcessorDelegate` and `LazyAgentScanningBeanPostProcessor` to `DelegatingAgentScanningBeanPostProcessor`, along with updates to associated references and logging.

### Class and Component Renaming:

* Renamed `AgentScanningBeanPostProcessor` to `AgentScanningPostProcessorDelegate` across the codebase, including its instantiation, logging, and references in `PostProcessBeansListener` and `AutoRegistration`. [[1]](diffhunk://#diff-4f979d9c7c8807ae469566f58696b5e6c7dda2e542486a9bd18fcbfa8223c611L18-R18) [[2]](diffhunk://#diff-4f979d9c7c8807ae469566f58696b5e6c7dda2e542486a9bd18fcbfa8223c611L45-R45) [[3]](diffhunk://#diff-d854979f85488b4dc19287da975c86eb9a26bd80cb5653902553e81df5108d64L42-R50) [[4]](diffhunk://#diff-d854979f85488b4dc19287da975c86eb9a26bd80cb5653902553e81df5108d64L93-R95)
* Renamed `LazyAgentScanningBeanPostProcessor` to `DelegatingAgentScanningBeanPostProcessor`, updated its logger, and replaced its dependency on `AgentScanningBeanPostProcessor` with `AgentScanningPostProcessorDelegate`. [[1]](diffhunk://#diff-d854979f85488b4dc19287da975c86eb9a26bd80cb5653902553e81df5108d64R72-R86) [[2]](diffhunk://#diff-d854979f85488b4dc19287da975c86eb9a26bd80cb5653902553e81df5108d64L93-R95)

### Documentation and Profile Updates:

* Updated class-level comments and documentation to reflect the new class names and added details about the purpose of the `DelegatingAgentScanningBeanPostProcessor`.
* Adjusted the `@Profile` annotation in `PostProcessBeansListener` to align with the renamed `AgentScanningPostProcessorDelegate`.