### PR TITLE
Start of HITL support for MCP

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/AgentProcessExecution.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/AgentProcessExecution.kt
@@ -51,6 +51,13 @@ class AgentProcessExecution private constructor(
 
     companion object {
 
+        @Throws(
+            ProcessExecutionException::class,
+            ProcessExecutionStuckException::class,
+            ProcessExecutionFailedException::class,
+            ProcessWaitingException::class,
+            ProcessExecutionTerminatedException::class,
+        )
         @Suppress("UNCHECKED_CAST")
         fun fromProcessStatus(
             basis: Any,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/Autonomy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/Autonomy.kt
@@ -58,6 +58,8 @@ class Autonomy(
     val properties: AutonomyProperties,
 ) {
 
+    private val logger = loggerFor<Autonomy>()
+
     private val eventListener = agentPlatform.platformServices.eventListener
 
     /**
@@ -158,7 +160,7 @@ class Autonomy(
             throw NoAgentFound(agentRankings = agentRankings, basis = userInput)
         }
 
-        loggerFor<AgentPlatform>().debug(
+        logger.debug(
             "Agent choice {} with confidence {} for user intent {}: Choices were {}",
             agentChoice.match.name,
             agentChoice.score,
@@ -264,7 +266,7 @@ class Autonomy(
             throw NoGoalFound(goalRankings = goalRankings, basis = userInput)
         }
 
-        loggerFor<AgentPlatform>().debug(
+        logger.debug(
             "Goal choice {} with confidence {} for user intent {}: Choices were {}",
             goalChoice.match.name,
             goalChoice.score,
@@ -309,25 +311,38 @@ class Autonomy(
         return GoalSeeker(agent = goalAgent, rankings = goalRankings)
     }
 
+    /**
+     * Create an agent to accomplish this goal from the given user input
+     * @param userInput
+     * @param agentScope scope to look for the agent
+     * @param goal the goal to accomplish
+     * @param prune whether to prune the agent to only relevant actions
+     */
     fun createGoalAgent(
         userInput: UserInput,
         agentScope: AgentScope,
-        goal: Goal
+        goal: Goal,
+        prune: Boolean = true,
     ): Agent {
-        return agentScope.createAgent(
+        val agent = agentScope.createAgent(
             name = "goal-${goal.name}",
             provider = Constants.EMBABEL_PROVIDER,
             description = goal.description,
         )
             .withSingleGoal(goal)
-            .prune(userInput)
+
+        return if (prune) {
+            agent.prune(userInput)
+        } else {
+            agent
+        }
     }
 
     /**
      * Agent with only relevant actions
      */
     private fun Agent.prune(userInput: UserInput): Agent {
-        loggerFor<Autonomy>().debug(
+        logger.debug(
             "Raw agent: {}",
             infoString(),
         )
@@ -335,17 +350,19 @@ class Autonomy(
         for (condition in this.planningSystem.knownConditions()) {
             map[condition] = ConditionDetermination.FALSE
         }
-        loggerFor<Autonomy>().info("Pruning agent instance from {}", map)
+        logger.info("Pruning agent instance from {}", map)
         map += ("it:${userInput::class.qualifiedName}" to ConditionDetermination.TRUE)
 
         val planner = AStarGoapPlanner(
-            WorldStateDeterminer.fromMap(
-                map
-            ),
+            WorldStateDeterminer.fromMap(map),
         )
+
         val pruned = planner.prune(planningSystem)
-        loggerFor<Autonomy>().info(
-            "Pruned planning system: {}",
+        val prunedActions = planningSystem.actions.subtract(pruned.actions)
+        logger.info(
+            "Pruned planning system removed {} actions - {}: \n\t{}",
+            prunedActions.size,
+            prunedActions.map { it.name },
             pruned.infoString(),
         )
         return pruneTo(pruned)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/MultiTransformationAction.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/MultiTransformationAction.kt
@@ -137,6 +137,10 @@ class MultiTransformationAction<O : Any>(
             fields
         }
     }
+
+    override fun toString(): String {
+        return "${javaClass.simpleName}: name=$name"
+    }
 }
 
 private fun calculateOutputs(outputVarName: String?, outputClass: Class<*>): Set<IoBinding> {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/TransformationAction.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/TransformationAction.kt
@@ -90,6 +90,9 @@ open class TransformationAction<I, O>(
             fields
         }
     }
+
+    override fun toString() =
+        "${javaClass.simpleName}: name=$name"
 }
 
 /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/Awaitable.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/Awaitable.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.core.hitl
 
-import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.AgentProcess
 import com.embabel.common.core.StableIdentified
 import com.embabel.common.core.types.HasInfoString
 import com.embabel.common.core.types.Timestamped
@@ -35,7 +35,7 @@ interface Awaitable<P : Any, R : AwaitableResponse> : StableIdentified, Timestam
      */
     fun onResponse(
         response: R,
-        processContext: ProcessContext,
+        agentProcess: AgentProcess,
     ): ResponseImpact
 
     override fun infoString(verbose: Boolean?): String {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/ConfirmationRequest.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/ConfirmationRequest.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.core.hitl
 
-import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.AgentProcess
 import com.embabel.common.util.loggerFor
 import java.time.Instant
 import java.util.*
@@ -35,7 +35,7 @@ class ConfirmationRequest<P : Any>(
 
     override fun onResponse(
         response: ConfirmationResponse,
-        processContext: ProcessContext,
+        agentProcess: AgentProcess,
     ): ResponseImpact {
 
         return if (response.accepted) {
@@ -43,7 +43,7 @@ class ConfirmationRequest<P : Any>(
                 "Accepted confirmation request. Promoting payload to blackboard: {}",
                 payload,
             )
-            processContext.blackboard += payload
+            agentProcess += payload
             ResponseImpact.UPDATED
         } else {
             loggerFor<ConfirmationRequest<*>>().info("Rejected confirmation request: {}", payload)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/FormBindingRequest.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/FormBindingRequest.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.core.hitl
 
-import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.AgentProcess
 import com.embabel.common.util.loggerFor
 import com.embabel.ux.form.DefaultFormProcessor
 import com.embabel.ux.form.Form
@@ -27,6 +27,7 @@ import java.util.*
 /**
  * Present the user with a form
  * and bind it to the given class
+ * @param O the class to bind the form submission to
  */
 class FormBindingRequest<O : Any>(
     form: Form,
@@ -39,7 +40,7 @@ class FormBindingRequest<O : Any>(
 
     override fun onResponse(
         response: FormResponse,
-        processContext: ProcessContext,
+        agentProcess: AgentProcess,
     ): ResponseImpact {
         val formSubmissionResult = DefaultFormProcessor().processSubmission(payload, response.formSubmission)
         if (!formSubmissionResult.valid) {
@@ -49,7 +50,7 @@ class FormBindingRequest<O : Any>(
         val boundInstance = formBinder.bind(formSubmissionResult)
         loggerFor<FormBindingRequest<*>>()
             .info("Bound form submission to {}", boundInstance)
-        processContext.blackboard += boundInstance
+        agentProcess += boundInstance
         return ResponseImpact.UPDATED
     }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/FormBindingRequest.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/FormBindingRequest.kt
@@ -38,6 +38,8 @@ class FormBindingRequest<O : Any>(
     persistent = persistent,
 ) {
 
+    private val logger = loggerFor<FormBindingRequest<O>>()
+
     override fun onResponse(
         response: FormResponse,
         agentProcess: AgentProcess,
@@ -48,8 +50,11 @@ class FormBindingRequest<O : Any>(
         }
         val formBinder = FormBinder(outputClass)
         val boundInstance = formBinder.bind(formSubmissionResult)
-        loggerFor<FormBindingRequest<*>>()
-            .info("Bound form submission to {}", boundInstance)
+        return bind(boundInstance, agentProcess)
+    }
+
+    fun bind(boundInstance: O, agentProcess: AgentProcess): ResponseImpact {
+        logger.info("Bound form submission to {}", boundInstance)
         agentProcess += boundInstance
         return ResponseImpact.UPDATED
     }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/LlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/LlmOperations.kt
@@ -59,7 +59,17 @@ interface LlmCall : LlmUse, ToolConsumer {
     val contextualPromptContributors: List<ContextualPromptElement>
 
     companion object {
-        operator fun invoke(): LlmCall = LlmCallImpl(name = MobyNameGenerator.generateName())
+
+        operator fun invoke(llm: LlmOptions? = null): LlmCall = LlmCallImpl(
+            llm = llm,
+            name = MobyNameGenerator.generateName(),
+        )
+
+        @JvmStatic
+        fun using(
+            llm: LlmOptions,
+        ): LlmCall = invoke(llm = llm)
+
     }
 }
 
@@ -101,6 +111,8 @@ data class LlmInteraction(
     override val name: String = id.value
 
     companion object {
+
+        @JvmStatic
         fun from(llm: LlmCall, id: InteractionId) = LlmInteraction(
             id = id,
             llm = llm.llm ?: LlmOptions(),
@@ -108,6 +120,12 @@ data class LlmInteraction(
             toolGroups = llm.toolGroups,
             promptContributors = llm.promptContributors,
             generateExamples = llm.generateExamples,
+        )
+
+        @JvmStatic
+        fun using(llm: LlmOptions) = from(
+            llm = LlmCall.using(llm),
+            id = InteractionId("using"),
         )
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/plan/goap/OptimizingGoapPlanner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/plan/goap/OptimizingGoapPlanner.kt
@@ -65,8 +65,9 @@ abstract class OptimizingGoapPlanner(
     override fun prune(planningSystem: GoapPlanningSystem): GoapPlanningSystem {
         val allPlans = plansToGoals(planningSystem)
         loggerFor<OptimizingGoapPlanner>().info(
-            "Plans to consider in pruning: {}",
-            allPlans.joinToString("\n") { it.infoString(false) }
+            "{} plans to consider in pruning:\n\t{}",
+            allPlans.size,
+            allPlans.joinToString("\n\t") { it.infoString(false) }
         )
         return planningSystem.copy(
             actions = planningSystem.actions.filter { action ->

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpSyncServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpSyncServerConfiguration.kt
@@ -130,7 +130,7 @@ class McpSyncServerConfiguration(
         val mcpToolExportCallbackPublishers =
             applicationContext.getBeansOfType(McpToolExportCallbackPublisher::class.java).values.toList()
         val allToolCallbacks = mcpToolExportCallbackPublishers.flatMap { it.toolCallbacks }
-        val separator = "~".repeat(BANNER_WIDTH)
+        val separator = "~ MCP " + "~".repeat(BANNER_WIDTH - 6)
         logger.info(
             "\n${separator}\n{} MCP tool exporters: {}\nExposing a total of {} MCP server tools:\n\t{}\n${separator}",
             mcpToolExportCallbackPublishers.size,

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/support/PerGoalToolCallbackProvider.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/support/PerGoalToolCallbackProvider.kt
@@ -15,25 +15,35 @@
  */
 package com.embabel.agent.mcpserver.support
 
+import com.embabel.agent.api.common.autonomy.AgentProcessExecution
 import com.embabel.agent.api.common.autonomy.Autonomy
 import com.embabel.agent.api.common.autonomy.ProcessWaitingException
 import com.embabel.agent.core.Goal
 import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.core.Verbosity
 import com.embabel.agent.core.hitl.FormBindingRequest
+import com.embabel.agent.core.hitl.ResponseImpact
 import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.domain.library.HasContent
 import com.embabel.agent.mcpserver.McpToolExportCallbackPublisher
+import com.embabel.agent.spi.LlmInteraction
+import com.embabel.agent.spi.LlmOperations
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.ModelSelectionCriteria
 import com.embabel.common.core.types.HasInfoString
 import com.embabel.common.util.loggerFor
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.modelcontextprotocol.server.McpSyncServerExchange
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.model.ToolContext
+import org.springframework.ai.support.ToolCallbacks
 import org.springframework.ai.tool.ToolCallback
+import org.springframework.ai.tool.annotation.Tool
 import org.springframework.ai.tool.definition.ToolDefinition
 import org.springframework.ai.util.json.schema.JsonSchemaGenerator
 import org.springframework.stereotype.Service
+
+const val FORM_SUBMIT_TOOL_NAME = "submitFormAndResumeProcess"
 
 /**
  * Return a tool callback for each goal.
@@ -43,112 +53,157 @@ import org.springframework.stereotype.Service
 class PerGoalToolCallbackProvider(
     private val autonomy: Autonomy,
     private val objectMapper: ObjectMapper,
+    private val llmOperations: LlmOperations,
 ) : McpToolExportCallbackPublisher {
+
+    private val logger = LoggerFactory.getLogger(PerGoalToolCallbackProvider::class.java)
 
     override val toolCallbacks: List<ToolCallback>
         get() {
             return autonomy.agentPlatform.goals.map { goal ->
                 toolForGoal(goal)
-            }
+            } + ToolCallbacks.from(this)
         }
+
+    @Tool(
+        name = FORM_SUBMIT_TOOL_NAME,
+        description = "Resume a process by providing the process ID and form content",
+    )
+    fun submitFormAndResumeProcess(
+        processId: String,
+        formData: String,
+    ): String {
+        val agentProcess = autonomy.agentPlatform.getAgentProcess(processId)
+            ?: return "No process found with ID $processId"
+        logger.info("Received AgentProcess {} form input: {}", processId, formData)
+        val formBindingRequest = agentProcess.lastResult() as? FormBindingRequest<Any>
+            ?: return "No form binding request found for process $processId"
+        val prompt = """
+            Given the content below, return the given object
+
+            # Content
+            $formData
+        """.trimIndent()
+        val formDataObject = llmOperations.doTransform(
+            prompt = prompt,
+            LlmInteraction.using(LlmOptions(criteria = ModelSelectionCriteria.Auto)),
+            outputClass = formBindingRequest.outputClass,
+            null,
+        )
+        val responseImpact = formBindingRequest.bind(
+            boundInstance = formDataObject,
+            agentProcess
+        )
+        if (responseImpact != ResponseImpact.UPDATED) {
+            TODO("Handle unchanged response impact")
+        }
+        // Resume the agent process with the form data
+        agentProcess.run()
+        val dp = AgentProcessExecution.fromProcessStatus(formData, agentProcess)
+        return toResponseString(dp)
+    }
+
+    private fun toResponseString(agentProcessExecution: AgentProcessExecution): String {
+        return when (val output = agentProcessExecution.output) {
+            is String -> output
+            is HasInfoString -> {
+                output.infoString(verbose = true)
+            }
+
+            is HasContent -> output.content
+            else -> output.toString()
+        }
+    }
 
     /**
      * Create a tool callback for the given goal.
      */
     fun toolForGoal(goal: Goal): ToolCallback {
-        return GoalToolCallback(goal, autonomy, objectMapper)
+        return GoalToolCallback(goal)
     }
 
     override fun infoString(verbose: Boolean?): String {
         return "${javaClass.name} with ${toolCallbacks.size} tools"
     }
-}
 
-/**
- * Spring AI ToolCallback implementation for a specific goal.
- */
-internal class GoalToolCallback(
-    private val goal: Goal,
-    private val autonomy: Autonomy,
-    private val objectMapper: ObjectMapper,
-) : ToolCallback {
 
-    private val logger = LoggerFactory.getLogger(javaClass)
+    /**
+     * Spring AI ToolCallback implementation for a specific goal.
+     */
+    internal inner class GoalToolCallback(
+        private val goal: Goal,
+    ) : ToolCallback {
 
-    override fun getToolDefinition(): ToolDefinition {
-        return object : ToolDefinition {
-            override fun name(): String {
-                val parts: List<String> = goal.name.split(".")
-                return parts.takeLast(2).joinToString("_")
-            }
-
-            override fun description(): String {
-                return goal.description
-            }
-
-            override fun inputSchema(): String {
-                val js = JsonSchemaGenerator.generateForType(UserInput::class.java)
-                loggerFor<PerGoalToolCallbackProvider>().debug("Generated schema for ${goal.name}: $js")
-                return js
-            }
-        }
-    }
-
-    override fun call(
-        toolInput: String,
-    ): String {
-        return call(toolInput, null)
-    }
-
-    override fun call(
-        toolInput: String,
-        toolContext: ToolContext?,
-    ): String {
-        val exchange = toolContext?.context["exchange"] as? McpSyncServerExchange
-        val verbosity = Verbosity(
-            showPrompts = true,
-        )
-        val userInput = objectMapper.readValue(toolInput, UserInput::class.java)
-        val processOptions = ProcessOptions(verbosity = verbosity)
-        val agent = autonomy.createGoalAgent(
-            userInput = userInput,
-            goal = goal,
-            agentScope = autonomy.agentPlatform,
-            // TODO Bug workaround
-            prune = false,
-        )
-        try {
-            val dynamicExecutionResult = autonomy.runAgent(
-                userInput = UserInput(toolInput),
-                processOptions = processOptions,
-                agent = agent,
-            )
-            logger.info("Goal response: {}", dynamicExecutionResult)
-
-            return when (val output = dynamicExecutionResult.output) {
-                is String -> output
-                is HasInfoString -> {
-                    output.infoString(verbose = true)
+        override fun getToolDefinition(): ToolDefinition {
+            return object : ToolDefinition {
+                override fun name(): String {
+                    val parts: List<String> = goal.name.split(".")
+                    return parts.takeLast(2).joinToString("_")
                 }
 
-                is HasContent -> output.content
-                else -> output.toString()
+                override fun description(): String {
+                    return goal.description
+                }
+
+                override fun inputSchema(): String {
+                    val js = JsonSchemaGenerator.generateForType(UserInput::class.java)
+                    loggerFor<PerGoalToolCallbackProvider>().debug("Generated schema for ${goal.name}: $js")
+                    return js
+                }
             }
-        } catch (pwe: ProcessWaitingException) {
+        }
+
+        override fun call(
+            toolInput: String,
+        ): String {
+            return call(toolInput, null)
+        }
+
+        override fun call(
+            toolInput: String,
+            toolContext: ToolContext?,
+        ): String {
+            val exchange = toolContext?.context["exchange"] as? McpSyncServerExchange
+            val verbosity = Verbosity(
+                showPrompts = true,
+            )
+            val userInput = objectMapper.readValue(toolInput, UserInput::class.java)
+            val processOptions = ProcessOptions(verbosity = verbosity)
+            val agent = autonomy.createGoalAgent(
+                userInput = userInput,
+                goal = goal,
+                agentScope = autonomy.agentPlatform,
+                // TODO Bug workaround
+                prune = false,
+            )
+            try {
+                val agentProcessExecution = autonomy.runAgent(
+                    userInput = UserInput(toolInput),
+                    processOptions = processOptions,
+                    agent = agent,
+                )
+                logger.info("Goal response: {}", agentProcessExecution)
+                return toResponseString(agentProcessExecution)
+            } catch (pwe: ProcessWaitingException) {
 //            require(exchange != null) {
 //                "ProcessWaitingException requires an exchange to handle waiting for user input."
 //            }
 //            exchange.createMessage()
-            val formBindingRequest = pwe.awaitable as FormBindingRequest<*>
-            val response = """
-                You must invoke the 'continue' tool to proceed with the goal "${goal.name}".
+                val formBindingRequest = pwe.awaitable as FormBindingRequest<*>
+                val response = """
+                You must invoke the $FORM_SUBMIT_TOOL_NAME tool to proceed with the goal "${goal.name}".
                 The arguments will be
-                processId: ${pwe.agentProcess!!.id},
-                You must provide the following structure:
+                - processId: ${pwe.agentProcess!!.id},
+                - formData: English text describing the form data to submit. See below
+
+                Before invoking this, you must obtain information from the user
+                as described in this form structure.
                 ${formBindingRequest.toString()}
             """.trimIndent()
-            logger.info("Returning waiting response:\n$response")
-            return response
+                logger.info("Returning waiting response:\n$response")
+                return response
+            }
         }
+
     }
 }

--- a/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProviderTest.kt
+++ b/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/PerGoalToolCallbackProviderTest.kt
@@ -23,6 +23,7 @@ import com.embabel.agent.test.dsl.userInputToFrogOrPersonBranch
 import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyAgentPlatform
 import com.embabel.agent.testing.integration.RandomRanker
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.mockk.mockk
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -37,7 +38,7 @@ class PerGoalToolCallbackProviderTest {
         agentPlatform.deploy(userInputToFrogOrPersonBranch())
         val autonomy = Autonomy(agentPlatform, RandomRanker(), AutonomyProperties())
 
-        val provider = PerGoalToolCallbackProvider(autonomy, jacksonObjectMapper())
+        val provider = PerGoalToolCallbackProvider(autonomy, jacksonObjectMapper(), mockk())
 
         val toolCallbacks = provider.toolCallbacks
 

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt
@@ -21,6 +21,7 @@ import com.embabel.agent.core.*
 import com.embabel.agent.event.logging.LoggingPersonality
 import com.embabel.agent.event.logging.personality.ColorPalette
 import com.embabel.agent.rag.Ingester
+import com.embabel.agent.shell.config.ShellProperties
 import com.embabel.chat.agent.shell.LastMessageIntentAgentPlatformChatSession
 import com.embabel.common.ai.model.ModelProvider
 import com.embabel.common.util.bold
@@ -28,7 +29,6 @@ import com.embabel.common.util.color
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.Logger
 import org.springframework.boot.SpringApplication
-import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.shell.standard.ShellComponent
@@ -36,7 +36,6 @@ import org.springframework.shell.standard.ShellMethod
 import org.springframework.shell.standard.ShellOption
 import java.util.concurrent.CompletableFuture
 import kotlin.system.exitProcess
-import com.embabel.agent.shell.config.ShellProperties
 
 /**
  * Shell configuration for the shell module (duplicate of API's ShellConfig for independence)
@@ -150,7 +149,11 @@ class ShellCommands(
     fun agents(): String {
         return "${"Agents:".bold()}\n${
             agentPlatform.agents()
-                .joinToString(separator = "\n${"-".repeat(shellProperties.lineLength)}\n") { "\t" + it.infoString(verbose = true) }
+                .joinToString(separator = "\n${"-".repeat(shellProperties.lineLength)}\n") {
+                    "\t" + it.infoString(
+                        verbose = true
+                    )
+                }
         }"
     }
 
@@ -486,7 +489,7 @@ class ShellCommands(
             }
             pwe.awaitable.onResponse(
                 response = awaitableResponse,
-                processContext = pwe.agentProcess!!.processContext
+                agentProcess = pwe.agentProcess!!,
             )
             return runProcess(verbosity, basis) {
                 AgentProcessExecution.fromProcessStatus(

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/TerminalServices.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/TerminalServices.kt
@@ -120,7 +120,7 @@ class TerminalServices(
 
     private fun confirmationResponseFromUserInput(
         confirmationRequest: ConfirmationRequest<*>,
-    ): ConfirmationResponse? {
+    ): ConfirmationResponse {
         val confirmed = confirm(confirmationRequest.message)
         return ConfirmationResponse(
             awaitableId = confirmationRequest.id,

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/chat/agent/shell/LastMessageIntentAgentPlatformChatSession.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/chat/agent/shell/LastMessageIntentAgentPlatformChatSession.kt
@@ -15,11 +15,16 @@
  */
 package com.embabel.chat.agent.shell
 
-import com.embabel.agent.api.common.autonomy.*
+import com.embabel.agent.api.common.autonomy.AgentProcessExecution
+import com.embabel.agent.api.common.autonomy.Autonomy
+import com.embabel.agent.api.common.autonomy.GoalChoiceApprover
+import com.embabel.agent.api.common.autonomy.ProcessWaitingException
 import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.shell.TerminalServices
 import com.embabel.agent.shell.config.ShellProperties
-import com.embabel.chat.*
+import com.embabel.chat.AgenticResultAssistantMessage
+import com.embabel.chat.AssistantMessage
+import com.embabel.chat.MessageListener
 import com.embabel.chat.agent.AgentPlatformChatSession
 
 /**
@@ -45,7 +50,7 @@ class LastMessageIntentAgentPlatformChatSession(
         }
         pwe.awaitable.onResponse(
             response = awaitableResponse,
-            processContext = pwe.agentProcess!!.processContext
+            agentProcess = pwe.agentProcess!!,
         )
         try {
             val agentProcess = pwe.agentProcess!!


### PR DESCRIPTION
Also 

- Works around a bug in planner pruning
- Improves logging of `Autonomy` operations
- Improves `Action` implementations `toString` methods for clarity
- Simplifies use of `LlmOperations`
- Changes form binding signatures to use `AgentProcess` instead of `ProcessContext`

