### PR TITLE
Add managed Mockito dependency with compile scope.

### DIFF
--- a/embabel-agent-test/pom.xml
+++ b/embabel-agent-test/pom.xml
@@ -23,8 +23,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
-    </dependencies>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
This pull request adds a new dependency to the `embabel-agent-test/pom.xml` file to support mocking in tests.

Testing improvements:

* Added the `mockito-core` dependency with compile scope to enable mocking capabilities for unit tests.