### PR TITLE
Add Bedrock chat models

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -138,7 +138,12 @@
 
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+            <artifactId>spring-ai-bedrock-converse</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-bedrock-ai</artifactId>
         </dependency>
 
         <dependency>

--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -137,6 +137,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/BedrockModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/BedrockModels.kt
@@ -50,7 +50,7 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient
 import java.time.LocalDate
 import kotlin.text.isNotBlank
 
-@ConfigurationProperties(prefix = "spring.ai.bedrock.aws")
+@ConfigurationProperties(prefix = "embabel.models.bedrock")
 data class BedrockProperties(
     val models: List<BedrockModelProperties> = emptyList()
 )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/BedrockModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/BedrockModels.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models
+
+import com.embabel.common.ai.model.ConfigurableModelProviderProperties
+import com.embabel.common.ai.model.DefaultOptionsConverter
+import com.embabel.common.ai.model.Llm
+import com.embabel.common.ai.model.OptionsConverter
+import com.embabel.common.ai.model.PerTokenPricingModel
+import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
+import com.embabel.common.util.loggerFor
+import io.micrometer.observation.ObservationRegistry
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.ai.bedrock.converse.BedrockProxyChatModel
+import org.springframework.ai.chat.model.ChatModel
+import org.springframework.ai.chat.observation.ChatModelObservationConvention
+import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionConfiguration
+import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionProperties
+import org.springframework.ai.model.tool.ToolCallingChatOptions
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Condition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.context.annotation.Conditional
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.core.env.Environment
+import org.springframework.core.type.AnnotatedTypeMetadata
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.regions.providers.AwsRegionProvider
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient
+import java.time.LocalDate
+import kotlin.text.isNotBlank
+
+@ConfigurationProperties(prefix = "spring.ai.bedrock.aws")
+data class BedrockProperties(
+    val models: List<BedrockModelProperties> = emptyList()
+)
+
+data class BedrockModelProperties(
+    val name: String = "",
+    val knowledgeCutoff: String = "",
+    val inputPrice: Double = 0.0,
+    val outputPrice: Double = 0.0
+)
+
+class BedrockAvailable : Condition {
+    override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata): Boolean {
+        val environment = context.environment
+        val accessKeyId = environment.getProperty("AWS_ACCESS_KEY_ID")
+        val secretAccessKey = environment.getProperty("AWS_SECRET_ACCESS_KEY")
+        val region = environment.getProperty("AWS_REGION")
+        return accessKeyId != null && accessKeyId.isNotBlank()
+                && secretAccessKey != null && secretAccessKey.isNotBlank()
+                && region != null && region.isNotBlank()
+    }
+}
+
+@Configuration
+@Conditional(BedrockAvailable::class)
+@Import(BedrockAwsConnectionConfiguration::class)
+@Profile("!test")
+@ExcludeFromJacocoGeneratedReport(reason = "Bedrock configuration can't be unit tested")
+@EnableConfigurationProperties(BedrockProperties::class)
+class BedrockModels(
+
+    private val bedrockProperties: BedrockProperties,
+    private val configurableBeanFactory: ConfigurableBeanFactory,
+    private val environment: Environment,
+    private val properties: ConfigurableModelProviderProperties,
+    private val credentialsProvider: AwsCredentialsProvider,
+    private val regionProvider: AwsRegionProvider,
+    private val connectionProperties: BedrockAwsConnectionProperties,
+    private val observationRegistry: ObjectProvider<ObservationRegistry>,
+    private val observationConvention: ObjectProvider<ChatModelObservationConvention>,
+    private val bedrockRuntimeClient: ObjectProvider<BedrockRuntimeClient>,
+    private val bedrockRuntimeAsyncClient: ObjectProvider<BedrockRuntimeAsyncClient>,
+) {
+    init {
+        loggerFor<BedrockModels>().info("Bedrock models are available")
+    }
+
+    private val logger = LoggerFactory.getLogger(BedrockModels::class.java)
+
+    @PostConstruct
+    fun registerModels() {
+        if (!environment.activeProfiles.contains(BEDROCK_PROFILE)) {
+            logger.info("Bedrock models will not be queried as the '{}' profile is not active", BEDROCK_PROFILE)
+            return
+        }
+
+        if (bedrockProperties.models.isEmpty()) {
+            logger.warn("No Bedrock models available.")
+            return
+        }
+
+        val configuredLlmModelNames = properties.llms.values.toSet() + properties.defaultLlm
+        if (configuredLlmModelNames.isEmpty()) {
+            logger.warn("No Bedrock models configured.")
+            return
+        }
+
+        logger.info("Registering Bedrock models: {}", configuredLlmModelNames)
+        bedrockProperties.models
+            .filter { configuredLlmModelNames.contains(it.name) }
+            .forEach { model ->
+                try {
+                    val beanName = "bedrockModel-${model.name.replace(":", "-").lowercase()}"
+                    val llmModel = llmOf(model)
+                    configurableBeanFactory.registerSingleton(beanName, llmModel)
+                    logger.debug("Successfully registered Bedrock model {} as bean {}", model.name, beanName)
+                } catch (e: Exception) {
+                    logger.error("Failed to register Bedrock model {}: {}", model.name, e.message)
+                }
+            }
+    }
+
+    private fun llmOf(model: BedrockModelProperties): Llm = Llm(
+        name = model.name,
+        model = chatModelOf(model.name),
+        optionsConverter = optionsConverter,
+        provider = PROVIDER,
+        knowledgeCutoffDate = LocalDate.parse(model.knowledgeCutoff),
+        pricingModel = PerTokenPricingModel(
+            usdPer1mInputTokens = model.inputPrice,
+            usdPer1mOutputTokens = model.outputPrice,
+        )
+    )
+
+    private fun chatModelOf(model: String): ChatModel {
+
+        val chatModel = BedrockProxyChatModel.builder()
+            .credentialsProvider(credentialsProvider)
+            .region(regionProvider.region)
+            .timeout(connectionProperties.timeout)
+            .defaultOptions(ToolCallingChatOptions.builder().model(model).build())
+            .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+            .bedrockRuntimeClient(bedrockRuntimeClient.getIfAvailable())
+            .bedrockRuntimeAsyncClient(bedrockRuntimeAsyncClient.getIfAvailable())
+            .build()
+
+        observationConvention.ifAvailable(chatModel::setObservationConvention)
+
+        return chatModel
+    }
+
+    private val optionsConverter: OptionsConverter = { options ->
+        DefaultOptionsConverter.invoke(options)
+    }
+
+    companion object {
+        const val BEDROCK_PROFILE = "bedrock"
+
+        // https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
+        const val EU_ANTHROPIC_CLAUDE_3_5_SONNET = "eu.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        const val EU_ANTHROPIC_CLAUDE_3_5_SONNET_V2 = "eu.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        const val EU_ANTHROPIC_CLAUDE_3_5_HAIKU = "eu.anthropic.claude-3-5-haiku-20241022-v1:0"
+        const val EU_ANTHROPIC_CLAUDE_3_7_SONNET = "eu.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        const val EU_ANTHROPIC_CLAUDE_SONNET_4 = "eu.anthropic.claude-sonnet-4-20250514-v1:0"
+        const val EU_ANTHROPIC_CLAUDE_OPUS_4 = "eu.anthropic.claude-opus-4-20250514-v1:0"
+
+        const val US_ANTHROPIC_CLAUDE_3_5_SONNET = "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        const val US_ANTHROPIC_CLAUDE_3_5_SONNET_V2 = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        const val US_ANTHROPIC_CLAUDE_3_5_HAIKU = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
+        const val US_ANTHROPIC_CLAUDE_3_7_SONNET = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        const val US_ANTHROPIC_CLAUDE_SONNET_4 = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        const val US_ANTHROPIC_CLAUDE_OPUS_4 = "us.anthropic.claude-opus-4-20250514-v1:0"
+
+        const val APAC_ANTHROPIC_CLAUDE_3_5_SONNET = "apac.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        const val APAC_ANTHROPIC_CLAUDE_3_5_SONNET_V2 = "apac.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        const val APAC_ANTHROPIC_CLAUDE_3_5_HAIKU = "apac.anthropic.claude-3-5-haiku-20241022-v1:0"
+        const val APAC_ANTHROPIC_CLAUDE_3_7_SONNET = "apac.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        const val APAC_ANTHROPIC_CLAUDE_SONNET_4 = "apac.anthropic.claude-sonnet-4-20250514-v1:0"
+        const val APAC_ANTHROPIC_CLAUDE_OPUS_4 = "apac.anthropic.claude-opus-4-20250514-v1:0"
+
+        const val PROVIDER = "Bedrock"
+    }
+}

--- a/embabel-agent-api/src/main/resources/application-bedrock.yml
+++ b/embabel-agent-api/src/main/resources/application-bedrock.yml
@@ -1,0 +1,84 @@
+spring:
+  ai:
+    bedrock:
+      aws:
+        region: ${AWS_REGION}
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+        timeout: 10m
+        models:
+          # US region
+          - name: us.anthropic.claude-3-5-sonnet-20240620-v1:0
+            knowledge-cutoff: 2024-04-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: us.anthropic.claude-3-5-sonnet-20241022-v2:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: us.anthropic.claude-3-5-haiku-20241022-v1:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 0.8
+            output-price: 4.0
+          - name: us.anthropic.claude-3-7-sonnet-20250219-v1:0
+            knowledge-cutoff: 2024-10-31
+            input-price: 3.0
+            output-price: 15.0
+          - name: us.anthropic.claude-sonnet-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: us.anthropic.claude-opus-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 15.0
+            output-price: 75.0
+          # EU region
+          - name: eu.anthropic.claude-3-5-sonnet-20240620-v1:0
+            knowledge-cutoff: 2024-04-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: eu.anthropic.claude-3-5-sonnet-20241022-v2:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: eu.anthropic.claude-3-5-haiku-20241022-v1:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 0.8
+            output-price: 4.0
+          - name: eu.anthropic.claude-3-7-sonnet-20250219-v1:0
+            knowledge-cutoff: 2024-10-31
+            input-price: 3.0
+            output-price: 15.0
+          - name: eu.anthropic.claude-sonnet-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: eu.anthropic.claude-opus-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 15.0
+            output-price: 75.0
+          # APAC region
+          - name: apac.anthropic.claude-3-5-sonnet-20240620-v1:0
+            knowledge-cutoff: 2024-04-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: apac.anthropic.claude-3-5-sonnet-20241022-v2:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: apac.anthropic.claude-3-5-haiku-20241022-v1:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 0.8
+            output-price: 4.0
+          - name: apac.anthropic.claude-3-7-sonnet-20250219-v1:0
+            knowledge-cutoff: 2024-10-31
+            input-price: 3.0
+            output-price: 15.0
+          - name: apac.anthropic.claude-sonnet-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: apac.anthropic.claude-opus-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 15.0
+            output-price: 75.0

--- a/embabel-agent-api/src/main/resources/application-bedrock.yml
+++ b/embabel-agent-api/src/main/resources/application-bedrock.yml
@@ -5,80 +5,83 @@ spring:
         region: ${AWS_REGION}
         access-key: ${AWS_ACCESS_KEY_ID}
         secret-key: ${AWS_SECRET_ACCESS_KEY}
-        timeout: 10m
-        models:
-          # US region
-          - name: us.anthropic.claude-3-5-sonnet-20240620-v1:0
-            knowledge-cutoff: 2024-04-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: us.anthropic.claude-3-5-sonnet-20241022-v2:0
-            knowledge-cutoff: 2024-07-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: us.anthropic.claude-3-5-haiku-20241022-v1:0
-            knowledge-cutoff: 2024-07-01
-            input-price: 0.8
-            output-price: 4.0
-          - name: us.anthropic.claude-3-7-sonnet-20250219-v1:0
-            knowledge-cutoff: 2024-10-31
-            input-price: 3.0
-            output-price: 15.0
-          - name: us.anthropic.claude-sonnet-4-20250514-v1:0
-            knowledge-cutoff: 2025-03-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: us.anthropic.claude-opus-4-20250514-v1:0
-            knowledge-cutoff: 2025-03-01
-            input-price: 15.0
-            output-price: 75.0
-          # EU region
-          - name: eu.anthropic.claude-3-5-sonnet-20240620-v1:0
-            knowledge-cutoff: 2024-04-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: eu.anthropic.claude-3-5-sonnet-20241022-v2:0
-            knowledge-cutoff: 2024-07-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: eu.anthropic.claude-3-5-haiku-20241022-v1:0
-            knowledge-cutoff: 2024-07-01
-            input-price: 0.8
-            output-price: 4.0
-          - name: eu.anthropic.claude-3-7-sonnet-20250219-v1:0
-            knowledge-cutoff: 2024-10-31
-            input-price: 3.0
-            output-price: 15.0
-          - name: eu.anthropic.claude-sonnet-4-20250514-v1:0
-            knowledge-cutoff: 2025-03-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: eu.anthropic.claude-opus-4-20250514-v1:0
-            knowledge-cutoff: 2025-03-01
-            input-price: 15.0
-            output-price: 75.0
-          # APAC region
-          - name: apac.anthropic.claude-3-5-sonnet-20240620-v1:0
-            knowledge-cutoff: 2024-04-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: apac.anthropic.claude-3-5-sonnet-20241022-v2:0
-            knowledge-cutoff: 2024-07-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: apac.anthropic.claude-3-5-haiku-20241022-v1:0
-            knowledge-cutoff: 2024-07-01
-            input-price: 0.8
-            output-price: 4.0
-          - name: apac.anthropic.claude-3-7-sonnet-20250219-v1:0
-            knowledge-cutoff: 2024-10-31
-            input-price: 3.0
-            output-price: 15.0
-          - name: apac.anthropic.claude-sonnet-4-20250514-v1:0
-            knowledge-cutoff: 2025-03-01
-            input-price: 3.0
-            output-price: 15.0
-          - name: apac.anthropic.claude-opus-4-20250514-v1:0
-            knowledge-cutoff: 2025-03-01
-            input-price: 15.0
-            output-price: 75.0
+
+embabel:
+  models:
+    bedrock:
+      models:
+        # US region
+        - name: us.anthropic.claude-3-5-sonnet-20240620-v1:0
+          knowledge-cutoff: 2024-04-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: us.anthropic.claude-3-5-sonnet-20241022-v2:0
+          knowledge-cutoff: 2024-07-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: us.anthropic.claude-3-5-haiku-20241022-v1:0
+          knowledge-cutoff: 2024-07-01
+          input-price: 0.8
+          output-price: 4.0
+        - name: us.anthropic.claude-3-7-sonnet-20250219-v1:0
+          knowledge-cutoff: 2024-10-31
+          input-price: 3.0
+          output-price: 15.0
+        - name: us.anthropic.claude-sonnet-4-20250514-v1:0
+          knowledge-cutoff: 2025-03-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: us.anthropic.claude-opus-4-20250514-v1:0
+          knowledge-cutoff: 2025-03-01
+          input-price: 15.0
+          output-price: 75.0
+        # EU region
+        - name: eu.anthropic.claude-3-5-sonnet-20240620-v1:0
+          knowledge-cutoff: 2024-04-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: eu.anthropic.claude-3-5-sonnet-20241022-v2:0
+          knowledge-cutoff: 2024-07-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: eu.anthropic.claude-3-5-haiku-20241022-v1:0
+          knowledge-cutoff: 2024-07-01
+          input-price: 0.8
+          output-price: 4.0
+        - name: eu.anthropic.claude-3-7-sonnet-20250219-v1:0
+          knowledge-cutoff: 2024-10-31
+          input-price: 3.0
+          output-price: 15.0
+        - name: eu.anthropic.claude-sonnet-4-20250514-v1:0
+          knowledge-cutoff: 2025-03-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: eu.anthropic.claude-opus-4-20250514-v1:0
+          knowledge-cutoff: 2025-03-01
+          input-price: 15.0
+          output-price: 75.0
+        # APAC region
+        - name: apac.anthropic.claude-3-5-sonnet-20240620-v1:0
+          knowledge-cutoff: 2024-04-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: apac.anthropic.claude-3-5-sonnet-20241022-v2:0
+          knowledge-cutoff: 2024-07-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: apac.anthropic.claude-3-5-haiku-20241022-v1:0
+          knowledge-cutoff: 2024-07-01
+          input-price: 0.8
+          output-price: 4.0
+        - name: apac.anthropic.claude-3-7-sonnet-20250219-v1:0
+          knowledge-cutoff: 2024-10-31
+          input-price: 3.0
+          output-price: 15.0
+        - name: apac.anthropic.claude-sonnet-4-20250514-v1:0
+          knowledge-cutoff: 2025-03-01
+          input-price: 3.0
+          output-price: 15.0
+        - name: apac.anthropic.claude-opus-4-20250514-v1:0
+          knowledge-cutoff: 2025-03-01
+          input-price: 15.0
+          output-price: 75.0


### PR DESCRIPTION
Allow the use of Anthropic LLM models available on AWS Bedrock.

Enabled with 'bedrock' Spring profile.

Only models defined in embabel bloc will be registered in Spring context.