### PR TITLE
Add trigger to publish docs automatically

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,12 +12,12 @@ on:
       environment:
         description: 'Deploy Environment'
         required: true
-        default: 'development'
+        default: 'embabel-dev'
         type: choice
         options:
-          - development
-          - staging
-          - production
+          - embabel-dev
+          - embabel-sit
+          - embabel-prod
       vm_instance:
         description: 'VM Instance Name'
         required: true
@@ -28,11 +28,26 @@ on:
         required: true
         default: 'us-east1-b'
         type: string
-
+  
+  # Automatic trigger on file changes
+  push:
+    branches:
+      - main
+    paths:
+      - 'embabel-agent/embabel-agent-docs/**'
+  
+  # Also trigger on pull requests to docs
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'embabel-agent/embabel-agent-docs/**'
+  
 env:
-  PROJECT_ID: embabel-dev
+  PROJECT_ID: ${{ github.event.inputs.environment || 'embabel-dev' }}
   SERVICE_ACCOUNT: embabel-ci-build@embabel-dev.iam.gserviceaccount.com
-  VM_INSTANCE: embabel-webserver
+  VM_INSTANCE: ${{ github.event.inputs.vm_instance || 'embabel-webserver' }}
+  VM_ZONE: ${{ github.event.inputs.vm_zone || 'us-east1-b' }}
 
 jobs:
   build:


### PR DESCRIPTION
This pull request updates the deployment workflow configuration in `.github/workflows/deploy-docs.yml` to support multiple environments and automate triggers for documentation changes. The most important changes include updating environment options, adding automatic triggers for file changes and pull requests, and improving the handling of input variables.

### Updates to environment configuration:
* Changed the default environment from `development` to `embabel-dev` and updated the list of environment options to include `embabel-dev`, `embabel-sit`, and `embabel-prod`.

### Automation enhancements:
* Added automatic triggers for the workflow on file changes in `embabel-agent-docs` and pull requests targeting the `main` branch.

### Input variable improvements:
* Updated `PROJECT_ID`, `VM_INSTANCE`, and `VM_ZONE` to dynamically resolve values using `github.event.inputs` with fallback defaults.