### PR TITLE
Issue #403 - Unable to connect to Zipkin during shell startup

### DIFF
--- a/embabel-agent-api/scripts/shell.cmd
+++ b/embabel-agent-api/scripts/shell.cmd
@@ -10,7 +10,7 @@ if errorlevel 1 (
 
 cd ..
 
-set SPRING_PROFILES_ACTIVE=shell,severance,observability
+set SPRING_PROFILES_ACTIVE=shell,severance
 
 cmd /c mvn spring-boot:run
 

--- a/embabel-agent-api/scripts/shell.ps1
+++ b/embabel-agent-api/scripts/shell.ps1
@@ -16,7 +16,7 @@ try {
     Set-Location ..
     
     # Set Spring profiles
-    $env:SPRING_PROFILES_ACTIVE = "shell,severance,observability"
+    $env:SPRING_PROFILES_ACTIVE = "shell,severance"
     
     # Run Maven in subprocess
     cmd /c "mvn spring-boot:run"

--- a/embabel-agent-api/scripts/shell.sh
+++ b/embabel-agent-api/scripts/shell.sh
@@ -3,5 +3,5 @@
 ./support/check_env.sh
 
 cd ..
-export SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop,observabilty
+export SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop
 mvn spring-boot:run

--- a/embabel-agent-api/scripts/shell_docker.cmd
+++ b/embabel-agent-api/scripts/shell_docker.cmd
@@ -10,7 +10,7 @@ if errorlevel 1 (
 
 cd ..
 
-set SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop,observability
+set SPRING_PROFILES_ACTIVE=shell,starwars,docker-desktop
 
 cmd /c mvn spring-boot:run
 

--- a/embabel-agent-api/src/main/resources/application-observability.yml
+++ b/embabel-agent-api/src/main/resources/application-observability.yml
@@ -3,14 +3,20 @@ spring:
     chat:
       observations:
         enabled: true
+        log-prompt: true
+        log-completion: true
         include-completion: true
         include-prompt: true
         include-error-logging: true
+    client:
+      observations:
+        log-prompt: true
+        log-completion: true
 management:
   tracing:
+    enabled: true
     sampling:
       probability: 1.0
-    enabled: true
   endpoints:
     web:
       exposure:

--- a/embabel-agent-api/src/main/resources/application.yml
+++ b/embabel-agent-api/src/main/resources/application.yml
@@ -8,19 +8,14 @@ spring:
     ansi:
       enabled: ALWAYS
   ai:
-    chat:
-      observations:
-        log-prompt: true
-        log-completion: true
-      client:
-        observations:
-          log-prompt: true
-          log-completion: true
-
     ollama:
       base-url: http://localhost:11434
     openai:
       api-key: ${OPENAI_API_KEY}
+
+management:
+  tracing:
+    enabled: false
 
 embabel:
   agent-platform:

--- a/embabel-agent-api/src/main/resources/application.yml
+++ b/embabel-agent-api/src/main/resources/application.yml
@@ -22,18 +22,6 @@ spring:
     openai:
       api-key: ${OPENAI_API_KEY}
 
-management:
-  tracing:
-    sampling:
-      probability: 1.0
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-  endpoint:
-    health:
-      show-details: always
-
 embabel:
   agent-platform:
     scanning:


### PR DESCRIPTION
This pull request includes updates to configuration files and scripts to refine the application's observability settings and streamline Spring profile management. The most significant changes include removing the "observability" Spring profile from various scripts, modifying observability-related configurations in `application-observability.yml`, and simplifying the `application.yml` file by disabling tracing and removing redundant settings.

### Updates to Spring Profile Management:
* Removed the "observability" Spring profile from the `SPRING_PROFILES_ACTIVE` environment variable in the following scripts: `shell.cmd`, `shell.ps1`, `shell.sh`, and `shell_docker.cmd`. This change ensures that observability settings are no longer applied by default in these scripts. [[1]](diffhunk://#diff-013696b1a8a589dadb335f9b6401bd2c317f21e690de6683997d0366d4b2ca1fL13-R13) [[2]](diffhunk://#diff-75b012cbe3adb7f86618ed2205e1d0d2b0bdbd97ebaa6383d8c19da07975c689L19-R19) [[3]](diffhunk://#diff-825a9b4e3d4d68ae5da7447a4a034cbc75759db759cc365fbc4f22168672abb2L6-R6) [[4]](diffhunk://#diff-909956e839d89cf630c60fe03c1619a66228aec3dba62281a35c3a62dd7006c4L13-R13)

### Changes to Observability Configuration:
* Updated `application-observability.yml` to add new logging options (`log-prompt` and `log-completion`) for both `chat` and `client` observations. Additionally, tracing was explicitly enabled, and redundant `enabled` settings for tracing were removed.

### Simplification of Default Application Configuration:
* Simplified `application.yml` by removing observability-related settings under `ai.chat` and `ai.client`, as well as sampling and endpoint configurations under `management.tracing`. Tracing is now explicitly disabled in this file.