### PR TITLE
Update API documentation link to use HTTPS

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/docinfo.html
+++ b/embabel-agent-docs/src/main/asciidoc/docinfo.html
@@ -7,7 +7,7 @@
         </div>
         <div class="navbar-actions">
             <a
-                    href="http://docs.embabel.com/embabel-agent/api-docs/{embabel-agent-version}/index.html"
+                    href="https://docs.embabel.com/embabel-agent/api-docs/{embabel-agent-version}/index.html"
                     target="_blank"
                     rel="noreferrer noopener"
                     class="link-button"


### PR DESCRIPTION
This pull request includes a minor update to the documentation navigation bar, specifically fixing the link to the Embabel Agent API docs to use a secure HTTPS connection.

* Updated the API documentation link in `docinfo.html` from `http` to `https` to ensure secure access.