### PR TITLE
Update deploy-docs.yml to include push triggers

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,6 +7,11 @@
 name: Publish Docs
 
 on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
   workflow_dispatch:  # Enables manual triggering
     inputs:
       environment:


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to trigger automatically on pushes to the `main` branch and on tags that start with `v`, in addition to manual triggering.

* Workflow triggers: The `.github/workflows/deploy-docs.yml` file now runs on pushes to the `main` branch and tags matching `v*`, allowing for automated documentation deployment on these events.