### PR TITLE
Remove docker-desktop from @EnableAgentMcp

### DIFF
--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.java
@@ -25,11 +25,11 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME) // Keep the annotation at runtime for reflection
 @Target(ElementType.TYPE)
-@EnableAgents("docker-desktop, web")
+@EnableAgents("mcp-server")
 public @interface EnableAgentMcp {
     /**
      * Optional logging theme for the MCP agent.
-     * Default is "severence".
+     * Default is "severance".
      */
-    String loggingTheme() default "severence";
+    String loggingTheme() default "severance";
 }

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentShell.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentShell.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
 public @interface EnableAgentShell {
     /**
      * Optional logging theme for the shell agent.
-     * Default is "severence".
+     * Default is "severance".
      */
-    String loggingTheme() default "severence";
+    String loggingTheme() default "severance";
 }


### PR DESCRIPTION
This pull request makes minor updates to the `EnableAgentMcp` and `EnableAgentShell` annotations by changing the default logging theme and updating the enabled agents for `EnableAgentMcp`.

Annotation updates:

* [`EnableAgentMcp`](diffhunk://#diff-2204808d8408e4664e6c10c4e0bd87c8429f4d8537e6ba3ff6b12897223c3b5fL28-R34): Updated the enabled agents from `"docker-desktop, web"` to `"mcp-server"` and corrected the default logging theme from `"severence"` to `"severance"`. (`embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.java`, [embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.javaL28-R34](diffhunk://#diff-2204808d8408e4664e6c10c4e0bd87c8429f4d8537e6ba3ff6b12897223c3b5fL28-R34))
* [`EnableAgentShell`](diffhunk://#diff-153cb4756da0ee6ba9da93d0d72ec318405b7538760eed243d2b36103a5a9803L32-R34): Corrected the default logging theme from `"severence"` to `"severance"`. (`embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentShell.java`, [embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentShell.javaL32-R34](diffhunk://#diff-153cb4756da0ee6ba9da93d0d72ec318405b7538760eed243d2b36103a5a9803L32-R34))