### PR TITLE
Upgrade spring ai

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/SelfToolCallbackPublisher.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/SelfToolCallbackPublisher.kt
@@ -18,8 +18,8 @@ package com.embabel.agent.api.common.support
 import com.embabel.agent.core.*
 import com.embabel.common.core.types.AssetCoordinates
 import com.embabel.common.core.types.Semver
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.ToolCallback
-import org.springframework.ai.tool.ToolCallbacks
 
 /**
  * Convenient interface a class can implement to publish @Tool

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/BedrockModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/BedrockModels.kt
@@ -176,8 +176,9 @@ class BedrockModels(
                 credentialsProvider,
                 regionProvider.region,
                 ModelOptionsUtils.OBJECT_MAPPER,
-                connectionProperties.timeout
-            )
+                connectionProperties.timeout,
+            ),
+            null,
         ).withInputType(bedrockTitanEmbeddingProperties.inputType),
         provider = PROVIDER,
     )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/springAiUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/springAiUtils.kt
@@ -16,8 +16,8 @@
 package com.embabel.agent.core.support
 
 import com.embabel.agent.api.common.ToolObject
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.ToolCallback
-import org.springframework.ai.tool.ToolCallbacks
 import org.springframework.ai.tool.definition.DefaultToolDefinition
 import org.springframework.ai.tool.definition.ToolDefinition
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/experimental/d/ToolGroupExposerKtTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/experimental/d/ToolGroupExposerKtTest.kt
@@ -20,7 +20,7 @@ import com.embabel.agent.experimental.dsl.exposeAsInterface
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.ai.tool.ToolCallbacks
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.annotation.Tool
 import kotlin.test.assertEquals
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -45,7 +45,7 @@ import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.DefaultChatOptions
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.ai.model.tool.ToolCallingChatOptions
-import org.springframework.ai.tool.ToolCallbacks
+import org.springframework.ai.support.ToolCallbacks
 import java.time.LocalDate
 import kotlin.test.assertEquals
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt
@@ -26,7 +26,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.springframework.ai.tool.ToolCallbacks
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.annotation.Tool
 
 class SimpleTools {

--- a/embabel-agent-eval/pom.xml
+++ b/embabel-agent-eval/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-client-chat</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-neo4j</artifactId>
         </dependency>
@@ -70,6 +75,7 @@
             <artifactId>embabel-agent-test</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
This pull request primarily focuses on updating imports to reflect a package change for `ToolCallbacks` and adding a new dependency to the `pom.xml` file. These changes improve code consistency and introduce a new library for AI-related functionalities.

### Updates to imports:

* Replaced `org.springframework.ai.tool.ToolCallbacks` with `org.springframework.ai.support.ToolCallbacks` across multiple files to reflect a package update. This change ensures the correct package is used for `ToolCallbacks`. [[1]](diffhunk://#diff-a75c29869e13c242b33eaf2a24fd17e7e77824ac7ce907983757fce3def67851R21-L22) [[2]](diffhunk://#diff-d5a68f3145511ab6db9943d6dd5064d671ee9be83a354caf0848269ac7ec476aR19-L20) [[3]](diffhunk://#diff-e4e268c6f399b945bece9104a5d94a4e93d21658e1c716ac6aa2c0b3a1e95560L23-R23) [[4]](diffhunk://#diff-bf29d55ce0e64fc95e602952f20dcc99f6b82aedb04dcc3baf0c82b96cbb7300L48-R48) [[5]](diffhunk://#diff-62dcaa4550cad628af5d444a1912216451a6740a8466acbb3dc5a7175248fad2L29-R29)

### Dependency additions:

* Added a new dependency for `spring-ai-client-chat` in the `pom.xml` file. This likely introduces new AI client chat capabilities to the project.

### Minor code adjustments:

* Updated the `BedrockModels` constructor to include a new `null` parameter, likely for future extensibility or to align with a new API signature.