### PR TITLE
Exclude embabel-shell-module from cpd check.

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,15 @@
+# Path to sources
+#sonar.sources=.
+#sonar.exclusions=
+#sonar.inclusions=
+
+# Path to tests
+#sonar.tests=
+#sonar.test.exclusions=
+#sonar.test.inclusions=
+
+# Source encoding
+#sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+sonar.cpd.exclusions=**/embabel-agent-shell/**


### PR DESCRIPTION
This pull request introduces a configuration update for SonarCloud analysis by adding a `.sonarcloud.properties` file. The most important change is the exclusion of files in the `embabel-agent-shell` directory from copy-paste detection.

SonarCloud configuration updates:

* [`.sonarcloud.properties`](diffhunk://#diff-679bb064ac2db7c8eab53b5a396d88ac78ebe2444f7d180bfcc0dc0df7b2152cR1-R15): Added a new file to configure SonarCloud analysis, including specifying the exclusion of `**/embabel-agent-shell/**` from copy-paste detection.