### PR TITLE
Add Validation for Multiple Parameters of Same Type in @Action and @Condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ embabel-agent-api/src/main/resources/mcp/**
 */*/target/**
 */*/*/target/**
 
+.junie/
 .idea/workspace.xml
 
 **/*.log

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -273,6 +273,7 @@ class AgentMetadataReader(
         method: Method,
         instance: Any,
     ): ComputedBooleanCondition {
+        requireNonAmbiguousParameters(method)
         val conditionAnnotation = method.getAnnotation(Condition::class.java)
         return ComputedBooleanCondition(
             name = conditionAnnotation.name.ifBlank {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
@@ -49,6 +49,7 @@ internal class DefaultActionMethodManager(
         instance: Any,
         toolCallbacksOnInstance: List<ToolCallback>,
     ): Action {
+        requireNonAmbiguousParameters(method)
         val actionAnnotation = method.getAnnotation(com.embabel.agent.api.annotation.Action::class.java)
         val inputClasses = method.parameters
             .map { it.type }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DuplicateParameterType.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DuplicateParameterType.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.annotation.support
+
+import java.lang.reflect.Method
+import java.lang.reflect.Parameter
+
+/**
+ * A class representing a method with multiple parameters of the same type that have not been annotated with
+ * [com.embabel.agent.api.annotation.RequireNameMatch].
+ */
+class DuplicateParameterType(
+    /** The method with multiple parameters of the same type which require @RequireNameMatch annotation */
+    val method: Method,
+    /** The type of the parameter that is ambiguous. */
+    val conflictingClassType: Class<*>,
+    /** The parameters that are ambiguous. */
+    val conflictingParameters: List<Parameter>,
+)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DuplicateParameterTypeException.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DuplicateParameterTypeException.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.annotation.support
+
+import com.embabel.agent.api.annotation.RequireNameMatch
+import java.lang.reflect.Method
+import java.lang.reflect.Parameter
+
+/**
+ * A class representing a method with multiple parameters of the same type that have not been annotated with
+ * [com.embabel.agent.api.annotation.RequireNameMatch].
+ */
+class DuplicateParameterTypeException(
+    val method: Method,
+    val duplicates: List<DuplicateParameterType>,
+) : RuntimeException(buildDuplicateParameterTypeMessage(method, duplicates))
+
+/**
+ * Checks if a method has multiple parameters with the same type, but no @RequireNameMatch annotation.
+ * This prevents any issue when the developer forgets to add @RequireNameMatch when parameters have the same type and
+ * the system is unable to determine the correct parameter order.
+ *
+ * @param method The method to check.
+ * @throws DuplicateParameterTypeException If the method has multiple parameters with the same type.
+ */
+fun requireNonAmbiguousParameters(method: Method) {
+    val parameterMap: Map<Class<*>, List<Parameter>> = method.parameters.groupBy { it.type }
+
+    // For any class type with more than one parameter, flag as duplicate only when
+    // ALL of those parameters are NOT annotated with @RequireNameMatch
+    val duplicates = parameterMap
+        .asSequence()
+        .filter { (_, params) -> params.size > 1 }
+        .filter { (_, params) -> isNotProperlyAnnotated(params) }
+        .map { (clazz, params) ->
+            DuplicateParameterType(
+                method = method,
+                conflictingClassType = clazz,
+                conflictingParameters = params
+            )
+        }
+        .toList()
+
+    if (duplicates.isNotEmpty()) {
+        throw DuplicateParameterTypeException(method = method, duplicates)
+    }
+}
+
+internal fun isNotProperlyAnnotated(params: List<Parameter>): Boolean =
+    !params.all { it.isAnnotationPresent(RequireNameMatch::class.java) } &&
+            !params.none { it.isAnnotationPresent(RequireNameMatch::class.java) }
+
+/**
+ * Builds a detailed error message for the [DuplicateParameterTypeException] that instructs the developer on how to
+ * resolve the issue.
+ *
+ * @param method The method with duplicate parameter types.
+ * @param duplicates The list of duplicate parameter types found in the method.
+ * @return A formatted error message describing the issue and how to resolve it.
+ */
+internal fun buildDuplicateParameterTypeMessage(
+    method: Method,
+    duplicates: List<DuplicateParameterType>,
+): String {
+    val declaring = method.declaringClass.name
+    val params = method.parameters
+    fun positionOf(p: Parameter) = params.indexOf(p)
+    val details = duplicates.joinToString(separator = "; ") { d ->
+        val positions = d.conflictingParameters.joinToString(
+            prefix = "(",
+            postfix = ")",
+            separator = ", "
+        ) { p ->
+            val idx = positionOf(p)
+            val name = p.name
+            "#$idx(name='$name')"
+        }
+        "${d.conflictingClassType.name} at $positions"
+    }
+
+    return """
+        Ambiguous parameters in $declaring.${method.name}(): multiple parameters share the same type without @RequireNameMatch.
+        Conflicts: $details. 
+        How to fix: annotate each parameter of the duplicated type with @RequireNameMatch so values are bound by parameter name, or make the parameter types unique.
+        """
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/RequireNonAmbiguousParametersTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/RequireNonAmbiguousParametersTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.annotation.support
+
+import com.embabel.agent.api.annotation.Condition
+import com.embabel.agent.api.annotation.RequireNameMatch
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+
+class RequireNonAmbiguousParametersTest {
+
+    private class Demo {
+        fun distinctTypes(
+            a: String,
+            b: Int,
+        ) {
+        }
+
+        @Condition
+        fun twoSameTypeBothAnnotated(
+            @RequireNameMatch a: String,
+            @RequireNameMatch b: String,
+        ) {
+        }
+
+        @Condition
+        fun twoSameTypeOneAnnotated(
+            @RequireNameMatch a: String,
+            b: String,
+        ) {
+        }
+
+        @Condition
+        fun threeSameTypeOneAnnotated(
+            @RequireNameMatch a: String,
+            b: String,
+            c: String,
+        ) {
+        }
+
+        @Condition
+        fun threeSameTypeAllAnnotated(
+            @RequireNameMatch a: String,
+            @RequireNameMatch b: String,
+            @RequireNameMatch c: String,
+        ) {
+        }
+    }
+
+    private fun method(name: String): Method = Demo::class.java.declaredMethods.first { it.name == name }
+
+    @Test
+    fun `distinct class types`() {
+        val m = method("distinctTypes")
+        assertDoesNotThrow { requireNonAmbiguousParameters(m) }
+    }
+
+    @Test
+    fun `two parameters same type both annotated`() {
+        val m = method("twoSameTypeBothAnnotated")
+        assertDoesNotThrow { requireNonAmbiguousParameters(m) }
+    }
+
+    @Test
+    fun `two parameters same type one annotated`() {
+        val m = method("twoSameTypeOneAnnotated")
+        assertThrows(DuplicateParameterTypeException::class.java) {
+            requireNonAmbiguousParameters(m)
+        }
+    }
+
+    @Test
+    fun `three parameters same type one annotated`() {
+        val m = method("threeSameTypeOneAnnotated")
+        assertThrows(DuplicateParameterTypeException::class.java) {
+            requireNonAmbiguousParameters(m)
+        }
+    }
+
+    @Test
+    fun `three parameters same type all annotated`() {
+        val m = method("threeSameTypeAllAnnotated")
+        assertDoesNotThrow { requireNonAmbiguousParameters(m) }
+    }
+}


### PR DESCRIPTION
This pull request introduces validation checks to handle cases where an @Action or @Condition has multiple parameters of the same type. To ensure accurate value binding in such scenarios, developers must now annotate the parameters with @RequireNameMatch. This annotation explicitly instructs the system on how to correctly map the parameter values.

## Changes:

- Added validation logic to detect multiple parameters of the same type in @Action and @Condition.
- Enforced usage of @RequireNameMatch for proper parameter binding.

## Motivation:
This change prevents ambiguous parameter binding and avoiding unexpected behavior when parameters have the same class type.

## Testing:

- Added unit tests to verify validation behavior for single and multiple parameters.
- Tested edge cases where @RequireNameMatch is omitted or incorrectly applied.