### PR TITLE
A2A: Implement message/stream endpoint:

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/a2a/server/A2ARequestHandler.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/a2a/server/A2ARequestHandler.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.a2a.server
 
 import com.embabel.agent.a2a.spec.JSONRPCRequest
 import com.embabel.agent.a2a.spec.JSONRPCResponse
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 
 /**
  * Handles JSON-RPC requests according to the A2A protocol.
@@ -29,4 +30,21 @@ interface A2ARequestHandler {
      * @return the JSON-RPC response
      */
     fun handleJsonRpc(request: JSONRPCRequest): JSONRPCResponse
+
+    /**
+     * Handles a streaming JSON-RPC request using Server-Sent Events (SSE).
+     * This method is called when a client requests a streaming response for methods like "message/stream".
+     *
+     * The default implementation throws [UnsupportedOperationException] as streaming is not supported.
+     * Override this method in implementations that support streaming responses.
+     *
+     * @param request The JSON-RPC request containing the method name, parameters, and request ID
+     * @return An [SseEmitter] that will be used to send streaming events to the client
+     * @throws UnsupportedOperationException if streaming is not supported by this implementation
+     * @see SseEmitter
+     * @see JSONRPCRequest
+     */
+    fun handleJsonRpcStream(request: JSONRPCRequest): SseEmitter {
+        throw UnsupportedOperationException("Streaming not supported by this implementation")
+    }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/a2a/server/support/A2AStreamingHandler.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/a2a/server/support/A2AStreamingHandler.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.a2a.server.support
+
+import com.embabel.agent.a2a.spec.*
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Handles streaming functionality for A2A messages
+ */
+@Service
+@Profile("a2a")
+class A2AStreamingHandler(
+    private val objectMapper: ObjectMapper
+) {
+    private val logger = LoggerFactory.getLogger(A2AStreamingHandler::class.java)
+    private val activeStreams = ConcurrentHashMap<String, SseEmitter>()
+    private val scheduler: ScheduledExecutorService = Executors.newScheduledThreadPool(1)
+
+    /**
+     * Creates a new SSE stream for the given stream ID
+     */
+    fun createStream(streamId: String): SseEmitter {
+        logger.info("Creating SSE stream for streamId: {}", streamId)
+
+        val emitter = SseEmitter(Long.MAX_VALUE)
+        activeStreams[streamId] = emitter
+
+        emitter.onCompletion {
+            logger.info("Stream completed for streamId: {}", streamId)
+            activeStreams.remove(streamId)
+        }
+
+        emitter.onTimeout {
+            logger.info("Stream timed out for streamId: {}", streamId)
+            activeStreams.remove(streamId)
+        }
+
+        // Send initial connection established event
+        try {
+            emitter.send(SseEmitter.event()
+                .name("connected")
+                .data(mapOf("streamId" to streamId))
+            )
+        } catch (e: Exception) {
+            logger.error("Error sending initial event", e)
+            emitter.completeWithError(e)
+        }
+
+        return emitter
+    }
+
+    /**
+     * Sends a streaming event to the specified stream
+     */
+    fun sendStreamEvent(streamId: String, event: StreamingResult) {
+        val emitter = activeStreams[streamId] ?: run {
+            logger.warn("No active stream found for streamId: {}", streamId)
+            return
+        }
+
+        try {
+            val eventData = when (event) {
+                is MessageResult -> {
+                    SseEmitter.event()
+                        .name("message")
+                        .data(objectMapper.writeValueAsString(event.message), MediaType.APPLICATION_JSON)
+                }
+                is TaskResult -> {
+                    SseEmitter.event()
+                        .name("task")
+                        .data(objectMapper.writeValueAsString(event.task), MediaType.APPLICATION_JSON)
+                }
+                is TaskStatusUpdateEvent -> {
+                    SseEmitter.event()
+                        .name("task-update")
+                        .data(objectMapper.writeValueAsString(JSONRPCSuccessResponse(
+                            jsonrpc = "2.0",
+                            id = streamId,
+                            result = event
+                        )), MediaType.APPLICATION_JSON)
+                }
+                is TaskArtifactUpdateEvent -> {
+                    SseEmitter.event()
+                        .name("task-update")
+                        .data(objectMapper.writeValueAsString(JSONRPCSuccessResponse(
+                            jsonrpc = "2.0",
+                            id = streamId,
+                            result = event
+                        )), MediaType.APPLICATION_JSON)
+                }
+            }
+            emitter.send(eventData)
+        } catch (e: Exception) {
+            logger.error("Error sending stream event", e)
+            emitter.completeWithError(e)
+        }
+    }
+
+    /**
+     * Closes the specified stream
+     */
+    fun closeStream(streamId: String) {
+        val emitter = activeStreams.remove(streamId)
+        emitter?.complete()
+    }
+
+    /**
+     * Shuts down the streaming handler
+     */
+    fun shutdown() {
+        scheduler.shutdown()
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                scheduler.shutdownNow()
+            }
+        } catch (e: InterruptedException) {
+            scheduler.shutdownNow()
+        }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/a2a/spec/a2a.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/a2a/spec/a2a.kt
@@ -690,3 +690,34 @@ object A2AErrorCodes {
 data class ResponseWrapper(
     val root: JSONRPCResponse
 )
+
+/**
+ * Parameters for streaming messages
+ */
+data class MessageStreamParams(
+    /** The ID of the task to stream messages for */
+    val taskId: String,
+
+    /** The message to process */
+    val message: Message? = null,
+
+    /** Optional configuration for streaming */
+    val configuration: StreamConfiguration? = null,
+
+    /** Extension metadata */
+    val metadata: Map<String, Any>? = null
+)
+
+/**
+ * Configuration for message streaming
+ */
+data class StreamConfiguration(
+    /** Whether to include message history */
+    val includeHistory: Boolean = false,
+
+    /** Maximum number of messages to include in history */
+    val historyLength: Int? = null,
+
+    /** Whether to stream in real-time */
+    val realTime: Boolean = true
+)


### PR DESCRIPTION
feature(a2a): Implement real-time streaming for agent responses

## Overview
This PR implements streaming support for the A2A protocol using Server-Sent Events (SSE)

## Changes
- Add streaming support for message/stream endpoint using Server-Sent Events (SSE)
- Implement A2AStreamingHandler to manage SSE connections and events
- Add streaming event types for messages, tasks, and status updates
- Handle streaming lifecycle, including connection, events, and cleanup
- Support error handling and graceful stream termination
- Add proper content type handling for streaming responses

## Technical Details
- Uses Spring's SseEmitter for SSE implementation
- Implements proper stream lifecycle management with connection tracking
- Handles various event types (messages, tasks, status updates)
- Includes comprehensive error handling and cleanup

## example:
```shell
curl --location 'http://localhost:8080/a2a' \
--header 'Content-Type: application/json' \
--data '{
  "jsonrpc": "2.0",
  "method": "message/stream",
  "params": {
    "taskId": "task_123",
    "message": {
      "role": "user",
      "parts": [
        {
          "kind": "text",
          "text": "find news for me"
        }
      ],
      "messageId": "msg_123",
      "contextId": "ctx_123"
    }
  },
  "id": "stream_123"
}'
```

and the response:

![image](https://github.com/user-attachments/assets/f9603407-84eb-4c0c-ba3c-c5c457b5b0c4)


## Impact
This change enables real-time streaming of agent responses through the A2A protocol, improving the user experience for long-running operations by providing immediate feedback and progress updates.