### PR TITLE
Update user guide with new starter model

### DIFF
--- a/embabel-agent-docs/pom.xml
+++ b/embabel-agent-docs/pom.xml
@@ -130,8 +130,11 @@
                                 <dir>${project.parent.basedir}/embabel-agent-api/src/main/java</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-a2a/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-autoconfigure/src/main/java</dir>
+                                <dir>${project.parent.basedir}/embabel-agent-code/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-eval/src/main/kotlin</dir>
-                                <dir>${project.parent.basedir}/embabel-agent-rag/src/main/kotlin</dir>
+                                <dir>${project.parent.basedir}/embabel-agent-mcpserver/src/main/kotlin</dir>
+                                <dir>${project.parent.basedir}/embabel-agent-rag/embabel-agent-rag-neo/src/main/kotlin</dir>
+                                <dir>${project.parent.basedir}/embabel-agent-rag/embabel-agent-rag-lucene/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-shell/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-discord/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-ux/src/main/kotlin</dir>

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing.adoc
@@ -5,7 +5,51 @@ The easiest way to get started with Embabel Agent is to add the Spring Boot star
 
 ==== Maven
 
-Add the Embabel Agent Spring Boot starter to your `pom.xml`:
+Add the appropriate Embabel Agent Spring Boot starter to your `pom.xml` depending on your application type:
+
+===== Shell Starter
+Starts the application in console mode with an interactive shell powered by Embabel.
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-shell</artifactId>
+    <version>${embabel-agent.version}</version>
+</dependency>
+----
+
+*Features:*
+
+* ✅ Interactive command-line interface
+* ✅ Agent discovery and registration
+* ✅ Human-in-the-loop capabilities
+* ✅ Progress tracking and logging
+* ✅ Development-friendly error handling
+
+===== MCP Server Starter
+Starts the application with HTTP listener where agents are autodiscovered and registered as MCP servers, available for integration via SSE protocol.
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-mcpserver</artifactId>
+    <version>${embabel-agent.version}</version>
+</dependency>
+----
+
+*Features:*
+
+* ☑️ MCP protocol server implementation
+* ☑️ Tool registration and discovery
+* ☑️ JSON-RPC communication via SSE (Server-Sent Events)
+* ☑️ Integration with MCP-compatible clients
+* ☑️ Security and sandboxing
+
+===== Basic Agent Platform Starter
+Initializes Embabel Agent Platform in the Spring Container. Platform beans are available via Spring Dependency Injection mechanism.
+Application startup mode (web, console, microservice, etc.) is determined by the Application Designer.
 
 [source,xml]
 ----
@@ -15,6 +59,15 @@ Add the Embabel Agent Spring Boot starter to your `pom.xml`:
     <version>${embabel-agent.version}</version>
 </dependency>
 ----
+
+*Features:*
+
+* ✔️ Application decides on startup mode (console, web application, etc)
+* ✔️ Agent discovery and registration
+* ✔️ Agent Platform beans available via Dependency Injection mechanism
+* ✔️ Progress tracking and logging
+* ✔️ Development-friendly error handling
+
 
 You'll also need to add the Embabel repository to your `pom.xml`:
 
@@ -80,12 +133,12 @@ repositories {
 }
 ----
 
-Add the Embabel Agent starter dependency:
+Add the Embabel Agent starter dependency of choice:
 
 [source,kotlin]
 ----
 dependencies {
-    implementation("com.embabel.agent:embabel-agent-starter:${embabel-agent.version}")
+    implementation("com.embabel.agent:embabel-agent-starter-shell:${embabel-agent.version}")
 }
 ----
 
@@ -116,7 +169,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.embabel.agent:embabel-agent-starter:${embabel-agent.version}'
+    implementation 'com.embabel.agent:embabel-agent-starter-shell:${embabel-agent.version}'
 }
 ----
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration.adoc
@@ -10,7 +10,6 @@ Example:
 [source,java]
 ----
 @SpringBootApplication
-@EnableAgentShell
 @EnableAgents(
     loggingTheme = LoggingThemes.STAR_WARS,
     localModels = { "docker" },
@@ -25,9 +24,6 @@ class MyAgentApplication {
 
 This is a normal Spring Boot application class.
 You can add other Spring Boot annotations as needed.
-`@EnableAgentShell` enables the agent shell, which allows you to interact with agents via a command line interface.
-This is optional.
-
 `@EnableAgents` enables the agent framework.
 It allows you to specify a logging theme (optional) and well-known sources of local models and MCP tools.
 In this case we're using Docker as a source of local models and MCP tools.


### PR DESCRIPTION
This pull request updates the documentation for Embabel Agent to clarify installation instructions and starter options, and refines the project build configuration to reflect new module structure. The most important changes are the addition of detailed starter descriptions, improved dependency instructions for different application types, and updates to source directories for new modules.

**Documentation improvements:**

* Expanded installation instructions in `installing.adoc` to describe three distinct Spring Boot starters: Shell Starter, MCP Server Starter, and Basic Agent Platform Starter, each with their own features and use cases. [[1]](diffhunk://#diff-6883347e1faea77a51bb7e4ec3c64ac5e1debdd302a490213b9b74b9bc777896L8-R52) [[2]](diffhunk://#diff-6883347e1faea77a51bb7e4ec3c64ac5e1debdd302a490213b9b74b9bc777896R63-R71)
* Updated Gradle and Maven dependency examples to use the specific starter relevant to the chosen application type, replacing the generic starter with `embabel-agent-starter-shell` in code samples. [[1]](diffhunk://#diff-6883347e1faea77a51bb7e4ec3c64ac5e1debdd302a490213b9b74b9bc777896L83-R141) [[2]](diffhunk://#diff-6883347e1faea77a51bb7e4ec3c64ac5e1debdd302a490213b9b74b9bc777896L119-R172)
* Removed references to the deprecated `@EnableAgentShell` annotation in configuration documentation, simplifying the example and clarifying agent enablement. [[1]](diffhunk://#diff-c41be3a669a2bbd4833286f9ea66b4626a78b297ac06ec61fabe1e67b3194507L13) [[2]](diffhunk://#diff-c41be3a669a2bbd4833286f9ea66b4626a78b297ac06ec61fabe1e67b3194507L28-L30)

**Build configuration updates:**

* Modified the `pom.xml` to update the list of source directories, reflecting new module structure by adding `embabel-agent-code`, `embabel-agent-mcpserver`, and submodules for RAG (`embabel-agent-rag-neo` and `embabel-agent-rag-lucene`), while removing the old `embabel-agent-rag` directory.