### PR TITLE
Add Diagnostic Logging for LLM Configuration Properties

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanner.kt
@@ -249,6 +249,8 @@ class DeprecatedPropertyScanner(
         put("embabel.anthropic", "embabel.agent.platform.models.anthropic")
         put("embabel.openai", "embabel.agent.platform.models.openai")
         put("embabel.llm-operations", "embabel.agent.platform.llm-operations")
+        put("embabel.llm-operations.data-binding", "embabel.agent.platform.llm-operations.data-binding")
+        put("embabel.llm-operations.prompts", "embabel.agent.platform.llm-operations.prompts")
         put("embabel.autonomy", "embabel.agent.platform.autonomy")
         put("embabel.sse", "embabel.agent.platform.sse")
         put("embabel.process-id-generation", "embabel.agent.platform.process-id-generation")

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/config/AgentPlatformPropertiesIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/config/AgentPlatformPropertiesIntegrationTest.kt
@@ -27,9 +27,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.ComponentScan
-import org.springframework.context.annotation.Import
-import org.springframework.context.annotation.Primary
 import org.springframework.core.env.Environment
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.ActiveProfiles
@@ -188,6 +185,7 @@ import org.springframework.test.context.ActiveProfiles
     "embabel.agent.platform.migration.scanning.enabled=true",
     "embabel.agent.platform.migration.scanning.include-packages[0]=com.embabel.agent",
     "embabel.agent.platform.migration.scanning.include-packages[1]=com.test.package",
+    "embabel.agent.platform.migration.warnings.enabled=true",
 
     // Legacy properties for val/var investigation (using @TestPropertySource instead of env vars)
     "embabel.autonomy.agent-confidence-cut-off=0.95",


### PR DESCRIPTION
Add Diagnostic Logging for LLM Configuration Properties
=========

  Summary
===

  Adds diagnostic logging to help developers understand whether their LLM Data Binding configuration property
  overrides are working correctly and provides visibility into property source detection during
  Spring Boot application startup.

  Problem
=====

  Developers reported confusion about whether their LLM configuration property overrides (e.g.,
  embabel.llm-operations.data-binding.max-attempts) were being applied. The system appears  working
  correctly, but lacked visibility into:
  - Whether Spring-managed property beans were being used vs fallback defaults
  - What the actual runtime configuration values are
  - Whether the migration detection system could find deprecated properties

  Changes Made
===

  1. Enhanced LLM Operations Diagnostic Logging

  File: src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt

  - Added ApplicationContext parameter for Spring bean detection
  - Added @PostConstruct method with comprehensive logging that:
    - Detects whether properties come from Spring-managed beans or fallback defaults
    - Logs current runtime configuration values (maxAttempts, timeout, etc.)
    - Helps developers verify their property overrides are taking effect

  2. Fixed Migration Detection Bug

  File: src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanner.kt

  - Added missing exact prefix mappings that prevented LlmDataBindingProperties and
  LlmOperationsPromptsProperties from being detected by the migration utility

  Testing

  - All existing tests pass
  - Integration tests verify migration detection works correctly
  - Manual testing confirms diagnostic logging appears in application startup logs

  Developer Experience Impact
=======

  - Before: Developers couldn't tell if their property overrides were working
  - After: Clear log messages show property source and actual values being used
  - Migration: Scanner now correctly detects all LLM-related configuration classes

  Example Log Output

  When Spring-managed properties overrides are used:
  INFO  - LLM Data Binding: Using Spring-managed properties
  INFO  - Current LLM settings: maxAttempts=5, fixedBackoffMillis=500ms, timeout=50s

  When fallback defaults are used:
  WARN  - LLM Data Binding: Using fallback defaults
  INFO  - Current LLM settings: maxAttempts=10, fixedBackoffMillis=30ms, timeout=60s

  This PR focuses on diagnostic improvements and migration detection fixes rather than changing
  core functionality, providing better visibility into existing working systems.

