### PR TITLE
Polishing Shell Starter

### DIFF
--- a/embabel-agent-starters/embabel-agent-starter-shell/src/main/java/com/embabel/agent/starter/shell/spi/ShellEnvironmentPostProcessor.java
+++ b/embabel-agent-starters/embabel-agent-starter-shell/src/main/java/com/embabel/agent/starter/shell/spi/ShellEnvironmentPostProcessor.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.starter.shell;
+package com.embabel.agent.starter.shell.spi;
 
 import com.embabel.agent.config.annotation.EnableAgentShell;
+import com.embabel.agent.starter.shell.AgentShellStarterProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;

--- a/embabel-agent-starters/embabel-agent-starter-shell/src/main/resources/META-INF/spring.factories
+++ b/embabel-agent-starters/embabel-agent-starter-shell/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 # Environment Post Processors
-org.springframework.boot.env.EnvironmentPostProcessor=com.embabel.agent.starter.shell.ShellEnvironmentPostProcessor
+org.springframework.boot.env.EnvironmentPostProcessor=com.embabel.agent.starter.shell.spi.ShellEnvironmentPostProcessor

--- a/embabel-agent-starters/embabel-agent-starter-shell/src/test/java/com/embabel/agent/starter/shell/spi/ShellEnvironmentPostProcessorTest.java
+++ b/embabel-agent-starters/embabel-agent-starter-shell/src/test/java/com/embabel/agent/starter/shell/spi/ShellEnvironmentPostProcessorTest.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.starter.shell;
+package com.embabel.agent.starter.shell.spi;
 
 import com.embabel.agent.config.annotation.EnableAgentShell;
+import com.embabel.agent.starter.shell.AgentShellStarterProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
This pull request makes a small but important organizational update to the `embabel-agent-starter-shell` module. The main change is moving the `ShellEnvironmentPostProcessor` class and its associated test to a new package for better code structure and clarity. The change also updates the Spring factories configuration to reflect the new location.

Most important changes:

**Code organization and structure:**

* Moved the `ShellEnvironmentPostProcessor` class from the `com.embabel.agent.starter.shell` package to the new `com.embabel.agent.starter.shell.spi` package, and updated its imports.
* Renamed and moved the `ShellEnvironmentPostProcessorTest` class to the corresponding `spi` package, updating its imports as well.

**Configuration update:**

* Updated `META-INF/spring.factories` to reference the new location of `ShellEnvironmentPostProcessor` so Spring Boot can discover it correctly.