### PR TITLE
Update deploy-docs.yml to remove push triggers

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,11 +7,6 @@
 name: Publish Docs
 
 on:
-  push:
-    branches:
-      - 'main'
-    tags:
-      - 'v*'
   workflow_dispatch:  # Enables manual triggering
     inputs:
       environment:


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow for documentation. The change removes automatic triggers for publishing docs on pushes to the `main` branch and tags starting with `v`, leaving only manual triggering via the workflow dispatch input.

([.github/workflows/deploy-docs.ymlL10-L14](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6L10-L14))Removed automatic triggers for push to main and version tags.