### PR TITLE
Enable Java version of StarNewsFinder example agent.

### DIFF
--- a/embabel-agent-examples/examples-java/horoscope/src/main/java/com/embabel/example/horoscope/java/StarNewsFinder.java
+++ b/embabel-agent-examples/examples-java/horoscope/src/main/java/com/embabel/example/horoscope/java/StarNewsFinder.java
@@ -40,8 +40,7 @@ import java.util.stream.Collectors;
 @Agent(
         name = "JavaStarNewsFinder",
         description = "Find news based on a person's star sign",
-        beanName = "javaStarNewsFinder",
-        scan = false)
+        beanName = "javaStarNewsFinder")
 public class StarNewsFinder {
 
     private final HoroscopeService horoscopeService;


### PR DESCRIPTION
This pull request makes a minor adjustment to the `StarNewsFinder` class in the `horoscope` example project. The change removes the `scan` attribute from the `@Agent` annotation, simplifying the configuration.

* [`embabel-agent-examples/examples-java/horoscope/src/main/java/com/embabel/example/horoscope/java/StarNewsFinder.java`](diffhunk://#diff-d54344772f9fd45da679067d8644d56b063ce2125453bbcda8698b879747006dL43-R43): Removed the `scan` attribute from the `@Agent` annotation, which previously had the value `false`.