### PR TITLE
Create dedicated maven profile to build docs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
     <modules>
         <module>embabel-agent-api</module>
         <module>embabel-agent-rag</module>
-        <module>embabel-agent-docs</module>
         <module>embabel-agent-shell</module>
         <module>embabel-agent-starter</module>
         <module>embabel-agent-autoconfigure</module>
@@ -115,6 +114,19 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Build Embabel Agent Documentation -->
+        <profile>
+            <id>embabel-agent-docs</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>embabel-agent-docs</module>
+            </modules>
+        </profile>
+    </profiles>
 
     
    <repositories>


### PR DESCRIPTION
This pull request modifies the `pom.xml` file to adjust how the `embabel-agent-docs` module is handled. The module is removed from the main list of modules and instead added under a new Maven profile, which is inactive by default. This change allows for more flexible builds where the documentation module can be included only when explicitly activated.

Changes to module handling:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L24): Removed `embabel-agent-docs` from the main `<modules>` section.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R118-R130): Added a new Maven profile for `embabel-agent-docs`, inactive by default, enabling selective inclusion during builds.