### PR TITLE
Support custom baseUrl for OpenAI and Anthropic APIs

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/AnthropicModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/AnthropicModels.kt
@@ -52,6 +52,10 @@ data class AnthropicProperties(
 @Profile("!test")
 @ExcludeFromJacocoGeneratedReport(reason = "Anthropic configuration can't be unit tested")
 class AnthropicModels(
+    @Value("\${ANTHROPIC_BASE_URL}")
+    private val baseUrl: String,
+    @Value("\${ANTHROPIC_API_KEY}")
+    private val apiKey: String,
     llms: List<Llm>,
     private val properties: AnthropicProperties,
 ) {
@@ -112,12 +116,9 @@ class AnthropicModels(
     }
 
     @Bean
-    fun claudeOpus4(
-        @Value("\${ANTHROPIC_BASE_URL}") baseUrl: String,
-        @Value("\${ANTHROPIC_API_KEY}") apiKey: String,
-    ): Llm {
+    fun claudeOpus4(): Llm {
         return anthropicModelOf(
-            CLAUDE_40_OPUS, baseUrl, apiKey,
+            CLAUDE_40_OPUS,
             knowledgeCutoffDate = LocalDate.of(2025, 3, 31),
             maxTokens = 200000,
         )
@@ -131,12 +132,9 @@ class AnthropicModels(
     }
 
     @Bean
-    fun claudeSonnet(
-        @Value("\${ANTHROPIC_BASE_URL}") baseUrl: String,
-        @Value("\${ANTHROPIC_API_KEY}") apiKey: String,
-    ): Llm {
+    fun claudeSonnet(): Llm {
         return anthropicModelOf(
-            CLAUDE_37_SONNET, baseUrl, apiKey,
+            CLAUDE_37_SONNET,
             knowledgeCutoffDate = LocalDate.of(2024, 10, 31),
             maxTokens = 20000,
         )
@@ -150,11 +148,8 @@ class AnthropicModels(
     }
 
     @Bean
-    fun claudeHaiku(
-        @Value("\${ANTHROPIC_BASE_URL}") baseUrl: String,
-        @Value("\${ANTHROPIC_API_KEY}") apiKey: String,
-    ): Llm = anthropicModelOf(
-        CLAUDE_35_HAIKU, baseUrl, apiKey,
+    fun claudeHaiku(): Llm = anthropicModelOf(
+        CLAUDE_35_HAIKU,
         knowledgeCutoffDate = LocalDate.of(2024, 10, 22),
         maxTokens = 8192,
     )
@@ -168,15 +163,13 @@ class AnthropicModels(
 
     private fun anthropicModelOf(
         name: String,
-        baseUrl: String,
-        apiKey: String,
         knowledgeCutoffDate: LocalDate?,
         maxTokens: Int,
     ): Llm {
         // Claude seems to need max tokens
         val chatModel = AnthropicChatModel
             .builder()
-            .anthropicApi(createAnthropicApi(baseUrl, apiKey))
+            .anthropicApi(createAnthropicApi())
             .retryTemplate(retryTemplate)
             .build()
         return Llm(
@@ -188,7 +181,7 @@ class AnthropicModels(
         )
     }
 
-    private fun createAnthropicApi(baseUrl: String, apiKey: String): AnthropicApi {
+    private fun createAnthropicApi(): AnthropicApi {
         val builder = AnthropicApi.builder().apiKey(apiKey)
         if (baseUrl.isNotBlank()) {
             logger.info("Using custom Anthropic base URL: $baseUrl")

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/AnthropicModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/AnthropicModels.kt
@@ -52,7 +52,7 @@ data class AnthropicProperties(
 @Profile("!test")
 @ExcludeFromJacocoGeneratedReport(reason = "Anthropic configuration can't be unit tested")
 class AnthropicModels(
-    @Value("\${ANTHROPIC_BASE_URL}")
+    @Value("\${ANTHROPIC_BASE_URL:}")
     private val baseUrl: String,
     @Value("\${ANTHROPIC_API_KEY}")
     private val apiKey: String,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/OpenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/OpenAiModels.kt
@@ -38,7 +38,7 @@ import java.time.LocalDate
 @Profile("!test")
 @ExcludeFromJacocoGeneratedReport(reason = "Open AI configuration can't be unit tested")
 class OpenAiModels(
-    @Value("\${OPENAI_BASE_URL}")
+    @Value("\${OPENAI_BASE_URL:}")
     private val baseUrl: String,
     @Value("\${OPENAI_API_KEY}")
     private val apiKey: String,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/OpenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/OpenAiModels.kt
@@ -38,6 +38,8 @@ import java.time.LocalDate
 @Profile("!test")
 @ExcludeFromJacocoGeneratedReport(reason = "Open AI configuration can't be unit tested")
 class OpenAiModels(
+    @Value("\${OPENAI_BASE_URL}")
+    private val baseUrl: String,
     @Value("\${OPENAI_API_KEY}")
     private val apiKey: String,
     private val observationRegistry: ObservationRegistry,
@@ -46,7 +48,16 @@ class OpenAiModels(
         loggerFor<OpenAiModels>().info("OpenAI AI models are available")
     }
 
-    private val openAiApi = OpenAiApi.builder().apiKey(apiKey).build()
+    private val openAiApi = createOpenAiApi()
+
+    private fun createOpenAiApi(): OpenAiApi {
+        val builder = OpenAiApi.builder().apiKey(apiKey)
+        if (baseUrl.isNotBlank()) {
+            loggerFor<OpenAiModels>().info("Using custom OpenAI base URL: $baseUrl")
+            builder.baseUrl(baseUrl)
+        }
+        return builder.build()
+    }
 
     @Bean
     fun gpt41mini(): Llm {


### PR DESCRIPTION
Due to restricted access to the official `OpenAI` and `Anthropic` APIs in certain regions, users often rely on proxy endpoints for connectivity. This commit adds support for custom baseUrl configuration, providing greater flexibility and ease of use in such environments.