### PR TITLE
Update build-parent to 0.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -15,7 +15,7 @@
     <description>Parent POM for Embabel Agent Modules</description>
 
     <properties>
-        <embabel-common.version>0.1.1-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.1</embabel-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request updates the `pom.xml` to use the stable release version `0.1.1` instead of the snapshot version for both the parent build and the `embabel-common` dependency. This ensures that the project references finalized dependencies rather than potentially unstable snapshot versions.