### PR TITLE
1. Add spring-ai-starter-mcp-server-webmvc

### DIFF
--- a/embabel-agent-mcpserver/pom.xml
+++ b/embabel-agent-mcpserver/pom.xml
@@ -23,6 +23,11 @@
             <artifactId>embabel-common-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>com.embabel.agent</groupId>


### PR DESCRIPTION
This pull request introduces a new dependency to the `embabel-agent-mcpserver` project. The addition is focused on enabling Spring AI features for MCP server implementations.

Dependency management:

* Added the `spring-ai-starter-mcp-server-webmvc` dependency from the `org.springframework.ai` group to the `pom.xml`, which will allow the project to leverage Spring AI capabilities for web MVC-based MCP server functionality.2. Starter with embedded HTTP listener actually makes sense here.