### PR TITLE
Introduce AgentInvocation

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -179,6 +179,14 @@
             <scope>test</scope>
         </dependency>
 
+<!--        TODO: move to proper place-->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.18.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/AgentInvocation.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/AgentInvocation.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.common.autonomy
+
+import com.embabel.agent.core.Agent
+import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.core.ProcessOptions
+import java.util.concurrent.CompletableFuture
+import java.util.function.Consumer
+
+
+/**
+ * Defines the contract for invoking an agent.
+ *
+ * Default instances are created with [AgentInvocation.Companion.create];
+ * [AgentInvocation.Companion.builder] allows for customization of the invocation
+ * before creation.
+ * Once created, [invoke] or [invokeAsync] is used to invoke the agent.
+ *
+ * @param T type of result returned by the invocation
+ */
+interface AgentInvocation<T> {
+
+    /**
+     * Invokes the agent with one or more arguments.
+     *
+     * @param obj the first (and possibly only) input value to be added to the blackboard
+     * @param objs additional input values to add to the blackboard
+     * @return the result of type [T] from the agent invocation
+     */
+    fun invoke(obj: Any, vararg objs: Any): T
+
+    /**
+     * Invokes the agent with a map of named inputs.
+     *
+     * @param map A [Map] that initializes the blackboard
+     * @return the result of type [T] from the agent invocation
+     */
+    fun invoke(map: Map<String, Any>): T
+
+    /**
+     * Invokes the agent asynchronously with one or more arguments.
+     *
+     * @param obj the first (and possibly only) input value to be added to the blackboard
+     * @param objs additional input values to add to the blackboard
+     * @return the result of type [T] from the agent invocation
+     */
+    fun invokeAsync(obj: Any, vararg objs: Any): CompletableFuture<T>
+
+    /**
+     * Invokes the agent asynchronously with a map of named inputs.
+     *
+     * @param map A [Map] that initializes the blackboard
+     * @return the result of type [T] from the agent invocation
+     */
+    fun invokeAsync(map: Map<String, Any>): CompletableFuture<T>
+
+    companion object {
+
+        /**
+         * Create a new [AgentInvocation] for the given platform and explicit result type.
+         *
+         * @param agentPlatform the platform in which this agent will run
+         * @param resultType the Java [Class] of the type of result the agent will return
+         * @param T type of result returned by the invocation
+         * @return a configured [AgentInvocation] that produces values of type [T]
+         */
+        @JvmStatic
+        fun <T : Any> create(agentPlatform: AgentPlatform, resultType: Class<T>): AgentInvocation<T> {
+            return builder(agentPlatform).build(resultType)
+        }
+
+        /**
+         * Create a new [AgentInvocation] for the given platform, inferring the result type
+         * from the reified type parameter.
+         *
+         * @param agentPlatform the platform or environment in which this agent will run
+         * @param T type of result returned by the invocation
+         * @return a configured [AgentInvocation] that produces values of type [T]
+         */
+        inline fun <reified T : Any> create(agentPlatform: AgentPlatform): AgentInvocation<T> {
+            return builder(agentPlatform).build()
+        }
+
+        /**
+         * Obtain a new [Builder] to customize agent settings before building.
+         *
+         * @param agentPlatform the platform or environment in which this agent will run
+         * @return a builder through which you can set processing options
+         */
+        @JvmStatic
+        fun builder(agentPlatform: AgentPlatform): Builder {
+            return Builder(agentPlatform)
+        }
+
+    }
+
+    /**
+     * Builder for configuring and creating instances of [AgentInvocation].
+     *
+     * Use this builder to set process options such as context, blackboard,
+     * verbosity, budget, and control policies before constructing the agent invocation.
+     */
+    class Builder internal constructor(
+        private val agentPlatform: AgentPlatform,
+    ) {
+
+        private var processOptions = ProcessOptions.DEFAULT
+
+        /**
+         * Set the [ProcessOptions] to use for this invocation.
+         * @param processOptions the process-level options
+         * @return this builder instance for chaining
+         */
+        fun options(processOptions: ProcessOptions): Builder {
+            this.processOptions = processOptions
+            return this
+        }
+
+        /**
+         * Begin configuring process options via a builder.
+         * @return a [ProcessOptions.Builder] for fine-grained option setup
+         */
+        fun options(consumer: Consumer<ProcessOptions.Builder>): Builder {
+            val builder = ProcessOptions.builder()
+            consumer.accept(builder)
+            this.processOptions = builder.build()
+            return this
+        }
+
+        /**
+         * Build the [AgentInvocation] with the given explicit result type.
+         * @param resultType the Java [Class] of the result type [T]
+         * @return a new [AgentInvocation] producing values of type [T]
+         */
+        fun <T : Any> build(resultType: Class<T>): AgentInvocation<T> {
+            return DefaultAgentInvocation(
+                agentPlatform = this.agentPlatform,
+                processOptions = this.processOptions,
+                resultType = resultType
+            )
+        }
+
+    }
+}
+
+
+/**
+ * Build the [AgentInvocation], inferring the result type from the reified type parameter.
+ * @param T type of result returned by the invocation
+ * @return a new [AgentInvocation] producing values of type [T]
+ */
+inline fun <reified T : Any> AgentInvocation.Builder.build(): AgentInvocation<T>  {
+    return build(T::class.java)
+}
+
+internal class DefaultAgentInvocation<T : Any> (
+    private val agentPlatform: AgentPlatform,
+    private val processOptions: ProcessOptions,
+    private val resultType: Class<T>
+): AgentInvocation<T> {
+
+    override fun invoke(obj: Any, vararg objs: Any): T {
+        return invokeAsync(obj, *objs)
+            .get()
+    }
+
+    override fun invoke(map: Map<String, Any>): T {
+        return invokeAsync(map)
+            .get()
+    }
+
+    override fun invokeAsync(obj: Any, vararg objs: Any): CompletableFuture<T> {
+        val agent = findAgentByResultType() ?: error("No agent with outputClass $resultType found.")
+        val args = arrayOf(obj, *objs)
+
+        val agentProcess = agentPlatform.createAgentProcessFrom(
+            agent = agent,
+            processOptions = processOptions,
+            *args
+        )
+        return agentPlatform.start(agentProcess)
+            .thenApply { it.last(resultType) }
+    }
+
+    override fun invokeAsync(map: Map<String, Any>): CompletableFuture<T> {
+        val agent = findAgentByResultType() ?: error("No agent with outputClass $resultType found.")
+
+        val agentProcess = agentPlatform.createAgentProcess(
+            agent = agent,
+            processOptions,
+            bindings = map
+        )
+        return agentPlatform.start(agentProcess)
+            .thenApply { it.last(resultType) }
+    }
+
+
+    private fun findAgentByResultType(): Agent? =
+        agentPlatform.agents().find { agent ->
+            agent.goals.any { goal ->
+                goal.outputClass?.let(resultType::isAssignableFrom) ?: false
+            }
+        }
+
+}

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/common/autonomy/AgentInvocationJavaTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/common/autonomy/AgentInvocationJavaTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.common.autonomy;
+
+import com.embabel.agent.core.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AgentInvocationJavaTest {
+
+    private final AgentPlatform agentPlatform = mock(AgentPlatform.class);
+
+    private final Agent agent = mock(Agent.class);
+
+    private final AgentProcess agentProcess = mock(AgentProcess.class);
+
+    @Test
+    public void defaultVarargsInvocation() {
+        Foo foo = new Foo();
+        Bar expected = new Bar();
+        Goal goal = Goal.createInstance("Test goal", Bar.class);
+        AgentInvocation<Bar> invocation =
+                AgentInvocation.create(agentPlatform, Bar.class);
+
+        when(agentPlatform.agents()).thenReturn(List.of(agent));
+        when(agent.getGoals()).thenReturn(Set.of(goal));
+        when(agentPlatform.createAgentProcessFrom(
+                eq(agent),
+                any(ProcessOptions.class),
+                eq(foo)
+        )).thenReturn(agentProcess);
+        when(agentPlatform.start(agentProcess))
+                .thenReturn(CompletableFuture.completedFuture(agentProcess));
+        when(agentProcess.last(Bar.class))
+                .thenReturn(expected);
+
+        Bar actual = invocation.invoke(foo);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void defaultMapInvocation() {
+        Foo foo = new Foo();
+        Map<String, Object> bindings = Map.of("id", foo);
+        Bar expected = new Bar();
+        Goal goal = Goal.createInstance("Test goal", Bar.class);
+        AgentInvocation<Bar> invocation =
+                AgentInvocation.create(agentPlatform, Bar.class);
+
+        when(agentPlatform.agents()).thenReturn(List.of(agent));
+        when(agent.getGoals()).thenReturn(Set.of(goal));
+        when(agentPlatform.createAgentProcess(
+                eq(agent),
+                any(ProcessOptions.class),
+                eq(bindings)
+        )).thenReturn(agentProcess);
+        when(agentPlatform.start(agentProcess))
+                .thenReturn(CompletableFuture.completedFuture(agentProcess));
+        when(agentProcess.last(Bar.class))
+                .thenReturn(expected);
+
+        Bar actual = invocation.invoke(bindings);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void customProcessingOptions() {
+        Goal goal = Goal.createInstance("Test goal", Bar.class);
+        AgentInvocation<Bar> invocation =
+                AgentInvocation.builder(agentPlatform)
+                        .options(options -> options
+                                .verbosity(verbosity -> verbosity
+                                        .debug(true)))
+                        .build(Bar.class);
+
+        when(agentPlatform.agents()).thenReturn(List.of(agent));
+        when(agent.getGoals()).thenReturn(Set.of(goal));
+        when(agentPlatform.createAgentProcessFrom(
+                eq(agent),
+                assertArg(processOptions -> assertTrue(processOptions.getVerbosity().getDebug())),
+                any()
+        )).thenReturn(agentProcess);
+        when(agentPlatform.start(agentProcess))
+                .thenReturn(CompletableFuture.completedFuture(agentProcess));
+        when(agentProcess.last(Bar.class))
+                .thenReturn(new Bar());
+
+        invocation.invoke(new Foo());
+    }
+
+    static class Foo {
+    }
+
+    static class Bar {
+    }
+
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/autonomy/AgentInvocationKotlinTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/autonomy/AgentInvocationKotlinTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.common.autonomy
+
+import com.embabel.agent.api.common.autonomy.AgentInvocation.Companion.builder
+import com.embabel.agent.api.common.autonomy.AgentInvocation.Companion.create
+import com.embabel.agent.core.*
+import com.embabel.agent.core.Goal.Companion.createInstance
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import kotlin.test.assertEquals
+
+class AgentInvocationKotlinTest {
+
+    private val agentPlatform = mockk<AgentPlatform>()
+
+    private val agent = mockk<Agent>()
+
+    private val agentProcess = mockk<AgentProcess>()
+
+    private val goal: Goal = createInstance("Test goal", Bar::class.java)
+
+    @Test
+    fun `default varargs invocation`() {
+        val foo = Foo()
+        val expected = Bar()
+        val invocation: AgentInvocation<Bar> = create(agentPlatform)
+
+        every {agentPlatform.agents()} returns listOf(agent)
+        every {agent.goals} returns setOf(goal)
+        every {agentPlatform.createAgentProcessFrom(
+            agent = agent,
+            processOptions = any(),
+            *arrayOf(foo)
+        )} returns agentProcess
+        every {agentPlatform.start(agentProcess)} returns CompletableFuture.completedFuture(agentProcess)
+        every {agentProcess.last(Bar::class.java)} returns expected
+
+        val bar: Bar = invocation.invoke(foo)
+        assertEquals(
+            expected = expected,
+            actual = bar
+        )
+    }
+
+    @Test
+    fun `default map invocation`() {
+        val foo = Foo()
+        val map = mapOf("id" to foo)
+        val expected = Bar()
+        val invocation: AgentInvocation<Bar> = create(agentPlatform)
+
+        every {agentPlatform.agents()} returns listOf(agent)
+        every {agent.goals} returns setOf(goal)
+        every {agentPlatform.createAgentProcess(
+            agent = agent,
+            processOptions = any(),
+            bindings = map
+        )} returns agentProcess
+        every {agentPlatform.start(agentProcess)} returns CompletableFuture.completedFuture(agentProcess)
+        every {agentProcess.last(Bar::class.java)} returns expected
+
+        val bar: Bar = invocation.invoke(map)
+        assertEquals(
+            expected = expected,
+            actual = bar
+        )
+    }
+
+    @Test
+    fun `custom processing options`() {
+        val processOptions = ProcessOptions(verbosity = Verbosity(debug = true))
+        val invocation: AgentInvocation<Bar> = builder(agentPlatform)
+            .options(processOptions)
+            .build()
+
+        every {agentPlatform.agents()} returns listOf(agent)
+        every {agent.goals} returns setOf(goal)
+        every {agentPlatform.createAgentProcessFrom(any(),
+            processOptions = processOptions,
+            any()
+        )} returns agentProcess
+        every {agentPlatform.start(agentProcess)} returns CompletableFuture.completedFuture(agentProcess)
+        every {agentProcess.last(Bar::class.java)} returns Bar()
+
+
+        invocation.invoke(Foo())
+    }
+
+}
+
+class Foo
+class Bar


### PR DESCRIPTION
This PR resolves #592, and introduces the AgentInvocation type, a convenient wrapper around AgentPlatform, meant to provide a user-friendly an alternative to directly using AgentPlatform.

This PR is a draft, because one TODO remains: implementing `AgentPlatform::findAgentByResultType`.