### PR TITLE
Update build-parent to 0.1.1-SNAPSHOT

### DIFF
--- a/embabel-agent-rag/pom.xml
+++ b/embabel-agent-rag/pom.xml
@@ -11,6 +11,10 @@
     <name>Embabel Agent Rag</name>
     <description>Embabel Agent Rag</description>
 
+    <properties>
+        <neo4j-ogm-spring-boot-starter.version>1.3.0</neo4j-ogm-spring-boot-starter.version>
+    </properties>
+
     <dependencies>
         <!-- Main Dependencies -->
         <dependency>
@@ -33,7 +37,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-ogm-spring-boot-starter</artifactId>
-            <version>1.3.0</version>
+            <version>${neo4j-ogm-spring-boot-starter.version}</version>
         </dependency>
 
         <!-- TODO could move RAG in here and not need this -->
@@ -51,7 +55,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>neo4j</artifactId>
-            <version>1.21.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>


### PR DESCRIPTION
This pull request makes a few minor dependency management improvements to the Maven configuration for both the parent and the `embabel-agent-rag` modules. The changes help centralize version management and update the build parent version.

Dependency and build configuration updates:

* Updated the parent project version in `pom.xml` from `0.1.0` to `0.1.1-SNAPSHOT` to use the latest snapshot build parent.
* Introduced a `neo4j-ogm-spring-boot-starter.version` property in `embabel-agent-rag/pom.xml` and refactored the dependency version to use this property, improving maintainability. [[1]](diffhunk://#diff-948916305efe387d4a5b496dee5aae337348a30063fb4f273b419222bd99431aR14-R17) [[2]](diffhunk://#diff-948916305efe387d4a5b496dee5aae337348a30063fb4f273b419222bd99431aL36-R40)
* Removed the explicit version for the `org.testcontainers:neo4j` test dependency in `embabel-agent-rag/pom.xml`, deferring version management to a parent or BOM.