### PR TITLE
Automatically set bedrock profile from the starter.

### DIFF
--- a/embabel-agent-starters/embabel-agent-starter-bedrock/src/main/java/com/embabel/agent/starter/bedrock/spi/BedrockEnvironmentPostProcessor.java
+++ b/embabel-agent-starters/embabel-agent-starter-bedrock/src/main/java/com/embabel/agent/starter/bedrock/spi/BedrockEnvironmentPostProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.starter.bedrock.spi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * An {@link org.springframework.boot.env.EnvironmentPostProcessor} to customize the environment
+ * for Bedrock-related configurations.
+ * <p>
+ * This class can be used to programmatically modify the application's environment before the
+ * application context is refreshed. It is particularly useful for setting up properties or
+ * profiles related to Bedrock services.
+ */
+public class BedrockEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+    private static final Logger logger = LoggerFactory.getLogger(BedrockEnvironmentPostProcessor.class);
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        //This is an interim solution to activate the bedrock profile when application-bedrock.yml is present.
+        //A better solution would be to shift responsibility to the user external configuration managed directly
+        //by the user
+        logger.debug("Bedrock Models detected - applying Bedrock environment configuration");
+        environment.addActiveProfile("bedrock");
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE + 10; // Run early, but after core Spring Boot processors
+    }
+}

--- a/embabel-agent-starters/embabel-agent-starter-bedrock/src/main/resources/META-INF/spring.factories
+++ b/embabel-agent-starters/embabel-agent-starter-bedrock/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.env.EnvironmentPostProcessor=com.embabel.agent.starter.bedrock.spi.BedrockEnvironmentPostProcessor

--- a/embabel-agent-starters/embabel-agent-starter-bedrock/src/test/java/com/embabel/agent/starter/bedrock/spi/BedrockEnvironmentPostProcessorTest.java
+++ b/embabel-agent-starters/embabel-agent-starter-bedrock/src/test/java/com/embabel/agent/starter/bedrock/spi/BedrockEnvironmentPostProcessorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.starter.bedrock.spi;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.Ordered;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+class BedrockEnvironmentPostProcessorTest {
+
+    @Test
+    void postProcessEnvironment() {
+        var environment = new org.springframework.mock.env.MockEnvironment();
+        var application = new org.springframework.boot.SpringApplication(Object.class);
+        var processor = new BedrockEnvironmentPostProcessor();
+
+        processor.postProcessEnvironment(environment, application);
+
+        assertTrue(environment.getActiveProfiles().length > 0);
+        assertEquals("bedrock", environment.getActiveProfiles()[0]);
+    }
+
+    @Test
+    void getOrder() {
+        var processor = new BedrockEnvironmentPostProcessor();
+        assertThat(processor.getOrder()).isGreaterThan(Ordered.HIGHEST_PRECEDENCE);
+    }
+}


### PR DESCRIPTION
This pull request introduces a mechanism to automatically activate the `bedrock` Spring profile when Bedrock-related configurations are present. It does so by adding a custom `EnvironmentPostProcessor`, registering it with Spring Boot, and including a corresponding unit test to ensure correct behavior.

**Spring Boot Environment Customization:**

* Added a new `BedrockEnvironmentPostProcessor` class that implements `EnvironmentPostProcessor` and `Ordered`, which programmatically activates the `bedrock` profile early in the application startup if Bedrock models are detected. (`BedrockEnvironmentPostProcessor.java`)
* Registered the new environment post-processor in `spring.factories` to ensure it is picked up automatically by Spring Boot. (`META-INF/spring.factories`)

**Testing:**

* Added a unit test `BedrockEnvironmentPostProcessorTest` to verify that the post-processor activates the `bedrock` profile and respects the intended order of execution. (`BedrockEnvironmentPostProcessorTest.java`)