### PR TITLE
Replace deprecated API ClassUtils isCglibProxy

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -34,6 +34,7 @@ import com.embabel.common.util.NameUtils
 import com.embabel.common.util.loggerFor
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.slf4j.LoggerFactory
+import org.springframework.cglib.proxy.Enhancer
 import org.springframework.context.support.StaticApplicationContext
 import org.springframework.stereotype.Service
 import org.springframework.util.ClassUtils
@@ -53,7 +54,7 @@ data class AgenticInfo(
 ) {
 
     // Unwrap proxy to get target class for annotation lookups
-    private val targetType: Class<*> = if (ClassUtils.isCglibProxyClass(type) ||
+    private val targetType: Class<*> = if (Enhancer.isEnhanced(type) ||
                                            Proxy.isProxyClass(type)) {
         ClassUtils.getUserClass(type)
     } else {


### PR DESCRIPTION
## Overview

API  ClassUtils.isCglibProxyClass(clazz)  gets deprecated.

Replaced with new API:

```
org.springframework.cglib.proxy.Enhancer.isEnhanced(clazz)

```

