### PR TITLE
Issue #450

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
@@ -70,6 +70,7 @@ class McpServerConfiguration(
         (applicationContext.beanFactory as DefaultListableBeanFactory)
             .registerSingleton("callbacks", ToolCallbackProvider { allToolCallbacks.toTypedArray() })
 
+        //TODO, add support for MCP Async Server, find out if needed.
         refreshBean("mcpSyncServer", McpSyncServer::class.java)
     }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
@@ -16,14 +16,21 @@
 package com.embabel.agent.mcpserver
 
 import com.embabel.agent.core.ToolCallbackPublisher
+import com.embabel.agent.event.AgentPlatformEvent
 import com.embabel.agent.event.logging.LoggingPersonality.Companion.BANNER_WIDTH
+import com.embabel.agent.spi.support.AgentScanningBeanPostProcessorEvent
 import com.embabel.common.core.types.HasInfoString
 import com.embabel.common.util.loggerFor
+import io.modelcontextprotocol.server.McpSyncServer
 import org.springframework.ai.tool.ToolCallbackProvider
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
+import org.springframework.context.event.EventListener
 
 /**
  * Tag interface extending Spring AI ToolCallbackProvider
@@ -38,14 +45,16 @@ interface McpToolExportCallbackPublisher : ToolCallbackPublisher, HasInfoString
 @Profile("!test")
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.ANY)
 class McpServerConfiguration(
-    private val mcpToolExportCallbackPublishers: List<McpToolExportCallbackPublisher>,
+    private val applicationContext: ConfigurableApplicationContext,
 ) {
 
     /**
      * Used by Spring MCP server
      */
-    @Bean
-    fun callbacks(): ToolCallbackProvider {
+    @EventListener(AgentScanningBeanPostProcessorEvent::class)
+    fun callbacks() {
+        val mcpToolExportCallbackPublishers: List<McpToolExportCallbackPublisher> =
+            applicationContext.getBeansOfType(McpToolExportCallbackPublisher::class.java).values.toList()
         val allToolCallbacks = mcpToolExportCallbackPublishers.flatMap { it.toolCallbacks }
         val separator = "~".repeat(BANNER_WIDTH)
         loggerFor<McpServerConfiguration>().info(
@@ -57,6 +66,38 @@ class McpServerConfiguration(
                 "\n\t"
             ) { "${it.toolDefinition.name()}: ${it.toolDefinition.description()}" }
         )
-        return ToolCallbackProvider { allToolCallbacks.toTypedArray() }
+
+        (applicationContext.beanFactory as DefaultListableBeanFactory)
+            .registerSingleton("callbacks", ToolCallbackProvider { allToolCallbacks.toTypedArray() })
+
+        refreshBean("mcpSyncServer", McpSyncServer::class.java)
+    }
+
+    internal fun refreshBean(beanName: String, beanClass: Class<*>) {
+        val beanFactory = applicationContext.beanFactory as? DefaultListableBeanFactory
+            ?: throw IllegalStateException("BeanFactory is not a DefaultListableBeanFactory")
+
+        try {
+            // Get current bean definition
+            if (!beanFactory.containsBeanDefinition(beanName)) {
+                loggerFor<McpServerConfiguration>().error("Bean definition for '$beanName' not found")
+                return
+            }
+            val beanDefinition = beanFactory.getBeanDefinition(beanName)
+
+            // Destroy current instance
+            if (beanFactory.containsSingleton(beanName)) {
+                beanFactory.destroySingleton(beanName)
+            }
+
+            val instance = beanFactory.getBean(beanName, beanClass)
+
+            loggerFor<McpServerConfiguration>().debug("Refreshing bean '$beanName' of type ${instance::class.java.name}")
+        } catch (ex: Exception) {
+            loggerFor<McpServerConfiguration>().error(
+                "Failed to refresh bean '$beanName'. Agent Server Tools will not be available: ${ex.message}",
+                ex
+            )
+        }
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
@@ -48,8 +48,13 @@ class McpServerConfiguration(
     private val applicationContext: ConfigurableApplicationContext,
 ) {
 
+
     /**
-     * Used by Spring MCP server
+     * Configures and initializes MCP server tool callbacks when the agent scanning process completes.
+     *
+     * This event-driven approach ensures that all tool callbacks are properly registered only after
+     * the application context is fully initialized and all agent beans have been processed and deployed.
+     * Without this synchronization, the MCP server might start without access to all available tools.
      */
     @EventListener(AgentScanningBeanPostProcessorEvent::class)
     fun callbacks() {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt
@@ -24,6 +24,8 @@ import org.springframework.beans.BeansException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationEvent
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.ApplicationListener
 import org.springframework.context.annotation.Profile
 import org.springframework.core.Ordered
@@ -33,6 +35,10 @@ import java.util.*
 import java.util.concurrent.ConcurrentLinkedQueue
 import org.springframework.context.event.ContextRefreshedEvent as ContextRefreshedEvent
 
+/**
+ * Event to signal that AgentScanningBeanPostProcessor has completed processing all beans.
+ */
+class AgentScanningBeanPostProcessorEvent(source: Any) : ApplicationEvent(source)
 
 /**
  * Autoregister beans with @Agent or @Agentic annotations
@@ -43,7 +49,7 @@ internal class AgentScanningPostProcessorDelegate(
     private val agentMetadataReader: AgentMetadataReader,
     private val agentPlatform: AgentPlatform,
     private val properties: AgentScanningProperties,
-)  {
+) {
 
     private val logger = LoggerFactory.getLogger(AgentScanningPostProcessorDelegate::class.java)
 
@@ -76,9 +82,10 @@ internal class AgentScanningPostProcessorDelegate(
 @Profile("!test")
 @Order(Ordered.LOWEST_PRECEDENCE)
 internal class DelegatingAgentScanningBeanPostProcessor(
-    @Autowired
-    val applicationContext: ApplicationContext,
-) : BeanPostProcessor,
+    private val applicationContext: ApplicationContext,
+    private val applicationEventPublisher: ApplicationEventPublisher,
+
+    ) : BeanPostProcessor,
     ApplicationListener<ContextRefreshedEvent?> {
 
     private val logger = LoggerFactory.getLogger(DelegatingAgentScanningBeanPostProcessor::class.java)
@@ -96,6 +103,11 @@ internal class DelegatingAgentScanningBeanPostProcessor(
 
         // Process all accumulated beans
         processPendingBeans()
+
+        // Notify that all beans have been processed
+        applicationEventPublisher.publishEvent(
+            AgentScanningBeanPostProcessorEvent("Post-processing completed")
+        )
 
         logger.info("All deferred beans got post-processed.")
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt
@@ -84,7 +84,6 @@ internal class AgentScanningPostProcessorDelegate(
 internal class DelegatingAgentScanningBeanPostProcessor(
     private val applicationContext: ApplicationContext,
     private val applicationEventPublisher: ApplicationEventPublisher,
-
     ) : BeanPostProcessor,
     ApplicationListener<ContextRefreshedEvent?> {
 


### PR DESCRIPTION
This pull request introduces event-driven synchronization to ensure proper initialization of tool callbacks in the MCP server and adds support for bean lifecycle management. It also introduces a new custom event to signal the completion of agent scanning. These changes improve the reliability and maintainability of the MCP server configuration and agent scanning processes.

### MCP Server Improvements:
* Replaced direct injection of `McpToolExportCallbackPublisher` with dynamic retrieval from the `applicationContext`, ensuring all tool callbacks are registered after application initialization. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.ktL41-R62](diffhunk://#diff-852afcc750a601c89ed8820142c1efa08c0746d843e3e829eca96573c6b151ffL41-R62))
* Added a method to refresh bean instances (`refreshBean`) for lifecycle management, improving flexibility for MCP server operations. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.ktL60-R107](diffhunk://#diff-852afcc750a601c89ed8820142c1efa08c0746d843e3e829eca96573c6b151ffL60-R107))

### Event-Driven Synchronization:
* Introduced `AgentScanningBeanPostProcessorEvent` to signal the completion of agent scanning, enabling event-driven initialization of MCP server tool callbacks. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.ktR38-R41](diffhunk://#diff-d854979f85488b4dc19287da975c86eb9a26bd80cb5653902553e81df5108d64R38-R41))
* Modified `DelegatingAgentScanningBeanPostProcessor` to publish the new event after processing all beans. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.ktR107-R111](diffhunk://#diff-d854979f85488b4dc19287da975c86eb9a26bd80cb5653902553e81df5108d64R107-R111))

### Dependency Updates:
* Added imports for `ApplicationEvent`, `ApplicationEventPublisher`, and related classes to support event-driven functionality. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt`, [[1]](diffhunk://#diff-852afcc750a601c89ed8820142c1efa08c0746d843e3e829eca96573c6b151ffR19-R33); `embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt`, [[2]](diffhunk://#diff-d854979f85488b4dc19287da975c86eb9a26bd80cb5653902553e81df5108d64R27-R28)