### PR TITLE
Enhance CI workflow for SonarCloud and forks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ (matrix.os == 'ubuntu-latest' && secrets.SONAR_TOKEN != '') && 0 || 1 }}
+          fetch-depth: ${{ matrix.os == 'ubuntu-latest' && 0 || 1 }}
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -38,8 +38,7 @@ jobs:
       - name: Linux-specific setup and SonarCloud analysis
         if: |
           matrix.os == 'ubuntu-latest' &&
-          (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
-          secrets.SONAR_TOKEN != ''
+          (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -50,6 +49,7 @@ jobs:
           
           # Run SonarCloud analysis
           mvn -P jacoco-code-coverage -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.2.0.4988:sonar -Dsonar.projectKey=embabel_embabel-agent
+  
   # Separate job for external forks
   build-fork:
     if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,9 +37,9 @@ jobs:
         run: mvn -U -B test verify
       - name: Linux-specific setup and SonarCloud analysis
         if: |
-         matrix.os == 'ubuntu-latest' &&
-         (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
-         secrets.SONAR_TOKEN != ''
+          matrix.os == 'ubuntu-latest' &&
+          (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
+          secrets.SONAR_TOKEN != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,6 @@ on:
   push:
   pull_request:
     types: [ opened, synchronize, reopened ]
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -20,6 +19,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ (matrix.os == 'ubuntu-latest' && secrets.SONAR_TOKEN != '') && 0 || 1 }}
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -35,7 +36,10 @@ jobs:
           SKIP_TESTCONTAINER_TESTS: true  # Do not run TestContainer Tests in Windows Matrix Build.
         run: mvn -U -B test verify
       - name: Linux-specific setup and SonarCloud analysis
-        if: matrix.os == 'ubuntu-latest'
+        if: |
+         matrix.os == 'ubuntu-latest' &&
+         (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) &&
+         secrets.SONAR_TOKEN != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -45,4 +49,29 @@ jobs:
           echo "testcontainers.reuse.enable=true" > /home/runner/.testcontainers.properties
           
           # Run SonarCloud analysis
-          mvn -P jacoco-code-coverage -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=embabel_embabel-agent
+          mvn -P jacoco-code-coverage -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.2.0.4988:sonar -Dsonar.projectKey=embabel_embabel-agent
+  # Separate job for external forks
+  build-fork:
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v4
+        
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+          
+      - name: Configure Testcontainers
+        run: |
+          mkdir -p /home/runner
+          echo "testcontainers.reuse.enable=true" > /home/runner/.testcontainers.properties
+          
+      - name: Build and test (no SonarCloud)
+        run: mvn -U -B clean verify
+        
+      - name: Fork notice
+        run: echo "Fork build completed successfully (SonarCloud analysis skipped for security)"


### PR DESCRIPTION
This pull request updates the `.github/workflows/maven.yml` workflow to improve security and CI reliability, especially for external pull requests and SonarCloud analysis. The main changes include stricter conditions for SonarCloud runs, a dedicated job for forked PRs, and improved checkout configuration.

**SonarCloud and Fork Handling:**

* Updated the condition for running SonarCloud analysis to ensure it only runs for pushes or PRs from the main repository, and when `SONAR_TOKEN` is available. This prevents exposing secrets to external forks.
* Changed the SonarCloud Maven plugin invocation to use a specific version (`5.2.0.4988`) for more reliable builds.

**Forked PR Support:**

* Added a new `build-fork` job that runs for PRs from external forks, skipping SonarCloud analysis for security. This job builds and tests the code, and provides a clear notice at the end.

**Checkout and Setup Improvements:**

* Improved the `actions/checkout` step to use `fetch-depth: 0` only when running SonarCloud analysis on Ubuntu with a valid token, reducing unnecessary history fetches.

**Workflow Structure:**

* Minor formatting updates to the workflow triggers for clarity.Updated SonarCloud analysis step to include version and added a separate job for external forks.