### PR TITLE
Update BOM with starter dep

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -72,6 +72,18 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-mcpserver</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-shell</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-test</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
This pull request adds two new dependencies to the `embabel-agent-dependencies/pom.xml` file. These additions will allow the project to use features provided by the `embabel-agent-starter-mcpserver` and `embabel-agent-starter-shell` modules.

Dependency additions:

* Added `embabel-agent-starter-mcpserver` as a dependency, enabling integration with the MCP server starter module.
* Added `embabel-agent-starter-shell` as a dependency, enabling integration with the shell starter module.