### PR TITLE
Polishing EnvironmentPostProcessor

### DIFF
--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/AgentPlatform.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/AgentPlatform.java
@@ -16,7 +16,7 @@
 package com.embabel.agent.config.annotation;
 
 import com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration;
-import com.embabel.agent.config.annotation.spi.EmbabelEnvironmentPostProcessor;
+import com.embabel.agent.config.annotation.spi.EnvironmentPostProcessor;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.ComponentScan;
@@ -109,7 +109,7 @@ import java.lang.annotation.Target;
  * }</pre>
  *
  * <h3>Implementation Note:</h3>
- * <p>The actual profile activation is handled by {@link EmbabelEnvironmentPostProcessor}
+ * <p>The actual profile activation is handled by {@link EnvironmentPostProcessor}
  * which processes this annotation during the Spring Boot startup sequence.
  *
  * @see EnableAgentShell

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.env.EnvironmentPostProcessor;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.annotation.MergedAnnotations;
@@ -79,12 +78,12 @@ import java.util.Set;
  * @author Embabel Team
  * @see EnableAgents
  * @see AgentPlatform
- * @see EnvironmentPostProcessor
+ * @see org.springframework.boot.env.EnvironmentPostProcessor
  * @since 1.0
  */
-public class EmbabelEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+public class EnvironmentPostProcessor implements org.springframework.boot.env.EnvironmentPostProcessor, Ordered {
 
-    private final Logger logger = LoggerFactory.getLogger(EmbabelEnvironmentPostProcessor.class);
+    private final Logger logger = LoggerFactory.getLogger(EnvironmentPostProcessor.class);
 
     private static final String SPRING_PROFILES_ACTIVE = "spring.profiles.active";
 

--- a/embabel-agent-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/embabel-agent-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.env.EnvironmentPostProcessor=com.embabel.agent.config.annotation.spi.EmbabelEnvironmentPostProcessor
+org.springframework.boot.env.EnvironmentPostProcessor=com.embabel.agent.config.annotation.spi.EnvironmentPostProcessor

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java
@@ -30,16 +30,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class EmbabelEnvironmentPostProcessorTest {
+class EnvironmentPostProcessorTest {
 
-    private EmbabelEnvironmentPostProcessor processor;
+    private EnvironmentPostProcessor processor;
     private MockEnvironment environment;
     private SpringApplication application;
     private String originalProfilesProperty;
 
     @BeforeEach
     void setUp() {
-        processor = new EmbabelEnvironmentPostProcessor();
+        processor = new EnvironmentPostProcessor();
         environment = new MockEnvironment();
         application = mock(SpringApplication.class);
 


### PR DESCRIPTION
This pull request introduces significant refactoring and renaming to improve clarity and maintainability in the `embabel-agent-autoconfigure` module. The primary change involves renaming the `EmbabelEnvironmentPostProcessor` class and related references to `EnvironmentPostProcessor`, alongside updates to method names and annotations to reflect this change. Additionally, the logic for processing MCP-related profiles has been updated to focus on "servers" instead of "clients."

### Refactoring and Renaming:

* Renamed the `EmbabelEnvironmentPostProcessor` class to `EnvironmentPostProcessor` and updated all references, including imports, logger initialization, and test class names.
* Updated the Spring `META-INF/spring.factories` file to reflect the new class name for the `EnvironmentPostProcessor` implementation. 
* 
### Profile Processing Updates:

* Replaced "MCP Clients" terminology with "MCP Servers" in the `EnvironmentPostProcessor` class, including method names (`findMcpClients` → `findMcpServers`), annotations, and logging messages. 

* Updated the example usage in the Javadoc to reflect the new focus on MCP servers and the use of constants for logging themes and local models. 