### PR TITLE
chore: update maven dependency to com.embabel.agent.example:examples

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -61,8 +61,8 @@
             </dependency>
 
             <dependency>
-                <groupId>com.embabel.agent</groupId>
-                <artifactId>embabel-agent-examples</artifactId>
+                <groupId>com.embabel.agent.example</groupId>
+                <artifactId>examples-common</artifactId>
                 <version>${project.version}</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Update Maven dependency to examples-common

Replaces com.embabel.agent:embabel-agent-examples with
com.embabel.agent.example:examples-common to reflect updated artifact structure.