### PR TITLE
Add autoconfiguration for deepseek models

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/DeepSeekModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/DeepSeekModels.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models
+
+/**
+ * Provides constants for DeepSeek AI model identifiers.
+ * This class contains the latest model versions for DeepSeek AI models offered by DeepSeek.
+ */
+class DeepSeekModels {
+
+    companion object {
+
+        const val DEEPSEEK_CHAT = "deepseek-chat";
+        const val DEEPSEEK_REASONER = "deepseek-reasoner";
+
+        const val PROVIDER = "deepseek";
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-autoconfigure</artifactId>
+        <version>0.1.3-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>embabel-agent-deepseek-autoconfigure</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Autoconfiguration Models Deepseek</name>
+    <description>Deepseek Models for Embabel Agent API</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-deepseek</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/deepseek/AgentDeepSeekAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/deepseek/AgentDeepSeekAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.deepseek;
+
+import com.embabel.agent.config.models.deepseek.DeepSeekModelsConfig;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Autoconfiguration for DeepSeek AI models in the Embabel Agent system.
+ * <p>
+ * This class serves as a Spring Boot autoconfiguration entry point that:
+ * - Scans for configuration properties in the "com.embabel.agent" package
+ * - Imports the [DeepSeekModels] configuration to register DeepSeek model beans
+ * <p>
+ * The configuration is automatically activated when the DeepSeek models
+ * dependencies are present on the classpath.
+ */
+@AutoConfiguration
+@AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
+@Import(DeepSeekModelsConfig.class)
+public class AgentDeepSeekAutoConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(AgentDeepSeekAutoConfiguration.class);
+
+    @PostConstruct
+    public void logEvent() {
+        logger.info("AgentDeepseekAutoConfiguration about to proceed...");
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.deepseek
+
+import com.embabel.agent.common.RetryProperties
+import com.embabel.agent.config.models.DeepSeekModels
+import com.embabel.common.ai.model.Llm
+import com.embabel.common.ai.model.OptionsConverter
+import com.embabel.common.ai.model.PerTokenPricingModel
+import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
+import org.slf4j.LoggerFactory
+import org.springframework.ai.deepseek.DeepSeekChatModel
+import org.springframework.ai.deepseek.DeepSeekChatOptions
+import org.springframework.ai.deepseek.api.DeepSeekApi
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.LocalDate
+
+/**
+ * Configuration properties for Deepseek models.
+ * These properties are bound from the Spring configuration with the prefix
+ * "embabel.agent.platform.models.deepseek" and control retry behavior
+ * when calling Deepseek APIs.
+ */
+@ConfigurationProperties(prefix = "embabel.agent.platform.models.deepseek")
+data class DeepSeekProperties(
+    override val maxAttempts: Int = 4,
+    override val backoffMillis: Long = 1500L,
+    override val backoffMultiplier: Double = 2.0,
+    override val backoffMaxInterval: Long = 60000L,
+) : RetryProperties
+
+/**
+ * Configuration class for DeepSeek models.
+ * This class provides beans for various DeepSeek models (chat, reasoner)
+ * and handles the creation of DeepSeek API clients with proper authentication.
+ */
+@Configuration
+@ExcludeFromJacocoGeneratedReport(reason = "DeepSeek configuration can't be unit tested")
+class DeepSeekModelsConfig(
+    @param:Value("\${DEEPSEEK_BASE_URL:}")
+    private val baseUrl: String,
+    @param:Value("\${DEEPSEEK_API_KEY}")
+    private val apiKey: String,
+    private val properties: DeepSeekProperties,
+) {
+    private val logger = LoggerFactory.getLogger(DeepSeekModelsConfig::class.java)
+
+    init {
+        logger.info("DeepSeek models are available: {}", properties)
+    }
+
+    @Bean
+    fun deepSeekChat(): Llm {
+        return deepSeekLlmOf(
+            DeepSeekModels.DEEPSEEK_CHAT,
+            knowledgeCutoffDate = LocalDate.of(2025, 8, 21),
+        )
+            // https://api-docs.deepseek.com/quick_start/pricing
+            // 1M Input tokens Cache hit $0.07
+            // 1M Input tokens Cache miss $0.56
+            .copy(
+                pricingModel = PerTokenPricingModel(
+                    usdPer1mInputTokens = 0.56,
+                    usdPer1mOutputTokens = 1.68,
+                )
+            )
+    }
+
+    @Bean
+    fun deepSeekReasoner(): Llm = deepSeekLlmOf(
+        DeepSeekModels.DEEPSEEK_REASONER,
+        knowledgeCutoffDate = LocalDate.of(2025, 5, 28),
+    )
+        // https://api-docs.deepseek.com/quick_start/pricing
+        // 1M Input tokens Cache hit $0.07
+        // 1M Input tokens Cache miss $0.56
+        .copy(
+            pricingModel = PerTokenPricingModel(
+                usdPer1mInputTokens = 0.56,
+                usdPer1mOutputTokens = 1.68,
+            )
+        )
+
+    private fun deepSeekLlmOf(
+        name: String,
+        knowledgeCutoffDate: LocalDate?
+    ): Llm {
+        val chatModel = DeepSeekChatModel
+            .builder()
+            .defaultOptions(
+                DeepSeekChatOptions.builder()
+                    .model(name)
+                    .build()
+            )
+            .deepSeekApi(createDeepSeekApi())
+            .retryTemplate(properties.retryTemplate(name))
+            .build()
+        return Llm(
+            name = name,
+            model = chatModel,
+            provider = DeepSeekModels.PROVIDER,
+            optionsConverter = DeepSeekOptionsConverter,
+            knowledgeCutoffDate = knowledgeCutoffDate,
+        )
+    }
+
+    private fun createDeepSeekApi(): DeepSeekApi {
+        val builder = DeepSeekApi.builder().apiKey(apiKey)
+        // If baseUrl is blank, use default baseUrl https://api.deepseek.com
+        if (baseUrl.isNotBlank()) {
+            logger.info("Using custom DeepSeek base URL: {}", baseUrl)
+            builder.baseUrl(baseUrl)
+        }
+        return builder.build()
+    }
+}
+
+val DeepSeekOptionsConverter: OptionsConverter<DeepSeekChatOptions> =
+    OptionsConverter { options ->
+        DeepSeekChatOptions.builder()
+            .frequencyPenalty(options.frequencyPenalty)
+            .maxTokens(options.maxTokens)
+            .presencePenalty(options.presencePenalty)
+            .temperature(options.temperature)
+            .topP(options.topP)
+            .build()
+
+        // logprobs/topLogprobs/responseFormat
+    }

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekOptionsConverterTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.deepseek
+
+import com.embabel.agent.test.models.OptionsConverterTestSupport
+import com.embabel.common.ai.model.LlmOptions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.ai.deepseek.DeepSeekChatOptions
+
+class DeepSeekOptionsConverterTest : OptionsConverterTestSupport<DeepSeekChatOptions>(
+    optionsConverter = DeepSeekOptionsConverter
+) {
+    @Test
+    fun `should set override maxTokens default`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withMaxTokens(200))
+        assertEquals(200, options.maxTokens)
+    }
+}

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -18,6 +18,7 @@
         <module>models/embabel-agent-anthropic-autoconfigure</module>
         <module>models/embabel-agent-ollama-autoconfigure</module>
         <module>models/embabel-agent-dockermodels-autoconfigure</module>
+        <module>models/embabel-agent-deepseek-autoconfigure</module>
     </modules>
 
     <build>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -78,6 +78,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-deepseek-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-eval</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -139,6 +145,12 @@
             <dependency>
                 <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-dockermodels</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-deepseek</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/embabel-agent-starters/embabel-agent-starter-deepseek/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-deepseek/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>0.1.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>embabel-agent-starter-deepseek</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent DeepSeek Starter</name>
+    <description>Embabel Agent DeepSeek Starter</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-deepseek-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -21,6 +21,7 @@
         <module>embabel-agent-starter-anthropic</module>
         <module>embabel-agent-starter-ollama</module>
         <module>embabel-agent-starter-dockermodels</module>
+        <module>embabel-agent-starter-deepseek</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This pull request add DeepSeek AI model auto-configuration in the Embabel Agent system. 

The most important changes are:

1. add maven modules blows:
    - embabel-agent-deepseek-autoconfigure
    - embabel-agent-starter-deepseek
    
2. add DeepSeekModels.kt to embabel-agent-api/models package

3. modify pom
   - embabel-agent-autoconfigure/pom.xml
   - embabel-agent-dependencies/pom.xml
   - embabel-agent-starters/pom.xml


