### PR TITLE
Update build-parent to 0.1.1

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.1</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>


### PR DESCRIPTION
This pull request includes a minor update to the `embabel-agent-dependencies/pom.xml` file, changing the parent dependency version from a snapshot (`0.1.1-SNAPSHOT`) to a stable release (`0.1.1`).