### PR TITLE
Build Polishing.

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -180,11 +180,9 @@
             <scope>test</scope>
         </dependency>
 
-<!--        TODO: move to proper place-->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.18.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -241,7 +239,6 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <configuration>
                     <excludes>
-                        <exclude>com/embabel/agent/shell/**</exclude>
                         <exclude>com/embabel/agent/testing/**</exclude>
                         <exclude>com/embabel/agent/experimental/**</exclude>
                         <exclude>com/embabel/agent/event/logging/personality/**</exclude>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.1.1-SNAPSHOT</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>
@@ -76,6 +76,12 @@
                 <version>${project.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-discord</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            
             <dependency>
                 <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-ux</artifactId>


### PR DESCRIPTION
This pull request updates dependency versions and configuration in the Maven `pom.xml` files for both `embabel-agent-api` and `embabel-agent-dependencies`. The main changes include updating the parent version, adding a new module dependency, and modifying the test and coverage configuration.

**Dependency and configuration updates:**

* Updated the parent project version in `embabel-agent-dependencies/pom.xml` from `0.1.0` to `0.1.1-SNAPSHOT` to track the latest snapshot version.
* Added a new dependency for `embabel-agent-discord` to the dependencies list in `embabel-agent-dependencies/pom.xml`.

**Test and coverage configuration:**

* Removed the version specification for the `mockito-core` test dependency in `embabel-agent-api/pom.xml`, possibly to use the default or managed version.
* Removed the exclusion of the `com/embabel/agent/shell/**` package from the JaCoCo coverage configuration in `embabel-agent-api/pom.xml`, allowing coverage reporting for this package.