### PR TITLE
Update Docker usage

### DIFF
--- a/embabel-agent-api/src/main/resources/application-docker-desktop.yml
+++ b/embabel-agent-api/src/main/resources/application-docker-desktop.yml
@@ -9,13 +9,9 @@ spring:
         request-timeout: 30s
         type: SYNC
 
-        stdio:
+        sse:
           connections:
-            # MCP server exposed by Docker Desktop MCP Toolkit extension
-            # Add --verbose to the args to enable verbose logging
-            docker-mcp:
-              command: docker
-              args:
-                - mcp
-                - gateway
-                - run
+            local:
+              # Allow the DOCKER_MCP environment variable to override the default URL
+              url: ${DOCKER_MCP:http://localhost:9011}
+


### PR DESCRIPTION
Update Docker usage to what I believe is current best practice.

This will be inherited by default by all projects that set `docker-desktop` profile or `McpServers.DOCKER_DESKTOP` in annotations.