### PR TITLE
Issue-825 AgentApplication for Integration Tests

### DIFF
--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/AgentApiTestApplication.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/AgentApiTestApplication.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+import org.springframework.context.annotation.ComponentScan
+
+@SpringBootApplication
+@ConfigurationPropertiesScan(
+    basePackages = [
+        "com.embabel.agent",
+        "com.embabel.example",
+    ]
+)
+@ComponentScan(
+    basePackages = [
+        "com.embabel.agent",
+        "com.embabel.example",
+    ]
+)
+class TestApplication {}

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/platform/AgentPlatformAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/platform/AgentPlatformAutoConfiguration.java
@@ -34,12 +34,14 @@ import org.springframework.context.annotation.Import;
 @AutoConfiguration
 @ConfigurationPropertiesScan(
         basePackages = {
-                "com.embabel.agent"
+                "com.embabel.agent",
+                "com.embabel.example"
         }
 )
 @ComponentScan(
         basePackages = {
-                "com.embabel.agent"
+                "com.embabel.agent",
+                "com.embabel.example"
         }
 )
 @ConditionalOnClass({AgentPlatformConfiguration.class, ToolGroupsConfiguration.class, RagServiceConfiguration.class})

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
@@ -17,6 +17,7 @@ package com.embabel.agent.config.annotation.spi;
 
 import com.embabel.agent.config.annotation.AgentPlatform;
 import com.embabel.agent.config.annotation.EnableAgents;
+import com.embabel.common.util.WinUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +87,15 @@ public class EnvironmentPostProcessor implements org.springframework.boot.env.En
     private final Logger logger = LoggerFactory.getLogger(EnvironmentPostProcessor.class);
 
     private static final String SPRING_PROFILES_ACTIVE = "spring.profiles.active";
+
+    static {
+        if (WinUtils.IS_OS_WINDOWS()) {
+            // Set console to UTF-8 on Windows and optimize font for Unicode display
+            // This is necessary to display non-ASCII characters correctly
+            WinUtils.CHCP_TO_UTF8();
+            WinUtils.SETUP_OPTIMAL_CONSOLE();
+        }
+    }
 
     /**
      * Post-processes the environment to activate profiles based on agent annotations.

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/pom.xml
@@ -39,6 +39,12 @@
             <artifactId>embabel-common-test-ai</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/embabel-agent-test/src/main/kotlin/com/embabel/agent/AgentTestApplication.kt
+++ b/embabel-agent-test/src/main/kotlin/com/embabel/agent/AgentTestApplication.kt
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.embabel.agent
-import com.embabel.common.util.WinUtils
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
@@ -33,19 +32,4 @@ import org.springframework.context.annotation.ComponentScan
         "com.embabel.example",
     ]
 )
-class AgentApplication {
-    companion object {
-        init {
-            if (WinUtils.IS_OS_WINDOWS()) {
-                // Set console to UTF-8 on Windows and optimize font for Unicode display
-                // This is necessary to display non-ASCII characters correctly
-                WinUtils.CHCP_TO_UTF8()
-                WinUtils.SETUP_OPTIMAL_CONSOLE()
-            }
-        }
-    }
-}
-
-fun main(args: Array<String>) {
-    runApplication<AgentApplication>(*args)
-}
+class AgentTestApplication {}


### PR DESCRIPTION
This pull request refactors how the test application is structured and improves platform compatibility, particularly for Windows environments. The main changes involve moving Windows-specific console setup logic from the application entry point to a platform-wide environment processor, introducing a dedicated test application module, and updating configuration scanning to include additional packages.

**Test application refactoring and modularization:**

* Moved the test application class from `embabel-agent-api/src/main/kotlin/com/embabel/agent/AgentApplication.kt` to `embabel-agent-api/src/test/kotlin/com/embabel/agent/AgentApiTestApplication.kt`, renamed it to `TestApplication`, and removed Windows-specific initialization logic from the test application entry point. [[1]](diffhunk://#diff-36f415ba3f15d11d22effa45cd388e9dec905e94a432ca24bf6d530b1211c40fL17) [[2]](diffhunk://#diff-36f415ba3f15d11d22effa45cd388e9dec905e94a432ca24bf6d530b1211c40fL36-R35)
* Added a new `embabel-agent-test` module containing `AgentTestApplication`, which is now responsible for test application configuration.
* Updated `embabel-agent-bedrock-autoconfigure/pom.xml` to include the new `embabel-agent-test` module as a test dependency.

**Configuration and scanning improvements:**

* Updated `AgentPlatformAutoConfiguration.java` to include both `com.embabel.agent` and `com.embabel.example` in its `@ConfigurationPropertiesScan` and `@ComponentScan` annotations, ensuring that beans from both packages are discovered.

**Platform compatibility improvements:**

* Moved Windows console setup logic into a static block within `EnvironmentPostProcessor`, ensuring that UTF-8 console setup is applied globally for Windows environments, rather than only in the application entry point. [[1]](diffhunk://#diff-aa642cbbd70594e22b8664cee1dfb70ee912a56521e3057f8e2c92e7b6cbb93eR20) [[2]](diffhunk://#diff-aa642cbbd70594e22b8664cee1dfb70ee912a56521e3057f8e2c92e7b6cbb93eR91-R99)