### PR TITLE
Issue-546 SPRING_ACTIVE_PROFILE was not getting added to the Environment

### DIFF
--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
@@ -236,19 +236,15 @@ public class EnvironmentPostProcessor implements org.springframework.boot.env.En
             mergedProfiles.addAll(Arrays.asList(existingProfiles.split(",")));
             // Add new profiles
             mergedProfiles.addAll(profiles);
-            // Update system property with merged set
-            System.setProperty(SPRING_PROFILES_ACTIVE, String.join(",", mergedProfiles));
+            // Update environment
+            mergedProfiles.forEach(environment::addActiveProfile);
         } else {
-            // No existing profiles, just set new ones
-            System.setProperty(SPRING_PROFILES_ACTIVE, newProfiles);
+            profiles.forEach(environment::addActiveProfile);
         }
 
-        // Also add profiles directly to Spring environment
-        // This ensures they're active even if system property is overridden
-        profiles.forEach(environment::addActiveProfile);
 
         // Log the final state for debugging
-        logger.info("Activated Spring profiles: {}", System.getProperty(SPRING_PROFILES_ACTIVE));
+        logger.info("Activated Spring profiles: {}", (Object[]) environment.getActiveProfiles());
     }
 
     /**

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
@@ -227,8 +227,7 @@ public class EnvironmentPostProcessor implements org.springframework.boot.env.En
     private void activateProfiles(ConfigurableEnvironment environment, Set<String> profiles) {
         // Get existing profiles from system property
         String existingProfiles = System.getProperty(SPRING_PROFILES_ACTIVE);
-        String newProfiles = String.join(",", profiles);
-
+        
         if (existingProfiles != null && !existingProfiles.isEmpty()) {
             // Merge with existing profiles, maintaining uniqueness
             var mergedProfiles = new LinkedHashSet<String>();

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java
@@ -211,6 +211,20 @@ class EnvironmentPostProcessorTest {
     }
 
     @Test
+    void testEmptyProfiles() {
+        class TestApp {
+        }
+        when(application.getAllSources()).thenReturn(Set.of(TestApp.class));
+
+        // When
+        processor.postProcessEnvironment(environment, application);
+
+        // Then
+        assertThat(getAddedProfiles()).isEmpty();
+        assertThat(System.getProperty("spring.profiles.active")).isNull();
+    }
+
+    @Test
     void testHighestPrecedenceOrder() {
         assertThat(processor.getOrder()).isEqualTo(Integer.MIN_VALUE);
     }

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java
@@ -86,7 +86,6 @@ class EnvironmentPostProcessorTest {
 
         // Then
         assertThat(getAddedProfiles()).containsExactly(StartupMode.SHELL);
-        assertThat(System.getProperty("spring.profiles.active")).isEqualTo(StartupMode.SHELL);
     }
 
     @Test
@@ -102,7 +101,6 @@ class EnvironmentPostProcessorTest {
 
         // Then
         assertThat(getAddedProfiles()).containsExactly(LoggingThemes.STAR_WARS);
-        assertThat(System.getProperty("spring.profiles.active")).isEqualTo(LoggingThemes.STAR_WARS);
     }
 
     @Test
@@ -118,8 +116,6 @@ class EnvironmentPostProcessorTest {
 
         // Then
         assertThat(getAddedProfiles()).containsExactlyInAnyOrder(LocalModels.OLLAMA, LocalModels.DOCKER);
-        assertThat(Arrays.stream(System.getProperty("spring.profiles.active").split(",")).collect(Collectors.toSet())
-        ).isEqualTo(Set.of(LocalModels.OLLAMA, LocalModels.DOCKER));
     }
 
     @Test
@@ -135,8 +131,6 @@ class EnvironmentPostProcessorTest {
 
         // Then
         assertThat(getAddedProfiles()).containsExactlyInAnyOrder(McpServers.DOCKER_DESKTOP);
-        assertThat(Arrays.stream(System.getProperty("spring.profiles.active").split(",")).collect(Collectors.toSet())
-        ).isEqualTo(Set.of(McpServers.DOCKER_DESKTOP));
     }
 
     @Test
@@ -157,9 +151,7 @@ class EnvironmentPostProcessorTest {
 
         // Then
         assertThat(getAddedProfiles())
-                .containsExactlyInAnyOrder(StartupMode.SHELL, LoggingThemes.STAR_WARS, LocalModels.OLLAMA, McpServers.DOCKER_DESKTOP);
-        assertThat(System.getProperty("spring.profiles.active"))
-                .isEqualTo("shell,starwars,ollama,docker-desktop");
+                .containsExactlyInAnyOrder(StartupMode.SHELL, LoggingThemes.STAR_WARS, LocalModels.OLLAMA, McpServers.DOCKER_DESKTOP);;
     }
 
     @Test
@@ -181,8 +173,6 @@ class EnvironmentPostProcessorTest {
         // Then
         assertThat(getAddedProfiles())
                 .containsExactlyInAnyOrder(StartupMode.SHELL, LoggingThemes.STAR_WARS, LocalModels.OLLAMA, McpServers.DOCKER_DESKTOP);
-        assertThat(System.getProperty("spring.profiles.active"))
-                .isEqualTo("shell,starwars,ollama,docker-desktop");
     }
 
     @Test
@@ -191,6 +181,7 @@ class EnvironmentPostProcessorTest {
         System.setProperty("spring.profiles.active", "existing,profiles");
 
         @EnableAgents(loggingTheme = LoggingThemes.STAR_WARS)
+        @EnableAgentShell
         class TestApp {
         }
         when(application.getAllSources()).thenReturn(Set.of(TestApp.class));
@@ -199,9 +190,8 @@ class EnvironmentPostProcessorTest {
         processor.postProcessEnvironment(environment, application);
 
         // Then
-        assertThat(getAddedProfiles()).containsExactly(LoggingThemes.STAR_WARS);
-        assertThat(System.getProperty("spring.profiles.active"))
-                .isEqualTo("existing,profiles,starwars");
+        assertThat(getAddedProfiles()).containsExactlyInAnyOrder("existing", "profiles", LoggingThemes.STAR_WARS, StartupMode.SHELL);
+
     }
 
     @Test

--- a/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java
+++ b/embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java
@@ -151,7 +151,7 @@ class EnvironmentPostProcessorTest {
 
         // Then
         assertThat(getAddedProfiles())
-                .containsExactlyInAnyOrder(StartupMode.SHELL, LoggingThemes.STAR_WARS, LocalModels.OLLAMA, McpServers.DOCKER_DESKTOP);;
+                .containsExactlyInAnyOrder(StartupMode.SHELL, LoggingThemes.STAR_WARS, LocalModels.OLLAMA, McpServers.DOCKER_DESKTOP);
     }
 
     @Test


### PR DESCRIPTION
This pull request refactors the `EnvironmentPostProcessor` to remove reliance on the `spring.profiles.active` system property and instead directly updates the Spring environment with active profiles. It also updates the corresponding tests to align with the new behavior.

### Refactoring of `EnvironmentPostProcessor`:

* Updated `EnvironmentPostProcessor` to use `environment.addActiveProfile` for managing active profiles instead of modifying the `spring.profiles.active` system property. This ensures profiles are added directly to the Spring environment. (`embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java`, [embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.javaL239-R247](diffhunk://#diff-4eb99aeedef78d221ee777dcfd8e6b91580dff796566830c15c1d7b9c14b19c1L239-R247))

### Updates to Tests:

* Removed assertions that check the `spring.profiles.active` system property in various test cases, as the property is no longer used. (`embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java`, [[1]](diffhunk://#diff-b30f173835a1c6ce78d439b5b15433a856fdc38e1880b89023e961a4b55bba6cL89) [[2]](diffhunk://#diff-b30f173835a1c6ce78d439b5b15433a856fdc38e1880b89023e961a4b55bba6cL105) [[3]](diffhunk://#diff-b30f173835a1c6ce78d439b5b15433a856fdc38e1880b89023e961a4b55bba6cL121-L122) [[4]](diffhunk://#diff-b30f173835a1c6ce78d439b5b15433a856fdc38e1880b89023e961a4b55bba6cL138-L139) [[5]](diffhunk://#diff-b30f173835a1c6ce78d439b5b15433a856fdc38e1880b89023e961a4b55bba6cL160-R154) [[6]](diffhunk://#diff-b30f173835a1c6ce78d439b5b15433a856fdc38e1880b89023e961a4b55bba6cL184-L185)
* Updated test cases to validate the profiles directly added to the Spring environment instead of relying on the system property. (`embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java`, [embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.javaL202-R194](diffhunk://#diff-b30f173835a1c6ce78d439b5b15433a856fdc38e1880b89023e961a4b55bba6cL202-R194))
* Added `@EnableAgentShell` annotation to a test class to ensure proper testing of the new behavior. (`embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.java`, [embabel-agent-autoconfigure/src/test/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessorTest.javaR184](diffhunk://#diff-b30f173835a1c6ce78d439b5b15433a856fdc38e1880b89023e961a4b55bba6cR184))