### PR TITLE
Testing library improvements

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
@@ -26,21 +26,10 @@ import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.core.types.ZeroToOne
 import org.springframework.ai.tool.ToolCallback
 
-
 /**
- * User code should always use this interface to execute prompts.
- * A PromptRunner is immutable once constructed, and has determined
- * LLM and hyperparameters.
- * Thus, a PromptRunner can be reused within an action implementation.
- * A contextual facade to LlmOperations.
- * @see com.embabel.agent.spi.LlmOperations
+ * User-facing interface for executing prompts.
  */
-interface PromptRunner : LlmUse {
-
-    /**
-     * Additional objects with @Tool annotation for use in this PromptRunner
-     */
-    val toolObjects: List<Any>
+interface PromptRunnerOperations {
 
     /**
      * Generate text
@@ -80,6 +69,25 @@ interface PromptRunner : LlmUse {
         context: String,
         confidenceThreshold: ZeroToOne = 0.8,
     ): Boolean
+
+}
+
+
+/**
+ * User code should always use this interface to execute prompts.
+ * A PromptRunner is immutable once constructed, and has determined
+ * LLM and hyperparameters.
+ * Thus, a PromptRunner can be reused within an action implementation.
+ * A contextual facade to LlmOperations.
+ * @see com.embabel.agent.spi.LlmOperations
+ */
+interface PromptRunner : LlmUse, PromptRunnerOperations {
+
+    /**
+     * Additional objects with @Tool annotation for use in this PromptRunner
+     */
+    val toolObjects: List<Any>
+
 
     /**
      * Specify an LLM for the PromptRunner

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/Autonomy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/Autonomy.kt
@@ -22,8 +22,8 @@ import com.embabel.agent.event.DynamicAgentCreationEvent
 import com.embabel.agent.event.RankingChoiceRequestEvent
 import com.embabel.agent.spi.Ranker
 import com.embabel.agent.spi.Rankings
-import com.embabel.agent.testing.FakeRanker
-import com.embabel.agent.testing.RandomRanker
+import com.embabel.agent.testing.integration.FakeRanker
+import com.embabel.agent.testing.integration.RandomRanker
 import com.embabel.common.core.types.ZeroToOne
 import com.embabel.common.util.loggerFor
 import com.embabel.plan.goap.AStarGoapPlanner

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
@@ -22,7 +22,7 @@ import com.embabel.agent.event.AgenticEventListener
 import com.embabel.agent.rag.RagService
 import com.embabel.agent.spi.*
 import com.embabel.agent.spi.support.InMemoryAgentProcessRepository
-import com.embabel.agent.testing.DummyObjectCreatingLlmOperations
+import com.embabel.agent.testing.integration.DummyObjectCreatingLlmOperations
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/LlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/LlmOperations.kt
@@ -47,6 +47,7 @@ interface LlmUse : PromptContributorConsumer, ToolGroupConsumer {
      * Defaults to unknown: Set to false if generating your own examples.
      */
     val generateExamples: Boolean?
+
 }
 
 /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/common/EventSavingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/common/EventSavingAgenticEventListener.kt
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.testing
+package com.embabel.agent.testing.common
 
 import com.embabel.agent.event.AgentPlatformEvent
 import com.embabel.agent.event.AgentProcessEvent
 import com.embabel.agent.event.AgenticEventListener
 
 /**
- * Simple implementation of [AgenticEventListener] that saves each kind of event to a list.
+ * Simple implementation of [com.embabel.agent.event.AgenticEventListener] that saves each kind of event to a list.
  */
 class EventSavingAgenticEventListener : AgenticEventListener {
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/DummyObjectCreatingLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/DummyObjectCreatingLlmOperations.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.testing
+package com.embabel.agent.testing.integration
 
 import com.embabel.agent.core.Action
 import com.embabel.agent.core.AgentProcess
@@ -88,7 +88,7 @@ open class DummyObjectCreatingLlmOperations(
          * style fake test
          */
         val LoremIpsum: LlmOperations = DummyObjectCreatingLlmOperations(
-            DummyInstanceCreator.Companion.LoremIpsums
+            LoremIpsums
         )
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/IntegrationTestUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/IntegrationTestUtils.kt
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.testing
+package com.embabel.agent.testing.integration
 
-import com.embabel.agent.core.Agent
-import com.embabel.agent.core.AgentPlatform
-import com.embabel.agent.core.AgentProcess
-import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.*
 import com.embabel.agent.core.support.DefaultAgentPlatform
 import com.embabel.agent.core.support.InMemoryBlackboard
 import com.embabel.agent.core.support.SimpleAgentProcess
@@ -29,6 +26,7 @@ import com.embabel.agent.spi.OperationScheduler
 import com.embabel.agent.spi.PlatformServices
 import com.embabel.agent.spi.ToolGroupResolver
 import com.embabel.agent.spi.support.RegistryToolGroupResolver
+import com.embabel.agent.testing.common.EventSavingAgenticEventListener
 
 object IntegrationTestUtils {
     /**
@@ -44,10 +42,15 @@ object IntegrationTestUtils {
         ragService: RagService? = null,
     ): AgentPlatform {
         return DefaultAgentPlatform(
-            llmOperations = llmOperations ?: DummyObjectCreatingLlmOperations.Companion.LoremIpsum,
-            eventListener = AgenticEventListener.from(listOfNotNull(EventSavingAgenticEventListener(), listener)),
+            llmOperations = llmOperations ?: DummyObjectCreatingLlmOperations.LoremIpsum,
+            eventListener = AgenticEventListener.Companion.from(
+                listOfNotNull(
+                    EventSavingAgenticEventListener(),
+                    listener
+                )
+            ),
             toolGroupResolver = toolGroupResolver ?: RegistryToolGroupResolver("empty", emptyList()),
-            ragService = ragService ?: RagService.empty(),
+            ragService = ragService ?: RagService.Companion.empty(),
             name = "dummy-agent-platform",
             description = "Dummy Agent Platform for Integration Testing",
         )
@@ -58,10 +61,10 @@ object IntegrationTestUtils {
     fun dummyPlatformServices(eventListener: AgenticEventListener? = null): PlatformServices {
         return PlatformServices(
             agentPlatform = dummyAgentPlatform(),
-            llmOperations = DummyObjectCreatingLlmOperations.Companion.LoremIpsum,
+            llmOperations = DummyObjectCreatingLlmOperations.LoremIpsum,
             eventListener = eventListener ?: EventSavingAgenticEventListener(),
-            operationScheduler = OperationScheduler.PRONTO,
-            ragService = RagService.empty(),
+            operationScheduler = OperationScheduler.Companion.PRONTO,
+            ragService = RagService.Companion.empty(),
         )
     }
 
@@ -74,6 +77,15 @@ object IntegrationTestUtils {
             blackboard = InMemoryBlackboard(),
             processOptions = ProcessOptions(),
             platformServices = dummyPlatformServices(),
+        )
+    }
+
+    @JvmStatic
+    fun dummyProcessContext(agent: Agent): ProcessContext {
+        return ProcessContext(
+            processOptions = ProcessOptions(),
+            platformServices = dummyPlatformServices(),
+            agentProcess = dummyAgentProcessRunning(agent),
         )
     }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/RandomRanker.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/RandomRanker.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.testing
+package com.embabel.agent.testing.integration
 
 import com.embabel.agent.spi.Ranker
 import com.embabel.agent.spi.Ranking

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/FakeAction.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/FakeAction.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.testing.unit
+
+import com.embabel.agent.api.common.support.TransformationAction
+import com.embabel.agent.core.ActionQos
+import com.embabel.agent.core.IoBinding
+import com.embabel.agent.core.ToolGroupRequirement
+import com.embabel.common.core.types.ZeroToOne
+
+class FakeAction(
+    name: String,
+    description: String = name,
+    pre: List<String> = emptyList(),
+    post: List<String> = emptyList(),
+    cost: ZeroToOne = 0.0,
+    value: ZeroToOne = 0.0,
+    canRerun: Boolean = false,
+    qos: ActionQos = ActionQos(),
+    inputClass: Class<Unit> = Unit::class.java,
+    outputVarName: String? = IoBinding.Companion.DEFAULT_BINDING,
+    referencedInputProperties: Set<String>? = null,
+    toolGroups: Set<ToolGroupRequirement> = emptySet(),
+) : TransformationAction<Unit, Unit>(
+    name = name,
+    description = description,
+    pre = pre,
+    post = post,
+    cost = cost,
+    value = value,
+    canRerun = canRerun,
+    qos = qos,
+    inputClass = inputClass,
+    outputClass = Unit::class.java,
+    outputVarName = outputVarName,
+    referencedInputProperties = referencedInputProperties,
+    toolGroups = toolGroups,
+    block = { },
+)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/FakeOperationContext.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/FakeOperationContext.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.testing.unit
+
+import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.api.common.PromptRunner
+import com.embabel.agent.common.Constants.EMBABEL_PROVIDER
+import com.embabel.agent.core.*
+import com.embabel.agent.prompt.element.ContextualPromptElement
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyProcessContext
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.prompt.PromptContributor
+import org.slf4j.LoggerFactory
+
+val DummyAgent = Agent(
+    name = "Dummy Agent",
+    provider = EMBABEL_PROVIDER,
+    description = "A dummy agent for testing purposes",
+    actions = emptyList(),
+    goals = emptySet(),
+)
+
+/**
+ * Pass into unit tests.
+ * Principally used to obtain a [PromptRunner] for testing purposes.
+ */
+class FakeOperationContext(
+    val agent: Agent = DummyAgent,
+    override val processContext: ProcessContext = dummyProcessContext(agent = agent),
+    override val operation: Operation = FakeAction(name = "test"),
+    override val toolGroups: Set<ToolGroupRequirement> = emptySet(),
+) : OperationContext, Blackboard by processContext.agentProcess {
+
+    val promptRunner: FakePromptRunner = FakePromptRunner(
+        llm = null,
+        toolGroups = toolGroups,
+        toolObjects = emptyList(),
+        promptContributors = emptyList(),
+        contextualPromptContributors = emptyList(),
+        generateExamples = null,
+        context = this,
+    )
+
+    private val logger = LoggerFactory.getLogger(FakeOperationContext::class.java)
+
+    init {
+        logger.info("FakeOperationContext created: ${hashCode()}: PromptRunner: ${promptRunner.hashCode()}")
+    }
+
+    val llmInvocations get() = promptRunner.llmInvocations
+
+    /**
+     * Add a response to the list of expected responses.
+     * This is used to simulate responses from the LLM.
+     */
+    fun expectResponse(response: Any?) {
+        promptRunner.expectResponse(response)
+    }
+
+    override fun promptRunner(
+        llm: LlmOptions,
+        toolGroups: Set<ToolGroupRequirement>,
+        toolObjects: List<Any>,
+        promptContributors: List<PromptContributor>,
+        contextualPromptContributors: List<ContextualPromptElement>,
+        generateExamples: Boolean
+    ): PromptRunner = promptRunner
+
+    companion object {
+
+        @JvmOverloads
+        @JvmStatic
+        fun create(
+            agent: Agent = DummyAgent,
+            processContext: ProcessContext = dummyProcessContext(agent = agent),
+            operation: Operation = FakeAction(name = "test"),
+            toolGroups: Set<ToolGroupRequirement> = emptySet(),
+        ) = FakeOperationContext(
+            processContext = processContext,
+            operation = operation,
+            toolGroups = toolGroups,
+        )
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/FakePromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/FakePromptRunner.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.testing.unit
+
+import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.api.common.PromptRunner
+import com.embabel.agent.core.ToolGroupRequirement
+import com.embabel.agent.core.support.safelyGetToolCallbacks
+import com.embabel.agent.prompt.element.ContextualPromptElement
+import com.embabel.agent.spi.InteractionId
+import com.embabel.agent.spi.LlmInteraction
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.prompt.PromptContributor
+import com.embabel.common.core.MobyNameGenerator
+import com.embabel.common.core.types.ZeroToOne
+import org.slf4j.LoggerFactory
+
+enum class Method {
+    CREATE_OBJECT,
+    CREATE_OBJECT_IF_POSSIBLE,
+    EVALUATE_CONDITION,
+}
+
+data class LlmInvocation(
+    val interaction: LlmInteraction,
+    val prompt: String,
+    val method: Method,
+)
+
+data class FakePromptRunner(
+    override val llm: LlmOptions?,
+    override val toolGroups: Set<ToolGroupRequirement>,
+    override val toolObjects: List<Any>,
+    override val promptContributors: List<PromptContributor>,
+    private val contextualPromptContributors: List<ContextualPromptElement>,
+    override val generateExamples: Boolean?,
+    private val context: OperationContext,
+    private val _llmInvocations: MutableList<LlmInvocation> = mutableListOf(),
+    private val responses: MutableList<Any?> = mutableListOf(),
+) : PromptRunner {
+
+    private val logger = LoggerFactory.getLogger(FakePromptRunner::class.java)
+
+    init {
+        logger.info("Fake prompt runner created: ${hashCode()}")
+    }
+
+    /**
+     * Add a response to the list of expected responses.
+     * This is used to simulate responses from the LLM.
+     */
+    fun expectResponse(response: Any?) {
+        responses.add(response)
+        logger.info(
+            "Expected response added: ${response?.javaClass?.name ?: "null"}"
+        )
+    }
+
+    private fun <T> getResponse(outputClass: Class<T>): T? {
+        if (responses.size < llmInvocations.size) {
+            throw IllegalStateException(
+                """
+                    Expected ${llmInvocations.size} responses, but got ${responses.size}.
+                    Make sure to call expectResponse() for each LLM invocation.
+                    """.trimIndent()
+            )
+        }
+        val maybeT = responses[llmInvocations.size - 1]
+        if (maybeT == null) {
+            return null
+        }
+        if (!outputClass.isInstance(maybeT)) {
+            throw IllegalStateException(
+                "Expected response of type ${outputClass.name}, but got ${maybeT?.javaClass?.name ?: "null"}."
+            )
+        }
+        return maybeT as T
+    }
+
+    /**
+     * The LLM calls that were made
+     */
+    val llmInvocations: List<LlmInvocation>
+        get() = _llmInvocations
+
+    override fun <T> createObject(
+        prompt: String,
+        outputClass: Class<T>,
+    ): T {
+        _llmInvocations += LlmInvocation(
+            interaction = createLlmInteraction(),
+            prompt = prompt,
+            method = Method.CREATE_OBJECT,
+        )
+        return getResponse(outputClass)!!
+    }
+
+    override fun <T> createObjectIfPossible(
+        prompt: String,
+        outputClass: Class<T>,
+    ): T? {
+        _llmInvocations += LlmInvocation(
+            interaction = createLlmInteraction(),
+            prompt = prompt,
+            method = Method.CREATE_OBJECT_IF_POSSIBLE,
+        )
+        return getResponse(outputClass)
+    }
+
+    override fun evaluateCondition(
+        condition: String,
+        context: String,
+        confidenceThreshold: ZeroToOne
+    ): Boolean {
+        _llmInvocations += LlmInvocation(
+            interaction = createLlmInteraction(),
+            prompt = condition,
+            method = Method.EVALUATE_CONDITION,
+        )
+        return true
+    }
+
+    override fun withLlm(llm: LlmOptions): PromptRunner =
+        copy(llm = llm)
+
+    override fun withToolGroup(toolGroup: ToolGroupRequirement): PromptRunner =
+        copy(toolGroups = this.toolGroups + toolGroup)
+
+    override fun withToolObject(toolObject: Any?): PromptRunner =
+        copy(toolObjects = (this.toolObjects + toolObject).filterNotNull())
+
+    override fun withPromptContributors(promptContributors: List<PromptContributor>): PromptRunner =
+        copy(promptContributors = this.promptContributors + promptContributors)
+
+    override fun withContextualPromptContributors(
+        contextualPromptContributors: List<ContextualPromptElement>,
+    ): PromptRunner =
+        copy(contextualPromptContributors = this.contextualPromptContributors + contextualPromptContributors)
+
+    override fun withGenerateExamples(generateExamples: Boolean): PromptRunner =
+        copy(generateExamples = generateExamples)
+
+    private fun createLlmInteraction() =
+        LlmInteraction(
+            llm = llm ?: LlmOptions(),
+            toolGroups = this.toolGroups + toolGroups,
+            toolCallbacks = safelyGetToolCallbacks(toolObjects),
+            promptContributors = promptContributors + contextualPromptContributors.map {
+                it.toPromptContributor(
+                    context
+                )
+            },
+            id = InteractionId(
+                MobyNameGenerator.generateName(
+                )
+            ),
+            generateExamples = generateExamples,
+        )
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/UnitTestUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/UnitTestUtils.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.testing
+package com.embabel.agent.testing.unit
 
 import com.embabel.agent.api.common.CreateObjectPromptException
 import com.embabel.agent.api.common.LlmCallRequest
@@ -30,9 +30,9 @@ object UnitTestUtils {
      * Should be a call to the agent method with the appropriate arguments.
      */
     @JvmStatic
-    fun captureLlmCall(block: () -> Unit): LlmCallRequest {
+    fun captureLlmCall(block: Runnable): LlmCallRequest {
         try {
-            block()
+            block.run()
             error("Expected an LLM call but none was made")
         } catch (epe: CreateObjectPromptException) {
             return epe

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/annotation/support/PackageVisibleTests.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/annotation/support/PackageVisibleTests.java
@@ -29,7 +29,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
-import static com.embabel.agent.testing.IntegrationTestUtils.dummyPlatformServices;
+import static com.embabel.agent.testing.integration.IntegrationTestUtils.dummyPlatformServices;
 import static com.embabel.common.core.types.Semver.DEFAULT_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/a2a/server/A2AWebIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/a2a/server/A2AWebIntegrationTest.kt
@@ -20,7 +20,7 @@ import com.embabel.agent.api.annotation.support.AgentMetadataReader
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.e2e.FakeConfig
 import com.embabel.agent.spi.LlmOperations
-import com.embabel.agent.testing.DummyObjectCreatingLlmOperations
+import com.embabel.agent.testing.integration.DummyObjectCreatingLlmOperations
 import com.embabel.common.core.types.Semver.Companion.DEFAULT_VERSION
 import com.embabel.example.simple.horoscope.TestHoroscopeService
 import com.embabel.example.simple.horoscope.java.TestStarNewsFinder

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderActionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderActionTest.kt
@@ -26,8 +26,8 @@ import com.embabel.agent.event.AgenticEventListener.Companion.DevNull
 import com.embabel.agent.spi.LlmInteraction
 import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.PlatformServices
-import com.embabel.agent.testing.IntegrationTestUtils
-import com.embabel.agent.testing.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.agent.testing.integration.IntegrationTestUtils
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyPlatformServices
 import com.embabel.common.ai.model.DefaultModelSelectionCriteria
 import com.embabel.plan.goap.ConditionDetermination
 import io.mockk.every

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderImportTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderImportTest.kt
@@ -20,7 +20,7 @@ import com.embabel.agent.core.Agent
 import com.embabel.agent.core.AgentProcessStatusCode
 import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.domain.io.UserInput
-import com.embabel.agent.testing.IntegrationTestUtils
+import com.embabel.agent.testing.integration.IntegrationTestUtils
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import kotlin.test.assertTrue

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/AutonomyActionLeakageTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/AutonomyActionLeakageTest.kt
@@ -19,8 +19,8 @@ import com.embabel.agent.api.common.autonomy.Autonomy
 import com.embabel.agent.api.common.autonomy.AutonomyProperties
 import com.embabel.agent.core.*
 import com.embabel.agent.domain.io.UserInput
-import com.embabel.agent.testing.IntegrationTestUtils
-import com.embabel.agent.testing.RandomRanker
+import com.embabel.agent.testing.integration.IntegrationTestUtils
+import com.embabel.agent.testing.integration.RandomRanker
 import com.embabel.common.core.types.ZeroToOne
 import com.embabel.plan.goap.ConditionDetermination
 import io.mockk.clearAllMocks

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/AutonomyAgentSelectionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/AutonomyAgentSelectionTest.kt
@@ -24,7 +24,7 @@ import com.embabel.agent.domain.library.HasContent
 import com.embabel.agent.event.AgenticEventListener
 import com.embabel.agent.spi.Ranking
 import com.embabel.agent.spi.Rankings
-import com.embabel.agent.testing.FakeRanker
+import com.embabel.agent.testing.integration.FakeRanker
 import io.mockk.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/AutonomyGoalSelectionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/AutonomyGoalSelectionTest.kt
@@ -25,7 +25,7 @@ import com.embabel.agent.domain.library.HasContent
 import com.embabel.agent.event.AgenticEventListener
 import com.embabel.agent.spi.Ranking
 import com.embabel.agent.spi.Rankings
-import com.embabel.agent.testing.FakeRanker
+import com.embabel.agent.testing.integration.FakeRanker
 import io.mockk.*
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.*

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/dsl/AgentBuilderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/dsl/AgentBuilderTest.kt
@@ -25,8 +25,8 @@ import com.embabel.agent.core.support.SimpleAgentProcess
 import com.embabel.agent.rag.RagService
 import com.embabel.agent.spi.PlatformServices
 import com.embabel.agent.support.Dog
-import com.embabel.agent.testing.DummyObjectCreatingLlmOperations
-import com.embabel.agent.testing.EventSavingAgenticEventListener
+import com.embabel.agent.testing.common.EventSavingAgenticEventListener
+import com.embabel.agent.testing.integration.DummyObjectCreatingLlmOperations
 import com.embabel.common.core.types.Semver
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/dsl/AgentScopeBuilderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/dsl/AgentScopeBuilderTest.kt
@@ -23,7 +23,7 @@ import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.core.all
 import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.spi.support.SpiPerson
-import com.embabel.agent.testing.IntegrationTestUtils.dummyAgentPlatform
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentPlatform
 import com.embabel.common.core.MobyNameGenerator
 import com.embabel.common.core.types.Semver
 import com.embabel.common.core.types.Semver.Companion.DEFAULT_VERSION

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/SimpleAgentProcessTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/SimpleAgentProcessTest.kt
@@ -32,8 +32,8 @@ import com.embabel.agent.domain.library.Person
 import com.embabel.agent.event.ObjectAddedEvent
 import com.embabel.agent.event.ObjectBoundEvent
 import com.embabel.agent.support.SimpleTestAgent
-import com.embabel.agent.testing.EventSavingAgenticEventListener
-import com.embabel.agent.testing.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.agent.testing.common.EventSavingAgenticEventListener
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyPlatformServices
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/AgentPlatformIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/AgentPlatformIntegrationTest.kt
@@ -32,7 +32,7 @@ import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.domain.library.HasContent
 import com.embabel.agent.spi.Ranking
 import com.embabel.agent.spi.Rankings
-import com.embabel.agent.testing.FakeRanker
+import com.embabel.agent.testing.integration.FakeRanker
 import com.embabel.common.core.types.Described
 import com.embabel.common.core.types.Named
 import com.embabel.example.simple.horoscope.TestHoroscopeService

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/event/AgenticEventListenerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/event/AgenticEventListenerTest.kt
@@ -16,7 +16,7 @@
 package com.embabel.agent.event
 
 import com.embabel.agent.api.dsl.evenMoreEvilWizard
-import com.embabel.agent.testing.IntegrationTestUtils.dummyAgentPlatform
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentPlatform
 import io.mockk.mockk
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/event/AgenticEventSerializationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/event/AgenticEventSerializationTest.kt
@@ -17,7 +17,7 @@ package com.embabel.agent.event
 
 import com.embabel.agent.api.dsl.evenMoreEvilWizard
 import com.embabel.agent.domain.io.UserInput
-import com.embabel.agent.testing.IntegrationTestUtils.dummyAgentPlatform
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentPlatform
 import com.embabel.common.util.loggerFor
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProviderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProviderTest.kt
@@ -19,8 +19,8 @@ import com.embabel.agent.api.common.autonomy.Autonomy
 import com.embabel.agent.api.common.autonomy.AutonomyProperties
 import com.embabel.agent.api.dsl.evenMoreEvilWizard
 import com.embabel.agent.api.dsl.userInputToFrogOrPersonBranch
-import com.embabel.agent.testing.IntegrationTestUtils.dummyAgentPlatform
-import com.embabel.agent.testing.RandomRanker
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentPlatform
+import com.embabel.agent.testing.integration.RandomRanker
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/AgenticEventListenerToolsStatsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/AgenticEventListenerToolsStatsTest.kt
@@ -17,7 +17,7 @@ package com.embabel.agent.spi.support
 
 import com.embabel.agent.api.dsl.evenMoreEvilWizard
 import com.embabel.agent.event.ToolCallResponseEvent
-import com.embabel.agent.testing.IntegrationTestUtils.dummyAgentProcessRunning
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentProcessRunning
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -25,7 +25,7 @@ import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.agent.spi.support.springai.MaybeReturn
 import com.embabel.agent.support.SimpleTestAgent
-import com.embabel.agent.testing.EventSavingAgenticEventListener
+import com.embabel.agent.testing.common.EventSavingAgenticEventListener
 import com.embabel.common.ai.model.*
 import com.embabel.common.textio.template.JinjavaTemplateRenderer
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
@@ -23,7 +23,7 @@ import com.embabel.agent.spi.LlmInteraction
 import com.embabel.agent.spi.PlatformServices
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.agent.spi.support.springai.MaybeReturn
-import com.embabel.agent.testing.EventSavingAgenticEventListener
+import com.embabel.agent.testing.common.EventSavingAgenticEventListener
 import com.embabel.common.ai.model.DefaultOptionsConverter
 import com.embabel.common.ai.model.Llm
 import com.embabel.common.ai.model.ModelProvider

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt
@@ -20,7 +20,7 @@ import com.embabel.agent.event.ToolCallRequestEvent
 import com.embabel.agent.event.ToolCallResponseEvent
 import com.embabel.agent.spi.OperationScheduler
 import com.embabel.agent.spi.PlatformServices
-import com.embabel.agent.testing.EventSavingAgenticEventListener
+import com.embabel.agent.testing.common.EventSavingAgenticEventListener
 import com.embabel.common.ai.model.LlmOptions
 import io.mockk.every
 import io.mockk.mockk

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/BlackboardWorldStateDeterminerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/BlackboardWorldStateDeterminerTest.kt
@@ -23,10 +23,10 @@ import com.embabel.agent.core.ProcessContext
 import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.core.support.BlackboardWorldStateDeterminer
 import com.embabel.agent.core.support.InMemoryBlackboard
-import com.embabel.agent.domain.special.Aggregation
 import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.domain.special.Aggregation
 import com.embabel.agent.spi.PlatformServices
-import com.embabel.agent.testing.EventSavingAgenticEventListener
+import com.embabel.agent.testing.common.EventSavingAgenticEventListener
 import com.embabel.plan.goap.ConditionDetermination
 import io.mockk.every
 import io.mockk.mockk

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/testing/unit/FakeOperationContextTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/testing/unit/FakeOperationContextTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.testing.unit
+
+class FakeOperationContextTest {
+
+}

--- a/embabel-agent-examples/examples-kotlin/horoscope/src/main/kotlin/com/embabel/example/horoscope/kotlin/StarNewsFinder.kt
+++ b/embabel-agent-examples/examples-kotlin/horoscope/src/main/kotlin/com/embabel/example/horoscope/kotlin/StarNewsFinder.kt
@@ -116,7 +116,7 @@ class StarNewsFinder(
     @Action
     fun extractPerson(userInput: UserInput): Person? =
         // All prompts are typesafe
-        usingDefaultLlm.createObjectIfPossible(
+        usingDefaultLlm.withGenerateExamples(true).createObjectIfPossible(
             """
             Create a person from this user input, extracting their name:
             ${userInput.content}

--- a/embabel-agent-examples/examples-kotlin/horoscope/src/test/kotlin/com/embabel/example/horoscope/StarNewsFinderTest.kt
+++ b/embabel-agent-examples/examples-kotlin/horoscope/src/test/kotlin/com/embabel/example/horoscope/StarNewsFinderTest.kt
@@ -17,7 +17,7 @@ package com.embabel.example.horoscope
 
 import com.embabel.agent.domain.library.NewsStory
 import com.embabel.agent.domain.library.RelevantNewsStories
-import com.embabel.agent.testing.UnitTestUtils
+import com.embabel.agent.testing.unit.UnitTestUtils
 import com.embabel.example.horoscope.kotlin.Horoscope
 import com.embabel.example.horoscope.kotlin.StarNewsFinder
 import com.embabel.example.horoscope.kotlin.StarPerson

--- a/embabel-agent-examples/examples-kotlin/movie/src/test/kotlin/com/embabel/example/movie/MovieFinderEndToEndTest.kt
+++ b/embabel-agent-examples/examples-kotlin/movie/src/test/kotlin/com/embabel/example/movie/MovieFinderEndToEndTest.kt
@@ -24,8 +24,8 @@ import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.domain.persistence.support.FinderInvocation
 import com.embabel.agent.domain.persistence.support.FinderInvocations
 import com.embabel.agent.spi.LlmInteraction
-import com.embabel.agent.testing.DummyObjectCreatingLlmOperations
-import com.embabel.agent.testing.IntegrationTestUtils.dummyAgentPlatform
+import com.embabel.agent.testing.integration.DummyObjectCreatingLlmOperations
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentPlatform
 import com.embabel.common.util.DummyInstanceCreator
 import io.mockk.every
 import io.mockk.mockk


### PR DESCRIPTION
- Split testing support into unit and integration testing
- Add `FakeOperationContext` and supporting classes to ease unit testing of action methods that need an `OperationContext` (typically to get a `PromptRunner`).