### PR TITLE
Update ProcessOptions builder to handle new fields

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
@@ -285,7 +285,7 @@ data class ProcessOptions(
      */
     class Builder internal constructor() {
 
-        private var processOptions = ProcessOptions.DEFAULT
+        private var processOptions = DEFAULT
 
         /**
          * Set the context identifier to use for the invocation. Can be null.
@@ -297,6 +297,16 @@ data class ProcessOptions(
         @JvmName("contextId")
         fun contextId(contextId: ContextId?): Builder {
             this.processOptions = processOptions.copy(contextId = contextId)
+            return this
+        }
+
+        /**
+         * Sets the identities associated with the process.
+         * @param identities the identities
+         * @return this [Builder]
+         */
+        fun identities(identities: Identities): Builder {
+            this.processOptions = processOptions.copy(identities = identities)
             return this
         }
 
@@ -384,6 +394,40 @@ data class ProcessOptions(
          */
         fun control(control: ProcessControl): Builder {
             this.processOptions = processOptions.copy(control = control)
+            return this
+        }
+
+        /**
+         * Whether to prune the agent to only relevant actions
+         * @param prune true to prune the agent to only relevant actions
+         * @return this [Builder]
+         */
+        fun prune(prune: Boolean): Builder {
+            this.processOptions = processOptions.copy(prune = prune)
+            return this
+        }
+
+        /**
+         * Add a listener to the list of [AgenticEventListener]s.
+         * @param listener the listener to add
+         * @return this [Builder]
+         */
+        fun listener(listener: AgenticEventListener): Builder {
+            val listeners = this.processOptions.listeners + listener
+            this.processOptions = processOptions.copy(listeners = listeners)
+            return this
+        }
+
+        /**
+         * Manipulate the listeners with the given consumer.
+         * The list provided to the consumer can be used to remove listeners, change ordering, etc.
+         * @param listener the listener to add
+         * @return this [Builder]
+         */
+        fun listeners(consumer: Consumer<List<AgenticEventListener>>): Builder {
+            val listeners = this.processOptions.listeners.toMutableList()
+            consumer.accept(listeners)
+            this.processOptions = processOptions.copy(listeners = listeners)
             return this
         }
 

--- a/embabel-agent-api/src/test/java/com/embabel/agent/core/ProcessOptionsBuilderTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/core/ProcessOptionsBuilderTest.java
@@ -16,8 +16,10 @@
 package com.embabel.agent.core;
 
 import com.embabel.agent.core.support.InMemoryBlackboard;
-import com.embabel.agent.testing.unit.FakeOperationContext;
+import com.embabel.agent.event.AgenticEventListener;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,11 +28,17 @@ class ProcessOptionsBuilderTest {
 
     @Test
     void builder() {
+        var identities = new Identities();
         var blackboard = new InMemoryBlackboard();
+        var listener  = AgenticEventListener.Companion.getDevNull();
 
         var po = ProcessOptions.builder()
+                .identities(identities)
                 .blackboard(blackboard)
                 .test(true)
+                .prune(true)
+                .listener(listener)
+                .listeners(listeners -> assertEquals(List.of(listener), listeners))
                 .verbosity(vb -> vb
                         .showPrompts(true)
                         .showLlmResponses(true)
@@ -45,8 +53,11 @@ class ProcessOptionsBuilderTest {
                 )
                 .build();
 
+        assertEquals(identities, po.getIdentities());
         assertEquals(blackboard, po.getBlackboard());
         assertTrue(po.getTest());
+        assertTrue(po.getPrune());
+        assertEquals(List.of(listener), po.getListeners());
 
         assertTrue(po.getVerbosity().getShowPrompts());
         assertTrue(po.getVerbosity().getShowLlmResponses());


### PR DESCRIPTION
This commit introduces builder options for ProcessOptions fields introduced since the builder's introduction.

See #659