### PR TITLE
Add LoggingTheme Enum.

### DIFF
--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcp.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
 public @interface EnableAgentMcp {
     /**
      * Optional logging theme for the MCP agent.
-     * Default is "severance".
+     * Default is SEVERANCE.
      */
-    String loggingTheme() default "severance";
+    LoggingTheme loggingTheme() default LoggingTheme.SEVERANCE;
 }

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingTheme.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingTheme.java
@@ -15,21 +15,22 @@
  */
 package com.embabel.agent.config.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+public enum LoggingTheme {
+    SEVERANCE("severance"),
+    STARWARS("starwars");
 
-/**
- * Enable Embabel Shell Agent application
- */
-@Retention(RetentionPolicy.RUNTIME) // Keep the annotation at runtime for reflection
-@Target(ElementType.TYPE)
-@EnableAgents("shell")
-public @interface EnableAgentShell {
-    /**
-     * Optional logging theme for the shell agent.
-     * Default is "severance".
-     */
-    LoggingTheme loggingTheme() default LoggingTheme.SEVERANCE;
+    private final String theme;
+
+    LoggingTheme(String theme) {
+        this.theme = theme;
+    }
+
+    public String getTheme() {
+        return theme;
+    }
+
+    @Override
+    public String toString() {
+        return theme;
+    }
 }

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessor.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessor.java
@@ -113,11 +113,11 @@ public class EmbabelEnvironmentProcessor implements EnvironmentPostProcessor, Or
                         (Class<?>) source, EnableAgentMcp.class);
 
                 if (enableAgentShell != null) {
-                    return enableAgentShell.loggingTheme();
+                    return enableAgentShell.loggingTheme().getTheme();
                 }
 
                 if (enableAgentMcp != null) {
-                    return enableAgentMcp.loggingTheme();
+                    return enableAgentMcp.loggingTheme().getTheme();
                 }
             }
         }

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/LoggingThemeParameterizedTest.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/LoggingThemeParameterizedTest.java
@@ -26,6 +26,7 @@ import org.springframework.mock.env.MockEnvironment;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
@@ -63,7 +64,7 @@ class LoggingThemeParameterizedTest {
     @DisplayName("Should handle @EnableAgentShell alone (inherits shell from @EnableAgents)")
     void testEnableAgentShellAlone() {
         // Given - Only @EnableAgentShell, no explicit @EnableAgents
-        @EnableAgentShell(loggingTheme = "starwars")
+        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
         class TestApp {}
 
         when(application.getAllSources()).thenReturn(new HashSet<>(Arrays.asList(TestApp.class)));
@@ -84,7 +85,7 @@ class LoggingThemeParameterizedTest {
     void testExplicitEnableAgentsOverride() {
         // Given - Both annotations, @EnableAgents with explicit values
         @EnableAgents({"custom1", "custom2"})
-        @EnableAgentShell(loggingTheme = "severance")
+        @EnableAgentShell(loggingTheme = LoggingTheme.SEVERANCE)
         class TestApp {}
 
         when(application.getAllSources()).thenReturn(new HashSet<>(Arrays.asList(TestApp.class)));
@@ -107,10 +108,10 @@ class LoggingThemeParameterizedTest {
     void testEnableAgentsEmptyArray() {
         // Given
         @EnableAgents({})
-        @EnableAgentShell(loggingTheme = "starwars")
+        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
         class TestApp {}
 
-        when(application.getAllSources()).thenReturn(new HashSet<>(Arrays.asList(TestApp.class)));
+        when(application.getAllSources()).thenReturn(new HashSet<>(List.of(TestApp.class)));
 
         // When
         processor.postProcessEnvironment(environment, application);

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessorTest.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessorTest.java
@@ -17,6 +17,7 @@ package com.embabel.agent.config.annotation.spi;
 
 import com.embabel.agent.config.annotation.EnableAgentShell;
 import com.embabel.agent.config.annotation.EnableAgents;
+import com.embabel.agent.config.annotation.LoggingTheme;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -84,7 +85,7 @@ class EmbabelEnvironmentProcessorTest {
     @DisplayName("Should activate starwars profile when loggingTheme is starwars")
     void testStarWarsThemeActivatesProfile() {
         // Given
-        @EnableAgentShell(loggingTheme = "starwars")
+        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
         class TestApp {
         }
 
@@ -104,7 +105,7 @@ class EmbabelEnvironmentProcessorTest {
     @DisplayName("Should activate severance profile when loggingTheme is severance")
     void testSeveranceThemeActivatesProfile() {
         // Given
-        @EnableAgentShell(loggingTheme = "severance")
+        @EnableAgentShell(loggingTheme = LoggingTheme.SEVERANCE)
         class TestApp {
         }
 
@@ -121,50 +122,12 @@ class EmbabelEnvironmentProcessorTest {
     }
 
     @Test
-    @DisplayName("Should not activate theme profile when loggingTheme is empty")
-    void testEmptyThemeDoesNotActivateProfile() {
-        // Given
-        @EnableAgentShell(loggingTheme = "")
-        class TestApp {
-        }
-
-        when(application.getAllSources()).thenReturn(new HashSet<>(List.of(TestApp.class)));
-
-        // When
-        processor.postProcessEnvironment(environment, application);
-
-        // Then
-        String activeProfiles = System.getProperty("spring.profiles.active");
-        assertThat(activeProfiles).contains("shell");
-        assertThat(activeProfiles).doesNotContain("starwars", "severance");
-    }
-
-    @Test
-    @DisplayName("Should handle unknown theme gracefully")
-    void testUnknownThemeIsIgnored() {
-        // Given
-        @EnableAgentShell(loggingTheme = "unknown")
-        class TestApp {
-        }
-
-        when(application.getAllSources()).thenReturn(new HashSet<>(List.of(TestApp.class)));
-
-        // When
-        processor.postProcessEnvironment(environment, application);
-
-        // Then
-        String activeProfiles = System.getProperty("spring.profiles.active");
-        assertThat(activeProfiles).contains("shell");
-        assertThat(activeProfiles).doesNotContain("unknown");
-    }
-
-    @Test
     @DisplayName("Should preserve existing profiles")
     void testPreservesExistingProfiles() {
         // Given
         System.setProperty("spring.profiles.active", "existing,profiles");
 
-        @EnableAgentShell(loggingTheme = "starwars")
+        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
         class TestApp {
         }
 
@@ -204,7 +167,7 @@ class EmbabelEnvironmentProcessorTest {
     @DisplayName("Should handle multiple source classes")
     void testMultipleSourceClasses() {
         // Given
-        @EnableAgentShell(loggingTheme = "starwars")
+        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
         class TestApp1 {
         }
 


### PR DESCRIPTION
This pull request introduces a new `LoggingTheme` enum to standardize logging theme values across the codebase, replacing string-based themes. It updates annotations, processing logic, and tests to use this enum. Additionally, redundant test cases for invalid or unknown themes have been removed. 

### Standardization of Logging Themes:
* Introduced a new `LoggingTheme` enum with predefined values `SEVERANCE` and `STARWARS`. This replaces string-based themes for better type safety and consistency. (`embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingTheme.java`)
* Updated the `loggingTheme` attribute in `@EnableAgentMcp` and `@EnableAgentShell` annotations to use the `LoggingTheme` enum instead of strings. (`EnableAgentMcp.java` [[1]](diffhunk://#diff-2204808d8408e4664e6c10c4e0bd87c8429f4d8537e6ba3ff6b12897223c3b5fL32-R34) `EnableAgentShell.java` [[2]](diffhunk://#diff-153cb4756da0ee6ba9da93d0d72ec318405b7538760eed243d2b36103a5a9803L34-R34))

### Updates to Processing Logic:
* Modified `EmbabelEnvironmentProcessor` to retrieve the theme value using the `getTheme()` method from the `LoggingTheme` enum. (`EmbabelEnvironmentProcessor.java`)

### Test Updates:
* Updated all test cases to use the `LoggingTheme` enum instead of string literals for `loggingTheme` values. (`LoggingThemeParameterizedTest.java` [[1]](diffhunk://#diff-91c907ba7d9542b678f892501140701c324b058efcf9fb79e536200a934b594fL66-R67) [[2]](diffhunk://#diff-91c907ba7d9542b678f892501140701c324b058efcf9fb79e536200a934b594fL87-R88) [[3]](diffhunk://#diff-91c907ba7d9542b678f892501140701c324b058efcf9fb79e536200a934b594fL110-R114) `EmbabelEnvironmentProcessorTest.java` [[4]](diffhunk://#diff-714e6727365a7113094ff3f8210620f9aae96622ae534d01718444ff9a3a1807L87-R88) [[5]](diffhunk://#diff-714e6727365a7113094ff3f8210620f9aae96622ae534d01718444ff9a3a1807L107-R108) [[6]](diffhunk://#diff-714e6727365a7113094ff3f8210620f9aae96622ae534d01718444ff9a3a1807L207-R170))
* Removed redundant test cases for invalid or unknown themes, as these scenarios are now inherently handled by the enum type. (`EmbabelEnvironmentProcessorTest.java`)

### Minor Changes:
* Added `List` import in `LoggingThemeParameterizedTest.java` for updated test logic.
* Added `LoggingTheme` import in `EmbabelEnvironmentProcessorTest.java`.