### PR TITLE
Fix: unresolved jacoco-maven-plugin by updating plugin version

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -13,6 +13,9 @@
     <packaging>pom</packaging>
     <name>Embabel Agent BOM</name>
     <description>Embabel Agent BOM</description>
+    <properties>
+        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -103,6 +106,29 @@
             </snapshots>
         </repository>
     </repositories>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <distributionManagement>
         <repository>


### PR DESCRIPTION
I added the `jacoco-maven-plugin` configuration in the `embabel-agent-dependencies` module to resolve the unresolved plugin error and fix the build.

### Changes:
- Added `<plugin>` definition for `org.jacoco:jacoco-maven-plugin`.
- Introduced a Maven property (`jacoco-maven-plugin.version`) for clean version management.
- Verified that the project builds successfully after the fix.

### Impact:
Ensures the Jacoco code coverage plugin resolves correctly, preventing build failures during Maven runs.

---

PS: This is my first PR 🙂 Please excuse any mistakes and I’ll be happy to improve based on feedback.
