### PR TITLE
Consistent Naming Conventions with Spring AI

### DIFF
--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.java
@@ -21,10 +21,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Enable MVP Profiles
+ * Enable MCP Profiles
  */
 @Retention(RetentionPolicy.RUNTIME) // Keep the annotation at runtime for reflection
 @Target(ElementType.TYPE)
-@EnableAgents("docker-desktop, docker-ce")
-public @interface EnableAgentMCP {
+@EnableAgents("docker-desktop, web")
+public @interface EnableAgentMcp {
 }


### PR DESCRIPTION
This pull request includes a renaming and update to the `EnableAgentMCP` annotation. The changes improve clarity and modify the default agent configuration.

Annotation updates:

* [`embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.java`](diffhunk://#diff-2204808d8408e4664e6c10c4e0bd87c8429f4d8537e6ba3ff6b12897223c3b5fL24-R29): Renamed the file and class from `EnableAgentMCP` to `EnableAgentMcp` to follow consistent naming conventions. Updated the annotation's description from "Enable MVP Profiles" to "Enable MCP Profiles" and changed the default agents from `"docker-desktop, docker-ce"` to `"docker-desktop, web"`.