### PR TITLE
Upgrade to Spring AI 1.0.0

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -108,6 +108,11 @@
         <!-- https://mvnrepository.com/artifact/org.springframework.ai/spring-ai-vector-store -->
         <dependency>
             <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-client-chat</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-vector-store</artifactId>
         </dependency>
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/SelfToolCallbackPublisher.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/SelfToolCallbackPublisher.kt
@@ -18,8 +18,8 @@ package com.embabel.agent.api.common.support
 import com.embabel.agent.core.*
 import com.embabel.common.core.types.AssetCoordinates
 import com.embabel.common.core.types.Semver
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.ToolCallback
-import org.springframework.ai.tool.ToolCallbacks
 
 /**
  * Convenient interface a class can implement to publish @Tool

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/BedrockModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/BedrockModels.kt
@@ -176,8 +176,8 @@ class BedrockModels(
                 credentialsProvider,
                 regionProvider.region,
                 ModelOptionsUtils.OBJECT_MAPPER,
-                connectionProperties.timeout
-            )
+                connectionProperties.timeout,
+            ),  observationRegistry.getIfUnique { ObservationRegistry.NOOP}
         ).withInputType(bedrockTitanEmbeddingProperties.inputType),
         provider = PROVIDER,
     )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/springAiUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/springAiUtils.kt
@@ -16,8 +16,8 @@
 package com.embabel.agent.core.support
 
 import com.embabel.agent.api.common.ToolObject
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.ToolCallback
-import org.springframework.ai.tool.ToolCallbacks
 import org.springframework.ai.tool.definition.DefaultToolDefinition
 import org.springframework.ai.tool.definition.ToolDefinition
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/experimental/d/ToolGroupExposerKtTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/experimental/d/ToolGroupExposerKtTest.kt
@@ -20,7 +20,7 @@ import com.embabel.agent.experimental.dsl.exposeAsInterface
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.springframework.ai.tool.ToolCallbacks
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.annotation.Tool
 import kotlin.test.assertEquals
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -45,7 +45,7 @@ import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.DefaultChatOptions
 import org.springframework.ai.chat.prompt.Prompt
 import org.springframework.ai.model.tool.ToolCallingChatOptions
-import org.springframework.ai.tool.ToolCallbacks
+import org.springframework.ai.support.ToolCallbacks
 import java.time.LocalDate
 import kotlin.test.assertEquals
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolDecoratorsKtTest.kt
@@ -26,7 +26,7 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.springframework.ai.tool.ToolCallbacks
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.annotation.Tool
 
 class SimpleTools {

--- a/embabel-agent-eval/pom.xml
+++ b/embabel-agent-eval/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-client-chat</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-neo4j</artifactId>
         </dependency>


### PR DESCRIPTION
This pull request introduces dependency updates and code adjustments to integrate the `spring-ai-client-chat` library and refactor imports for `ToolCallbacks`. Additionally, it includes a minor change to the `BedrockModels` configuration to support observation registries.

### Dependency Updates:
* Added the `spring-ai-client-chat` dependency to `embabel-agent-api/pom.xml` and `embabel-agent-eval/pom.xml` to enable chat client functionality. [[1]](diffhunk://#diff-c161fccae45bca8f24d2ba5c90f64d55eb224d566485532dbf0d4abf7109d034R109-R113) [[2]](diffhunk://#diff-2b64a4488eca14ff91f45c005ca5190d872ccafe459b02ae442ae47b83d4a2bfR27-R31)

### Refactoring Imports:
* Updated import statements across multiple files to use `org.springframework.ai.support.ToolCallbacks` instead of `org.springframework.ai.tool.ToolCallbacks`. This change aligns with the updated package structure. [[1]](diffhunk://#diff-a75c29869e13c242b33eaf2a24fd17e7e77824ac7ce907983757fce3def67851R21-L22) [[2]](diffhunk://#diff-d5a68f3145511ab6db9943d6dd5064d671ee9be83a354caf0848269ac7ec476aR19-L20) [[3]](diffhunk://#diff-e4e268c6f399b945bece9104a5d94a4e93d21658e1c716ac6aa2c0b3a1e95560L23-R23) [[4]](diffhunk://#diff-bf29d55ce0e64fc95e602952f20dcc99f6b82aedb04dcc3baf0c82b96cbb7300L48-R48) [[5]](diffhunk://#diff-62dcaa4550cad628af5d444a1912216451a6740a8466acbb3dc5a7175248fad2L29-R29)

### Configuration Updates:
* Modified the `BedrockModels` class to include an observation registry (`ObservationRegistry.NOOP`) for better observability support.