### PR TITLE
Add property configuration auto completion for module embabel-agent-a…

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
@@ -40,12 +40,27 @@ import java.time.LocalDate
  * when calling Anthropic APIs.
  */
 @ConfigurationProperties(prefix = "embabel.agent.platform.models.anthropic")
-data class AnthropicProperties(
-    override val maxAttempts: Int = 10,
-    override val backoffMillis: Long = 5000L,
-    override val backoffMultiplier: Double = 5.0,
-    override val backoffMaxInterval: Long = 180000L,
-) : RetryProperties
+class AnthropicProperties : RetryProperties {
+    /**
+     *  Maximum number of attempts.
+     */
+    override var maxAttempts: Int = 10
+
+    /**
+     * Initial backoff interval (in milliseconds).
+     */
+    override var backoffMillis: Long = 5000L
+
+    /**
+     * Backoff interval multiplier.
+     */
+    override var backoffMultiplier: Double = 5.0
+
+    /**
+     * Maximum backoff interval (in milliseconds).
+     */
+    override var backoffMaxInterval: Long = 180000L
+}
 
 
 /**
@@ -53,7 +68,7 @@ data class AnthropicProperties(
  * This class provides beans for various Claude models (Opus, Sonnet, Haiku)
  * and handles the creation of Anthropic API clients with proper authentication.
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ExcludeFromJacocoGeneratedReport(reason = "Anthropic configuration can't be unit tested")
 class AnthropicModelsConfig(
     @param:Value("\${ANTHROPIC_BASE_URL:}")

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModels.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModels.kt
@@ -41,6 +41,7 @@ import org.springframework.boot.autoconfigure.AutoConfigureBefore
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -52,16 +53,28 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient
 
 @ConfigurationProperties(prefix = "embabel.models.bedrock")
-data class BedrockProperties(
-    val models: List<BedrockModelProperties> = emptyList(),
-)
+class BedrockProperties {
+    /**
+     * List of LLM provider by Bedrock
+     */
+    @NestedConfigurationProperty
+    var models: List<BedrockModelProperties> = emptyList()
+}
 
-data class BedrockModelProperties(
-    val name: String = "",
-    val knowledgeCutoff: String = "",
-    val inputPrice: Double = 0.0,
-    val outputPrice: Double = 0.0,
-)
+@ConfigurationProperties(prefix = "embabel.models.bedrock.models")
+class BedrockModelProperties {
+    /**
+     * Name of the LLM, such as "gpt-3.5-turbo"
+     */
+    var name: String = ""
+
+    /**
+     * model's knowledge cutoff date
+     */
+    var knowledgeCutoff: String = ""
+    var inputPrice: Double = 0.0
+    var outputPrice: Double = 0.0
+}
 
 @ConditionalOnClass(
     BedrockProxyChatModel::class,
@@ -70,7 +83,8 @@ data class BedrockModelProperties(
     TitanEmbeddingBedrockApi::class,
     CohereEmbeddingBedrockApi::class
 )
-@Configuration
+
+@Configuration(proxyBeanMethods = false)
 @Import(BedrockAwsConnectionConfiguration::class)
 @EnableConfigurationProperties(
     BedrockProperties::class,

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
@@ -38,19 +38,34 @@ import java.time.LocalDate
  * when calling Deepseek APIs.
  */
 @ConfigurationProperties(prefix = "embabel.agent.platform.models.deepseek")
-data class DeepSeekProperties(
-    override val maxAttempts: Int = 4,
-    override val backoffMillis: Long = 1500L,
-    override val backoffMultiplier: Double = 2.0,
-    override val backoffMaxInterval: Long = 60000L,
-) : RetryProperties
+class DeepSeekProperties : RetryProperties {
+    /**
+     *  Maximum number of attempts.
+     */
+    override var maxAttempts: Int = 4
+
+    /**
+     * Initial backoff interval (in milliseconds).
+     */
+    override var backoffMillis: Long = 1500L
+
+    /**
+     * Backoff interval multiplier.
+     */
+    override var backoffMultiplier: Double = 2.0
+
+    /**
+     * Maximum backoff interval (in milliseconds).
+     */
+    override var backoffMaxInterval: Long = 60000L
+}
 
 /**
  * Configuration class for DeepSeek models.
  * This class provides beans for various DeepSeek models (chat, reasoner)
  * and handles the creation of DeepSeek API clients with proper authentication.
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ExcludeFromJacocoGeneratedReport(reason = "DeepSeek configuration can't be unit tested")
 class DeepSeekModelsConfig(
     @param:Value("\${DEEPSEEK_BASE_URL:}")

--- a/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/docker/AgentDockerModelsAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/docker/AgentDockerModelsAutoConfiguration.java
@@ -16,13 +16,11 @@
 package com.embabel.agent.autoconfigure.models.docker;
 
 import com.embabel.agent.config.models.docker.DockerLocalModelsConfig;
-import com.embabel.agent.config.models.docker.DockerProperties;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/docker/DockerLocalModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/docker/DockerLocalModelsConfig.kt
@@ -31,6 +31,7 @@ import org.springframework.ai.openai.OpenAiEmbeddingOptions
 import org.springframework.ai.openai.api.OpenAiApi
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.env.Environment
 import org.springframework.http.MediaType
@@ -38,13 +39,28 @@ import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
 
 @ConfigurationProperties(prefix = "embabel.docker.models")
-data class DockerProperties(
-    val baseUrl: String = "http://localhost:12434/engines",
-    override val maxAttempts: Int = 10,
-    override val backoffMillis: Long = 2000L,
-    override val backoffMultiplier: Double = 5.0,
-    override val backoffMaxInterval: Long = 180000L,
-) : RetryProperties
+class DockerProperties : RetryProperties {
+    /**
+     * The base url for docker
+     */
+    var baseUrl: String = "http://localhost:12434/engines"
+    /**
+     *  Maximum number of attempts.
+     */
+    override var maxAttempts: Int = 10
+    /**
+     * Initial backoff interval (in milliseconds).
+     */
+    override var backoffMillis: Long = 5000L
+    /**
+     * Backoff interval multiplier.
+     */
+    override var backoffMultiplier: Double = 5.0
+    /**
+     * Maximum backoff interval (in milliseconds).
+     */
+    override var backoffMaxInterval: Long = 180000L
+}
 
 /**
  * Docker local models
@@ -54,7 +70,8 @@ data class DockerProperties(
  * http://localhost:12434/engines/v1/models (assuming default port).
  */
 @ExcludeFromJacocoGeneratedReport(reason = "Docker model configuration can't be unit tested")
-@Configuration
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(DockerProperties::class)
 class DockerLocalModelsConfig(
     private val dockerProperties: DockerProperties,
     private val configurableBeanFactory: ConfigurableBeanFactory,

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/ollama/AgentOllamaAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/ollama/AgentOllamaAutoConfiguration.java
@@ -20,11 +20,7 @@ import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.AutoConfigureOrder;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Import;
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
@@ -38,7 +38,7 @@ import org.springframework.web.client.body
  * from Ollama unless the "ollama" profile is set.
  */
 @ExcludeFromJacocoGeneratedReport(reason = "Ollama configuration can't be unit tested")
-@Configuration
+@Configuration(proxyBeanMethods = false)
 class OllamaModelsConfig(
     @Value("\${spring.ai.ollama.base-url}")
     private val baseUrl: String,

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -36,12 +36,27 @@ import java.time.LocalDate
  * prefix embabel.agent.platform.models.openai.
  */
 @ConfigurationProperties(prefix = "embabel.agent.platform.models.openai")
-data class OpenAiProperties(
-    override val maxAttempts: Int = 10,
-    override val backoffMillis: Long = 5000L,
-    override val backoffMultiplier: Double = 5.0,
-    override val backoffMaxInterval: Long = 180000L,
-) : RetryProperties
+class OpenAiProperties : RetryProperties {
+    /**
+     *  Maximum number of attempts.
+     */
+    override var maxAttempts: Int = 10
+
+    /**
+     * Initial backoff interval (in milliseconds).
+     */
+    override var backoffMillis: Long = 5000L
+
+    /**
+     * Backoff interval multiplier.
+     */
+    override var backoffMultiplier: Double = 5.0
+
+    /**
+     * Maximum backoff interval (in milliseconds).
+     */
+    override var backoffMaxInterval: Long = 180000L
+}
 
 /**
  * Configuration for well-known OpenAI language and embedding models.

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -56,6 +56,21 @@
                             </sourceDirs>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>kapt</id>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-configuration-processor</artifactId>
+                                    <version>${spring-boot.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
#845 

This pull request introduces improvements to the build process and the configuration properties in Maven module embabel-agent-autoconfigure.

The most significant changes involve enhancing annotation processing support in the Maven build and refactoring the class with @ConfigurationProperties annotation.

### Build process improvements:
-  Added a `kapt` execution to Maven build (embabel-agent-autoconfigure/pom.xml) to enable annotation processing, , specifically including the spring-boot-configuration-processor for improved Spring Boot configuration metadata generation.

### Codebase and configuration model refactoring:
#### embabel-agent-anthropic-autoconfigure
 - Refactored the AnthropicProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val)。
 - Change the @Configuration annotation on the AnthropicModelsConfig class to @Configuration(proxyBeanMethods = false).

#### embabel-agent-bedrock-autoconfigure
- Refactored the `BedrockProperties`  and `BedrockModelProperties`  type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val)。
- Add ` @NestedConfigurationProperty` annotation on property models In `BedrockProperties`.
- Added the @ConfigurationProperties(prefix = "embabel.models.bedrock.models") annotation to the BedrockModelProperties class and specified the prefix.
- Change the @Configuration annotation on the `BedrockModels` class to @Configuration(proxyBeanMethods = false).

#### embabel-agent-deepseek-autoconfigure
- Refactored the `DeepSeekProperties`   type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val). 
-  Change the @Configuration annotation on the `DeepSeekModelsConfig` class to @Configuration(proxyBeanMethods = false).

#### embabel-agent-dockermodels-autoconfigure
- Refactored the `DockerProperties`   type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val)。
- Change the @Configuration annotation on the `DockerLocalModelsConfig` class to @Configuration(proxyBeanMethods = false). and add @EnableConfigurationProperties(DockerProperties::class) on it.

#### embabel-agent-ollama-autoconfigure
-  Change the @Configuration annotation on the `OllamaModelsConfig` class to @Configuration(proxyBeanMethods = false).

#### embabel-agent-openai-autoconfigure
- Refactored the `OpenAiProperties`  type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val). and added detailed KDoc comments for each property to improve maintainability and clarity.