### PR TITLE
Remove embabel-agent-autoconfigure from dokka docs build.

### DIFF
--- a/embabel-agent-docs/pom.xml
+++ b/embabel-agent-docs/pom.xml
@@ -128,7 +128,6 @@
                                 <dir>${project.parent.basedir}/embabel-agent-api/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-api/src/main/java</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-a2a/src/main/kotlin</dir>
-                                <dir>${project.parent.basedir}/embabel-agent-autoconfigure/src/main/java</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-code/src/main/kotlin</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java</dir>
                                 <dir>${project.parent.basedir}/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/java</dir>


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file for the `embabel-agent-docs` module. The change removes a redundant or outdated source directory reference for `embabel-agent-autoconfigure`, likely to prevent duplicate or incorrect source inclusion.

* Removed the `<dir>${project.parent.basedir}/embabel-agent-autoconfigure/src/main/java</dir>` entry from the list of source directories in `embabel-agent-docs/pom.xml`.