### PR TITLE
Fix Brave MCP

### DIFF
--- a/embabel-agent-api/src/main/resources/application-docker-ce.yml
+++ b/embabel-agent-api/src/main/resources/application-docker-ce.yml
@@ -18,9 +18,12 @@ spring:
                 - -i
                 - --rm
                 - -e
+                - BRAVE_MCP_TRANSPORT
+                - -e
                 - BRAVE_API_KEY
                 - mcp/brave-search
               env:
+                BRAVE_MCP_TRANSPORT: "stdio"
                 BRAVE_API_KEY: ${BRAVE_API_KEY}
             fetch-mcp:
               command: docker

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/McpServers.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/McpServers.java
@@ -20,7 +20,7 @@ package com.embabel.agent.config.annotation;
  */
 public class McpServers {
 
-    public static final String DOCKER = "docker";
+    public static final String DOCKER = "docker-ce";
 
     public static final String DOCKER_DESKTOP = "docker-desktop";
 }


### PR DESCRIPTION
Merged PR #803 contributed by https://github.com/npiv and approved by @slimslenderslacks 

This pull request updates the configuration and constants for Docker environments, specifically standardizing the naming convention for Docker Community Edition (CE) and updating related environment variables.

Configuration updates:

* Changed the constant `DOCKER` to `docker-ce` in `McpServers`, ensuring consistency with Docker CE naming throughout the codebase.

Environment variable improvements:

* Updated the Docker command configuration in `application-docker-ce.yml` to include the `BRAVE_MCP_TRANSPORT` environment variable with a value of `"stdio"`, ensuring the correct transport is set for Brave MCP.