### PR TITLE
Update README.md

### DIFF
--- a/embabel-agent-examples/README.md
+++ b/embabel-agent-examples/README.md
@@ -100,7 +100,7 @@ These examples cover prompt engineering, tool integration, and orchestration pat
 ## Maven Profiles
 
 Example agents are provisioned as runtime dependencies to the Shell or MCP Server, and will be auto detected and deployed via component scan from the JVM classpath.
-In the embabel-agent-api/pom.xml we have two dedicated Maven Profiles desinged to bootstrap Kotlin and / or Java Agents.
+In the embabel-agent-api/pom.xml we have two dedicated Maven Profiles designed to bootstrap Kotlin and / or Java Agents.
 
 - **agent-examples-kotlin**
 - **agent-examples-java**

--- a/embabel-agent-examples/README.md
+++ b/embabel-agent-examples/README.md
@@ -114,7 +114,7 @@ cmd /c mvn -P agent-examples-kotlin -Dmaven.test.skip=true spring-boot:run
 If you would like to launch Shell as SpringBootAppliction from your IDE such as IntelliJ, Maven profile must be selected prior to running Shell.
 This can be done via IntelliJ Maven Profile selection (View/Tools/Maven)
 
-<img width="353" alt="image" src="https://github.com/user-attachments/assets/8b3b9a98-c1df-490f-97aa-b12e20b974de" />
+<img width="353" alt="IntelliJ Maven profile selection dialog" src="https://github.com/user-attachments/assets/8b3b9a98-c1df-490f-97aa-b12e20b974de" />
 
 ---
 

--- a/embabel-agent-examples/README.md
+++ b/embabel-agent-examples/README.md
@@ -111,7 +111,7 @@ Startup scripts are configured to bootstrap Kotlin Example Agents (we will add J
 cmd /c mvn -P agent-examples-kotlin -Dmaven.test.skip=true spring-boot:run
 ```
 
-If you would like to launch Shell as SpringBootAppliction from your IDE such as IntelliJ, Maven profile must be selected prior to running Shell.
+If you would like to launch Shell as SpringBootApplication from your IDE such as IntelliJ, Maven profile must be selected prior to running Shell.
 This can be done via IntelliJ Maven Profile selection (View/Tools/Maven)
 
 <img width="353" alt="IntelliJ Maven profile selection dialog" src="https://github.com/user-attachments/assets/8b3b9a98-c1df-490f-97aa-b12e20b974de" />

--- a/embabel-agent-examples/README.md
+++ b/embabel-agent-examples/README.md
@@ -99,13 +99,22 @@ These examples cover prompt engineering, tool integration, and orchestration pat
 
 ## Maven Profiles
 
-Example agents are included as Maven profiles for flexible activation. For example:
+Example agents are provisioned as runtime dependencies to the Shell or MCP Server, and will be auto detected and deployed via component scan from the JVM classpath.
+In the embabel-agent-api/pom.xml we have two dedicated Maven Profiles desinged to bootstrap Kotlin and / or Java Agents.
 
-```bash
-mvn spring-boot:run -Pagent-examples-kotlin
+- **agent-examples-kotlin**
+- **agent-examples-java**
+
+Startup scripts are configured to bootstrap Kotlin Example Agents (we will add Java Agents shortly)
+   
+```
+cmd /c mvn -P agent-examples-kotlin -Dmaven.test.skip=true spring-boot:run
 ```
 
-Profiles can be combined with Spring profiles to control which agents and features are active.
+If you would like to launch Shell as SpringBootAppliction from your IDE such as IntelliJ, Maven profile must be selected prior to running Shell.
+This can be done via IntelliJ Maven Profile selection (View/Tools/Maven)
+
+<img width="353" alt="image" src="https://github.com/user-attachments/assets/8b3b9a98-c1df-490f-97aa-b12e20b974de" />
 
 ---
 


### PR DESCRIPTION
This pull request updates the `README.md` file in `embabel-agent-examples` to clarify the setup and activation of example agents. The changes include a shift from Maven profiles to runtime dependencies, updated instructions for launching agents, and additional details for IDE configuration.

### Updated agent provisioning and setup:

* [`embabel-agent-examples/README.md`](diffhunk://#diff-33caf7200f896ae9ed3495249ad2cc599e045f24b063294c71b385c2d8f75a25L102-R117): Example agents are now provisioned as runtime dependencies and auto-detected via component scan from the JVM classpath, replacing the previous Maven profile activation approach. Two dedicated Maven profiles (`agent-examples-kotlin` and `agent-examples-java`) are introduced for bootstrapping agents.

### Improved instructions for launching agents:

* [`embabel-agent-examples/README.md`](diffhunk://#diff-33caf7200f896ae9ed3495249ad2cc599e045f24b063294c71b385c2d8f75a25L102-R117): Updated startup script command for launching Kotlin Example Agents, with a note about skipping tests during execution.

### IDE configuration guidance:

* [`embabel-agent-examples/README.md`](diffhunk://#diff-33caf7200f896ae9ed3495249ad2cc599e045f24b063294c71b385c2d8f75a25L102-R117): Added instructions for selecting Maven profiles in IntelliJ to launch Shell as a SpringBootApplication.