### PR TITLE
Automatically adjust font to render Embabel Themes on Windows OS

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/AgentApplication.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/AgentApplication.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.embabel.agent
-
 import com.embabel.common.util.WinUtils
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
@@ -35,13 +34,13 @@ import org.springframework.context.annotation.ComponentScan
     ]
 )
 class AgentApplication {
-
     companion object {
         init {
             if (WinUtils.IS_OS_WINDOWS()) {
-                // Set console to UTF-8 on Windows
+                // Set console to UTF-8 on Windows and optimize font for Unicode display
                 // This is necessary to display non-ASCII characters correctly
                 WinUtils.CHCP_TO_UTF8()
+                WinUtils.SETUP_OPTIMAL_CONSOLE()
             }
         }
     }


### PR DESCRIPTION
This pull request introduces a minor improvement to the `AgentApplication` class in the `embabel-agent-api` module. It enhances console setup on Windows by adding a method to optimize the font for Unicode display.

Console setup enhancement:

* [`embabel-agent-api/src/main/kotlin/com/embabel/agent/AgentApplication.kt`](diffhunk://#diff-1dc5f35dc29c54a1bf2c93e66eb007eaf9363cbcc6c09e03e73e0906548c9388L38-R43): Updated the initialization block to include a call to `WinUtils.SETUP_OPTIMAL_CONSOLE()`, which optimizes the console font for Unicode display on Windows.