### PR TITLE
Remove toolCallbacks from PromptRunner

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/actionMethodPromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/actionMethodPromptRunner.kt
@@ -19,14 +19,12 @@ import com.embabel.agent.api.annotation.support.MethodReturnPromptRunner
 import com.embabel.agent.api.common.PromptRunner
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
-import org.springframework.ai.tool.ToolCallback
 
 /**
  * Return a prompt runner for use to return in an @Action method, specifying
  * LLM options.
  * @param llm specification of LLM to use
  * @param toolGroups tool groups to request
- * @param toolCallbacks individual tools to expose
  * @param toolObjects objects with @Tool annotations to expose to the LLM.
  * Note that domain objects passed into the @Action method will automatically
  * expose any @Tool methods.
@@ -37,7 +35,6 @@ import org.springframework.ai.tool.ToolCallback
 fun using(
     llm: LlmOptions? = null,
     toolGroups: Set<String> = emptySet(),
-    toolCallbacks: List<ToolCallback> = emptyList(),
     toolObjects: List<Any> = emptyList(),
     promptContributors: List<PromptContributor> = emptyList(),
     generateExamples: Boolean? = null,
@@ -45,7 +42,6 @@ fun using(
     MethodReturnPromptRunner(
         llm = llm,
         toolGroups = toolGroups,
-        toolCallbacks = toolCallbacks,
         toolObjects = toolObjects,
         promptContributors = promptContributors,
         generateExamples = generateExamples,
@@ -56,7 +52,6 @@ fun using(
  * that uses the given model with default hyperparameters
  * @param model name of LLM to use
  * @param toolGroups tool groups to request
- * @param toolCallbacks individual tools to expose
  * @param toolObjects objects with @Tool annotations to expose to the LLM.
  * Note that domain objects passed into the @Action method will automatically
  * expose any @Tool methods.
@@ -67,7 +62,6 @@ fun using(
 fun usingModel(
     model: String,
     toolGroups: Set<String> = emptySet(),
-    toolCallbacks: List<ToolCallback> = emptyList(),
     toolObjects: List<Any> = emptyList(),
     promptContributors: List<PromptContributor> = emptyList(),
     generateExamples: Boolean? = null,
@@ -75,7 +69,6 @@ fun usingModel(
     MethodReturnPromptRunner(
         llm = LlmOptions(model = model),
         toolGroups = toolGroups,
-        toolCallbacks = toolCallbacks,
         toolObjects = toolObjects,
         promptContributors = promptContributors,
         generateExamples = generateExamples,
@@ -89,7 +82,6 @@ val usingDefaultLlm: PromptRunner =
     MethodReturnPromptRunner(
         llm = null,
         toolGroups = emptySet(),
-        toolCallbacks = emptyList(),
         toolObjects = emptyList(),
         promptContributors = emptyList(),
         generateExamples = null,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -328,7 +328,6 @@ class AgentMetadataReader(
             // It is not a failure
             val promptRunner = operationContext.promptRunner(
                 llm = e.llm ?: LlmOptions(),
-                toolCallbacks = emptyList(),
                 promptContributors = emptyList(),
             )
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
@@ -94,9 +94,6 @@ internal class DefaultActionMethodManager(
     ): O {
         logger.debug("Invoking action method {} with payload {}", method.name, context.input)
 
-        val toolCallbacksToUse = context.toolCallbacksOnDomainObjects()
-        logger.debug("Tool callbacks on domain objects: {}", toolCallbacksToUse)
-
         var args = context.input.toTypedArray()
         if (method.parameters.any { OperationContext::class.java.isAssignableFrom(it.type) }) {
             // We need to add the payload as the last argument
@@ -113,8 +110,7 @@ internal class DefaultActionMethodManager(
                 llm = cope.llm ?: LlmOptions(),
                 // Remember to add tool groups from the context to those the exception specified at the call site
                 toolGroups = cope.toolGroups + context.toolGroups,
-                toolCallbacks = toolCallbacksToUse,
-                toolObjects = cope.toolObjects,
+                toolObjects = (cope.toolObjects + context.domainObjectInstances()).distinct(),
                 promptContributors = promptContributors,
                 generateExamples = cope.generateExamples == true,
             )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/MethodReturnPromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/MethodReturnPromptRunner.kt
@@ -21,7 +21,6 @@ import com.embabel.agent.api.common.PromptRunner
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.core.types.ZeroToOne
-import org.springframework.ai.tool.ToolCallback
 
 /**
  * PromptRunner implementation that can be used to return a value
@@ -30,13 +29,10 @@ import org.springframework.ai.tool.ToolCallback
 internal data class MethodReturnPromptRunner(
     override val llm: LlmOptions?,
     override val toolGroups: Set<String>,
-    override val toolCallbacks: List<ToolCallback>,
     override val toolObjects: List<Any>,
     override val promptContributors: List<PromptContributor>,
     override val generateExamples: Boolean?,
 ) : PromptRunner {
-
-    override val name = "MethodReturnPromptRunner"
 
     override fun <T> createObject(
         prompt: String,
@@ -48,7 +44,7 @@ internal data class MethodReturnPromptRunner(
             requireResult = true,
             outputClass = outputClass,
             toolGroups = toolGroups,
-            toolCallbacks = toolCallbacks,
+            toolCallbacks = emptyList(),
             toolObjects = toolObjects,
             promptContributors = promptContributors,
         )
@@ -64,7 +60,7 @@ internal data class MethodReturnPromptRunner(
             requireResult = false,
             outputClass = outputClass,
             toolGroups = toolGroups,
-            toolCallbacks = toolCallbacks,
+            toolCallbacks = emptyList(),
             toolObjects = toolObjects,
             promptContributors = promptContributors,
         )
@@ -82,7 +78,7 @@ internal data class MethodReturnPromptRunner(
             llm = llm,
             requireResult = false,
             toolGroups = toolGroups,
-            toolCallbacks = toolCallbacks,
+            toolCallbacks = emptyList(),
             toolObjects = toolObjects,
             promptContributors = promptContributors,
         )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.api.common
 import com.embabel.agent.api.annotation.using
 import com.embabel.agent.experimental.primitive.Determination
 import com.embabel.agent.spi.LlmCall
+import com.embabel.agent.spi.LlmUse
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.core.types.ZeroToOne
@@ -32,7 +33,7 @@ import org.springframework.ai.tool.ToolCallback
  * A contextual facade to LlmOperations.
  * @see com.embabel.agent.spi.LlmOperations
  */
-interface PromptRunner : LlmCall {
+interface PromptRunner : LlmUse {
 
     /**
      * Additional objects with @Tool annotation for use in this PromptRunner

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextPromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextPromptRunner.kt
@@ -26,7 +26,6 @@ import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.core.types.ZeroToOne
 import com.embabel.common.util.loggerFor
-import org.springframework.ai.tool.ToolCallback
 
 /**
  * Uses the platform's LlmOperations to execute the prompt.
@@ -36,13 +35,10 @@ internal data class OperationContextPromptRunner(
     private val context: OperationContext,
     override val llm: LlmOptions,
     override val toolGroups: Set<String>,
-    override val toolCallbacks: List<ToolCallback>,
     override val toolObjects: List<Any>,
     override val promptContributors: List<PromptContributor>,
     override val generateExamples: Boolean?,
 ) : PromptRunner {
-
-    override val name = "OperationContextPromptRunner"
 
     val action = (context as? ActionContext)?.action
 
@@ -59,7 +55,7 @@ internal data class OperationContextPromptRunner(
             interaction = LlmInteraction(
                 llm = llm,
                 toolGroups = this.toolGroups + toolGroups,
-                toolCallbacks = toolCallbacks + safelyGetToolCallbacks(toolObjects),
+                toolCallbacks = safelyGetToolCallbacks(toolObjects),
                 promptContributors = promptContributors,
                 id = idForPrompt(prompt, outputClass),
             ),
@@ -78,7 +74,7 @@ internal data class OperationContextPromptRunner(
             interaction = LlmInteraction(
                 llm = llm,
                 toolGroups = this.toolGroups + toolGroups,
-                toolCallbacks = toolCallbacks + safelyGetToolCallbacks(toolObjects),
+                toolCallbacks = safelyGetToolCallbacks(toolObjects),
                 promptContributors = promptContributors,
                 id = idForPrompt(prompt, outputClass),
             ),

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/dsl/AgentScopeBuilder.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/dsl/AgentScopeBuilder.kt
@@ -20,10 +20,8 @@ import com.embabel.agent.api.common.*
 import com.embabel.agent.api.common.support.*
 import com.embabel.agent.core.*
 import com.embabel.agent.core.support.Rerun
-import com.embabel.agent.core.support.safelyGetToolCallbacks
 import com.embabel.common.core.MobyNameGenerator
 import com.embabel.common.util.loggerFor
-import org.springframework.ai.tool.ToolCallback
 import java.util.function.Function as JavaFunction
 
 inline fun <reified A, reified B : Any> doSplit(
@@ -352,8 +350,8 @@ data class BiInputActionContext<A1, A2>(
 
     override val inputs: List<Any> get() = listOfNotNull(input1, input2)
 
-    override fun toolCallbacksOnDomainObjects(): List<ToolCallback> =
-        safelyGetToolCallbacks(setOfNotNull(input1, input2))
+    override fun domainObjectInstances(): List<Any> =
+        listOfNotNull(input1, input2)
 }
 
 inline fun <reified A1, reified A2, reified B : Any, reified C> biAggregate(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/dsl/support/promptTransformer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/dsl/support/promptTransformer.kt
@@ -65,7 +65,6 @@ fun <I, O : Any> promptTransformer(
         it.promptRunner(
             llm = llm,
             toolGroups = toolGroups,
-            toolCallbacks = toolCallbacks.toList(),
             promptContributors = promptContributors,
         ).createObject(
             prompt = prompt(it),

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/LlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/LlmOperations.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.spi
 import com.embabel.agent.core.Action
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.ToolConsumer
+import com.embabel.agent.core.ToolGroupConsumer
 import com.embabel.agent.event.LlmRequestEvent
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
@@ -37,17 +38,23 @@ value class InteractionId(val value: String) {
 
 /**
  * Spec for calling an LLM. Optional LlmOptions,
- * plus tool callbacks and prompt contributors.
+ * plus tool groups and prompt contributors.
  */
-interface LlmCall : PromptContributorConsumer, ToolConsumer {
+interface LlmUse : PromptContributorConsumer, ToolGroupConsumer {
     val llm: LlmOptions?
-    override val promptContributors: List<PromptContributor>
 
     /**
      * Whether to generate examples for the prompt.
      * Defaults to unknown: Set to false if generating your own examples.
      */
     val generateExamples: Boolean?
+}
+
+/**
+ * Spec for calling an LLM. Optional LlmOptions,
+ * plus tool callbacks and prompt contributors.
+ */
+interface LlmCall : LlmUse, ToolConsumer {
 
     companion object {
         operator fun invoke(): LlmCall = LlmCallImpl(name = MobyNameGenerator.generateName())

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextPromptRunnerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextPromptRunnerTest.kt
@@ -54,7 +54,6 @@ class OperationContextPromptRunnerTest {
             context = mockOperationContext,
             llm = LlmOptions(),
             toolGroups = emptySet(),
-            toolCallbacks = emptyList(),
             toolObjects = emptyList(),
             promptContributors = emptyList(),
             generateExamples = false,


### PR DESCRIPTION
`PromptRunner` is a higher level API and should not deal with anything lower level than ToolGroups or tool objects. Thus directly exposing Spring AI `ToolCallback` instances is an abstraction leak.

Note that none of the examples were impacted by this.