### PR TITLE
Make embabel-starter a JAR depenency

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -50,7 +50,7 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
-                <artifactId>embabel-agent-starters</artifactId>
+                <artifactId>embabel-agent-starter</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/embabel-agent-starters/embabel-agent-starter/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter/pom.xml
@@ -8,7 +8,6 @@
         <version>0.1.0-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-agent-starter</artifactId>
-    <packaging>pom</packaging>
     <name>Embabel Agent Starter</name>
     <description>Embabel Agent Starter. Parent to all starters</description>
 


### PR DESCRIPTION
This pull request includes updates to the Maven configuration files to correct artifact references and refine packaging details. These changes ensure consistency and proper dependency management across the project.

Dependency and artifact corrections:

* [`embabel-agent-dependencies/pom.xml`](diffhunk://#diff-afe07651950d7d2835eb6cc02163f9241976a101f42ab11fe2d932fc246750f9L53-R53): Updated the artifact ID from `embabel-agent-starters` to `embabel-agent-starter` to fix a naming inconsistency.

Packaging refinement:

* [`embabel-agent-starters/embabel-agent-starter/pom.xml`](diffhunk://#diff-12b13ec3361f83bd85031fac40992f1bd1d47266de643cd40084b14f623d159fL11): Removed the `<packaging>` element, which previously specified `pom`, as it is no longer needed for this module.