### PR TITLE
Update build to use common-0.1.1-SNAPSHOT.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Parent POM for Embabel Agent Modules</description>
 
     <properties>
-        <embabel-common.version>0.1.0</embabel-common.version>
+        <embabel-common.version>0.1.1-SNAPSHOT</embabel-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request includes a small change to the project versioning in the `pom.xml` file. The version of the `embabel-common` dependency has been updated from `0.1.0` to `0.1.1-SNAPSHOT`.