### PR TITLE
Add support for MCP prompts

### DIFF
--- a/embabel-agent-api/src/main/java/com/embabel/agent/api/annotation/AchievesGoal.java
+++ b/embabel-agent-api/src/main/java/com/embabel/agent/api/annotation/AchievesGoal.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation that can be added to an @Action method
+ * to indicate that its execution achieves a goal
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AchievesGoal {
+
+    /**
+     * Description of the goal. The name will be auto-generated
+     */
+    String description();
+
+    /**
+     * Value of achieving the goal
+     */
+    double value() default 0.0;
+
+    /**
+     * Set of tags describing classes or capabilities for this goal.
+     * Example: ["cooking", "customer support", "billing"]
+     */
+    String[] tags() default {};
+
+    /**
+     * Set of example scenarios that the goal can achieve.
+     * Example: ["I need a recipe for bread", "I want to support a customer with a billing issue"]
+     */
+    String[] examples() default {};
+
+    /**
+     * Any starting input types for the goal we might want to prompt for
+     */
+    // This annotation is implemented in Java because the following is impossible in Kotlin:
+    Class<?>[] startingInputTypes() default {};
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/annotations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/annotations.kt
@@ -143,25 +143,6 @@ annotation class Action(
     val toolGroupRequirements: Array<ToolGroup> = [],
 )
 
-/**
- * Annotation that can be added to an @Action method
- * to indicate that its execution achieves a goal
- * @param description description of the goal. The name will be auto-generated
- * @param value value of achieving the goal
- * @param tags set of tags describing classes or capabilities for this goal.
- *   example: ["cooking", "customer support", "billing"]
- * @param examples set of example scenarios that the goal can achieve.
- *   example: ["I need a recipe for bread", "I want to support a customer with a billing issue"]
- */
-@Target(AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.RUNTIME)
-@MustBeDocumented
-annotation class AchievesGoal(
-    val description: String,
-    val value: Double = 0.0,
-    val tags: Array<String> = [],
-    val examples: Array<String> = [],
-)
 
 /**
  * Annotation that can added to parameters of an @Action method

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -365,10 +365,7 @@ class AgentMetadataReader(
         instance: Any,
     ): AgentCoreGoal? {
         val actionAnnotation = method.getAnnotation(Action::class.java)
-        val goalAnnotation = method.getAnnotation(AchievesGoal::class.java)
-        if (goalAnnotation == null) {
-            return null
-        }
+        val goalAnnotation = method.getAnnotation(AchievesGoal::class.java) ?: return null
         val inputBinding = IoBinding(
             name = actionAnnotation.outputBinding,
             type = method.returnType.name,
@@ -380,6 +377,7 @@ class AgentMetadataReader(
             value = goalAnnotation.value,
             // Add precondition of the action having run
             pre = setOf(Rerun.hasRunCondition(action)) + action.preconditions.keys.toSet(),
+            startingInputTypes = goalAnnotation.startingInputTypes.map { it.java }.toSet(),
         )
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
@@ -133,10 +133,9 @@ internal class DefaultActionMethodManager(
                     if (lastArg == null) {
                         val kParam = kFunction?.parameters?.firstOrNull { kfp -> kfp.name == parameter.name }
                         val isNullable =
-                            kParam?.isOptional ?: kParam?.type?.isMarkedNullable
-                            ?: false
-                        if (isNullable) {
-                            error("Action ${actionContext.action.name}: No value found in blackboard for parameter ${parameter.name}:${parameter.type.name}")
+                            (kParam?.isOptional == true) || (kParam?.type?.isMarkedNullable == true)
+                        if (!isNullable) {
+                            error("Action ${actionContext.action.name}: Internal error. No value found in blackboard for non-nullable parameter ${parameter.name}:${parameter.type.name}")
                         }
                     }
                     args += lastArg

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/Goal.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/Goal.kt
@@ -33,6 +33,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore
  * @param examples The set of example scenarios that the skill can perform.
  * Will be used by the client as a hint to understand how the skill can be used.
  *  example: ["I need a recipe for bread"]
+ *  @param startingInputTypes input types that we can prompt the user from to get to this goal.
+ *  Useful for MCP prompts. A Goal may not know all possible input types, but
+ *  it is still useful to be able to specify some of them.
  */
 data class Goal(
     override val name: String,
@@ -42,6 +45,7 @@ data class Goal(
     override val value: ZeroToOne = 0.0,
     val tags: Set<String> = emptySet(),
     val examples: Set<String> = emptySet(),
+    val startingInputTypes: Set<Class<*>> = emptySet(),
 ) : GoapGoal, AgentSystemStep {
 
     // These methods are for Java, to obviate the builder antipattern

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpPromptFactory.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpPromptFactory.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import com.embabel.common.core.types.Described
+import com.embabel.common.core.types.Named
+import com.embabel.common.core.types.Timestamped
+import com.embabel.common.util.NameUtils
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import io.modelcontextprotocol.server.McpServerFeatures
+import io.modelcontextprotocol.spec.McpSchema
+import org.springframework.util.ReflectionUtils.doWithFields
+import java.lang.reflect.Method
+
+/**
+ * Create Prompt specifications for the MCP server.
+ * @param excludedInterfaces Set of interfaces whose fields should be excluded from the prompt arguments.
+ */
+class McpPromptFactory(
+    val excludedInterfaces: Set<Class<*>> = setOf(
+        Timestamped::class.java,
+    )
+) {
+
+    /**
+     * Creates a synchronous prompt specification for a given type.
+     * @param goal The goal for which the prompt is created.
+     * @param inputType The class type of the
+     * @param inputType The class type of the input for the prompt.
+     * @param name The name of the prompt if we want to customize it
+     * @param description A description of the prompt if we want to customize it
+     */
+    fun <G> syncPromptSpecificationForType(
+        goal: G,
+        inputType: Class<*>,
+        name: String = goal.name,
+        description: String = goal.description,
+    ): McpServerFeatures.SyncPromptSpecification where G : Named, G : Described {
+        return McpServerFeatures.SyncPromptSpecification(
+            McpSchema.Prompt(
+                name,
+                description,
+                argumentsFromType(inputType),
+            )
+        ) { syncServerExchange, getPromptRequest ->
+            McpSchema.GetPromptResult(
+                "$name-result",
+                listOf(
+                    McpSchema.PromptMessage(
+                        McpSchema.Role.USER,
+                        McpSchema.TextContent(
+                            """
+                            Use the following information to achieve goal ${goal.name}" - <${goal.description}>:
+                            ${
+                                getPromptRequest.arguments.entries.joinToString(separator = "\n") { "${it.key}=${it.value}" }
+                            }
+                        """.trimIndent()
+                        )
+                    )
+                ),
+            )
+        }
+    }
+
+    /**
+     * Extracts MCP prompt arguments from a given type,
+     * excluding fields that match methods in the excluded interfaces.
+     */
+    internal fun argumentsFromType(type: Class<*>): List<McpSchema.PromptArgument> {
+        val excludedFields: Iterable<Method> = excludedInterfaces.flatMap {
+            it.methods.toList()
+        }
+        val args = mutableListOf<McpSchema.PromptArgument>()
+        doWithFields(type) { field ->
+            if (field.isSynthetic) {
+                return@doWithFields
+            }
+            if (excludedFields.any { NameUtils.beanMethodToPropertyName(it.name) == field.name }) {
+                return@doWithFields
+            }
+            val name = field.name
+            val description = field.getAnnotation(JsonPropertyDescription::class.java)?.value ?: name
+            val descriptionWithType = "$description: ${field.type.simpleName}"
+            args.add(McpSchema.PromptArgument(name, descriptionWithType, true))
+        }
+        return args
+    }
+}

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/PerGoalStartingInputTypesPromptPublisher.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/PerGoalStartingInputTypesPromptPublisher.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import com.embabel.agent.api.common.autonomy.Autonomy
+import com.embabel.agent.core.Goal
+import io.modelcontextprotocol.server.McpServerFeatures
+import org.springframework.stereotype.Service
+
+@Service
+class PerGoalStartingInputTypesPromptPublisher(
+    private val autonomy: Autonomy,
+) : McpPromptPublisher {
+
+    override fun prompts(): List<McpServerFeatures.SyncPromptSpecification> {
+        return autonomy.agentPlatform.goals.flatMap { goal ->
+            promptsForGoal(goal)
+        }
+    }
+
+    fun promptsForGoal(goal: Goal): List<McpServerFeatures.SyncPromptSpecification> {
+        val mcpPromptFactory = McpPromptFactory()
+        return goal.startingInputTypes.map { inputType ->
+            mcpPromptFactory.syncPromptSpecificationForType(
+                goal = goal,
+                inputType,
+            )
+        }
+    }
+
+    override fun infoString(verbose: Boolean?): String {
+        return "PerGoalStartingInputTypesPromptPublisher(prompts=${prompts().size})"
+    }
+
+}

--- a/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpPromptFactoryTest.kt
+++ b/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpPromptFactoryTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.common.core.types.Described
+import com.embabel.common.core.types.Named
+import io.mockk.mockk
+import io.modelcontextprotocol.spec.McpSchema
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class McpPromptFactoryTest {
+
+    @Test
+    fun noArgs() {
+        class EmptyChild
+
+        val factory = McpPromptFactory()
+        val spec = factory.syncPromptSpecificationForType(
+            NamedAndDescribed("EmptyChild", "A child with no arguments"),
+            EmptyChild::class.java,
+        )
+        assertTrue(
+            spec.prompt.arguments.isEmpty(),
+            "Expected no arguments for EmptyChild, but got: ${spec.prompt.arguments}"
+        )
+    }
+
+    @Test
+    fun oneArg() {
+        val factory = McpPromptFactory()
+        val goal = NamedAndDescribed("oneArg", "A class with one argument")
+        val spec = factory.syncPromptSpecificationForType(
+            goal,
+            UserInput::class.java,
+        )
+        assertEquals(
+            spec.prompt.arguments.size,
+            1,
+            "Expected 1 argument for UserInput, but got: ${spec.prompt.arguments}"
+        )
+        assertEquals(
+            setOf("content"), spec.prompt.arguments.map { it.name }.toSet(),
+            "Expected argument 'content' for UserInput, but got: ${spec.prompt.arguments.map { it.name }}",
+        )
+        val p = spec.promptHandler.apply(mockk(), McpSchema.GetPromptRequest("oneArg", mapOf("content" to "test")))
+        assertEquals(1, p.messages.size)
+        val m = p.messages.first()
+        assertEquals(McpSchema.Role.USER, m.role)
+        val tc = m.content as McpSchema.TextContent
+        assertTrue(
+            tc.text.contains(goal.name),
+            "Expected message content to contain goal name, but got: ${m.content}"
+        )
+        assertTrue(
+            tc.text.contains(goal.description),
+            "Expected message content to contain goal description, but got: ${m.content}"
+        )
+        assertTrue(
+            tc.text.contains("test"),
+            "Expected message content to contain 'test', but got: ${m.content}"
+        )
+    }
+
+}
+
+
+data class NamedAndDescribed(override val name: String, override val description: String) : Named, Described


### PR DESCRIPTION
Fixes #609 

Requires moving `@AchievesGoal` annotation to Java as Kotlin does not support an array of Java `Class` in annotations.

Also fixes a bug in handling of nullable parameters to `@Action` methods.