### PR TITLE
Issue #509 jline warning.

### DIFF
--- a/embabel-agent-api/src/main/resources/logback-spring.xml
+++ b/embabel-agent-api/src/main/resources/logback-spring.xml
@@ -21,6 +21,7 @@
     <logger name="com.embabel.agent.api.annotation.support.AgentMetadataReader" level="INFO"/>
     <logger name="com.embabel.agent.spi.support.LlmRanker" level="INFO"/>
     <logger name="com.embabel.agent.spi.support.com.embabel.agent.spi.support.springai.ChatClientLlmOperations" level="INFO"/>
+    <logger name="org.jline" level="ERROR"/>
 
     <!-- 🔍 Root Logger -->
     <root level="INFO">


### PR DESCRIPTION
This pull request makes a small configuration change to the logging setup. The change sets the log level for the `org.jline` package to `ERROR`, which will reduce log verbosity from this package and help keep the logs cleaner.

([embabel-agent-api/src/main/resources/logback-spring.xmlR24](diffhunk://#diff-c2e63efacbe8cdc8e98b01dc9fb0ad997e609c741874dac01c92da509d06d69bR24))