### PR TITLE
Fix issue 433 price formatting locale in test

### DIFF
--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/LlmInvocationHistoryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/LlmInvocationHistoryTest.kt
@@ -42,7 +42,7 @@ class LlmInvocationHistoryTest {
         assertEquals(0, llmih.usage().promptTokens, "No prompt tokens yet")
         assertEquals(0, llmih.usage().completionTokens, "No completion tokens yet")
         assertEquals(
-            "LLMs: []; prompt tokens: 0; completion tokens: 0; cost: $0.0000",
+            "LLMs: []; prompt tokens: 0; completion tokens: 0; cost: $${"%.4f".format(0.0)}",
             llmih.costInfoString(false),
             "No cost info yet"
         )
@@ -66,7 +66,7 @@ class LlmInvocationHistoryTest {
         assertEquals(100, llmih.usage().promptTokens, "Correct prompt tokens")
         assertEquals(200, llmih.usage().completionTokens, "Correct completion tokens")
         assertEquals(
-            "LLMs: [Mock LLM]; prompt tokens: ${usage.promptTokens}; completion tokens: ${usage.completionTokens}; cost: $0.0000",
+            "LLMs: [Mock LLM]; prompt tokens: ${usage.promptTokens}; completion tokens: ${usage.completionTokens}; cost: $${"%.4f".format(0.0)}",
             llmih.costInfoString(false),
             "No cost info yet"
         )


### PR DESCRIPTION
Running mvn test leads to failing tests with when writing price with a '.', some locale uses ','.

This fix (issue #433) removes hardcoded '.' and also use the default locale in test, matching the default locale usage in code