### PR TITLE
Refactor deployment to copy generated-docs directory

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -90,14 +90,10 @@ jobs:
       - name: Deploy to VM with sudo
         run: |
           # Step 1: Copy to user's home directory first
-          gcloud compute scp target/generated-docs/index.html \
-            ${{ github.event.inputs.vm_instance }}:~/index.html \
+          gcloud compute scp --recurse target/generated-docs \
+            ${{ github.event.inputs.vm_instance }}:~/guide \
             --zone=${{ github.event.inputs.vm_zone }}
           
-          gcloud compute scp --recurse target/generated-docs/images \
-            ${{ github.event.inputs.vm_instance }}:~/images \
-            --zone=${{ github.event.inputs.vm_zone }}
-
           gcloud compute scp --recurse target/dokka-aggregate \
             ${{ github.event.inputs.vm_instance }}:~/dokka \
             --zone=${{ github.event.inputs.vm_zone }}          
@@ -109,8 +105,7 @@ jobs:
               sudo rm -rf /var/www/html/embabel-agent &&
               sudo mkdir -p /var/www/html/embabel-agent/guide &&
               sudo mkdir -p /var/www/html/embabel-agent/api-docs &&
-              sudo cp ~/index.html /var/www/html/embabel-agent/guide/ &&
-              sudo cp -r ~/images /var/www/html/embabel-agent/guide &&
+              sudo cp -r ~/guide/*  /var/www/html/embabel-agent/guide &&
               sudo cp -r ~/dokka/*  /var/www/html/embabel-agent/api-docs
               "
 


### PR DESCRIPTION
This pull request updates the deployment workflow for documentation to simplify and streamline the process of copying generated docs to the VM and deploying them to the web server. The main change is consolidating the copying of documentation files into a single step and updating the deployment commands accordingly.

**Deployment process simplification:**

* The workflow now copies the entire `target/generated-docs` directory recursively to the VM as `~/guide`, instead of copying `index.html` and `images` separately. (`.github/workflows/deploy-docs.yml`)
* The deployment step on the VM is updated to copy all contents of `~/guide` into `/var/www/html/embabel-agent/guide`, replacing the previous separate copy commands for `index.html` and `images`. (`.github/workflows/deploy-docs.yml`)Updated deployment script to copy entire generated-docs directory instead of individual files.