### PR TITLE
Update Examples README.md

### DIFF
--- a/embabel-agent-examples/README.md
+++ b/embabel-agent-examples/README.md
@@ -105,10 +105,16 @@ In the embabel-agent-api/pom.xml we have two dedicated Maven Profiles designed t
 - **agent-examples-kotlin**
 - **agent-examples-java**
 
-Startup scripts are configured to bootstrap Kotlin Example Agents (we will add Java Agents shortly)
-   
+Startup scripts are configured to bootstrap Kotlin Example Agents as a default setup.
+
 ```
 cmd /c mvn -P agent-examples-kotlin -Dmaven.test.skip=true spring-boot:run
+```
+
+**Java Examples:** To run Java version of Horoscope Agent, please modify shell startup script and specify **-P agent-examples-java** accordingly.
+   
+```
+cmd /c mvn -P agent-examples-java -Dmaven.test.skip=true spring-boot:run
 ```
 
 If you would like to launch Shell as SpringBootApplication from your IDE such as IntelliJ, Maven profile must be selected prior to running Shell.


### PR DESCRIPTION
This pull request updates the `embabel-agent-examples/README.md` file to clarify the startup process for Java and Kotlin example agents. It introduces instructions for running Java examples and refines the description of the default setup for Kotlin examples.

### Documentation updates:

* Updated the description of the default setup to specify that Kotlin Example Agents are the default configuration.
* Added instructions for running the Java version of the Horoscope Agent by modifying the shell startup script to use the `agent-examples-java` Maven profile.