### PR TITLE
Tool handoff support

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/actionMethodPromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/actionMethodPromptRunner.kt
@@ -34,6 +34,7 @@ import com.embabel.common.ai.prompt.PromptContributor
  * @promptContributors promptContributors to expose
  * @generateExamples whether to override default example generation
  */
+@Deprecated("Use an OperationContext to obtain a PromptRunner. Define it as an argument to your @Action method.")
 @JvmOverloads
 fun using(
     llm: LlmOptions? = null,
@@ -49,7 +50,7 @@ fun using(
         toolObjects = toolObjects,
         promptContributors = promptContributors,
         generateExamples = generateExamples,
-        contextualPromptContributors = contextualPromptContributors, // No contextual contributors for this runner
+        contextualPromptContributors = contextualPromptContributors, // No contextual contributors for this runner,
     )
 
 /**
@@ -63,6 +64,7 @@ fun using(
  * @promptContributors promptContributors to expose
  * @generateExamples whether to override default example generation
  */
+@Deprecated("Use an OperationContext to obtain a PromptRunner. Define it as an argument to your @Action method.")
 @JvmOverloads
 fun usingModel(
     model: String,
@@ -85,6 +87,7 @@ fun usingModel(
  * Return a PromptRunner instance for use in @Action methods
  * that uses default LLM and hyperparameters.
  */
+@Deprecated("Use an OperationContext to obtain a PromptRunner. Define it as an argument to your @Action method.")
 val usingDefaultLlm: PromptRunner =
     MethodReturnPromptRunner(
         llm = null,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/MethodReturnPromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/MethodReturnPromptRunner.kt
@@ -77,7 +77,7 @@ internal data class MethodReturnPromptRunner(
     override fun evaluateCondition(
         condition: String,
         context: String,
-        confidenceThreshold: ZeroToOne
+        confidenceThreshold: ZeroToOne,
     ): Boolean {
         throw EvaluateConditionPromptException(
             condition = condition,
@@ -92,6 +92,10 @@ internal data class MethodReturnPromptRunner(
             contextualPromptContributors = contextualPromptContributors,
             generateExamples = generateExamples,
         )
+    }
+
+    override fun withHandoffs(vararg inputTypes: Class<*>): PromptRunner {
+        TODO("Probably won't be implemented as this class is likely to be deprecated")
     }
 
     override fun withLlm(llm: LlmOptions): PromptRunner =

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/OperationContext.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/OperationContext.kt
@@ -64,7 +64,7 @@ interface OperationContext : Blackboard, ToolGroupConsumer {
     ): PromptRunner {
         val promptContributorsToUse = (promptContributors + CurrentDate()).distinctBy { it.promptContribution().role }
         return OperationContextPromptRunner(
-            this,
+            context = this,
             llm = llm,
             toolGroups = toolGroups,
             toolObjects = toolObjects,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
@@ -176,6 +176,13 @@ interface PromptRunner : LlmUse, PromptRunnerOperations {
     ): PromptRunner
 
     /**
+     * Add a list of handoffs to agents on this platform
+     */
+    fun withHandoffs(
+        vararg inputTypes: Class<*>,
+    ): PromptRunner
+
+    /**
      * Add a prompt contributor
      * @param promptContributor
      * @return PromptRunner instance with the added PromptContributor

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.ApplicationContext
 import org.springframework.core.io.Resource
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
 import org.springframework.core.io.support.ResourcePatternResolver
@@ -37,9 +38,9 @@ import java.util.concurrent.ConcurrentHashMap
 
 @Service
 internal class DefaultAgentPlatform(
-    @Value("\${embabel.agent-platform.name:default-agent-platform}")
+    @param:Value("\${embabel.agent-platform.name:default-agent-platform}")
     override val name: String,
-    @Value("\${embabel.agent-platform.description:Default Agent Platform}")
+    @param:Value("\${embabel.agent-platform.description:Default Agent Platform}")
     override val description: String,
     private val llmOperations: LlmOperations,
     override val toolGroupResolver: ToolGroupResolver,
@@ -49,6 +50,8 @@ internal class DefaultAgentPlatform(
     private val operationScheduler: OperationScheduler = OperationScheduler.PRONTO,
     private val ragService: RagService,
     private val asyncer: Asyncer,
+    private val objectMapper: ObjectMapper,
+    private val applicationContext: ApplicationContext? = null,
 ) : AgentPlatform {
 
     private val logger = LoggerFactory.getLogger(DefaultAgentPlatform::class.java)
@@ -64,6 +67,8 @@ internal class DefaultAgentPlatform(
         operationScheduler = operationScheduler,
         ragService = ragService,
         asyncer = asyncer,
+        objectMapper = objectMapper,
+        applicationContext = applicationContext,
     )
 
     init {
@@ -166,7 +171,7 @@ internal class DefaultAgentPlatform(
 
     override fun createChildProcess(
         agent: Agent,
-        parentAgentProcess: AgentProcess
+        parentAgentProcess: AgentProcess,
     ): AgentProcess {
         val childBlackboard = parentAgentProcess.processContext.blackboard.spawn()
         val processOptions = parentAgentProcess.processContext.processOptions

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlatformServices.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlatformServices.kt
@@ -16,9 +16,12 @@
 package com.embabel.agent.spi
 
 import com.embabel.agent.api.common.Asyncer
+import com.embabel.agent.api.common.autonomy.Autonomy
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.event.AgenticEventListener
 import com.embabel.agent.rag.RagService
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.context.ApplicationContext
 
 /**
  * Services used by the platform and available to user-authored code.
@@ -34,4 +37,15 @@ data class PlatformServices(
     val operationScheduler: OperationScheduler,
     val asyncer: Asyncer,
     val ragService: RagService,
-)
+    val objectMapper: ObjectMapper,
+    private val applicationContext: ApplicationContext?,
+) {
+
+    // We get this from the context because of circular dependencies
+    fun autonomy(): Autonomy {
+        if (applicationContext == null) {
+            throw IllegalStateException("Application context is not available, cannot retrieve Autonomy bean.")
+        }
+        return applicationContext.getBean(Autonomy::class.java)
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/IntegrationTestUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/IntegrationTestUtils.kt
@@ -28,6 +28,7 @@ import com.embabel.agent.spi.ToolGroupResolver
 import com.embabel.agent.spi.support.ExecutorAsyncer
 import com.embabel.agent.spi.support.RegistryToolGroupResolver
 import com.embabel.agent.testing.common.EventSavingAgenticEventListener
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.util.concurrent.Executors
 
 object IntegrationTestUtils {
@@ -55,7 +56,8 @@ object IntegrationTestUtils {
             ragService = ragService ?: RagService.Companion.empty(),
             name = "dummy-agent-platform",
             description = "Dummy Agent Platform for Integration Testing",
-            asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor())
+            asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor()),
+            objectMapper = jacksonObjectMapper(),
         )
     }
 
@@ -66,9 +68,11 @@ object IntegrationTestUtils {
             agentPlatform = dummyAgentPlatform(),
             llmOperations = DummyObjectCreatingLlmOperations.LoremIpsum,
             eventListener = eventListener ?: EventSavingAgenticEventListener(),
-            operationScheduler = OperationScheduler.Companion.PRONTO,
-            ragService = RagService.Companion.empty(),
-            asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor())
+            operationScheduler = OperationScheduler.PRONTO,
+            ragService = RagService.empty(),
+            asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor()),
+            objectMapper = jacksonObjectMapper(),
+            applicationContext = null,
         )
     }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/FakePromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/unit/FakePromptRunner.kt
@@ -124,7 +124,7 @@ data class FakePromptRunner(
     override fun evaluateCondition(
         condition: String,
         context: String,
-        confidenceThreshold: ZeroToOne
+        confidenceThreshold: ZeroToOne,
     ): Boolean {
         _llmInvocations += LlmInvocation(
             interaction = createLlmInteraction(),
@@ -170,4 +170,8 @@ data class FakePromptRunner(
             ),
             generateExamples = generateExamples,
         )
+
+    override fun withHandoffs(vararg inputTypes: Class<*>): PromptRunner {
+        TODO("Implement handoff support")
+    }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/agent/Handoffs.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/agent/Handoffs.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.tools.agent
+
+import com.embabel.agent.api.common.autonomy.Autonomy
+import com.embabel.agent.core.ToolCallbackPublisher
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.ai.tool.ToolCallback
+
+/**
+ * Handoffs to local agents.
+ */
+class Handoffs(
+    autonomy: Autonomy,
+    objectMapper: ObjectMapper,
+    val inputTypes: List<Class<*>>,
+    applicationName: String,
+) : ToolCallbackPublisher {
+
+    private val goalToolCallbackPublisher = PerGoalToolCallbackPublisher(
+        autonomy = autonomy,
+        objectMapper = objectMapper,
+        applicationName = applicationName,
+        textCommunicator = PromptedTextCommunicator,
+    )
+
+    override val toolCallbacks: List<ToolCallback>
+        get() = goalToolCallbackPublisher.goalTools(remoteOnly = false)
+            .filter { goalToolCallback ->
+                inputTypes.any { inputType ->
+                    goalToolCallback.goal.export.startingInputTypes.any { it.isAssignableFrom(inputType) }
+                }
+            }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/dsl/AgentBuilderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/dsl/AgentBuilderTest.kt
@@ -29,6 +29,7 @@ import com.embabel.agent.support.Dog
 import com.embabel.agent.testing.common.EventSavingAgenticEventListener
 import com.embabel.agent.testing.integration.DummyObjectCreatingLlmOperations
 import com.embabel.common.core.types.Semver
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
@@ -113,7 +114,9 @@ class AgentBuilderTest {
                 operationScheduler = mockk(),
                 agentPlatform = mockk(),
                 ragService = mockk(),
-                asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor())
+                asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor()),
+                objectMapper = jacksonObjectMapper(),
+                applicationContext = null,
             )
             val processContext = ProcessContext(
                 agentProcess = SimpleAgentProcess(
@@ -149,7 +152,9 @@ class AgentBuilderTest {
                 operationScheduler = mockk(),
                 agentPlatform = mockk(),
                 ragService = RagService.empty(),
-                asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor())
+                asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor()),
+                objectMapper = jacksonObjectMapper(),
+                applicationContext = null,
             )
             val processContext = ProcessContext(
                 agentProcess = SimpleAgentProcess(


### PR DESCRIPTION
Fixes #638 

Adds tool handoffs capability on `PromptRunner`

Deprecates magic action runner for use in `Action` methods.

Exposes `Autonomy` on `PlatformServices` to support new functionality.