### PR TITLE
Supress AWS Warning. Need to revisit AutoConfiguration seutp.

### DIFF
--- a/embabel-agent-api/src/main/resources/application.yml
+++ b/embabel-agent-api/src/main/resources/application.yml
@@ -68,3 +68,7 @@ logging:
     com.embabel.agent.spi.support.LlmRanker: INFO
     com.embabel.agent.spi.support.com.embabel.agent.spi.support.springai.ChatClientLlmOperations: INFO
 
+    # Suppress AWS Bedrock warnings until Autoconfiguration Issue is resolved.
+    org.springframework.ai.bedrock: ERROR
+    software.amazon.awssdk: ERROR
+


### PR DESCRIPTION
This pull request introduces a small but important configuration update to the logging settings in the `application.yml` file. The change suppresses warnings from AWS Bedrock and the AWS SDK by setting their logging levels to `ERROR`, ensuring cleaner logs until an autoconfiguration issue is resolved.