### PR TITLE
Add managed plugins to generate Kotlin and Java sources.jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,14 @@
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This pull request updates the Maven build configuration in the `pom.xml` file to include additional plugins for enhanced functionality.

Build configuration updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R108-R115): Added the `build-helper-maven-plugin` and `maven-source-plugin` to the `<plugins>` section to support advanced build tasks and source code packaging.