### PR TITLE
Prepare for release.

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.3</version>
+        <version>0.1.4</version>
         <relativePath/>
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.3</version>
+        <version>0.1.4</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -14,7 +14,7 @@
     <description>Parent POM for Embabel Agent Modules</description>
 
     <properties>
-        <embabel-common.version>0.1.3-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.3</embabel-common.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This pull request updates parent POM versions and dependency versions in the project to ensure all modules use the latest stable releases. The changes are focused on version alignment and removing the use of snapshot dependencies.

Version updates:

* Updated the parent POM version in `pom.xml` from `0.1.3` to `0.1.4` to use the latest build parent.
* Updated the parent POM version in `embabel-agent-dependencies/pom.xml` from `0.1.3` to `0.1.4` for dependency management.

Dependency version alignment:

* Changed the `embabel-common.version` property in `pom.xml` from `0.1.3-SNAPSHOT` to the stable `0.1.3` release.