### PR TITLE
Enable Jacoco Report.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
This pull request introduces a small change to the `pom.xml` file. It adds the `jacoco-maven-plugin` to the build plugins section, enabling code coverage analysis.