### PR TITLE
Add embabel-agent-discord docs.

### DIFF
--- a/embabel-agent-docs/pom.xml
+++ b/embabel-agent-docs/pom.xml
@@ -129,6 +129,7 @@
                                 <dir>${project.parent.basedir}/embabel-agent-eval/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-rag/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-shell/src/main/kotlin</dir>
+                                <dir>${project.parent.basedir}/embabel-agent-discord/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-ux/src/main/kotlin</dir>
                             </sourceDirectories>
                             <samples>


### PR DESCRIPTION
This pull request adds the `embabel-agent-discord` module to the documentation build process by including its source directory in the `embabel-agent-docs/pom.xml` file. This ensures that documentation for the Discord agent is now generated along with other modules.