### PR TITLE
Use two spaces instead of tab.

### DIFF
--- a/embabel-agent-api/src/test/kotlin/com/embabel/plan/PlanTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/plan/PlanTest.kt
@@ -146,16 +146,16 @@ class PlanTest {
 
         val plan = Plan(actions, goal)
 
-        val verboseInfo = plan.infoString(verbose = true)
+        val verboseInfo = plan.infoString(verbose = true, indent = 1)
 
         // Check format with indentation
-        assertTrue(verboseInfo.contains("\t".repeat(1) + "Action1"))
-        assertTrue(verboseInfo.contains("\t".repeat(2) + "Action2"))
-        assertTrue(verboseInfo.contains("\t".repeat(3) + "Action3"))
+        assertTrue(verboseInfo.contains("  ".repeat(1) + "Action1"))
+        assertTrue(verboseInfo.contains("  ".repeat(2) + "Action2"))
+        assertTrue(verboseInfo.contains("  ".repeat(3) + "Action3"))
 
         // Should contain cost and netValue
-        assertTrue(verboseInfo.contains("cost="))
-        assertTrue(verboseInfo.contains("netValue="))
+        assertTrue(verboseInfo.contains("cost:"))
+        assertTrue(verboseInfo.contains("netValue:"))
     }
 
     @Test


### PR DESCRIPTION
This pull request updates the `PlanTest` class in `PlanTest.kt` to improve the readability and consistency of test assertions by modifying the formatting of strings and indentation.

### Test improvements:
* Updated the `infoString` method call to include an `indent` parameter for better control over indentation.
* Replaced tab-based indentation (`\t`) with spaces (`  `) in test assertions for improved readability and consistency.
* Changed the format of `cost` and `netValue` assertions from `=` to `:` for consistency with other output formats.