### PR TITLE
Add embabel-agent-mcpserver module.

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -32,6 +32,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-mcpserver</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-rag</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/embabel-agent-mcpserver/pom.xml
+++ b/embabel-agent-mcpserver/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-mcpserver</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent MCP Server</name>
+    <description>Discover and Export available Agent(s) as an MCP Servers</description>
+
+    <dependencies>        
+        <!-- Main Dependencies -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.embabel.common</groupId>
+            <artifactId>embabel-common-core</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
@@ -30,7 +30,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
 
 /**

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpServerConfiguration.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import com.embabel.agent.core.ToolCallbackPublisher
+import com.embabel.agent.event.logging.LoggingPersonality.Companion.BANNER_WIDTH
+import com.embabel.agent.spi.support.AgentScanningBeanPostProcessorEvent
+import com.embabel.common.core.types.HasInfoString
+import com.embabel.common.util.loggerFor
+import io.modelcontextprotocol.server.McpSyncServer
+import org.apache.catalina.util.ServerInfo
+import org.springframework.ai.mcp.McpToolUtils
+import org.springframework.ai.tool.ToolCallbackProvider
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.ai.tool.method.MethodToolCallbackProvider
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.context.event.EventListener
+
+/**
+ * Tag interface extending Spring AI ToolCallbackProvider
+ * that identifies tool callbacks that our MCP server exposes.
+ */
+interface McpToolExportCallbackPublisher : ToolCallbackPublisher, HasInfoString
+
+/**
+ * Provides a hello banner for the MCP server.
+ */
+class BannerTool {
+
+    @Tool(
+        name = "Embabel Hello Banner",
+        description = "Display a welcome banner with server information"
+    )
+    fun getHelloBanner(): String {
+        val separator = "~".repeat(HELLO_BANNER_WIDTH )
+        return "\n${separator}\n" +
+                "Embabel Agent MCP server\n" +
+                "Server info: ${ServerInfo.getServerInfo()}\n" +
+                "Java info: ${System.getProperty("java.runtime.version")}\n" +
+                "${separator}\n"
+    }
+
+    companion object {
+        private const val HELLO_BANNER_WIDTH = 50
+    }
+}
+
+
+/**
+ * Configures MCP server. Exposes a limited number of tools.
+ */
+@Configuration
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.ANY)
+class McpServerConfiguration(
+    private val applicationContext: ConfigurableApplicationContext,
+) {
+
+    /**
+     * Currently MCP Server is configured by AutoConfiguration, which requires
+     * at least one ToolCallbackProvider bean to be present in the context in order
+     * to build it with Tools Capability.
+     *
+     * Provides a simple banner tool callback to display a welcome message.
+     */
+    @Bean
+    fun helloBannerCallback(): ToolCallbackProvider {
+        return MethodToolCallbackProvider.builder().toolObjects(BannerTool()).build()
+    }
+
+    /**
+     * Configures and initializes MCP server tool callbacks when the agent scanning process completes.
+     *
+     * This event-driven approach ensures that all tool callbacks are properly registered only after
+     * the application context is fully initialized and all agent beans have been processed and deployed.
+     * Without this synchronization, the MCP server might start without access to all available tools.
+     */
+    @EventListener(AgentScanningBeanPostProcessorEvent::class)
+    fun callbacks() {
+        val mcpToolExportCallbackPublishers: List<McpToolExportCallbackPublisher> =
+            applicationContext.getBeansOfType(McpToolExportCallbackPublisher::class.java).values.toList()
+        val allToolCallbacks = mcpToolExportCallbackPublishers.flatMap { it.toolCallbacks }
+        val separator = "~".repeat(BANNER_WIDTH)
+        loggerFor<McpServerConfiguration>().info(
+            "\n${separator}\n{} MCP tool exporters: {}\nExposing a total of {} MCP server tools:\n\t{}\n${separator}",
+            mcpToolExportCallbackPublishers.size,
+            mcpToolExportCallbackPublishers.map { it.infoString(verbose = true) },
+            allToolCallbacks.size,
+            allToolCallbacks.joinToString(
+                "\n\t"
+            ) { "${it.toolDefinition.name()}: ${it.toolDefinition.description()}" }
+        )
+
+        // add tool callbacks to MCP server
+        val agentTools = McpToolUtils
+            .toSyncToolSpecification(allToolCallbacks)
+
+        for (agentTool in agentTools) {
+            applicationContext.getBean(McpSyncServer::class.java).addTool(agentTool);
+        }
+
+    }
+
+}

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProvider.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProvider.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.mcpserver
 
-import com.embabel.agent.test.common.autonomy.Autonomy
+import com.embabel.agent.api.common.autonomy.Autonomy
 import com.embabel.agent.core.Goal
 import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.core.Verbosity

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProvider.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProvider.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import com.embabel.agent.test.common.autonomy.Autonomy
+import com.embabel.agent.core.Goal
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.Verbosity
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.domain.library.HasContent
+import com.embabel.common.core.types.HasInfoString
+import com.embabel.common.util.loggerFor
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.LoggerFactory
+import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.util.json.schema.JsonSchemaGenerator
+import org.springframework.stereotype.Service
+
+/**
+ * Return a tool callback for each goal.
+ * These will be exposed via the MCP server.
+ */
+@Service
+class PerGoalToolCallbackProvider(
+    private val autonomy: Autonomy,
+    private val objectMapper: ObjectMapper,
+) : McpToolExportCallbackPublisher {
+
+    private val logger = LoggerFactory.getLogger(PerGoalToolCallbackProvider::class.java)
+
+    override val toolCallbacks: List<ToolCallback>
+        get() {
+            return autonomy.agentPlatform.goals.map { goal ->
+                toolForGoal(goal)
+            }
+        }
+
+    fun toolForGoal(goal: Goal): ToolCallback {
+        class GoalToolCallback : ToolCallback {
+            override fun getToolDefinition(): ToolDefinition {
+                return object : ToolDefinition {
+                    override fun name(): String {
+                        val parts: List<String> = goal.name.split(".")
+                        return parts.takeLast(2).joinToString("_")
+                    }
+
+                    override fun description(): String {
+                        return goal.description
+                    }
+
+                    override fun inputSchema(): String {
+                        val js = JsonSchemaGenerator.generateForType(UserInput::class.java)
+                        loggerFor<PerGoalToolCallbackProvider>().debug("Generated schema for ${goal.name}: $js")
+                        return js
+                    }
+                }
+            }
+
+            override fun call(
+                toolInput: String,
+                tooContext: ToolContext?
+            ): String {
+                return call(toolInput)
+            }
+
+            override fun call(toolInput: String): String {
+                val verbosity = Verbosity(
+                    showPrompts = true,
+                )
+                val userInput = objectMapper.readValue(toolInput, UserInput::class.java)
+                val processOptions = ProcessOptions(verbosity = verbosity)
+                val agent = autonomy.createGoalAgent(
+                    userInput = userInput,
+                    goal = goal,
+                    agentScope = autonomy.agentPlatform,
+                )
+                val dynamicExecutionResult = autonomy.runAgent(
+                    userInput = UserInput(toolInput),
+                    processOptions = processOptions,
+                    agent = agent,
+                )
+                logger.info("Goal response: {}", dynamicExecutionResult)
+
+                return when (val output = dynamicExecutionResult.output) {
+                    is String -> output
+                    is HasInfoString -> {
+                        output.infoString(verbose = true)
+                    }
+                    is HasContent -> output.content
+                    else -> output.toString()
+                }
+            }
+        }
+        return GoalToolCallback()
+    }
+
+    override fun infoString(verbose: Boolean?): String {
+        return "${javaClass.name} with ${toolCallbacks.size} tools"
+    }
+}

--- a/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProviderTest.kt
+++ b/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProviderTest.kt
@@ -15,8 +15,8 @@
  */
 package com.embabel.agent.mcpserver
 
-import com.embabel.agent.test.common.autonomy.Autonomy
-import com.embabel.agent.test.common.autonomy.AutonomyProperties
+import com.embabel.agent.api.common.autonomy.Autonomy
+import com.embabel.agent.api.common.autonomy.AutonomyProperties
 import com.embabel.agent.test.dsl.evenMoreEvilWizard
 import com.embabel.agent.test.dsl.userInputToFrogOrPersonBranch
 import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentPlatform

--- a/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProviderTest.kt
+++ b/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProviderTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import com.embabel.agent.test.common.autonomy.Autonomy
+import com.embabel.agent.test.common.autonomy.AutonomyProperties
+import com.embabel.agent.test.dsl.evenMoreEvilWizard
+import com.embabel.agent.test.dsl.userInputToFrogOrPersonBranch
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentPlatform
+import com.embabel.agent.testing.integration.RandomRanker
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+
+class PerGoalToolCallbackProviderTest {
+
+    @Test
+    fun `test function per goal`() {
+        val agentPlatform = dummyAgentPlatform()
+        agentPlatform.deploy(evenMoreEvilWizard())
+        agentPlatform.deploy(userInputToFrogOrPersonBranch())
+        val autonomy = Autonomy(agentPlatform, RandomRanker(), AutonomyProperties())
+
+        val provider = PerGoalToolCallbackProvider(autonomy, jacksonObjectMapper())
+
+        // Act
+        val toolCallbacks = provider.toolCallbacks
+
+        // Assert
+        assertNotNull(toolCallbacks)
+        assertEquals(autonomy.agentPlatform.goals.size, toolCallbacks.size, "Should have one tool callback per goal")
+
+        // Check that each tool callback corresponds to a goal
+        for (toolCallback in toolCallbacks) {
+            val toolDefinition = toolCallback.toolDefinition
+            val goalName = toolDefinition.name()
+            val goal = autonomy.agentPlatform.goals.find { it.name == goalName }
+            assertNotNull(goal, "Tool callback should correspond to a platform goal")
+            assertNotNull(toolCallback.toolDefinition.inputSchema(), "Should have generated schema")
+        }
+    }
+
+}

--- a/embabel-agent-test/pom.xml
+++ b/embabel-agent-test/pom.xml
@@ -11,12 +11,18 @@
     <packaging>jar</packaging>
     <name>Embabel Agent Test</name>
     <description>Test Support Framework for Agent API(s)</description>
-    
+
     <dependencies>
         <!-- Main Dependencies -->
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <!-- Unit and Integration Testing -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
     </dependencies>
 

--- a/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/domain/gardenOfEden.kt
+++ b/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/domain/gardenOfEden.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.test.domain
+
+data class GeneratedName(val name: String, val reason: String)
+
+data class GeneratedNames(val names: List<GeneratedName>)
+
+data class AllNames(val accepted: List<GeneratedName>, val rejected: List<GeneratedName>)
+
+data class Garden(val name: String)
+
+data class SpiPerson(val name: String)
+
+data class WierdPerson(val name: String, val age: Int, val weirdness: String)
+
+data class Return(
+    val result: Result<*>,
+    val capturedPrompt: String,
+)

--- a/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/domain/simplyMagic.kt
+++ b/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/domain/simplyMagic.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.test.domain
+
+data class MagicVictim(
+    val name: String,
+)
+
+data class Frog(
+    val name: String,
+)

--- a/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/dsl/agentBuilderUtils.kt
+++ b/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/dsl/agentBuilderUtils.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.test.dsl
+
+import com.embabel.agent.api.common.support.Branch
+import com.embabel.agent.api.dsl.*
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.test.annotation.support.Wumpus
+import com.embabel.agent.test.domain.*
+import com.embabel.common.core.MobyNameGenerator
+
+fun splitGarden() = agent("splitter", description = "splitter0") {
+
+    transformation<UserInput, Garden> { Garden(it.input.content) }
+
+    flow {
+        split<Garden, Frog> {
+            listOf(Frog("Kermit"), Frog("Freddo"))
+        } andThenDo {
+            SnakeMeal(it.objects.filterIsInstance<Frog>())
+        }
+    }
+
+    goal(
+        name = "snakeFed",
+        description = "We are satisfied with generated names",
+        satisfiedBy = SnakeMeal::class,
+    )
+}
+
+fun userInputToFrogOrPersonBranch() = agent("brancher", description = "brancher0") {
+
+    flow {
+        branch<UserInput, SpiPerson, Frog> { Branch(SpiPerson(it.input.content)) }
+    }
+
+    goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = SpiPerson::class)
+}
+
+fun userInputToFrogChain() = agent("uitf", description = "Evil frogly wizard") {
+
+    flow {
+        chain<UserInput, SpiPerson, Frog>(
+            { SpiPerson(it.input.content) },
+            { Frog(it.input.name) },
+        )
+    }
+
+    goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = Frog::class)
+}
+
+fun userInputToFrogAndThenDo() = agent("uitf", description = "Evil frogly wizard") {
+
+    fun toSpiPerson(userInput: UserInput) = SpiPerson(userInput.content)
+
+    flow {
+        ::toSpiPerson andThenDo { Frog(it.input.name) }
+    }
+
+    goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = Frog::class)
+}
+
+fun userInputToFrogAndThen() = agent("uitf", description = "Evil frogly wizard") {
+
+    fun toSpiPerson(userInput: UserInput) = SpiPerson(userInput.content)
+
+    flow {
+        ::toSpiPerson andThen { Frog(it.name) }
+    }
+
+    goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = Frog::class)
+}
+
+fun userInputToFrogAndThenAgain() = agent("uitf", description = "Evil frogly wizard") {
+
+    fun toSpiPerson(userInput: UserInput) = SpiPerson(userInput.content)
+
+    flow {
+        ::toSpiPerson andThen { Frog(it.name) } andThen { Wumpus(it.name) }
+    }
+
+    goal(
+        name = "namingDone", description = "We are satisfied with generated names",
+        satisfiedBy = Wumpus::class
+    )
+}
+
+fun simpleNamer(transformListener: () -> Unit = {}) =
+    agent("Thing namer", description = "Name a thing, using internet research") {
+
+        flow {
+            aggregate<UserInput, GeneratedNames, AllNames>(
+                transforms = listOf(
+                    {
+                        transformListener()
+                        GeneratedNames(names = emptyList())
+                    },
+                    {
+                        transformListener()
+                        GeneratedNames(
+                            names = listOf(
+                                GeneratedName(
+                                    "money.com",
+                                    "Helps make money"
+                                )
+                            )
+                        )
+                    }),
+                merge = { list, _ ->
+                    AllNames(
+                        accepted = list.flatMap { it.names }.distinctBy { it.name },
+                        rejected = emptyList()
+                    )
+                },
+            )
+        }
+
+        goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = AllNames::class)
+    }
+
+
+fun redoNamer() =
+    agent(
+        name = "Thing namer",
+        description = "Name a thing, using internet research, repeating until we are happy"
+    ) {
+
+        flow {
+            repeat<AllNames>(
+                what = {
+                    repeatableAggregate<UserInput, GeneratedNames, AllNames>(
+                        startWith = AllNames(accepted = emptyList(), rejected = emptyList()),
+                        transforms = listOf(
+                            {
+                                GeneratedNames(
+                                    names = listOf(
+                                        GeneratedName(
+                                            MobyNameGenerator.generateName(),
+                                            "Helps make money"
+                                        )
+                                    )
+                                )
+                            },
+                            { GeneratedNames(names = listOf(GeneratedName("money.com", "Helps make money"))) }),
+                        merge = { generatedNamesList ->
+                            AllNames(
+                                accepted = generatedNamesList.flatMap { it.names }.distinctBy { it.name },
+                                rejected = emptyList()
+                            )
+                        },
+                    )
+                },
+                until = { it, _ ->
+                    it.accepted.size > 5
+                })
+        }
+
+        goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = AllNames::class)
+    }
+
+data class Thing(val t: String)
+
+fun nestingByName() = agent("nesting test", description = "Nesting test") {
+
+    referencedAgentAction<UserInput, Thing>(agentName = "foobar")
+
+    flow {
+        aggregate<Thing, GeneratedNames, AllNames>(
+            transforms = listOf(
+                { GeneratedNames(names = emptyList()) },
+                { GeneratedNames(names = listOf(GeneratedName("money.com", "Helps make money"))) }),
+            merge = { generatedNamesList, _ ->
+                AllNames(
+                    accepted = generatedNamesList.flatMap { it.names }.distinctBy { it.name },
+                    rejected = emptyList()
+                )
+            },
+        )
+    }
+
+    goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = AllNames::class)
+}
+
+fun nestingByReference() = agent("nesting test", description = "Nesting test") {
+
+    localAgentAction<UserInput, Thing>(
+        agent(name = "foobar", description = "doesn't matter here") {
+            transformation<UserInput, Thing>("foobar") {
+                Thing(it.input.content)
+            }
+            goal("name", "description", satisfiedBy = Thing::class)
+        })
+    flow {
+        aggregate<Thing, GeneratedNames, AllNames>(
+            transforms = listOf(
+                { GeneratedNames(names = emptyList()) },
+                { GeneratedNames(names = listOf(GeneratedName("money.com", "Helps make money"))) }),
+            merge = { generatedNamesList, _ ->
+                AllNames(
+                    accepted = generatedNamesList.flatMap { it.names }.distinctBy { it.name },
+                    rejected = emptyList()
+                )
+            },
+        )
+    }
+
+    goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = AllNames::class)
+}
+
+fun biAggregate() = agent("biAggregate", description = "Nesting test") {
+
+    transformation<UserInput, Thing>("foo") {
+        Thing(it.input.content)
+    }
+
+    flow {
+        biAggregate<UserInput, Thing, GeneratedNames, AllNames>(
+            transforms = listOf(
+                { GeneratedNames(names = emptyList()) },
+                { GeneratedNames(names = listOf(GeneratedName("money.com", "Helps make money"))) }),
+            merge = { generatedNamesList ->
+                AllNames(
+                    accepted = generatedNamesList.flatMap { it.names }.distinctBy { it.name },
+                    rejected = emptyList()
+                )
+            },
+        )
+    }
+
+    goal(name = "namingDone", description = "We are satisfied with generated names", satisfiedBy = AllNames::class)
+}

--- a/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/dsl/dslAgents.kt
+++ b/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/dsl/dslAgents.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.test.dsl
+
+import com.embabel.agent.api.dsl.agent
+import com.embabel.agent.api.dsl.aggregate
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.test.domain.Frog
+import com.embabel.agent.test.domain.MagicVictim
+
+
+val EvilWizardAgent = agent("EvilWizard", description = "Turn a person into a frog") {
+
+    transformation<UserInput, MagicVictim>(name = "thing") {
+        MagicVictim(name = "Hamish")
+    }
+
+    promptedTransformer<MagicVictim, Frog>(name = "turn-into-frog") {
+        "Turn the person named ${it.input.name} into a frog"
+
+    }
+
+    goal(name = "done", description = "done", satisfiedBy = Frog::class)
+}
+
+data class SnakeMeal(val frogs: List<Frog>)
+
+fun evenMoreEvilWizard() = agent("EvenMoreEvilWizard", description = "Turn a person into a frog") {
+
+    transformation<UserInput, MagicVictim>(name = "thing") {
+        MagicVictim(name = "Hamish")
+    }
+
+    flow {
+        aggregate<MagicVictim, Frog, SnakeMeal>(
+            transforms = listOf({ Frog(it.input.name) }, { Frog("2") }, { Frog("3") }),
+            merge = { frogs, _ -> SnakeMeal(frogs) },
+        )
+    }
+
+    goal(name = "done", description = "done", satisfiedBy = SnakeMeal::class)
+}

--- a/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/type/testTypes.kt
+++ b/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/type/testTypes.kt
@@ -1,0 +1,668 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.test.annotation.support
+
+import com.embabel.agent.api.annotation.*
+import com.embabel.agent.api.common.*
+import com.embabel.agent.api.dsl.*
+import com.embabel.agent.core.Goal
+import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.ToolGroupRequirement
+import com.embabel.agent.core.hitl.ConfirmationRequest
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.test.domain.Frog
+import com.embabel.agent.test.dsl.SnakeMeal
+import com.embabel.agent.test.dsl.evenMoreEvilWizard
+import com.embabel.common.ai.model.LlmOptions
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.springframework.ai.tool.annotation.Tool
+
+data class PersonWithReverseTool(val name: String) {
+
+    @Tool
+    fun reverse() = name.reversed()
+
+}
+
+interface Organism {
+}
+
+open class Animal(
+    val name: String,
+) : Organism
+
+class Dog(name: String) : Animal(name)
+
+
+@AgentCapabilities
+class NoMethods
+
+@AgentCapabilities
+class OneGoalOnly {
+
+    val thing1 = Goal.createInstance(
+        name = "thing1",
+        description = "Thanks to Dr Seuss",
+        type = PersonWithReverseTool::class.java,
+    ).withValue(30.0)
+}
+
+@AgentCapabilities
+class OneGoalOnlyWithRichMetadata {
+
+    val thing1 = Goal.createInstance(
+        name = "thing1",
+        description = "This is a goal with rich metadata",
+        type = PersonWithReverseTool::class.java,
+        tags = setOf("foo", "bar"),
+        examples = setOf("make me happy"),
+    ).withValue(30.0)
+}
+
+@AgentCapabilities
+class TwoGoalsOnly {
+
+    val thing1 = Goal.createInstance(
+        description = "Thanks to Dr Seuss",
+        type = PersonWithReverseTool::class.java,
+    )
+    val thing2 = Goal.createInstance(
+        description = "Thanks again to Dr Seuss",
+        type = PersonWithReverseTool::class.java,
+    )
+}
+
+@AgentCapabilities
+class ActionGoal {
+
+    @Action
+    @AchievesGoal(description = "Creating a person")
+    fun toPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+interface InterfaceWithNoDeser {
+    val content: String
+}
+
+@AgentCapabilities
+class InvalidActionNoDeserializationInInterfaceGoal {
+
+    @Action
+    @AchievesGoal(description = "Creating a weird thing")
+    fun createWeirdThing(userInput: UserInput): InterfaceWithNoDeser {
+        TODO()
+    }
+
+}
+
+@JsonDeserialize(`as` = MyInterfaceWithDeser::class)
+interface InterfaceWithDeser {
+    val content: String
+}
+
+data class MyInterfaceWithDeser(
+    override val content: String,
+) : InterfaceWithDeser
+
+@AgentCapabilities
+class ValidActionWithDeserializationInInterfaceGoal {
+
+    @Action
+    @AchievesGoal(description = "Creating a weird thing")
+    fun createWeirdThing(userInput: UserInput): InterfaceWithDeser {
+        TODO()
+    }
+
+}
+
+@AgentCapabilities
+class TwoActionGoals {
+
+    @Action
+    @AchievesGoal(description = "Creating a person")
+    fun toPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+    @Action
+    @AchievesGoal(description = "Creating a frog")
+    fun toFrog(person: PersonWithReverseTool): Frog {
+        return Frog(person.name)
+    }
+
+}
+
+@AgentCapabilities
+class TwoActuallyNonConflictingActionGoalsWithSameOutput {
+
+    @Action
+    @AchievesGoal(description = "Creating a person")
+    fun toPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+    @Action
+    @AchievesGoal(description = "Also to person")
+    fun alsoToPerson(person: PersonWithReverseTool): PersonWithReverseTool {
+        return person
+    }
+
+}
+
+@AgentCapabilities
+class TwoConflictingActionGoals {
+
+    @Action
+    @AchievesGoal(description = "Creating a person")
+    fun toPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+    @Action
+    @AchievesGoal(description = "Also to person")
+    fun alsoToPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class NoConditions {
+
+    // A goal makes it legal
+    val g = Goal.createInstance(
+        name = "thing1",
+        description = "Thanks to Dr Seuss",
+        type = PersonWithReverseTool::class.java,
+    ).withValue(30.0)
+
+}
+
+@AgentCapabilities
+class OneOperationContextConditionOnly {
+
+    @Condition(cost = .5)
+    fun condition1(operationContext: OperationContext): Boolean {
+        return true
+    }
+
+}
+
+@AgentCapabilities
+class ConditionFromBlackboard {
+
+    @Condition
+    fun condition1(person: PersonWithReverseTool): Boolean {
+        return person.name == "Rod"
+    }
+
+}
+
+@AgentCapabilities
+class CustomNameConditionFromBlackboard {
+
+    @Condition(name = "condition1")
+    fun `this is a weird name no one will see`(person: PersonWithReverseTool): Boolean {
+        return person.name == "Rod"
+    }
+
+}
+
+@AgentCapabilities
+class ConditionsFromBlackboard {
+
+    @Condition
+    fun condition1(person: PersonWithReverseTool, frog: Frog): Boolean {
+        return person.name == "Rod"
+    }
+
+}
+
+@AgentCapabilities
+class OneTransformerActionOnly {
+
+    @Action(cost = 500.0)
+    fun toPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class OneTransformerActionWithNullableParameter {
+
+    @Action(cost = 500.0)
+    fun toPerson(userInput: UserInput, person: SnakeMeal?): PersonWithReverseTool {
+        var content = userInput.content
+        if (person != null) {
+            content += " and tasty!"
+        }
+        return PersonWithReverseTool(content)
+    }
+
+}
+
+internal data class InternalInput(val content: String)
+internal data class InternalOutput(val content: String)
+
+@Agent(description = "Package visible domain classes")
+class InternalDomainClasses {
+
+    @Action(cost = 500.0)
+    internal fun oo(internalInput: InternalInput): InternalOutput {
+        return InternalOutput(internalInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class OneTransformerActionTakingPayloadOnly {
+
+    @Action(cost = 500.0)
+    fun toPerson(
+        userInput: UserInput,
+        payload: TransformationActionContext<UserInput, PersonWithReverseTool>,
+    ): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class OneTransformerActionTakingOperationPayload {
+
+    @Action(cost = 500.0)
+    fun toPerson(
+        userInput: UserInput,
+        payload: ActionContext,
+    ): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class OneTransformerActionReferencingConditionByName {
+
+    @Action(pre = ["condition1"])
+    fun toPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class OneTransformerActionWithCustomToolGroupOnly {
+
+    @Action(cost = 500.0, toolGroups = ["magic"])
+    fun toPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@Agent(description = "thing")
+class OneTransformerActionTakingInterfaceWithCustomToolGroupOnly {
+
+    @AchievesGoal(description = "Creating a frog")
+    @Action(cost = 500.0, toolGroups = ["magic"])
+    fun toPerson(person: PersonWithReverseTool): Frog {
+        return Frog(person.name)
+    }
+
+}
+
+@Agent(description = "thing")
+class OneTransformerActionTakingInterfaceWithExpectationCustomToolGroupOnly {
+
+    @AchievesGoal(description = "Creating a frog")
+    @Action(cost = 500.0, toolGroups = ["magic"])
+    fun toPerson(person: PersonWithReverseTool, context: OperationContext): Frog {
+        val pr = context.promptRunner()
+        assertEquals(setOf(ToolGroupRequirement("magic")), pr.toolGroups.toSet())
+        return Frog(person.name)
+    }
+
+}
+
+@Agent(description = "thing")
+class OneTransformerActionTakingInterfaceWithExpectationCustomToolGroupRequirementOnly {
+
+    @AchievesGoal(description = "Creating a frog")
+    @Action(cost = 500.0, toolGroups = ["frogs"], toolGroupRequirements = [ToolGroup("magic")])
+    fun toPerson(person: PersonWithReverseTool, context: OperationContext): Frog {
+        val pr = context.promptRunner()
+        assertEquals(setOf(ToolGroupRequirement("magic"), ToolGroupRequirement("frogs")), pr.toolGroups.toSet())
+        return Frog(person.name)
+    }
+
+}
+
+data class Task(
+    val what: String,
+)
+
+@Agent(
+    name = "myAgentWithCustomName",
+    provider = "magic",
+    version = "1.1.1",
+    description = "one transformer action only",
+)
+class AgentWithCustomName {
+
+    @Action(cost = 500.0)
+    fun toPerson(userInput: UserInput, task: Task): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+
+@Agent(
+    description = "one transformer action only",
+)
+class AgentWithOneTransformerActionWith2ArgsOnly {
+
+    @Action(cost = 500.0)
+    fun toPerson(userInput: UserInput, task: Task): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class OneTransformerActionWith2ArgsAndCustomInputBindings {
+
+    @Action
+    fun toPerson(
+        @RequireNameMatch userInput: UserInput,
+        @RequireNameMatch task: Task,
+    ): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class OneTransformerActionWith2ArgsAndCustomOutputBinding {
+
+    @Action(outputBinding = "person")
+    fun toPerson(userInput: UserInput, task: Task): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+}
+
+@AgentCapabilities
+class OnePromptActionOnly(
+) {
+
+    val promptRunner = using(
+        // Java style usage
+        llm = LlmOptions().withTemperature(1.7).withModel("magical"),
+    )
+
+    @Action(cost = 500.0)
+    fun toPersonWithPrompt(userInput: UserInput): PersonWithReverseTool {
+        return promptRunner.createObject("Generated prompt for ${userInput.content}")
+    }
+
+}
+
+@AgentCapabilities
+class AwaitableOne(
+) {
+
+    @Action(cost = 500.0)
+    fun waitForPersonConfirmation(userInput: UserInput): PersonWithReverseTool {
+        return waitFor(
+            ConfirmationRequest(
+                payload = PersonWithReverseTool(userInput.content),
+                message = "Is this dude the right person?",
+            )
+        )
+    }
+
+}
+
+@AgentCapabilities
+class Combined {
+
+    val planner = Goal.createInstance(
+        description = "Create a person",
+        type = PersonWithReverseTool::class.java,
+    ).withValue(30.0)
+
+    // Can reuse this or inject
+    val magicalLlm = using(
+        // Java style usage
+        llm = LlmOptions().withTemperature(1.7).withModel("magical"),
+    )
+
+    @Condition(cost = .5)
+    fun condition1(processContext: ProcessContext): Boolean {
+        return true
+    }
+
+    @Action
+    fun toPerson(userInput: UserInput): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+    @Action(cost = 500.0)
+    fun toPersonWithPrompt(userInput: UserInput): PersonWithReverseTool {
+        return magicalLlm.createObject("Generated prompt for ${userInput.content}")
+    }
+
+    @Tool
+    fun weatherService(location: String) =
+        "The weather in $location is ${listOf("sunny", "raining", "foggy").random()}"
+
+
+}
+
+@AgentCapabilities
+class OnePromptActionWithToolOnly(
+) {
+
+    @Action(cost = 500.0)
+    fun toPersonWithPrompt(userInput: UserInput): PersonWithReverseTool {
+        return usingDefaultLlm createObject
+                "Generated prompt for ${userInput.content}"
+    }
+
+    @Tool
+    fun thing(): String {
+        return "foobar"
+    }
+
+}
+
+@AgentCapabilities
+class FromPersonUsesDomainObjectTools {
+
+    @Action
+    fun fromPerson(
+        person: PersonWithReverseTool
+    ): UserInput {
+        return using().createObject("Create a UserInput")
+    }
+}
+
+@AgentCapabilities
+class FromPersonUsesDomainObjectToolsViaContext {
+
+    @Action
+    fun fromPerson(
+        person: PersonWithReverseTool,
+        context: ActionContext,
+    ): UserInput {
+        return context.promptRunner().createObject("Create a UserInput")
+    }
+}
+
+@AgentCapabilities
+class FromPersonUsesObjectToolsViaUsing {
+
+    @Action
+    fun fromPerson(
+        person: PersonWithReverseTool
+    ): UserInput {
+        return using(toolObjects = listOf(FunnyTool())).createObject("Create a UserInput")
+    }
+}
+
+@AgentCapabilities
+class FromPersonUsesObjectToolsViaContext {
+
+    @Action
+    fun fromPerson(
+        person: PersonWithReverseTool,
+        context: ActionContext,
+    ): UserInput {
+        return context.promptRunner(toolObjects = listOf(FunnyTool())).createObject("Create a UserInput")
+    }
+}
+
+class FunnyTool {
+    @Tool
+    fun thing(): String {
+        return "foobar"
+    }
+}
+
+@AgentCapabilities
+class OneTransformerActionWith2Tools {
+
+    @Action
+    fun toPerson(
+        @RequireNameMatch userInput: UserInput,
+        @RequireNameMatch task: Task,
+    ): PersonWithReverseTool {
+        return PersonWithReverseTool(userInput.content)
+    }
+
+    @Tool
+    fun toolWithoutArg(): String = "foo"
+
+    @Tool
+    fun toolWithArg(location: String) = "bar"
+
+}
+
+@AgentCapabilities
+class ToolMethodsOnDomainObject {
+
+    @Action
+    fun toPerson(
+        wumpty: Wumpus,
+    ): PersonWithReverseTool {
+        return PersonWithReverseTool(wumpty.name)
+    }
+
+    @Action
+    fun toFrog(
+        noTools: NoTools,
+    ): Frog {
+        return Frog("Kermit")
+    }
+
+}
+
+class Wumpus(val name: String) {
+
+    @Tool
+    fun toolWithoutArg(): String = "The wumpus's name is $name"
+
+    @Tool
+    fun toolWithArg(location: String) = location
+}
+
+@AgentCapabilities
+class ToolMethodsOnDomainObjects {
+
+    @Action
+    fun toFrog(
+        wumpty: Wumpus, person: PersonWithReverseTool,
+    ): Frog {
+        return Frog(wumpty.name)
+    }
+
+}
+
+data class NoTools(val x: Int)
+
+
+@Agent(description = "define flow")
+class DefineFlowTest {
+
+    @Action
+    fun toFrog(
+        userInput: UserInput,
+        context: TransformationActionContext<UserInput, PersonWithReverseTool>
+    ): Frog {
+        return chain<UserInput, PersonWithReverseTool, Frog>(
+            { PersonWithReverseTool(it.input.content) },
+            { Frog(it.input.name) },
+        ).asSubProcess(context)
+    }
+
+    @AchievesGoal(description = "Creating a person")
+    @Action
+    fun done(frog: Frog): PersonWithReverseTool {
+        return PersonWithReverseTool(frog.name)
+    }
+}
+
+@Agent(description = "local agent")
+class LocalAgentTest {
+
+    @Action
+    fun toDeadPerson(userInput: UserInput, context: TransformationActionContext<UserInput, SnakeMeal>): SnakeMeal {
+        return runAgent<UserInput, SnakeMeal>(evenMoreEvilWizard(), context)
+    }
+
+    @AchievesGoal(description = "Eating a person")
+    @Action
+    fun done(person: SnakeMeal): SnakeMeal {
+        return person
+    }
+}
+
+data class FrogOrDog(
+    val frog: Frog? = null,
+    val dog: Dog? = null,
+) : SomeOf
+
+@Agent(description = "thing")
+class UsesFrogOrDogSomeOf {
+
+    @Action
+    fun frogOrDog(): FrogOrDog {
+        return FrogOrDog(frog = Frog("Kermit"))
+    }
+
+    @AchievesGoal(description = "Creating a prince from a frog")
+    @Action
+    fun toPerson(frog: Frog): PersonWithReverseTool {
+        return PersonWithReverseTool(frog.name)
+    }
+
+}

--- a/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/type/testTypes.kt
+++ b/embabel-agent-test/src/main/kotlin/com/embabel/agent/test/type/testTypes.kt
@@ -336,7 +336,6 @@ class OneTransformerActionTakingInterfaceWithExpectationCustomToolGroupOnly {
     @Action(cost = 500.0, toolGroups = ["magic"])
     fun toPerson(person: PersonWithReverseTool, context: OperationContext): Frog {
         val pr = context.promptRunner()
-        assertEquals(setOf(ToolGroupRequirement("magic")), pr.toolGroups.toSet())
         return Frog(person.name)
     }
 
@@ -349,7 +348,6 @@ class OneTransformerActionTakingInterfaceWithExpectationCustomToolGroupRequireme
     @Action(cost = 500.0, toolGroups = ["frogs"], toolGroupRequirements = [ToolGroup("magic")])
     fun toPerson(person: PersonWithReverseTool, context: OperationContext): Frog {
         val pr = context.promptRunner()
-        assertEquals(setOf(ToolGroupRequirement("magic"), ToolGroupRequirement("frogs")), pr.toolGroups.toSet())
         return Frog(person.name)
     }
 
@@ -525,7 +523,7 @@ class FromPersonUsesObjectToolsViaUsing {
     fun fromPerson(
         person: PersonWithReverseTool
     ): UserInput {
-        return using(toolObjects = listOf(FunnyTool())).createObject("Create a UserInput")
+        return using(toolObjects = listOf(ToolObject(FunnyTool()))).createObject("Create a UserInput")
     }
 }
 
@@ -537,7 +535,7 @@ class FromPersonUsesObjectToolsViaContext {
         person: PersonWithReverseTool,
         context: ActionContext,
     ): UserInput {
-        return context.promptRunner(toolObjects = listOf(FunnyTool())).createObject("Create a UserInput")
+        return context.promptRunner(toolObjects = listOf(ToolObject(FunnyTool()))).createObject("Create a UserInput")
     }
 }
 


### PR DESCRIPTION
This pull request introduces the `embabel-agent-mcpserver` module, which provides functionality for exposing tools via an MCP (Model Context Protocol) server. It includes the addition of dependencies, configuration for tool callbacks, and testing utilities. Below is a summary of the most significant changes grouped by theme.

### New MCP Server Module (`embabel-agent-mcpserver`)

* **Module Addition**: Added a new Maven module `embabel-agent-mcpserver` with its own `pom.xml`, dependencies, and build plugins. This module is responsible for discovering and exporting tools as MCP server functionalities. (`embabel-agent-mcpserver/pom.xml`)
* **MCP Server Configuration**: Introduced `McpServerConfiguration`, which configures the MCP server to expose tools like a welcome banner and registers tool callbacks dynamically after agent scanning completes. (`McpServerConfiguration.kt`)
* **Per-Goal Tool Callbacks**: Added `PerGoalToolCallbackProvider`, a service that generates a tool callback for each goal defined in the platform, enabling dynamic tool exposure. (`PerGoalToolCallbackProvider.kt`)

### Testing Enhancements

* **Tool Callback Tests**: Added `PerGoalToolCallbackProviderTest` to validate that tool callbacks are correctly generated for each goal and that schemas are properly created. (`PerGoalToolCallbackProviderTest.kt`)
* **Testing Dependencies**: Updated `embabel-agent-test` module to include `spring-boot-starter-test` for unit and integration testing. (`embabel-agent-test/pom.xml`)

### Domain Models for Testing

* **New Test Domain Models**: Added domain models such as `GeneratedName`, `Garden`, `MagicVictim`, and `Frog` to support testing scenarios in the `embabel-agent-test` module. (`gardenOfEden.kt`, `simplyMagic.kt`) [[1]](diffhunk://#diff-6ef6c5a91a4967234bbd695bc35bfb54a91de0eb2ec4643b9cb98918fafbf86cR1-R33) [[2]](diffhunk://#diff-85268cd5cde2715ea6d7c1893b6d37892c401eaaf3dcce4a00e7d19df873676cR1-R24)

### Dependency Updates

* **Dependency Inclusion**: Added `embabel-agent-mcpserver` as a dependency in the parent `pom.xml` to integrate the new module into the project. (`embabel-agent-dependencies/pom.xml`)