### PR TITLE
Fix docker-ce profile not activating, brave MCP misonfigured

### DIFF
--- a/embabel-agent-api/src/main/resources/application-docker-ce.yml
+++ b/embabel-agent-api/src/main/resources/application-docker-ce.yml
@@ -18,9 +18,12 @@ spring:
                 - -i
                 - --rm
                 - -e
+                - BRAVE_MCP_TRANSPORT
+                - -e
                 - BRAVE_API_KEY
                 - mcp/brave-search
               env:
+                BRAVE_MCP_TRANSPORT: "stdio"
                 BRAVE_API_KEY: ${BRAVE_API_KEY}
             fetch-mcp:
               command: docker

--- a/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/McpServers.java
+++ b/embabel-agent-autoconfigure/src/main/java/com/embabel/agent/config/annotation/McpServers.java
@@ -20,7 +20,7 @@ package com.embabel.agent.config.annotation;
  */
 public class McpServers {
 
-    public static final String DOCKER = "docker";
+    public static final String DOCKER = "docker-ce";
 
     public static final String DOCKER_DESKTOP = "docker-desktop";
 }


### PR DESCRIPTION
- **Fix docker not enabling correctly as profile is docker-ce**
- **Fix brave mcp starts as server by default needs to be configured for stdio in docker config**

Fixes:

1) 
`@EnableAgents(mcpServers = {McpServers.DOCKER})`

Is currently not working as the profile doesnt match the name.

2)
brave mcp starts as server by default, and needs to be configured to start as stdio. 
see https://hub.docker.com/mcp/server/brave/overview 