### PR TITLE
fix(validation): Resolve NO_STARTING_ACTION error and refactor validations

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -25,6 +25,7 @@ import com.embabel.agent.core.ComputedBooleanCondition
 import com.embabel.agent.core.IoBinding
 import com.embabel.agent.core.support.Rerun
 import com.embabel.agent.core.support.safelyGetToolCallbacksFrom
+import com.embabel.agent.validation.AgentStructureValidator
 import com.embabel.agent.validation.AgentValidationManager
 import com.embabel.agent.validation.DefaultAgentValidationManager
 import com.embabel.agent.validation.GoapPathToCompletionValidator
@@ -34,6 +35,7 @@ import com.embabel.common.util.NameUtils
 import com.embabel.common.util.loggerFor
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.slf4j.LoggerFactory
+import org.springframework.context.support.StaticApplicationContext
 import org.springframework.stereotype.Service
 import org.springframework.util.ReflectionUtils
 import java.lang.reflect.Method
@@ -82,13 +84,25 @@ data class AgenticInfo(
 class AgentMetadataReader(
     private val actionMethodManager: ActionMethodManager = DefaultActionMethodManager(),
     private val nameGenerator: MethodDefinedOperationNameGenerator = MethodDefinedOperationNameGenerator(),
+    private val agentStructureValidator: AgentStructureValidator,
+    private val goapPathToCompletionValidator: GoapPathToCompletionValidator
+) {
+    // test-friendly constructor
+    constructor() : this(
+        DefaultActionMethodManager(),
+        MethodDefinedOperationNameGenerator(),
+        AgentStructureValidator(StaticApplicationContext()),
+        GoapPathToCompletionValidator()
+    )
+
+    private val logger = LoggerFactory.getLogger(AgentMetadataReader::class.java)
+
     private val agentValidationManager: AgentValidationManager = DefaultAgentValidationManager(
         listOf(
-            GoapPathToCompletionValidator()
+            agentStructureValidator,
+            goapPathToCompletionValidator
         )
     )
-) {
-    private val logger = LoggerFactory.getLogger(AgentMetadataReader::class.java)
 
     fun createAgentScopes(vararg instances: Any): List<AgentScope> =
         instances.mapNotNull { createAgentMetadata(it) }


### PR DESCRIPTION
###Description

This PR fixes a bug (#449) that caused some agents to fail validation with a `NO_STARTING_ACTION` error. The issue stemmed from the `GoapPathToCompletionValidator`, which, under certain conditions, failed to identify valid starting actions and build a correct initial world state for the planner.
In addition to the bug fix, this PR introduces a structural improvement by refactoring the `AgentMetadataReader` to use constructor-based dependency injection for its validators, enhancing clarity and testability.

---
### The Bug Fix (#449)
The `GoapPathToCompletionValidator` failed to get the first actions and create a correct initial world state under special conditions for the agent. It didn't account for external inputs, leading to behavior where all actions depended on the outputs of other actions, resulting in **no possible starting point**. So the validator logic has been updated, and now it correctly identifies the first actions and the initial state needed by the planner. It provides the effects of a goal action, not just its preconditions, for the planner.

---
### Structural Improvement
The `AgentMetadataReader` was manually creating its validator dependencies (`DefaultAgentValidationManager`, `GoapPathToCompletionValidator`). So, refactored the class to use constructor injection for validators, aligning with IoC and allowing Spring to manage dependencies.

---
### How to Test
- Pull this branch and install on local: `mvn clean install`
- Try to start an agent (e.g., Coder) that was previously failing with the validation error.
- The agent now passes validation as expected, with no more `NO_STARTING_ACTION` errors.