### PR TITLE
revert change to mcp gateway config

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,9 +367,8 @@ Optional:
 
 ### Services
 
-You will need Docker Desktop with the Docker MCP extension installed for
-Docker MCP tools such as web search tools. Be sure to activate
-the following tools from the catalog:
+You will need a Docker Desktop version [`>4.43.2`](https://docs.docker.com/desktop/release-notes/).
+Be sure to activate the following MCP tools from the catalog:
 
 - Brave Search
 - Fetch

--- a/embabel-agent-api/src/main/resources/application-docker-desktop.yml
+++ b/embabel-agent-api/src/main/resources/application-docker-desktop.yml
@@ -9,9 +9,13 @@ spring:
         request-timeout: 30s
         type: SYNC
 
-        sse:
+        stdio:
           connections:
-            local:
-              # Allow the DOCKER_MCP environment variable to override the default URL
-              url: ${DOCKER_MCP:http://localhost:9011}
-
+            # MCP server exposed by Docker Desktop MCP Toolkit extension
+            # Add --verbose to the args to enable verbose logging
+            docker-mcp:
+              command: docker
+              args:
+                - mcp
+                - gateway
+                - run


### PR DESCRIPTION
docker mcp gateway run is still the right default config

The issue we were seeing was a bug in Docker Desktop.  The issue is fixed in Docker version 4.43.2