### PR TITLE
Add flake.nix dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ embabel-agent-api/src/main/resources/mcp/**
 .idea/workspace.xml
 
 **/*.log
+.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1750741721,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4b1164c3215f018c4442463a27689d973cffd750",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,139 @@
+{
+  description = "Embabel Agent Framework - JVM-based AI agent framework";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        
+        jdk = pkgs.jdk21; # Spring Boot 3.x requires JDK 17+, JDK 21 is LTS
+        
+        # Build the project
+        embabel-agent = pkgs.stdenv.mkDerivation {
+          pname = "embabel-agent";
+          version = "0.1.0-SNAPSHOT";
+          
+          src = ./.;
+          
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          buildInputs = [ jdk pkgs.maven ];
+          
+          buildPhase = ''
+            export JAVA_HOME=${jdk}
+            mvn clean package -DskipTests
+          '';
+          
+          installPhase = ''
+            mkdir -p $out/lib $out/bin
+            cp embabel-agent-shell/target/*.jar $out/lib/
+            
+            makeWrapper ${jdk}/bin/java $out/bin/embabel-agent \
+              --add-flags "-jar $out/lib/embabel-agent-shell-*.jar" \
+              --set JAVA_HOME ${jdk}
+          '';
+        };
+        
+      in
+      {
+        packages = {
+          default = embabel-agent;
+          inherit embabel-agent;
+        };
+        
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            # Java/Kotlin development
+            jdk
+            maven
+            kotlin
+            gradle # Alternative build tool
+            
+            # Development tools
+            jdt-language-server # Java LSP
+            kotlin-language-server
+            
+            # Database tools (for testing)
+            postgresql
+            redis
+            
+            # Container tools
+            docker
+            docker-compose
+            
+            # Additional tools
+            git
+            jq
+            httpie
+            curl
+            
+            # IDE support
+            jetbrains.idea-community
+          ];
+          
+          shellHook = ''
+            export JAVA_HOME=${jdk}
+            export PATH=$JAVA_HOME/bin:$PATH
+            
+            echo "Embabel Agent Development Environment"
+            echo "====================================="
+            echo "Java version: $(java -version 2>&1 | head -n 1)"
+            echo "Maven version: $(mvn -version | head -n 1)"
+            echo "Kotlin version: $(kotlin -version 2>&1)"
+            echo ""
+            echo "Common commands:"
+            echo "  mvn clean install       - Build entire project"
+            echo "  mvn test               - Run tests"
+            echo "  mvn spring-boot:run    - Run application"
+            echo ""
+            echo "Run with shell profile:"
+            echo "  mvn spring-boot:run -Dspring.profiles.active=shell"
+            echo ""
+            echo "Environment variables needed:"
+            echo "  export OPENAI_API_KEY=your-key"
+            echo "  export ANTHROPIC_API_KEY=your-key (optional)"
+          '';
+        };
+        
+        # Additional specialized shells
+        devShells = {
+          # Minimal shell for CI/CD
+          ci = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              jdk
+              maven
+            ];
+            
+            shellHook = ''
+              export JAVA_HOME=${jdk}
+            '';
+          };
+          
+          # Shell with documentation tools
+          docs = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              jdk
+              maven
+              asciidoctor
+              graphviz # For dot files
+              pandoc
+            ];
+            
+            shellHook = ''
+              export JAVA_HOME=${jdk}
+              echo "Documentation shell - includes AsciiDoc tools"
+              echo "Build docs with: mvn clean install -Pembabel-agent-docs"
+            '';
+          };
+        };
+        
+        # Provide a simple app runner
+        apps.default = flake-utils.lib.mkApp {
+          drv = embabel-agent;
+        };
+      });
+}


### PR DESCRIPTION
This pull request introduces a new `flake.nix` file to set up a Nix-based development environment for the Embabel Agent Framework. The file defines dependencies, build processes, and development shells tailored for different use cases, such as general development, CI/CD, and documentation.

### Key Changes:

#### Nix Flake Configuration:
* Added a `flake.nix` file that describes the project, specifies dependencies (`nixpkgs`, `flake-utils`), and defines outputs for building and developing the project.

#### Build Process:
* Configured the build process for the Embabel Agent Framework using `maven` and `jdk21`. The project is packaged into a JAR file, and a wrapper script is created for running the application.

#### Development Shells:
* Defined a default development shell with tools for Java/Kotlin development, database testing, container management, and IDE support. Includes a `shellHook` to set up environment variables and display helpful information.
* Added specialized shells:
  - **CI/CD Shell**: Minimal environment with only `jdk` and `maven` for continuous integration workflows.
  - **Documentation Shell**: Includes tools like `asciidoctor`, `graphviz`, and `pandoc` for generating project documentation. ([flake.nixR1-R139](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R1-R139)