### PR TITLE
Add Graphfiz for UML diagrams

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,6 +20,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      # Install Graphviz for PlantUML diagrams
+      - name: Install Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
This pull request adds a new step to the Maven workflow configuration to install Graphviz, which is required for generating PlantUML diagrams.

Workflow enhancement:

* [`.github/workflows/maven.yml`](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446R23-R27): Added a step to install Graphviz using `apt-get`, enabling support for PlantUML diagram generation during the workflow execution.Install Graphviz for PlantUML diagrams.