### PR TITLE
Make parseResource to work on Windows

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-tika/src/main/kotlin/com/embabel/agent/rag/ingestion/HierarchicalContentReader.kt
+++ b/embabel-agent-rag/embabel-agent-rag-tika/src/main/kotlin/com/embabel/agent/rag/ingestion/HierarchicalContentReader.kt
@@ -93,7 +93,9 @@ class HierarchicalContentReader {
         metadata: Metadata = Metadata(),
     ): MaterializedContentRoot {
         val resource: Resource = DefaultResourceLoader().getResource(resourcePath)
-        return parseContent(resource.inputStream, metadata, resource.uri.toString())
+        return resource.inputStream.use { inputStream ->
+            parseContent(inputStream, metadata, resource.uri.toString())
+        }
     }
 
     /**
@@ -467,9 +469,9 @@ class HierarchicalContentReader {
                 return null
             }
 
-            // Use file:// protocol for local files as expected by Spring Resource
-            val resourcePath = "file://" + fileTools.resolvePath(filePath).toAbsolutePath()
-            val result = parseResource(resourcePath)
+            // Use file URI for local files - convert to proper URI format
+            val fileUri = fileTools.resolvePath(filePath).toUri().toString()
+            val result = parseResource(fileUri)
 
             logger.info(
                 "Successfully parsed file '{}' - {} sections extracted",


### PR DESCRIPTION
This pull request improves resource handling in the `HierarchicalContentReader` class by updating how file URIs are constructed and ensuring input streams are properly closed after use. These changes enhance compatibility with URI standards and improve resource management to prevent potential leaks.

Resource handling improvements:

* Updated file URI construction to use `toUri().toString()` instead of manual string concatenation, ensuring proper URI formatting for local files.
* Wrapped the use of `resource.inputStream` in a `use` block to ensure the input stream is automatically closed after parsing, improving resource management.