### PR TITLE
Remove test scenario with implicit dependency on missing AWS configur…

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/bedrock/EmbabelBedrockProxyChatModelBuilderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/bedrock/EmbabelBedrockProxyChatModelBuilderTest.kt
@@ -38,12 +38,6 @@ import java.time.Duration
 class EmbabelBedrockProxyChatModelBuilderTest {
 
     @Test
-    fun `AWS BedrockProxyChatModel builder logs warn message on init`(output: CapturedOutput) {
-        BedrockProxyChatModel.builder()
-        assertFalse({ output.isEmpty() }, "Output should not be empty, had [$output]")
-    }
-
-    @Test
     fun `Custom BedrockProxyChatModel builder should not log warn message on init`(output: CapturedOutput) {
         EmbabelBedrockProxyChatModelBuilder()
         assertTrue({ output.isEmpty() }, "Output should be empty, had [$output]")


### PR DESCRIPTION
This pull request makes a minor update to the unit tests for the Bedrock chat model builder. The main change is the removal of a test that checked for a warning log message during initialization of the default builder.

* Removed the test `AWS BedrockProxyChatModel builder logs warn message on init` from `EmbabelBedrockProxyChatModelBuilderTest.kt`, which previously asserted that a warning message was logged on initialization.…ation