### PR TITLE
Prepare for 0.1.2 release.

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.1</version>
+        <version>0.1.3</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.1.3</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -15,7 +15,7 @@
     <description>Parent POM for Embabel Agent Modules</description>
 
     <properties>
-        <embabel-common.version>0.1.2-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.2</embabel-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request updates project dependencies and parent versions to use stable releases instead of snapshot versions. The main changes are focused on upgrading the parent POM versions and the `embabel-common` dependency to ensure consistency and stability across the build.

Dependency and parent version updates:

* Updated the parent version in `pom.xml` from `0.1.2-SNAPSHOT` to `0.1.3`, switching from a snapshot to a stable release.
* Updated the parent version in `embabel-agent-dependencies/pom.xml` from `0.1.1` to `0.1.3` to align with the latest stable parent release.
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.2-SNAPSHOT` to `0.1.2`, ensuring the use of a stable dependency version.