### PR TITLE
Make File and Git Tests OS agnostic.

### DIFF
--- a/embabel-agent-code/src/test/kotlin/com/embabel/coding/tools/GitReferenceTest.kt
+++ b/embabel-agent-code/src/test/kotlin/com/embabel/coding/tools/GitReferenceTest.kt
@@ -37,7 +37,7 @@ class GitReferenceTest {
             assertTrue(Files.exists(clonedRepo.localPath.resolve(".git")))
 
             // Verify absolute path is returned
-            assertTrue(clonedRepo.root.startsWith("/"))
+            assertTrue(clonedRepo.localPath.isAbsolute)
             assertEquals(clonedRepo.localPath.toAbsolutePath().toString(), clonedRepo.root)
 
             // Verify some expected files exist (Hello-World repo has README)
@@ -162,8 +162,12 @@ class GitReferenceTest {
 
         // Initialize empty git repo
         Git.init().setDirectory(emptyRepo.toFile()).call().use { git ->
-            // Create an empty commit
-            git.commit().setMessage("Initial commit").setAllowEmpty(true).call()
+            // Create an empty commit without signing
+            git.commit()
+                .setMessage("Initial commit")
+                .setAllowEmpty(true)
+                .setSign(false)  // Disable GPG signing for tests
+                .call()
         }
 
         val clonedRepo = ClonedRepository(localPath = emptyRepo, shouldDeleteOnClose = false)


### PR DESCRIPTION
This pull request improves cross-platform compatibility and reliability of file system operations in both the agent API and code modules. The main changes involve switching from `Files.walk` to `Files.walkFileTree` with a `FileVisitor` to handle directory traversal, especially for excluding `.git` directories, and handling file access errors gracefully. Several test improvements and minor refactorings are also included.

**File system traversal and cross-platform compatibility:**

* Refactored `fileCount()` in `FileReadTools` (`FileTools.kt`) to use `Files.walkFileTree` with a custom `FileVisitor`, ensuring `.git` directories are properly excluded and file counting works on both Windows and Linux. Also added error logging for inaccessible files.
* Updated `writeAllFilesToString()` in `ClonedRepository` (`GitReference.kt`) to use `Files.walkFileTree` for robust file listing and `.git` exclusion, collecting files in a list, sorting, and then processing them.

**Imports and dependencies:**

* Consolidated and updated imports in both `FileTools.kt` and `GitReference.kt` to support new file traversal and attribute handling logic. [[1]](diffhunk://#diff-f3642ea3c682dc65a157342e01940b8f4c4e598adc8dd3c45949fd4c992bda45L29-R32) [[2]](diffhunk://#diff-37deb6e717007a92b5ea914c81300706789b03b2351211320386fb9e5b15259dL26-R28)

**Testing and reliability improvements:**

* Updated `GitReferenceTest` to use `localPath.isAbsolute` for path checks, improving test clarity and reliability.
* Modified test repository initialization in `GitReferenceTest` to disable GPG signing for empty commits, preventing test failures in environments without GPG configuration.