### PR TITLE
Refactor TestApplication to AgentApiTestApplication

### DIFF
--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/AgentApiTestApplication.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/AgentApiTestApplication.kt
@@ -32,4 +32,4 @@ import org.springframework.context.annotation.ComponentScan
         "com.embabel.example",
     ]
 )
-class TestApplication {}
+class AgentApiTestApplication {}


### PR DESCRIPTION
This pull request makes a small update to the test application class name in the `embabel-agent-api` test source. The class has been renamed from `TestApplication` to `AgentApiTestApplication` to better reflect its purpose.