### PR TITLE
Disable test fixtures failing under Windows OS, pending investigation

### DIFF
--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsTest.kt
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
@@ -61,6 +63,7 @@ class FileReadToolsTest {
         }
 
         @Test
+        @DisabledOnOs(OS.WINDOWS)
         fun `should find files by extension excluding root`() {
             val result = fileReadTools.findFiles("**/*.txt")
 
@@ -85,6 +88,7 @@ class FileReadToolsTest {
         }
 
         @Test
+        @DisabledOnOs(OS.WINDOWS)
         fun `should find files in specific directory`() {
             val result = fileReadTools.findFiles("dir1/*")
             assertEquals(1, result.size)


### PR DESCRIPTION
See Issue #488

This pull request introduces changes to the `FileReadToolsTest` class to improve test behavior by adding conditional execution annotations. The most significant updates involve disabling specific tests on Windows operating systems.

Test behavior improvements:

* [`embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsTest.kt`](diffhunk://#diff-d6599cc36267c69d30f2ea7fc8555d32187fc77658a36d3fec4a3db06b95375dR66): Added the `@DisabledOnOs(OS.WINDOWS)` annotation to the `should find files by extension excluding root` test to prevent it from running on Windows.
* [`embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsTest.kt`](diffhunk://#diff-d6599cc36267c69d30f2ea7fc8555d32187fc77658a36d3fec4a3db06b95375dR91): Added the `@DisabledOnOs(OS.WINDOWS)` annotation to the `should find files in specific directory` test to prevent it from running on Windows.

Supporting changes:

* [`embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsTest.kt`](diffhunk://#diff-d6599cc36267c69d30f2ea7fc8555d32187fc77658a36d3fec4a3db06b95375dR24-R25): Imported `DisabledOnOs` and `OS` from `org.junit.jupiter.api.condition` to enable conditional test execution.