### PR TITLE
Modify Maven repository details for Embabel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1044,11 +1044,13 @@ Binary Packages are located in Embabel Maven Repository.
 You would need to add Embabel Snapshot Repository to your pom.xml or configure in settings.xml
 
 ```xml
-
 <repositories>
     <repository>
-        <id>embabel-snapshots</id>
-        <url>https://repo.embabel.com/artifactory/libs-snapshot</url>
+        <id>embabel-releases</id>
+        <url>https://repo.embabel.com/artifactory/libs-release</url>
+        <releases>
+            <enabled>true</enabled>
+        </releases>
         <snapshots>
             <enabled>false</enabled>
         </snapshots>


### PR DESCRIPTION
This pull request updates the Maven repository configuration instructions in the `README.md` to point to the correct Embabel releases repository instead of the snapshots repository.

- Documentation update:
  * Changed the example Maven `<repository>` configuration to use the Embabel releases repository (`libs-release`) instead of the snapshots repository (`libs-snapshot`), and explicitly enabled releases while disabling snapshots.Updated Maven repository configuration in README.