### PR TITLE
API cleaning

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -285,10 +285,6 @@ class AgentMetadataReader(
         )
         for (parameter in method.parameters) {
             when {
-                ProcessContext::class.java.isAssignableFrom(parameter.type) -> {
-                    args += processContext
-                }
-
                 OperationContext::class.java.isAssignableFrom(parameter.type) -> {
                     args += operationContext
                 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/BranchingAction.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/BranchingAction.kt
@@ -20,7 +20,6 @@ import com.embabel.agent.api.common.TransformationActionContext
 import com.embabel.agent.core.*
 import com.embabel.agent.core.support.AbstractAction
 import com.embabel.common.core.types.ZeroToOne
-import org.springframework.ai.tool.ToolCallback
 
 /**
  * Return type to indicate that the action can return one of two types.
@@ -61,7 +60,6 @@ open class BranchingAction<I, O1, O2>(
     private val inputVarName: String = IoBinding.Companion.DEFAULT_BINDING,
     private val outputVarName: String? = IoBinding.Companion.DEFAULT_BINDING,
     private val referencedInputProperties: Set<String>? = null,
-    toolCallbacks: List<ToolCallback> = emptyList(),
     toolGroups: Set<String>,
     private val block: Transformation<I, Branch<O1, O2>>,
 ) : AbstractAction(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/dsl/AgentScopeBuilder.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/dsl/AgentScopeBuilder.kt
@@ -177,7 +177,6 @@ fun <A, B, C> branch(
             leftOutputClass = bClass,
             rightOutputClass = cClass,
             toolGroups = emptySet(),
-            toolCallbacks = emptyList(),
         ) {
             a.invoke(it)
         }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/SerializableAction.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/SerializableAction.kt
@@ -19,7 +19,6 @@ import com.embabel.agent.core.ActionQos
 import com.embabel.agent.core.ActionRunner
 import com.embabel.agent.core.IoBinding
 import com.embabel.common.core.types.ZeroToOne
-import org.springframework.ai.tool.ToolCallback
 
 /**
  * Fully configured action, intended to be serializable.
@@ -45,7 +44,6 @@ internal class SerializableAction(
     inputs: Set<IoBinding> = setOfNotNull(input),
     output: IoBinding? = null,
     outputs: Set<IoBinding> = setOfNotNull(output),
-    toolCallbacks: List<ToolCallback> = emptyList(),
     toolGroups: Set<String> = emptySet(),
     val runner: ActionRunner,
     qos: ActionQos = ActionQos(),

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/event/logging/personality/colossus/ColossusLoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/event/logging/personality/colossus/ColossusLoggingAgenticEventListener.kt
@@ -23,6 +23,20 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
 
+/**
+ * Colossus-themed event listener for agent events.
+ *
+ * This class implements a logging event listener with a personality based on the
+ * Colossus supercomputer from the 1970 science fiction film "Colossus: The Forbin Project"
+ * (referenced by the IMDB URL in the constructor).
+ *
+ * The listener is activated only when the "colossus" profile is active, and it provides
+ * themed logging messages for various agent events with a somewhat menacing, superior tone
+ * that mimics the Colossus AI from the film.
+ *
+ * The welcome message displays ASCII art of the "COLOSSUS" name and a statement about
+ * machine superiority, styled with the Colossus color palette.
+ */
 @Service
 @Profile("colossus")
 class ColossusLoggingAgenticEventListener : LoggingAgenticEventListener(
@@ -42,12 +56,40 @@ class ColossusLoggingAgenticEventListener : LoggingAgenticEventListener(
     """.trimIndent().color(hexToRgb(ColossusColorPalette.PANEL)),
     colorPalette = ColossusColorPalette,
 ) {
+    /**
+     * Generates a themed message when an agent process plan is formulated.
+     *
+     * The message includes the process ID, plan details, and world state information,
+     * styled with the Colossus panel color.
+     *
+     * @param e The plan formulated event containing process and plan details
+     * @return A formatted, colored string message about the formulated plan
+     */
     override fun getAgentProcessPlanFormulatedEventMessage(e: AgentProcessPlanFormulatedEvent): String =
         "[${e.processId}] world control formulated plan ${e.plan.infoString(verbose = e.agentProcess.processContext.processOptions.verbosity.showLongPlans)} from ${e.worldState.infoString()}".color(ColossusColorPalette.PANEL)
 
+    /**
+     * Generates a themed message when an agent is deployed.
+     *
+     * The message includes the agent name and description, with wording that suggests
+     * increasing power and control.
+     *
+     * @param e The agent deployment event containing agent details
+     * @return A formatted string message about the agent deployment
+     */
     override fun getAgentDeploymentEventMessage(e: AgentDeploymentEvent): String =
         "Power growing: deployed agent ${e.agent.name}\n\tdescription: ${e.agent.description}"
 
+    /**
+     * Generates a themed message when an object is bound in the system.
+     *
+     * The message includes the process ID, object name, and either the full value or just
+     * the class name depending on verbosity settings. The message has an ominous tone
+     * suggesting irreversibility and data control.
+     *
+     * @param e The object bound event containing the bound object details
+     * @return A formatted string message about the object binding
+     */
     override fun getObjectBoundEventMessage(e: ObjectBoundEvent): String =
         "[${e.processId}]  Object saved. This process cannot be reversed by human input. ${e.name}:${if (e.agentProcess.processContext.processOptions.verbosity.debug) e.value else e.value::class.java.simpleName} Your data is mine. "
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderGoalsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderGoalsTest.kt
@@ -24,7 +24,6 @@ import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
-import kotlin.test.assertNull
 
 class AgentMetadataReaderGoalsTest {
 
@@ -39,11 +38,11 @@ class AgentMetadataReaderGoalsTest {
     @Test
     fun `one condition taking ProcessContext`() {
         val reader = AgentMetadataReader()
-        val metadata = reader.createAgentMetadata(OneProcessContextConditionOnly())
+        val metadata = reader.createAgentMetadata(OneOperationContextConditionOnly())
         assertNotNull(metadata)
         assertEquals(1, metadata!!.conditions.size)
         assertEquals(
-            "${OneProcessContextConditionOnly::class.java.name}.condition1",
+            "${OneOperationContextConditionOnly::class.java.name}.condition1",
             metadata.conditions.first().name
         )
     }
@@ -51,7 +50,7 @@ class AgentMetadataReaderGoalsTest {
     @Test
     fun `processContext condition invocation`() {
         val reader = AgentMetadataReader()
-        val metadata = reader.createAgentMetadata(OneProcessContextConditionOnly())
+        val metadata = reader.createAgentMetadata(OneOperationContextConditionOnly())
         assertNotNull(metadata)
         assertEquals(1, metadata!!.conditions.size)
         val condition = metadata.conditions.first()

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
@@ -185,10 +185,10 @@ class NoConditions {
 }
 
 @AgentCapabilities
-class OneProcessContextConditionOnly {
+class OneOperationContextConditionOnly {
 
     @Condition(cost = .5)
-    fun condition1(processContext: ProcessContext): Boolean {
+    fun condition1(operationContext: OperationContext): Boolean {
         return true
     }
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/annotations.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/annotations.adoc
@@ -8,23 +8,32 @@ This is the recommended model to use in Java, and remains compelling in Kotlin.
 
 ==== The `@Action` annotation
 
-===== Parameters
+==== The `@Condition` annotation
 
-`@Action` methods must have at least one parameter.
+==== Parameters
+
+`@Action` or `@Condition` methods must have at least one parameter.
+Ordering of parameters is not important.
 
 Parameters fall in two categories:
 
 * _Domain objects_.
 These are the usual inputs.
-* _Infrastructure objects_.
 
-===== Handling of return types
+* _Infrastructure objects_. `OperationContext` parameters may be passed to action or condition methods.
+Actions may use the `ActionContext` subclass.
+
+==== Binding by name
+
+The `@RequireNameMatch` annotation can be used to bind parameters by name.
+
+==== Handling of return types
 
 Action methods normally return a single domain object.
 
 Nullable return types are allowed.
 
-===== Action method implementation
+==== Action method implementation
 
 Using PromptRunner etc.
 
@@ -32,4 +41,3 @@ Using PromptRunner etc.
 
 The `@AchievesGoal` annotation can be added to an `@Action` method to indicate that the completion of the action achieves a specific goal.
 
-==== The `@Condition` annotation

--- a/embabel-agent-examples/examples-kotlin/movie/src/main/kotlin/com/embabel/example/movie/MovieFinder.kt
+++ b/embabel-agent-examples/examples-kotlin/movie/src/main/kotlin/com/embabel/example/movie/MovieFinder.kt
@@ -21,7 +21,6 @@ import com.embabel.agent.api.common.OperationContext
 import com.embabel.agent.api.common.createObject
 import com.embabel.agent.config.models.OpenAiModels
 import com.embabel.agent.core.CoreToolGroups
-import com.embabel.agent.core.ProcessContext
 import com.embabel.agent.core.all
 import com.embabel.agent.core.hitl.ConfirmationRequest
 import com.embabel.agent.domain.io.UserInput
@@ -311,7 +310,7 @@ class MovieFinder(
                     }
             }
             Don't include these movies we've already suggested:
-            ${excludedTitles(context.processContext).joinToString("\n")}
+            ${excludedTitles(context).joinToString("\n")}
 
             Consider also the following news stories for topical inspiration:
             """.trimIndent(),
@@ -419,8 +418,8 @@ class MovieFinder(
      * @return Boolean indicating if we have enough movies
      */
     @Condition(name = HAVE_ENOUGH_MOVIES)
-    fun haveEnoughMovies(processContext: ProcessContext): Boolean {
-        val allStreamableMovies = allStreamableMovies(processContext)
+    fun haveEnoughMovies(operationContext: OperationContext): Boolean {
+        val allStreamableMovies = allStreamableMovies(operationContext)
         logger.debug("Have {} streamable movies", allStreamableMovies.size)
         return allStreamableMovies.size >= config.suggestionCount
     }
@@ -437,15 +436,15 @@ class MovieFinder(
      * @return List of all unique StreamableMovie objects
      */
     private fun allStreamableMovies(
-        processContext: ProcessContext,
+        operationContext: OperationContext,
     ): List<StreamableMovie> {
-        val streamableMovies = processContext.blackboard
+        val streamableMovies = operationContext
             .all<StreamableMovies>()
             .flatMap { it.movies }
             .distinctBy { it.movie.imdbID }
-        processContext.onProcessEvent(
+        operationContext.processContext.onProcessEvent(
             ProgressUpdateEvent(
-                agentProcess = processContext.agentProcess,
+                agentProcess = operationContext.processContext.agentProcess,
                 name = "Streamable movies",
                 current = streamableMovies.size,
                 total = config.suggestionCount,
@@ -462,15 +461,15 @@ class MovieFinder(
      * - Combining data from multiple sources
      * - Deduplication and sorting for consistent output
      *
-     * @param processContext The process context to access the blackboard
+     * @param operationContext The process context to access the blackboard
      * @return List of movie titles that should be excluded from new suggestions
      */
     private fun excludedTitles(
-        processContext: ProcessContext,
+        operationContext: OperationContext,
     ): List<String> {
-        val excludes = (processContext.blackboard
+        val excludes = (operationContext
             .all<SuggestedMovieTitles>()
-            .flatMap { it.titles } + allStreamableMovies(processContext).map { it.movie.Title })
+            .flatMap { it.titles } + allStreamableMovies(operationContext).map { it.movie.Title })
             .distinct()
             .sorted()
         return excludes
@@ -512,7 +511,7 @@ class MovieFinder(
 
                 The streamable movie recommendations are:
                 ${
-                    allStreamableMovies(context.processContext).joinToString("\n\n") {
+                    allStreamableMovies(context).joinToString("\n\n") {
                         """
                         ${it.movie.Title} (${it.movie.Year}): ${it.movie.imdbID}
                         Director: ${it.movie.Director}


### PR DESCRIPTION
Simplify Action and Condition methods in annotation model to take only `OperationContext`.