### PR TITLE
Fixes related to Agent startup and auto configuration.

### DIFF
--- a/embabel-agent-autoconfigure/README.md
+++ b/embabel-agent-autoconfigure/README.md
@@ -58,29 +58,41 @@ public class ShellAgentApplication {
 The `@EnableAgents` annotation provides additional configuration options:
 
 ```java
+import com.embabel.agent.config.annotation.LocalModels;
+import com.embabel.agent.config.annotation.LoggingThemes;
+import com.embabel.agent.config.annotation.McpServers;
+
 @SpringBootApplication
 @EnableAgents(
-    loggingTheme = "starwars",      // Activates "starwars" profile
-    localModels = {"ollama"},        // Activates "ollama" profile
-    mcpClients = {"filesystem"}      // Activates "filesystem" profile
+        loggingTheme = LoggingThemes.STAR_WARS,         // Activates "starwars" profile
+        localModels =  {LocalModels.OLLAMA},            // Activates "ollama" profile
+        mcpServers =   {McpServers.DOCKER_DESKTOP}      // Activates "filesystem" profile
 )
 public class CustomAgentApplication {
-    // Result: Profiles "starwars", "ollama", "filesystem" are active
+    public static void main(String[] args) {
+        SpringApplication.run(CustomAgentApplication.class, args);
+    }
 }
 ```
 
 ### Combining Platform and Agent Annotations
 
 ```java
+import com.embabel.agent.config.annotation.LocalModels;
+import com.embabel.agent.config.annotation.LoggingThemes;
+import com.embabel.agent.config.annotation.McpServers;
+
 @SpringBootApplication
 @EnableAgentShell                    // Activates "shell" profile
 @EnableAgents(
-    loggingTheme = "starwars",      // Activates "starwars" profile
-    localModels = {"ollama", "llamacpp"},  // Activates "ollama" and "llamacpp" profiles
-    mcpClients = {"docker", "github"}      // Activates "docker" and "github" profiles
+        loggingTheme = LoggingThemes.STAR_WARS,         // Activates "starwars" profile
+        localModels = {LocalModels.OLLAMA},             // Activates "ollama" and "llamacpp" profiles
+        mcpServers = {McpServers.DOCKER_DESKTOP}        // Activates "docker" and "github" profiles
 )
-public class AdvancedAgentApplication {
-    // Result: Profiles "shell", "starwars", "ollama", "llamacpp", "docker", "github" are active
+public class AdvancedAgentApplication { 
+    public static void main(String[] args) {
+        SpringApplication.run(AdvancedAgentApplication.class, args);
+    }
 }
 ```
 
@@ -91,7 +103,7 @@ The `EmbabelEnvironmentPostProcessor` activates profiles in the following order:
 1. **Platform Profiles** - From `@AgentPlatform` or meta-annotations like `@EnableAgentShell`
 2. **Logging Theme** - From `@EnableAgents(loggingTheme="...")`
 3. **Local Models** - From `@EnableAgents(localModels={...})`
-4. **MCP Clients** - From `@EnableAgents(mcpClients={...})`
+4. **MCP Servers** - From `@EnableAgents(mcpServers={...})`
 
 ## Available Logging Themes
 

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/AgentPlatform.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/AgentPlatform.java
@@ -142,7 +142,6 @@ public @interface AgentPlatform {
      *
      * <h4>Common Values:</h4>
      * <ul>
-     *   <li>{@code "default"} - Basic platform features only</li>
      *   <li>{@code "shell"} - Interactive CLI mode</li>
      *   <li>{@code "mcp-server"} - MCP protocol server</li>
      *   <li>{@code "bedrock"} - AWS Bedrock integration</li>
@@ -151,10 +150,10 @@ public @interface AgentPlatform {
      * <h4>Multiple Profiles:</h4>
      * <p>Multiple profiles can be specified to combine features:
      * <pre>{@code
-     * @AgentPlatform({"shell", "metrics", "debug"})
+     * @AgentPlatform({"shell", "metrics", "observability"})
      * }</pre>
      *
      * @return array of profile names to activate
      */
-    String[] value() default {"default"};
+    String[] value() default {};
 }

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcpServer.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentMcpServer.java
@@ -56,5 +56,5 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@AgentPlatform("mcp-server")
+@AgentPlatform(StartupMode.MCP_SERVER)
 public @interface EnableAgentMcpServer {}

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentShell.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgentShell.java
@@ -85,10 +85,11 @@ import java.lang.annotation.Target;
  * @see EnableAgentMcpServer
  * @see EnableAgents
  * @see AgentPlatform
+ * @see StartupMode
  * @since 1.0
  * @author Embabel Team
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@AgentPlatform("shell")
+@AgentPlatform(StartupMode.SHELL)
 public @interface EnableAgentShell {}

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgents.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/EnableAgents.java
@@ -83,7 +83,7 @@ public @interface EnableAgents {
      *
      * @return the logging theme name, or empty string for default logging
      */
-    String loggingTheme() default LoggingThemes.STAR_WARS;
+    String loggingTheme() default "";
 
     /**
      * Specifies local AI model providers to enable.

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/StartupMode.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/StartupMode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.annotation;
+
+public class StartupMode {
+
+    public static final String SHELL = "shell";
+
+    public static final String MCP_SERVER = "mcp-server";
+}
+

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/EnableAgentsAnnotationIT.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/EnableAgentsAnnotationIT.java
@@ -87,16 +87,6 @@ class EnableAgentsAnnotationIT {
     }
 
     @Test
-    @DisplayName("Should activate default profile when no specific profile is set")
-    void testDefaultProfileActivation() {
-        // Verify default profile is active
-        String[] activeProfiles = environment.getActiveProfiles();
-        assertThat(activeProfiles)
-                .as("Should have at least the default profile active")
-                .contains("default");
-    }
-
-    @Test
     @DisplayName("Should register agent platform configuration beans")
     void testAgentPlatformConfigurationBeans() {
         // Verify that agent platform specific beans are registered
@@ -120,7 +110,6 @@ class EnableAgentsAnnotationIT {
         // For example, if @EnableAgents had attributes:
         // - loggingTheme: verify theme profile is active
         // - localModels: verify model profiles are active
-        // - mcpClients: verify client profiles are active
 
         // Since the test class uses @EnableAgents with defaults,
         // we just verify the base configuration works
@@ -159,18 +148,17 @@ class EnableAgentsWithAttributesIT {
         assertThat(activeProfiles)
                 .as("Should contain all configured profiles")
                 .contains(
-                        "default",        // From @AgentPlatform
-                        "starwars",       // From loggingTheme
-                        "ollama",         // From localModels
-                        "filesystem"      // From mcpClients
+                        LoggingThemes.STAR_WARS,       // From loggingTheme
+                        LocalModels.OLLAMA,            // From localModels
+                        McpServers.DOCKER_DESKTOP      // From mcpClients
                 );
     }
 
     @SpringBootApplication
     @EnableAgents(
-            loggingTheme = "starwars",
-            localModels = {"ollama"},
-            mcpServers = {"filesystem"}
+            loggingTheme = LoggingThemes.STAR_WARS,
+            localModels = {LocalModels.OLLAMA},
+            mcpServers = {McpServers.DOCKER_DESKTOP}
     )
     static class CustomAttributesTestApplication {
         // Configuration with custom attributes


### PR DESCRIPTION
This pull request introduces several updates to the `embabel-agent-autoconfigure` module, focusing on refactoring annotations, improving profile management, and enhancing test coverage. The changes include replacing hardcoded strings with constants, introducing a new `StartupMode` class, and updating tests to reflect these modifications.

### Changes to annotations and profile management:

* Introduced a new `StartupMode` class to define constants for profile names like `SHELL` and `MCP_SERVER`, replacing hardcoded string values in annotations such as `@EnableAgentShell` and `@EnableAgentMcpServer` (`embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/StartupMode.java`, [embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/StartupMode.javaR1-R24](diffhunk://#diff-0dc8783bc38276c90c40098969ae9de2c762ac20ab053f265d7ca11ce29b9111R1-R24)).  
* Updated `@EnableAgents` and related annotations to use constants from `StartupMode`, `LoggingThemes`, `LocalModels`, and `McpServers` for better type safety and maintainability (`EnableAgents.java`, `EnableAgentShell.java`, `EnableAgentMcpServer.java`, [[1]](diffhunk://#diff-4b16db409e2f05a199891435b44c76e97d665de30b5f6748242578c710506ad4L86-R86) [[2]](diffhunk://#diff-153cb4756da0ee6ba9da93d0d72ec318405b7538760eed243d2b36103a5a9803R88-R94) [[3]](diffhunk://#diff-a80c66abb5cd6586a51c31ee5056a97757d9ebfcfdf02eccae879431d6e7b26fL59-R59).  
* Removed the default `"default"` profile from the `@AgentPlatform` annotation, allowing for more explicit configuration (`AgentPlatform.java`, [embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/AgentPlatform.javaL154-R158](diffhunk://#diff-ff2ebd010e3328acd6d909d2a7a200fcdea8cc8e83e77e2020132aa155048ab7L154-R158)).

### Changes to environment processing:

* Refactored the `EmbabelEnvironmentPostProcessor` to use `MergedAnnotations` for more robust handling of annotations, including meta-annotations, enabling the collection of all platform profiles (`EmbabelEnvironmentPostProcessor.java`, [embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentPostProcessor.javaL145-R163](diffhunk://#diff-e3800249b2fc0a19fcf205a728b784e6db89da13f71ba99d5b2562460d8af2e7L145-R163)).  
* Updated the profile activation order in the documentation to reflect the renaming of `mcpClients` to `mcpServers` (`README.md`, [embabel-agent-autoconfigure/README.mdL94-R106](diffhunk://#diff-60f2a60ea8f2d7d36829c03982a6f57a31daf0eec5bbc21c53dde1b5da28270eL94-R106)).

### Changes to tests:

* Updated integration and unit tests to use constants from `StartupMode`, `LoggingThemes`, `LocalModels`, and `McpServers`, ensuring consistency with the refactored annotations (`EnableAgentsAnnotationIT.java`, `EmbabelEnvironmentPostProcessorTest.java`, [[1]](diffhunk://#diff-7d7432283d86295cc6a266022fb465a8fe4bbf8666f45686225b33f7b7abacf3L89-L98) [[2]](diffhunk://#diff-670b63cbb84e65cab6fb5a39c5ee43589e90dcbc9fb36ec69506bab532467383L89-R89).  
* Removed tests for the default profile activation (`EnableAgentsAnnotationIT.java`, [embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/EnableAgentsAnnotationIT.javaL89-L98](diffhunk://#diff-7d7432283d86295cc6a266022fb465a8fe4bbf8666f45686225b33f7b7abacf3L89-L98)).  
* Added a new test to validate the precedence of `@EnableAgentShell` when combined with `@EnableAgents` (`EmbabelEnvironmentPostProcessorTest.java`, [embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EmbabelEnvironmentPostProcessorTest.javaL161-R193](diffhunk://#diff-670b63cbb84e65cab6fb5a39c5ee43589e90dcbc9fb36ec69506bab532467383L161-R193)).  

These changes collectively improve the maintainability, clarity, and extensibility of the `embabel-agent-autoconfigure` module.