### PR TITLE
Adding support for providing a name to use with @RequireNameMatch

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/annotations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/annotations.kt
@@ -152,10 +152,13 @@ annotation class Action(
  * Otherwise, it can match the latest ("it") value.
  * Must be combined with the outputBinding method on Action for the action
  * producing the input
+ * @param value The name of the input binding that this parameter should match; "" indicates using the parameter name.
  * @see Action
  * @see IoBinding
  */
 @Target(AnnotationTarget.VALUE_PARAMETER)
 @Retention(AnnotationRetention.RUNTIME)
 @MustBeDocumented
-annotation class RequireNameMatch
+annotation class RequireNameMatch (
+    val value: String = ""
+)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -310,11 +310,7 @@ class AgentMetadataReader(
                 else -> {
                     val requireNameMatch = parameter.getAnnotation(RequireNameMatch::class.java)
                     val domainTypes = context.agentProcess.agent.jvmTypes.map { it.clazz }
-                    val variable = if (requireNameMatch != null) {
-                        parameter.name
-                    } else {
-                        IoBinding.DEFAULT_BINDING
-                    }
+                    val variable = getBindingParameterName(parameter, requireNameMatch)
                     args += context.getValue(
                         variable = variable,
                         type = parameter.type.name,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
@@ -22,7 +22,6 @@ import com.embabel.agent.api.common.TransformationActionContext
 import com.embabel.agent.api.common.support.MultiTransformationAction
 import com.embabel.agent.api.common.support.expandInputBindings
 import com.embabel.agent.core.Action
-import com.embabel.agent.core.IoBinding
 import com.embabel.agent.core.ProcessContext
 import com.embabel.agent.core.ToolGroupRequirement
 import org.slf4j.LoggerFactory
@@ -65,7 +64,7 @@ internal class DefaultActionMethodManager(
             .map {
                 val nameMatchAnnotation = it.getAnnotation(RequireNameMatch::class.java)
                 expandInputBindings(
-                    if (nameMatchAnnotation != null) it.name else IoBinding.Companion.DEFAULT_BINDING,
+                    getBindingParameterName(it, nameMatchAnnotation),
                     it.type
                 )
             }
@@ -118,12 +117,7 @@ internal class DefaultActionMethodManager(
 
                 else -> {
                     val requireNameMatch = parameter.getAnnotation(RequireNameMatch::class.java)
-                    val domainTypes = actionContext.processContext.agentProcess.agent.jvmTypes.map { it.clazz }
-                    val variable = if (requireNameMatch != null) {
-                        parameter.name
-                    } else {
-                        IoBinding.DEFAULT_BINDING
-                    }
+                    val variable = getBindingParameterName(parameter, requireNameMatch)
                     val lastArg = actionContext.getValue(
                         variable = variable,
                         type = parameter.type.name,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/utils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/utils.kt
@@ -15,7 +15,10 @@
  */
 package com.embabel.agent.api.annotation.support
 
+import com.embabel.agent.api.annotation.RequireNameMatch
 import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.core.IoBinding
+import java.lang.reflect.Parameter
 
 /**
  * Convenient method to deploy instances to an agent platform
@@ -27,4 +30,18 @@ fun AgentPlatform.deployAnnotatedInstances(
     instances
         .mapNotNull { agentMetadataReader.createAgentMetadata(it) }
         .forEach { deploy(it) }
+}
+
+/**
+ * Returns the name of the parameter based on the provided [RequireNameMatch].
+ */
+fun getBindingParameterName(
+    parameter: Parameter,
+    requireNameMatch: RequireNameMatch?,
+): String {
+    if (requireNameMatch == null) {
+        return IoBinding.DEFAULT_BINDING
+    }
+
+    return requireNameMatch.value.ifBlank { parameter.name }
 }


### PR DESCRIPTION
This PR introduces support for explicit binding names. Developers can now specify a binding name directly, eliminating the need to rely on the `--parameter` flag during Java compilation. It also allows developers to be explicit in binding names and preventing issues caused by unintentional variable renaming.