### PR TITLE
GitHub Action to publish Docs.

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,8 +8,7 @@ name: Publish Docs
 
 on:
   workflow_dispatch:  # Enables manual triggering
-  
-  inputs:
+    inputs:
       environment:
         description: 'Deploy Environment'
         required: true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,87 @@
+# This workflow will build a Ascii Doctor project with Maven, 
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Publish Docs
+
+on:
+  workflow_dispatch:  # Enables manual triggering
+  
+  inputs:
+      environment:
+        description: 'Deploy Environment'
+        required: true
+        default: 'development'
+        type: choice
+        options:
+          - development
+          - staging
+          - production
+      vm_instance:
+        description: 'VM Instance Name'
+        required: true
+        default: 'embabel-webserver'
+        type: string
+      vm_zone:
+        description: 'VM Zone'
+        required: true
+        default: 'us-east1-b'
+        type: string
+
+env:
+  PROJECT_ID: embabel-dev
+  SERVICE_ACCOUNT: embabel-ci-build@embabel-dev.iam.gserviceaccount.com
+  VM_INSTANCE: embabel-webserver
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    # Set default working directory for all steps
+    defaults:
+      run:
+        working-directory: ./embabel-agent-docs
+
+    steps:
+      - uses: actions/checkout@v4
+      # Install Graphviz for PlantUML diagrams
+      - name: Install Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven  
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn package
+
+      - name: Google Auth
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_CREDENTIALS}}
+          service_account: embabel-ci-build@embabel-dev.iam.gserviceaccount.com
+      
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy to VM
+        run: |
+          # Copy index.html and image folder
+          gcloud compute scp target/generated-docs/index.html \
+            ${{ github.event.inputs.vm_instance }}:/var/www/html/embabel-agent/guide \
+            --zone=${{ github.event.inputs.vm_zone }}
+          # Copy schema.ddl file
+          gcloud compute scp --recurse target/generated-docs/images \
+            ${{ github.event.inputs.vm_instance }}:/var/www/html/embabel-agent/guide \
+            --zone=${{ github.event.inputs.vm_zone }}
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,11 +20,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      # Install Graphviz for PlantUML diagrams
-      - name: Install Graphviz
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y graphviz
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying documentation to a virtual machine and removes redundant steps from an existing Maven build workflow. The changes streamline the build process and enable automated deployment of generated documentation.

### New Workflow for Documentation Deployment:

* [`.github/workflows/deploy-docs.yml`](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R1-R86): Added a new workflow named "Publish Docs" that builds documentation using Maven and deploys it to a specified VM instance. The workflow includes steps for setting up Java, installing Graphviz for PlantUML diagrams, authenticating with Google Cloud, and deploying files to the VM. It supports manual triggering with configurable inputs for environment, VM instance name, and zone.

### Streamlining Maven Workflow:

* [`.github/workflows/maven.yml`](diffhunk://#diff-5dbf1a803ecc13ff945a08ed3eb09149a83615e83f15320550af8e3a91976446L23-L27): Removed the step for installing Graphviz, as it is now part of the new documentation deployment workflow. This reduces redundancy in the Maven build process.