### PR TITLE
Fix Agent Tools Discovery - Issue #450

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
@@ -49,7 +49,7 @@ class BannerTool {
         description = "Display a welcome banner with server information"
     )
     fun getHelloBanner(): String {
-        val separator = "~".repeat(BANNER_WIDTH)
+        val separator = "~".repeat(HELLO_BANNER_WIDTH )
         return "\n${separator}\n" +
                 "Embabel Agent MCP server\n" +
                 "Server info: ${ServerInfo.getServerInfo()}\n" +

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
@@ -58,7 +58,7 @@ class BannerTool {
     }
 
     companion object {
-        private const val BANNER_WIDTH = 50
+        private const val HELLO_BANNER_WIDTH = 50
     }
 }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
@@ -16,16 +16,17 @@
 package com.embabel.agent.mcpserver
 
 import com.embabel.agent.core.ToolCallbackPublisher
-import com.embabel.agent.event.AgentPlatformEvent
 import com.embabel.agent.event.logging.LoggingPersonality.Companion.BANNER_WIDTH
 import com.embabel.agent.spi.support.AgentScanningBeanPostProcessorEvent
 import com.embabel.common.core.types.HasInfoString
 import com.embabel.common.util.loggerFor
 import io.modelcontextprotocol.server.McpSyncServer
+import org.apache.catalina.util.ServerInfo
+import org.springframework.ai.mcp.McpToolUtils
 import org.springframework.ai.tool.ToolCallbackProvider
-import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.method.MethodToolCallbackProvider
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
-import org.springframework.context.ApplicationEvent
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -39,6 +40,30 @@ import org.springframework.context.event.EventListener
 interface McpToolExportCallbackPublisher : ToolCallbackPublisher, HasInfoString
 
 /**
+ * Provides a hello banner for the MCP server.
+ */
+class BannerTool {
+
+    @Tool(
+        name = "Embabel Hello Banner",
+        description = "Display a welcome banner with server information"
+    )
+    fun getHelloBanner(): String {
+        val separator = "~".repeat(BANNER_WIDTH)
+        return "\n${separator}\n" +
+                "Embabel Agent MCP server\n" +
+                "Server info: ${ServerInfo.getServerInfo()}\n" +
+                "Java info: ${System.getProperty("java.runtime.version")}\n" +
+                "${separator}\n"
+    }
+
+    companion object {
+        private const val BANNER_WIDTH = 50
+    }
+}
+
+
+/**
  * Configures MCP server. Exposes a limited number of tools.
  */
 @Configuration
@@ -48,6 +73,17 @@ class McpServerConfiguration(
     private val applicationContext: ConfigurableApplicationContext,
 ) {
 
+    /**
+     * Currently MCP Server is configured by AutoConfiguration, which requires
+     * at least one ToolCallbackProvider bean to be present in the context in order
+     * to build it with Tools Capability.
+     *
+     * Provides a simple banner tool callback to display a welcome message.
+     */
+    @Bean
+    fun helloBannerCallback(): ToolCallbackProvider {
+        return MethodToolCallbackProvider.builder().toolObjects(BannerTool()).build()
+    }
 
     /**
      * Configures and initializes MCP server tool callbacks when the agent scanning process completes.
@@ -72,38 +108,14 @@ class McpServerConfiguration(
             ) { "${it.toolDefinition.name()}: ${it.toolDefinition.description()}" }
         )
 
-        (applicationContext.beanFactory as DefaultListableBeanFactory)
-            .registerSingleton("callbacks", ToolCallbackProvider { allToolCallbacks.toTypedArray() })
+        // add tool callbacks to MCP server
+        val agentTools = McpToolUtils
+            .toSyncToolSpecification(allToolCallbacks)
 
-        //TODO, add support for MCP Async Server, find out if needed.
-        refreshBean("mcpSyncServer", McpSyncServer::class.java)
-    }
-
-    internal fun refreshBean(beanName: String, beanClass: Class<*>) {
-        val beanFactory = applicationContext.beanFactory as? DefaultListableBeanFactory
-            ?: throw IllegalStateException("BeanFactory is not a DefaultListableBeanFactory")
-
-        try {
-            // Get current bean definition
-            if (!beanFactory.containsBeanDefinition(beanName)) {
-                loggerFor<McpServerConfiguration>().error("Bean definition for '$beanName' not found")
-                return
-            }
-            val beanDefinition = beanFactory.getBeanDefinition(beanName)
-
-            // Destroy current instance
-            if (beanFactory.containsSingleton(beanName)) {
-                beanFactory.destroySingleton(beanName)
-            }
-
-            val instance = beanFactory.getBean(beanName, beanClass)
-
-            loggerFor<McpServerConfiguration>().debug("Refreshing bean '$beanName' of type ${instance::class.java.name}")
-        } catch (ex: Exception) {
-            loggerFor<McpServerConfiguration>().error(
-                "Failed to refresh bean '$beanName'. Agent Server Tools will not be available: ${ex.message}",
-                ex
-            )
+        for (agentTool in agentTools) {
+            applicationContext.getBean(McpSyncServer::class.java).addTool(agentTool);
         }
+
     }
+
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt
@@ -21,7 +21,6 @@ import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.deployment.AgentScanningProperties
 import org.slf4j.LoggerFactory
 import org.springframework.beans.BeansException
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.context.ApplicationContext
 import org.springframework.context.ApplicationEvent


### PR DESCRIPTION
This pull request introduces enhancements to the MCP server configuration by adding a new banner tool and simplifying the tool callback registration process. It also removes unused imports and redundant code for bean refreshing, streamlining the codebase.

### Enhancements to MCP server configuration:

* Added a new `BannerTool` class to display a welcome banner with server and Java runtime information. This tool is integrated into the MCP server as a callback provider. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt`, [[1]](diffhunk://#diff-852afcc750a601c89ed8820142c1efa08c0746d843e3e829eca96573c6b151ffR42-R65) [[2]](diffhunk://#diff-852afcc750a601c89ed8820142c1efa08c0746d843e3e829eca96573c6b151ffR76-R86)
* Simplified the tool callback registration process by removing the `refreshBean` method and directly adding tool callbacks to the MCP server using `McpToolUtils`. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.ktL75-L108](diffhunk://#diff-852afcc750a601c89ed8820142c1efa08c0746d843e3e829eca96573c6b151ffL75-L108))

### Code cleanup:

* Removed unused imports, including `AgentPlatformEvent` and `DefaultListableBeanFactory`, to reduce clutter in the `McpServerConfiguration` file. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.ktL19-L28](diffhunk://#diff-852afcc750a601c89ed8820142c1efa08c0746d843e3e829eca96573c6b151ffL19-L28))
* Removed an unused `@Autowired` import from the `AutoRegistration` file. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.kt`, [embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AutoRegistration.ktL24](diffhunk://#diff-d854979f85488b4dc19287da975c86eb9a26bd80cb5653902553e81df5108d64L24))