### PR TITLE
Add test scope to embabel-agent-test dependency

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/pom.xml
@@ -27,6 +27,7 @@
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This pull request makes a minor update to the `embabel-agent-openai-autoconfigure` module's dependencies. The change specifies that the `embabel-agent-test` dependency should only be used for testing purposes.

- Added `<scope>test</scope>` to the `embabel-agent-test` dependency in `pom.xml` to ensure it is only included in the test classpath.