### PR TITLE
Introduce custom argument resolvers

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/ActionMethodArgumentResolver.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/ActionMethodArgumentResolver.kt
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.annotation.support
+
+import com.embabel.agent.api.annotation.RequireNameMatch
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.api.common.support.expandInputBindings
+import com.embabel.agent.core.IoBinding
+import com.embabel.agent.core.ProcessContext
+import java.lang.reflect.Parameter
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.full.findAnnotation
+
+/**
+ * Strategy interface for resolving action method parameters into argument values and input bindings.
+ *
+ * @see DefaultActionMethodManager
+ */
+interface ActionMethodArgumentResolver {
+
+    /**
+     * Whether the given method parameter is supported by this resolver.
+     * @param javaParameter the Java method parameter to check
+     * @param kotlinParameter the Kotlin method parameter to check. Can be `null` if `kotlin-reflect` is unavailable.
+     * @param operationContext the current operation context when invoked before [resolveArgument];
+     * `null` when invoked before [resolveInputBinding]
+     * @return `true` if this resolver supports the supplied parameter; `false` otherwise
+     */
+    fun supportsParameter(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext?,
+    ): Boolean
+
+    /**
+     * @param javaParameter the Java method parameter to check. This parameter must have previously been passed to
+     * [supportsParameter] which must have returned `true`.
+     * @param kotlinParameter the Kotlin method parameter to check. Can be `null` if `kotlin-reflect` is unavailable.
+     * @return a set of bindings. Returns an empty set by default.
+     */
+    fun resolveInputBinding(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+    ): Set<IoBinding> = emptySet()
+
+    /**
+     * Resolve an action method parameter into an argument value. An `OperationContext` provides access to the
+     * context of the current action.
+     * @param javaParameter the Java method parameter to check. This parameter must have previously been passed to
+     * [supportsParameter] which must have returned `true`.
+     * @param kotlinParameter the Kotlin method parameter to check. Can be `null` if `kotlin-reflect` is unavailable.
+     * @param operationContext the current operation context
+     */
+    fun resolveArgument(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext,
+    ): Any?
+
+}
+
+/**
+ * Resolves [ProcessContext] arguments.
+ */
+class ProcessContextArgumentResolver : ActionMethodArgumentResolver {
+
+    override fun supportsParameter(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext?,
+    ): Boolean {
+        return ProcessContext::class.java.isAssignableFrom(javaParameter.type)
+    }
+
+    override fun resolveArgument(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext
+    ): Any {
+        return operationContext.processContext
+    }
+}
+
+/**
+ * Resolves [OperationContext] arguments.
+ */
+class OperationContextArgumentResolver : ActionMethodArgumentResolver {
+
+    override fun supportsParameter(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext?,
+    ): Boolean {
+        return OperationContext::class.java.isAssignableFrom(javaParameter.type)
+    }
+
+    override fun resolveArgument(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext
+    ): Any {
+        return operationContext
+    }
+}
+
+/**
+ * Resolves [Ai] arguments.
+ */
+class AiArgumentResolver : ActionMethodArgumentResolver {
+
+    override fun supportsParameter(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext?,
+    ): Boolean {
+        return Ai::class.java.isAssignableFrom(javaParameter.type)
+    }
+
+    override fun resolveArgument(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext
+    ): Any {
+        return operationContext.ai()
+    }
+}
+
+/**
+ * Resolves arguments that can be found on the [com.embabel.agent.core.Blackboard]
+ */
+class BlackboardArgumentResolver : ActionMethodArgumentResolver {
+
+    override fun supportsParameter(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext?,
+    ): Boolean {
+        if (kotlinParameter != null) {
+            val classifier = kotlinParameter.type.classifier
+            if (classifier is KClass<*>) {
+                if (operationContext == null) {
+                    return true
+                }
+                val annotation = kotlinParameter.findAnnotation<RequireNameMatch>()
+                val name = getBindingParameterName(kotlinParameter.name, annotation)
+                    ?: error("Parameter name should be available")
+                return operationContext.hasValue(
+                    variable = name,
+                    type = classifier.java.name,
+                    dataDictionary = operationContext.processContext.agentProcess.agent,
+                )
+            } else {
+                return false
+            }
+        } else if (operationContext != null) {
+            val annotation = javaParameter.getAnnotation(RequireNameMatch::class.java)
+            val name = getBindingParameterName(javaParameter.name, annotation)
+                ?: error("Parameter name should be available")
+            return operationContext.hasValue(
+                variable = name,
+                type = javaParameter.type.name,
+                dataDictionary = operationContext.processContext.agentProcess.agent,
+            )
+        } else {
+            return true
+        }
+    }
+
+    override fun resolveInputBinding(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?
+    ): Set<IoBinding> {
+        if (kotlinParameter != null) {
+            if (kotlinParameter.type.isMarkedNullable) {
+                return emptySet()
+            }
+            val annotation = kotlinParameter.findAnnotation<RequireNameMatch>()
+            val name = getBindingParameterName(kotlinParameter.name, annotation) ?: throw IllegalArgumentException(
+                "Name for argument of type [${kotlinParameter.type}] not specified, and parameter name information not " +
+                        "available via reflection. Ensure that the compiler uses the '-parameters' flag."
+            )
+
+            return expandInputBindings(
+                name,
+                (kotlinParameter.type.classifier as KClass<*>).java
+            )
+        } else {
+            val annotation = javaParameter.getAnnotation(RequireNameMatch::class.java)
+            val parameterName = if (javaParameter.isNamePresent) javaParameter.name else null
+            val name =
+                getBindingParameterName(parameterName, annotation) ?: throw IllegalArgumentException(
+                    "Name for argument of type [${javaParameter.type}] not specified, and parameter name information not " +
+                            "available via reflection. Ensure that the kotlinc compiler uses the '-java-parameters' flag, " +
+                            "and that the javac compiler uses the '-parameters' flag."
+                )
+
+            return expandInputBindings(
+                name,
+                javaParameter.type
+            )
+        }
+    }
+
+    override fun resolveArgument(
+        javaParameter: Parameter,
+        kotlinParameter: KParameter?,
+        operationContext: OperationContext
+    ): Any? {
+        if (kotlinParameter != null) {
+            val classifier = kotlinParameter.type.classifier
+            if (classifier is KClass<*>) {
+                val annotation = kotlinParameter.findAnnotation<RequireNameMatch>()
+                val name = getBindingParameterName(kotlinParameter.name, annotation)
+                    ?: error("Parameter name should be available")
+                val arg = operationContext.getValue(
+                    variable = name,
+                    type = classifier.java.name,
+                    dataDictionary = operationContext.processContext.agentProcess.agent,
+                )
+                if (arg == null) {
+                    val isNullable = kotlinParameter.isOptional || kotlinParameter.type.isMarkedNullable
+                    if (!isNullable) {
+                        error("Operation ${operationContext.operation.name}: Internal error. No value found in blackboard for non-nullable parameter ${kotlinParameter.name}:${classifier.java.name}")
+                    }
+                }
+                return arg
+            }
+        }
+        val annotation = javaParameter.getAnnotation(RequireNameMatch::class.java)
+        val name = getBindingParameterName(javaParameter.name, annotation)
+            ?: error("Parameter name should be available")
+        return operationContext.getValue(
+            variable = name,
+            type = javaParameter.type.name,
+            dataDictionary = operationContext.processContext.agentProcess.agent,
+        )
+
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/ActionMethodArgumentResolverTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/ActionMethodArgumentResolverTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.annotation.support
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.core.IoBinding
+import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.testing.unit.FakeOperationContext
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+import kotlin.reflect.full.valueParameters
+import kotlin.reflect.jvm.kotlinFunction
+import kotlin.test.DefaultAsserter.assertSame
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ActionMethodArgumentResolverTest {
+
+    private val operationContext = FakeOperationContext()
+
+    private val method: Method = javaClass.getDeclaredMethod(
+        "arguments", ProcessContext::class.java,
+        OperationContext::class.java, Ai::class.java, CustomType::class.java,
+    )
+
+    @Test
+    fun processContext() {
+        val argumentResolver = ProcessContextArgumentResolver()
+        val javaParameter = method.parameters[0]
+        val kotlinParameter = method.kotlinFunction!!.valueParameters[0]
+
+        assertTrue { argumentResolver.supportsParameter(javaParameter, kotlinParameter, operationContext) }
+        assertTrue { argumentResolver.supportsParameter(javaParameter, null, null) }
+        assertFalse { argumentResolver.supportsParameter(method.parameters[1], null, null) }
+
+        assertTrue { argumentResolver.resolveInputBinding(javaParameter, kotlinParameter).isEmpty() }
+
+        val arg = argumentResolver.resolveArgument(javaParameter, kotlinParameter, operationContext)
+        assertSame(
+            message = "Invalid resolved argument",
+            expected = operationContext.processContext,
+            actual = arg
+        )
+    }
+
+    @Test
+    fun operationContext() {
+        val argumentResolver = OperationContextArgumentResolver()
+        val javaParameter = method.parameters[1]
+        val kotlinParameter = method.kotlinFunction!!.valueParameters[1]
+
+        assertTrue { argumentResolver.supportsParameter(javaParameter, kotlinParameter, operationContext) }
+        assertTrue { argumentResolver.supportsParameter(javaParameter, null, null) }
+        assertFalse { argumentResolver.supportsParameter(method.parameters[0], null, null) }
+
+        assertTrue { argumentResolver.resolveInputBinding(javaParameter, kotlinParameter).isEmpty() }
+
+        val arg = argumentResolver.resolveArgument(javaParameter, kotlinParameter, operationContext)
+        assertSame(
+            message = "Invalid resolved argument",
+            expected = operationContext,
+            actual = arg
+        )
+    }
+
+    @Test
+    fun ai() {
+        val argumentResolver = AiArgumentResolver()
+        val javaParameter = method.parameters[2]
+        val kotlinParameter = method.kotlinFunction!!.valueParameters[2]
+
+        assertTrue { argumentResolver.supportsParameter(javaParameter, kotlinParameter, operationContext) }
+        assertTrue { argumentResolver.supportsParameter(javaParameter, null, null) }
+        assertFalse { argumentResolver.supportsParameter(method.parameters[0], null, null) }
+
+        assertTrue { argumentResolver.resolveInputBinding(javaParameter, kotlinParameter).isEmpty() }
+
+        val arg = argumentResolver.resolveArgument(javaParameter, kotlinParameter, operationContext)
+
+        assertNotNull(
+            message = "Invalid resolved argument",
+            actual = arg
+        )
+    }
+
+    @Test
+    fun blackboard() {
+        val argumentResolver = BlackboardArgumentResolver()
+        val expected = CustomType()
+        operationContext.set(IoBinding.DEFAULT_BINDING, expected)
+
+        val javaParameter = method.parameters[3]
+        val kotlinParameter = method.kotlinFunction!!.valueParameters[3]
+        assertTrue { argumentResolver.supportsParameter(javaParameter, kotlinParameter, operationContext) }
+        assertTrue { argumentResolver.supportsParameter(javaParameter, null, null) }
+
+        assertTrue { argumentResolver.resolveInputBinding(javaParameter, kotlinParameter).isNotEmpty() }
+
+        val arg = argumentResolver.resolveArgument(javaParameter, kotlinParameter, operationContext)
+        assertSame(
+            message = "Invalid resolved argument",
+            expected = expected,
+            actual = arg
+        )
+    }
+
+
+    private fun arguments(
+        processContext: ProcessContext,
+        operationContext: OperationContext,
+        ai: Ai,
+        customType: CustomType,
+    ) {
+
+    }
+
+    class CustomType
+
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderActionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderActionTest.kt
@@ -271,6 +271,13 @@ class AgentMetadataReaderActionTest {
         every { mockPlatformServices.llmOperations } returns mockk()
         every { mockPlatformServices.eventListener } returns DevNull
         val blackboard = InMemoryBlackboard().bind(IoBinding.DEFAULT_BINDING, UserInput("John Doe"))
+        every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+            blackboard.hasValue(
+                firstArg(),
+                secondArg(),
+                thirdArg(),
+            )
+        }
         every { mockAgentProcess.getValue(any(), any(), any()) } answers {
             blackboard.getValue(
                 firstArg(),
@@ -361,6 +368,13 @@ class AgentMetadataReaderActionTest {
         every { mockPlatformServices.llmOperations } returns mockk()
         every { mockPlatformServices.eventListener } returns DevNull
         val blackboard = InMemoryBlackboard().bind(IoBinding.DEFAULT_BINDING, UserInput("John Doe"))
+        every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+            blackboard.hasValue(
+                firstArg(),
+                secondArg(),
+                thirdArg(),
+            )
+        }
         every { mockAgentProcess.getValue(any(), any(), any()) } answers {
             blackboard.getValue(
                 firstArg(),
@@ -450,6 +464,13 @@ class AgentMetadataReaderActionTest {
         every { mockPlatformServices.llmOperations } returns mockk()
         every { mockPlatformServices.eventListener } returns DevNull
         val blackboard = InMemoryBlackboard().bind(IoBinding.DEFAULT_BINDING, UserInput("John Doe"))
+        every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+            blackboard.hasValue(
+                firstArg(),
+                secondArg(),
+                thirdArg(),
+            )
+        }
         every { mockAgentProcess.getValue(any(), any(), any()) } answers {
             blackboard.getValue(
                 firstArg(),
@@ -495,6 +516,13 @@ class AgentMetadataReaderActionTest {
         val blackboard = InMemoryBlackboard()
         blackboard += UserInput("John Doe")
         blackboard += ("task" to Task("task"))
+        every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+            blackboard.hasValue(
+                firstArg(),
+                secondArg(),
+                thirdArg(),
+            )
+        }
         every { mockAgentProcess.getValue(any(), any(), any()) } answers {
             blackboard.getValue(
                 firstArg(),
@@ -540,6 +568,13 @@ class AgentMetadataReaderActionTest {
         val blackboard = InMemoryBlackboard()
         blackboard += UserInput("John Doe")
         blackboard += ("task" to Task("task"))
+        every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+            blackboard.hasValue(
+                firstArg(),
+                secondArg(),
+                thirdArg(),
+            )
+        }
         every { mockAgentProcess.getValue(any(), any(), any()) } answers {
             blackboard.getValue(
                 firstArg(),
@@ -662,6 +697,13 @@ class AgentMetadataReaderActionTest {
             every { mockPlatformServices.outputChannel } returns DevNullOutputChannel
 
             val blackboard = InMemoryBlackboard().bind(IoBinding.DEFAULT_BINDING, UserInput("John Doe"))
+            every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+                blackboard.hasValue(
+                    firstArg(),
+                    secondArg(),
+                    thirdArg(),
+                )
+            }
             every { mockAgentProcess.getValue(any(), any(), any()) } answers {
                 blackboard.getValue(
                     firstArg(),
@@ -717,6 +759,13 @@ class AgentMetadataReaderActionTest {
             every { mockPlatformServices.eventListener } returns DevNull
             every { mockPlatformServices.outputChannel } returns DevNullOutputChannel
             val blackboard = InMemoryBlackboard().bind(IoBinding.DEFAULT_BINDING, UserInput("John Doe"))
+            every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+                blackboard.hasValue(
+                    firstArg(),
+                    secondArg(),
+                    thirdArg(),
+                )
+            }
             every { mockAgentProcess.getValue(any(), any(), any()) } answers {
                 blackboard.getValue(
                     firstArg(),
@@ -837,6 +886,13 @@ class AgentMetadataReaderActionTest {
             every { mockPlatformServices.outputChannel } returns DevNullOutputChannel
 
             val blackboard = InMemoryBlackboard().bind(IoBinding.DEFAULT_BINDING, PersonWithReverseTool("John Doe"))
+            every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+                blackboard.hasValue(
+                    firstArg(),
+                    secondArg(),
+                    thirdArg(),
+                )
+            }
             every { mockAgentProcess.getValue(any(), any(), any()) } answers {
                 blackboard.getValue(
                     firstArg(),
@@ -896,6 +952,13 @@ class AgentMetadataReaderActionTest {
             every { mockPlatformServices.eventListener } returns DevNull
             every { mockPlatformServices.outputChannel } returns DevNullOutputChannel
             val blackboard = InMemoryBlackboard().bind(IoBinding.DEFAULT_BINDING, UserInput("John Doe"))
+            every { mockAgentProcess.hasValue(any(), any(), any()) } answers {
+                blackboard.hasValue(
+                    firstArg(),
+                    secondArg(),
+                    thirdArg(),
+                )
+            }
             every { mockAgentProcess.getValue(any(), any(), any()) } answers {
                 blackboard.getValue(
                     firstArg(),


### PR DESCRIPTION
This commit introduces the ActionMethodArgumentResolver, a strategy interface used by the DefaultActionMethodManager to delegate action method resolution to.

This commit introduces `Blackboard::hasValue`, used by the `BlackBoardArgumentResolver` to determine whether a argument can be resolved.

See gh-575