### PR TITLE
Annotate `asyncer` bean with `@Qualifier` for specific executor use.

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AsyncConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AsyncConfiguration.kt
@@ -17,6 +17,8 @@ package com.embabel.agent.config
 
 import com.embabel.agent.api.common.Asyncer
 import com.embabel.agent.spi.support.ExecutorAsyncer
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.concurrent.Executor
@@ -25,7 +27,10 @@ import java.util.concurrent.Executor
 class AsyncConfiguration {
 
     @Bean
-    fun asyncer(executor: Executor): Asyncer {
+    fun asyncer(
+        @Qualifier(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
+        executor: Executor
+    ): Asyncer {
         return ExecutorAsyncer(executor)
     }
 }


### PR DESCRIPTION
This PR fixes the condition noted in the issue [#702](https://github.com/embabel/embabel-agent/issues/702).

It applies the Spring `@Qualifier` annotation to the injected Executor bean so that it avoids the condition where multiple beans exist in the application context.