### PR TITLE
Use java reflection when kotlin-reflect is unavailable

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -310,7 +310,8 @@ class AgentMetadataReader(
                 else -> {
                     val requireNameMatch = parameter.getAnnotation(RequireNameMatch::class.java)
                     val domainTypes = context.agentProcess.agent.jvmTypes.map { it.clazz }
-                    val variable = getBindingParameterName(parameter, requireNameMatch)
+                    val variable = getBindingParameterName(parameter.name, requireNameMatch)
+                        ?: error("Parameter name should be available")
                     args += context.getValue(
                         variable = variable,
                         type = parameter.type.name,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/utils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/utils.kt
@@ -18,7 +18,6 @@ package com.embabel.agent.api.annotation.support
 import com.embabel.agent.api.annotation.RequireNameMatch
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.IoBinding
-import java.lang.reflect.Parameter
 
 /**
  * Convenient method to deploy instances to an agent platform
@@ -36,12 +35,12 @@ fun AgentPlatform.deployAnnotatedInstances(
  * Returns the name of the parameter based on the provided [RequireNameMatch].
  */
 fun getBindingParameterName(
-    parameter: Parameter,
-    requireNameMatch: RequireNameMatch?,
-): String {
+    parameterName: String?,
+    requireNameMatch: RequireNameMatch?
+): String? {
     if (requireNameMatch == null) {
         return IoBinding.DEFAULT_BINDING
     }
 
-    return requireNameMatch.value.ifBlank { parameter.name }
+    return requireNameMatch.value.ifBlank { parameterName }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/RequireNonAmbiguousParametersTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/RequireNonAmbiguousParametersTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class RequireNonAmbiguousParametersTest {
 
@@ -118,7 +119,7 @@ class RequireNonAmbiguousParametersTest {
         val m = method("annotatedWithValue")
         val p = m.parameters[0]
         val ann = p.getAnnotation(RequireNameMatch::class.java)
-        val result = getBindingParameterName(p, ann)
+        val result = getBindingParameterName(p.name, ann)
         assertEquals("bindingX", result)
     }
 
@@ -128,15 +129,24 @@ class RequireNonAmbiguousParametersTest {
         val p = m.parameters[0]
         val ann = p.getAnnotation(RequireNameMatch::class.java)
         val expected = p.name
-        val result = getBindingParameterName(p, ann)
+        val result = getBindingParameterName(p.name, ann)
         assertEquals(expected, result)
+    }
+
+    @Test
+    fun `getParameterName returns null parameter name when parameter name is null`() {
+        val m = method("annotatedWithoutValue")
+        val p = m.parameters[0]
+        val ann = p.getAnnotation(RequireNameMatch::class.java)
+        val result = getBindingParameterName(null, ann)
+        assertNull(result)
     }
 
     @Test
     fun `getParameterName returns DEFAULT_BINDING when annotation is null`() {
         val m = method("distinctTypes")
         val p = m.parameters[0]
-        val result = getBindingParameterName(p, null)
+        val result = getBindingParameterName(p.name, null)
         assertEquals(IoBinding.DEFAULT_BINDING, result)
     }
 }


### PR DESCRIPTION
This PR changes the `DefaultActionMethodManager` so that it only uses the Kotlin reflection API when available, and falls back to the Java reflection API when it is not. Before this PR, methods were invoked using both Java and Kotlin reflection.

Furthermore, this commit throws an exception when code is compiled without the -java-parameters or -parameters flag (see #728).