### PR TITLE
Bug Fix: embabel-agent-api inner application.yml gets ignored in certain scenarios

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformPropertiesLoader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformPropertiesLoader.kt
@@ -57,7 +57,7 @@ import jakarta.annotation.PostConstruct
  * @since 1.x
  */
 @Configuration
-@PropertySource("classpath:agent-platform.properties")
+@PropertySource("classpath:agent-platform.properties", "classpath:embabel-agent.properties")
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class AgentPlatformPropertiesLoader {
 
@@ -65,6 +65,6 @@ class AgentPlatformPropertiesLoader {
 
     @PostConstruct
     fun init() {
-        logger.info("Agent platform properties loaded from classpath:agent-platform.properties")
+        logger.info("Agent platform properties loaded from classpath:agent-platform.properties and embabel-agent-properties")
     }
 }

--- a/embabel-agent-api/src/main/resources/embabel-agent.properties
+++ b/embabel-agent-api/src/main/resources/embabel-agent.properties
@@ -1,0 +1,45 @@
+# Spring Boot Application Properties
+spring.application.name=agent-api
+spring.threads.virtual.enabled=true
+spring.output.ansi.enabled=ALWAYS
+
+# AI Configuration
+spring.ai.ollama.base-url=http://localhost:11434
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+
+# Management
+management.tracing.enabled=false
+
+# Embabel Agent Platform
+embabel.agent-platform.name=embabel-default
+embabel.agent-platform.description=Embabel Default Agent Platform
+embabel.agent-platform.scanning.annotation=true
+embabel.agent-platform.scanning.bean=true
+embabel.agent-platform.ranking.max-attempts=5
+
+# Embabel Autonomy
+embabel.autonomy.agent-confidence-cut-off=0.6
+embabel.autonomy.goal-confidence-cut-off=0.6
+
+# Process ID Generation
+embabel.process-id-generation.include-agent-name=false
+embabel.process-id-generation.include-version=false
+
+# LLM Operations
+embabel.llm-operations.prompts.generate-examples-by-default=true
+
+# Models
+embabel.models.default-llm=gpt-4.1-mini
+embabel.models.default-embedding-model=text-embedding-3-small
+
+# Logging
+logging.pattern.console=%clr(%d{HH:mm:ss.SSS}){faint} %clr([%t]){magenta} %clr(%-5level) %clr(%logger{0}){cyan} %clr(-){faint} %msg%n
+
+# Logging Levels - unused, see logback-spring.xml
+logging.level.org.springframework.ai.converter.BeanOutputConverter=OFF
+logging.level.com.embabel.agent.core.support.BlackboardWorldStateDeterminer=INFO
+logging.level.com.embabel.agent.api.annotation.support.AgentMetadataReader=INFO
+logging.level.com.embabel.agent.spi.support.LlmRanker=INFO
+logging.level.com.embabel.agent.spi.support.com.embabel.agent.spi.support.springai.ChatClientLlmOperations=INFO
+logging.level.org.springframework.ai.bedrock=ERROR
+logging.level.software.amazon.awssdk=ERROR

--- a/embabel-agent-api/src/main/resources/logback-spring.xml
+++ b/embabel-agent-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- ✅ Enable Spring Boot's custom converters like %clr -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- 🔧 Inject console pattern from application.yml or .properties -->
+    <springProperty name="CONSOLE_PATTERN" source="logging.pattern.console"/>
+
+    <!-- 🖥️ Console Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                ${CONSOLE_PATTERN:-%clr(%d{HH:mm:ss.SSS}){faint} %clr([%t]){magenta} %clr(%-5level) %clr(%logger{0}){cyan} %clr(-){faint} %msg%n}
+            </pattern>
+        </encoder>
+    </appender>
+
+    <!-- 🔧 Logger Levels -->
+    <logger name="org.springframework.ai.converter.BeanOutputConverter" level="OFF"/>
+    <logger name="com.embabel.agent.core.support.BlackboardWorldStateDeterminer" level="INFO"/>
+    <logger name="com.embabel.agent.api.annotation.support.AgentMetadataReader" level="INFO"/>
+    <logger name="com.embabel.agent.spi.support.LlmRanker" level="INFO"/>
+    <logger name="com.embabel.agent.spi.support.com.embabel.agent.spi.support.springai.ChatClientLlmOperations" level="INFO"/>
+    <logger name="org.springframework.ai.bedrock" level="ERROR"/>
+    <logger name="software.amazon.awssdk" level="ERROR"/>
+
+    <!-- 🔍 Root Logger -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>
+
+

--- a/embabel-agent-api/src/test/resources/application.properties
+++ b/embabel-agent-api/src/test/resources/application.properties
@@ -1,0 +1,45 @@
+# Spring Boot Application Properties
+spring.application.name=agent-api
+spring.threads.virtual.enabled=true
+spring.output.ansi.enabled=ALWAYS
+
+# AI Configuration
+spring.ai.ollama.base-url=http://localhost:11434
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+
+# Management
+management.tracing.enabled=false
+
+# Embabel Agent Platform
+embabel.agent-platform.name=embabel-default
+embabel.agent-platform.description=Embabel Default Agent Platform
+embabel.agent-platform.scanning.annotation=true
+embabel.agent-platform.scanning.bean=true
+embabel.agent-platform.ranking.max-attempts=5
+
+# Embabel Autonomy
+embabel.autonomy.agent-confidence-cut-off=0.6
+embabel.autonomy.goal-confidence-cut-off=0.6
+
+# Process ID Generation
+embabel.process-id-generation.include-agent-name=false
+embabel.process-id-generation.include-version=false
+
+# LLM Operations
+embabel.llm-operations.prompts.generate-examples-by-default=true
+
+# Models
+embabel.models.default-llm=gpt-4.1-mini
+embabel.models.default-embedding-model=text-embedding-3-small
+
+# Logging
+logging.pattern.console=%clr(%d{HH:mm:ss.SSS}){faint} %clr([%t]){magenta} %clr(%-5level) %clr(%logger{0}){cyan} %clr(-){faint} %msg%n
+
+# Logging Levels
+logging.level.org.springframework.ai.converter.BeanOutputConverter=OFF
+logging.level.com.embabel.agent.core.support.BlackboardWorldStateDeterminer=INFO
+logging.level.com.embabel.agent.api.annotation.support.AgentMetadataReader=INFO
+logging.level.com.embabel.agent.spi.support.LlmRanker=INFO
+logging.level.com.embabel.agent.spi.support.com.embabel.agent.spi.support.springai.ChatClientLlmOperations=INFO
+logging.level.org.springframework.ai.bedrock=ERROR
+logging.level.software.amazon.awssdk=ERROR


### PR DESCRIPTION
PROBLEM STATEMENT
=========
See issue https://github.com/embabel/embabel-agent/issues/663

User is not able to extend / override "inner" application.yml (inside JAR embabel-agent-api).

ANALYSIS
========
Inner JAR got ingnored when user added external to JAR application.yml in user's application).

Here is what is happening:
1.  User defined thru annotations EnableAgentShell / EnableAgents profiles "shell", "starwars"
2. Profiles got set by Environment Post Processor in auto-configuration spi
3. Application-level application.yml got processed
4. Spring continues with profiles "shell", "starwars"
5. There is no "default" profile defined
6. Therefore, inner applivation.yml (inside JAR) got skipped
7. As result required properties not being bound, application failed to start

SOLUTION
=========

One solution would be to always ammend profiles with "default" one. However, solution conflicts with ongoing refactoring embabel-agent-api as "library"  and enforces heavy involvement of spring boot infrastructure inside library.

**Proposed solution** utilizes infrastructure built for "agent api as library" in order to bootstrap application properties without reliance on spring boot.
1.  application.yml got converted into embabel-agent.properties
2. propertis got loaded by AgentPlatformLoader along with system properties
3. **application.yml will be deprecated as soon as possible** (unused now), can be renamed as application.yml.deprecated
4. complication arized from logging area, since logging infrastructure got intialized ar early stages, prior to Application Context got fully available
5. per best practice recommendations on managing spring logging definitions inside library, default logging spec has been moved to logback-spring.xml, parameterized by logging pattern
