### PR TITLE
Add embabel-agent-ux and embabel-agent-a2a modules.

### DIFF
--- a/embabel-agent-a2a/pom.xml
+++ b/embabel-agent-a2a/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-a2a</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel A2A</name>
+    <description>Embabel Agent To Agent Protocol</description>
+
+    <dependencies>
+        <!-- Main Dependencies -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/embabel-agent-a2a/src/main/kotlin/com/embabel/agent/a2a/.gitkeep
+++ b/embabel-agent-a2a/src/main/kotlin/com/embabel/agent/a2a/.gitkeep
@@ -1,0 +1,1 @@
+ECHO is on.

--- a/embabel-agent-a2a/src/main/resources/.gitkeep
+++ b/embabel-agent-a2a/src/main/resources/.gitkeep
@@ -1,0 +1,1 @@
+ECHO is on.

--- a/embabel-agent-a2a/src/tests/kotlin/com/embabel/agent/a2a/.gitkeep
+++ b/embabel-agent-a2a/src/tests/kotlin/com/embabel/agent/a2a/.gitkeep
@@ -1,0 +1,1 @@
+ECHO is on.

--- a/embabel-agent-a2a/src/tests/resources/.gitkeep
+++ b/embabel-agent-a2a/src/tests/resources/.gitkeep
@@ -1,0 +1,1 @@
+ECHO is on.

--- a/embabel-agent-ux/pom.xml
+++ b/embabel-agent-ux/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-parent</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-ux</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent UI UX</name>
+    <description>Embabel Agent Web Components</description>
+
+    <dependencies>
+        <!-- Main Dependencies -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/embabel-agent-ux/src/main/kotlin/com/embabel/agent/ux/.gitkeep
+++ b/embabel-agent-ux/src/main/kotlin/com/embabel/agent/ux/.gitkeep
@@ -1,0 +1,1 @@
+ECHO is on.

--- a/embabel-agent-ux/src/main/resources/.gitkeep
+++ b/embabel-agent-ux/src/main/resources/.gitkeep
@@ -1,0 +1,1 @@
+ECHO is on.

--- a/embabel-agent-ux/src/tests/kotlin/com/embabel/agent/ux/.gitkeep
+++ b/embabel-agent-ux/src/tests/kotlin/com/embabel/agent/ux/.gitkeep
@@ -1,0 +1,1 @@
+ECHO is on.

--- a/embabel-agent-ux/src/tests/resources/.gitkeep
+++ b/embabel-agent-ux/src/tests/resources/.gitkeep
@@ -1,0 +1,1 @@
+ECHO is on.


### PR DESCRIPTION
This pull request introduces two new Maven modules, `embabel-agent-a2a` and `embabel-agent-ux`, along with their respective project structures. The most significant changes include the addition of `pom.xml` files for both modules and the creation of `.gitkeep` files to establish the directory structure.

### Addition of Maven Modules:

* [`embabel-agent-a2a/pom.xml`](diffhunk://#diff-d6cba7ad69a2b8311836cc61ca5b1d7a6c8ede204b236d165134938974b17ab6R1-R44): Added a `pom.xml` file to define the `embabel-agent-a2a` module, including dependencies (`embabel-agent-api`, `embabel-agent-test`) and build plugins (`kotlin-maven-plugin`, `maven-surefire-plugin`).
* [`embabel-agent-ux/pom.xml`](diffhunk://#diff-b26615d698adf4c5a1bf7cfb2fd6fad10e2cb4aa350c0a27c8c54b30f30b574dR1-R44): Added a `pom.xml` file to define the `embabel-agent-ux` module, including dependencies (`embabel-agent-api`, `embabel-agent-test`) and build plugins (`kotlin-maven-plugin`, `maven-surefire-plugin`).

### Project Structure Initialization:

* `.gitkeep` files: Added `.gitkeep` files in the `src/main/kotlin`, `src/main/resources`, `src/tests/kotlin`, and `src/tests/resources` directories for both `embabel-agent-a2a` and `embabel-agent-ux` modules to ensure the directory structure is committed to the repository.