### PR TITLE
Update deploy-docs.yml

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -110,7 +110,7 @@ jobs:
               sudo mkdir -p /var/www/html/embabel-agent/api-docs &&
               sudo cp ~/index.html /var/www/html/embabel-agent/guide/ &&
               sudo cp -r ~/images /var/www/html/embabel-agent/guide &&
-              sudo cp -r ~/dokka  /var/www/html/embabel-agent/api-docs
+              sudo cp -r ~/dokka/*  /var/www/html/embabel-agent/api-docs
               "
 
       - name: Verify deployment

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -97,14 +97,20 @@ jobs:
           gcloud compute scp --recurse target/generated-docs/images \
             ${{ github.event.inputs.vm_instance }}:~/images \
             --zone=${{ github.event.inputs.vm_zone }}
+
+          gcloud compute scp --recurse target/dokka-aggregate \
+            ${{ github.event.inputs.vm_instance }}:~/dokka \
+            --zone=${{ github.event.inputs.vm_zone }}          
           
           # Step 2: Move files with sudo via SSH
           gcloud compute ssh ${{ github.event.inputs.vm_instance }} \
             --zone=${{ github.event.inputs.vm_zone }} \
             --command="
               sudo mkdir -p /var/www/html/embabel-agent/guide &&
+              sudo mkdir -p /var/www/html/embabel-agent/api-docs &&
               sudo cp ~/index.html /var/www/html/embabel-agent/guide/ &&
-              sudo cp -r ~/images /var/www/html/embabel-agent/guide
+              sudo cp -r ~/images /var/www/html/embabel-agent/guide &&
+              sudo cp -r ~/dokka  /var/www/html/embabel-agent/api-docs
               "
 
       - name: Verify deployment


### PR DESCRIPTION
This pull request updates the deployment workflow for documentation to include the deployment of API documentation generated by Dokka. The most important changes involve adding steps to copy the Dokka-generated files to the target server and updating the server's file structure to accommodate the new API documentation.

### Deployment workflow updates:
* [`.github/workflows/deploy-docs.yml`](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R101-R113): Added a step to copy the `dokka-aggregate` directory to the target server under `~/dokka` using `gcloud compute scp`.
* [`.github/workflows/deploy-docs.yml`](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R101-R113): Updated the server-side commands to create a new directory for API documentation (`/var/www/html/embabel-agent/api-docs`) and copy the Dokka files to this location.