### PR TITLE
Ensure bedrock models are injected into ModelProvider

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformConfiguration.kt
@@ -114,12 +114,12 @@ internal class AgentPlatformConfiguration(
         ProcessOptionsOperationScheduler()
 
     /**
-     * Ollama and Docker models won't be loaded unless the profile is set.
+     * Ollama, Docker and Bedrock models won't be loaded unless the profile is set.
      * However, we need to depend on them to make sure any LLMs they
      * might create get injected here
      */
     @Bean
-    @DependsOn("ollamaModels", "dockerLocalModels")
+    @DependsOn("ollamaModels", "dockerLocalModels", "bedrockModels")
     fun modelProvider(
         llms: List<Llm>,
         embeddingServices: List<EmbeddingService>,


### PR DESCRIPTION
### Overview
This complete PR https://github.com/embabel/embabel-agent/pull/423, bedrock LLMs are created but not available in ModelProvider

### Details
Add BedrockModels bean name reference to the @DependsOn annotation of modelProvider in AgentPlatformConfiguration

Sorry for the missing change