### PR TITLE
Polishing LoggingTheme Enum

### DIFF
--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingTheme.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingTheme.java
@@ -17,7 +17,7 @@ package com.embabel.agent.config.annotation;
 
 public enum LoggingTheme {
     SEVERANCE("severance"),
-    STARWARS("starwars");
+    STAR_WARS("starwars");
 
     private final String theme;
 

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/LoggingThemeParameterizedTest.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/LoggingThemeParameterizedTest.java
@@ -64,7 +64,7 @@ class LoggingThemeParameterizedTest {
     @DisplayName("Should handle @EnableAgentShell alone (inherits shell from @EnableAgents)")
     void testEnableAgentShellAlone() {
         // Given - Only @EnableAgentShell, no explicit @EnableAgents
-        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+        @EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
         class TestApp {}
 
         when(application.getAllSources()).thenReturn(new HashSet<>(Arrays.asList(TestApp.class)));
@@ -108,7 +108,7 @@ class LoggingThemeParameterizedTest {
     void testEnableAgentsEmptyArray() {
         // Given
         @EnableAgents({})
-        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+        @EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
         class TestApp {}
 
         when(application.getAllSources()).thenReturn(new HashSet<>(List.of(TestApp.class)));

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessorTest.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessorTest.java
@@ -85,7 +85,7 @@ class EmbabelEnvironmentProcessorTest {
     @DisplayName("Should activate starwars profile when loggingTheme is starwars")
     void testStarWarsThemeActivatesProfile() {
         // Given
-        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+        @EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
         class TestApp {
         }
 
@@ -127,7 +127,7 @@ class EmbabelEnvironmentProcessorTest {
         // Given
         System.setProperty("spring.profiles.active", "existing,profiles");
 
-        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+        @EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
         class TestApp {
         }
 
@@ -167,7 +167,7 @@ class EmbabelEnvironmentProcessorTest {
     @DisplayName("Should handle multiple source classes")
     void testMultipleSourceClasses() {
         // Given
-        @EnableAgentShell(loggingTheme = LoggingTheme.STARWARS)
+        @EnableAgentShell(loggingTheme = LoggingTheme.STAR_WARS)
         class TestApp1 {
         }
 


### PR DESCRIPTION
This pull request standardizes the naming convention for the `LoggingTheme` enum by changing `STARWARS` to `STAR_WARS` and updates all related test cases accordingly.

### Updates to `LoggingTheme` Enum:

* Renamed `STARWARS` to `STAR_WARS` in the `LoggingTheme` enum to align with consistent naming conventions. (`embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingTheme.java`)

### Updates to Test Cases:

* Updated test cases in `LoggingThemeParameterizedTest` to use the renamed `LoggingTheme.STAR_WARS`:
  - Modified `testEnableAgentShellAlone` method. (`embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/LoggingThemeParameterizedTest.java`)
  - Modified `testEnableAgentsEmptyArray` method. (`embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/LoggingThemeParameterizedTest.java`)

* Updated test cases in `EmbabelEnvironmentProcessorTest` to use the renamed `LoggingTheme.STAR_WARS`:
  - Modified `testStarWarsThemeActivatesProfile` method. (`embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessorTest.java`)
  - Modified `testPreservesExistingProfiles` method. (`embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessorTest.java`)
  - Modified `testMultipleSourceClasses` method. (`embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentProcessorTest.java`)