### PR TITLE
Bedrock starter

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -12,6 +12,7 @@
         <module name="embabel-agent-autoconfigure" />
         <module name="embabel-agent-rag" />
         <module name="embabel-agent-starter" />
+        <module name="embabel-agent-starter-bedrock" />
         <module name="embabel-agent-api" />
         <module name="embabel-movie-example" />
         <module name="embabel-agent-test" />

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -27,6 +27,7 @@
     <file url="file://$PROJECT_DIR$/embabel-agent-shell/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/embabel-agent-starter/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/embabel-agent-starter/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/embabel-agent-starters/embabel-agent-starter-bedrock/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/embabel-agent-starters/embabel-agent-starter-platform/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/embabel-agent-starters/embabel-agent-starter-platform/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/embabel-agent-starters/embabel-agent-starter/src/main/java" charset="UTF-8" />

--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -132,12 +132,14 @@
 
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-bedrock-converse</artifactId>
+            <artifactId>spring-ai-starter-model-bedrock</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-autoconfigure-model-bedrock-ai</artifactId>
+            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/embabel-agent-api/src/main/resources/application-bedrock.yml
+++ b/embabel-agent-api/src/main/resources/application-bedrock.yml
@@ -1,10 +1,16 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.ai.model.bedrock.converse.autoconfigure.BedrockConverseProxyChatAutoConfiguration
+      - org.springframework.ai.model.bedrock.cohere.autoconfigure.BedrockCohereEmbeddingAutoConfiguration
+      - org.springframework.ai.model.bedrock.titan.autoconfigure.BedrockTitanEmbeddingAutoConfiguration
   ai:
     bedrock:
       aws:
-        region: ${AWS_REGION}
-        access-key: ${AWS_ACCESS_KEY_ID}
-        secret-key: ${AWS_SECRET_ACCESS_KEY}
+        region: ${AWS_REGION:}
+        access-key: ${AWS_ACCESS_KEY_ID:}
+        secret-key: ${AWS_SECRET_ACCESS_KEY:}
+        session-token: ${AWS_SESSION_TOKEN:}
 
 embabel:
   models:

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/config/models/BedrockModelsIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/config/models/BedrockModelsIntegrationTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models
+
+import com.embabel.agent.config.models.BedrockModels.Companion.EU_ANTHROPIC_CLAUDE_3_7_SONNET
+import com.embabel.agent.config.models.BedrockModels.Companion.EU_ANTHROPIC_CLAUDE_OPUS_4
+import com.embabel.agent.config.models.BedrockModels.Companion.EU_ANTHROPIC_CLAUDE_SONNET_4
+import com.embabel.common.ai.model.AiModel
+import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.ai.model.Llm
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingModel.COHERE_EMBED_ENGLISH_V3
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V3
+import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingModel.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@SpringBootTest
+@ActiveProfiles(value = ["test", "bedrock"])
+class MisconfiguredBedrockModelsIntegrationTest {
+
+    @Autowired(required = false)
+    private lateinit var bedrockModels: BedrockModels
+
+    @Autowired
+    private lateinit var applicationContext: ApplicationContext
+
+    @Test
+    fun `should register Bedrock models when profile is active`() {
+        // Verify the bean exists
+        assertNotNull(bedrockModels)
+
+        // No bedrock models were registered
+        val bedrockModelBeans =
+            applicationContext.getBeanNamesForType(AiModel::class.java).filter { it.startsWith("bedrockModel-") }
+
+        assertTrue(bedrockModelBeans.isEmpty())
+    }
+}
+
+@SpringBootTest(
+    properties = [
+        "spring.ai.bedrock.aws.region=eu-west-3",
+        "spring.ai.bedrock.aws.access-key=AWSACCESSKEYID",
+        "spring.ai.bedrock.aws.secret-key=AWSSECRETACCESSKEY",
+    ]
+)
+@ActiveProfiles(value = ["test", "bedrock"])
+class BedrockModelsIntegrationDefaultTest {
+
+    @Autowired
+    private lateinit var applicationContext: ApplicationContext
+
+    @Test
+    fun `should register Titan and Cohere embedding services when 'bedrock' profile is active`() {
+        val embeddingServices = applicationContext.getBeanNamesForType(EmbeddingService::class.java)
+                .filter { it.startsWith("bedrockModel-") }
+                .map<String, EmbeddingService> {
+                    applicationContext.getBean(it, EmbeddingService::class.java)
+                }
+        assertTrue(
+            embeddingServices.map { it.name }.containsAll(
+                listOf(
+                    TITAN_EMBED_IMAGE_V1.id(),
+                    TITAN_EMBED_TEXT_V1.id(),
+                    TITAN_EMBED_TEXT_V2.id(),
+                    COHERE_EMBED_MULTILINGUAL_V3.id(),
+                    COHERE_EMBED_ENGLISH_V3.id(),
+                )
+            )
+        )
+
+        val bedrockLlmBeanNames = applicationContext.getBeanNamesForType(Llm::class.java)
+            .filter { it.startsWith("bedrockModel-") }
+        assertTrue(bedrockLlmBeanNames.isEmpty())
+    }
+}
+
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=${EU_ANTHROPIC_CLAUDE_SONNET_4}",
+        "embabel.models.llms.cheapest=${EU_ANTHROPIC_CLAUDE_SONNET_4}",
+        "embabel.models.llms.best=${EU_ANTHROPIC_CLAUDE_OPUS_4}",
+        "spring.ai.bedrock.aws.region=eu-west-3",
+        "spring.ai.bedrock.aws.access-key=AWSACCESSKEYID",
+        "spring.ai.bedrock.aws.secret-key=AWSSECRETACCESSKEY",
+    ]
+)
+@ActiveProfiles(value = ["test", "bedrock"])
+class BedrockModelsIntegrationTest {
+
+    @Autowired
+    private lateinit var applicationContext: ApplicationContext
+
+    @Test
+    fun `should register only configured Llms when 'bedrock' profile is active`() {
+        val bedrockLlmsNames = applicationContext.getBeanNamesForType(Llm::class.java)
+            .filter { it.startsWith("bedrockModel-") }
+            .map { applicationContext.getBean(it, Llm::class.java) }
+            .map { it.name }
+
+        assertTrue(bedrockLlmsNames.containsAll(listOf(EU_ANTHROPIC_CLAUDE_SONNET_4, EU_ANTHROPIC_CLAUDE_OPUS_4)))
+        assertFalse(bedrockLlmsNames.contains(EU_ANTHROPIC_CLAUDE_3_7_SONNET))
+    }
+}

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -56,6 +56,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-bedrock</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-autoconfigure</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/embabel-agent-starters/embabel-agent-starter-bedrock/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-bedrock/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-starter-bedrock</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Bedrock Starter</name>
+    <description>Embabel Agent Bedrock Starter</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-bedrock</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-model-bedrock-converse</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -14,6 +14,7 @@
     <modules>
         <module>embabel-agent-starter</module>
         <module>embabel-agent-starter-platform</module>
+        <module>embabel-agent-starter-bedrock</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This PR adds a embabel-agent-starter for Bedrock, to avoid non-bedrock users to depends on useless libraries.

This also adds bedrock embedding models (Titan, Cohere) using enums from spring-ai-bedrock :
- COHERE_EMBED_MULTILINGUAL_V3("cohere.embed-multilingual-v3")
- COHERE_EMBED_ENGLISH_V3("cohere.embed-english-v3")
- TITAN_EMBED_IMAGE_V1("amazon.titan-embed-image-v1")
- TITAN_EMBED_TEXT_V1("amazon.titan-embed-text-v1")
- TITAN_EMBED_TEXT_V2("amazon.titan-embed-text-v2:0")