### PR TITLE
Switch to embabel-common 0.1.2-SNAPSHOT

### DIFF
--- a/embabel-agent-docs/pom.xml
+++ b/embabel-agent-docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.agent</groupId>
         <artifactId>embabel-agent-parent</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.1.2-SNAPSHOT</version>
     </parent>
     <artifactId>embabel-agent-docs</artifactId>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Parent POM for Embabel Agent Modules</description>
 
     <properties>
-        <embabel-common.version>0.1.1</embabel-common.version>
+        <embabel-common.version>0.1.2-SNAPSHOT</embabel-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request updates version references in Maven configuration files to prepare for the next development iteration. The changes ensure that both the parent and common module dependencies use the new `0.1.2-SNAPSHOT` version.

Version updates:

* Updated the parent version in `embabel-agent-docs/pom.xml` from `0.1.1-SNAPSHOT` to `0.1.2-SNAPSHOT` to align with the new development cycle.
* Changed the `embabel-common.version` property in the root `pom.xml` from `0.1.1` to `0.1.2-SNAPSHOT` for consistency across modules.