### PR TITLE
Generate Dependabot Vulnerability Summary Report

### DIFF
--- a/.github/scripts/dependabot-group-alerts.sh
+++ b/.github/scripts/dependabot-group-alerts.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is not set}"
+
+# Fetch alerts using GitHub CLI
+gh api repos/"$GITHUB_REPOSITORY"/dependabot/alerts \
+  --paginate \
+  --jq '.' > alerts.json
+
+# Group and format alerts
+cat alerts.json | jq -s '
+  add
+  | group_by([.dependency.package.name, .security_advisory.ghsa_id])
+  | .[]
+  | {
+      key: "\(. | .[0].dependency.package.name) — \(. | .[0].security_advisory.ghsa_id)",
+      paths: ([.[] | .dependency.manifest_path] | unique | sort),
+      alerts: (
+        [.[] | {
+          severity: (.security_advisory.severity | ascii_downcase),
+          summary: .security_advisory.summary,
+          recommendation: (
+            if (.security_advisory.recommendation != null and .security_advisory.recommendation != "") then
+              .security_advisory.recommendation
+            else
+              "Upgrade \(.dependency.package.name) to a safe version (see advisory below)"
+            end
+          ),
+          advisory_url: "https://github.com/advisories/\(.security_advisory.ghsa_id)"
+        }]
+        | unique
+        | sort_by(
+            .severity
+            | if . == "critical" then 4
+              elif . == "high" then 3
+              elif . == "moderate" then 2
+              elif . == "low" then 1
+              else 0 end
+          )
+        | reverse
+      )
+    }
+' | jq -r '
+  . as $group |
+  "\n🔐 \($group.key) (\($group.alerts | length) unique alerts)",
+  "  Affected modules:",
+  ($group.paths[] | "    - \(. )"),
+  ($group.alerts[] |
+    "  - Severity: \(.severity) | \(.summary)",
+    "    ↪ Recommendation: \(.recommendation)",
+    "    ↪ Advisory URL: \(.advisory_url)"
+  )
+'

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -16,10 +16,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup GitHub CLI
-        uses: cli/gh-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update
+          sudo apt install -y gh
+
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
       - name: Run alert grouping script
         run: .github/scripts/dependabot-group-alerts.sh
+

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4  # ✅ Official action, safe to use
 
       - name: Install GitHub CLI
         run: |
@@ -22,8 +22,12 @@ jobs:
           sudo apt install -y gh
 
       - name: Authenticate GitHub CLI
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh auth login --with-token <<< "$GH_TOKEN"
+
+      - name: Verify GitHub CLI Auth
+        run: gh auth status
 
       - name: Run alert grouping script
         run: .github/scripts/dependabot-group-alerts.sh
-

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -1,0 +1,25 @@
+name: Dependabot Insights
+
+on:
+  workflow_dispatch:  # Manual trigger only
+
+permissions:
+  contents: read
+  security-events: read  # Required to access Dependabot alerts
+
+jobs:
+  generate-insights:
+    name: Generate Dependabot Insights
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup GitHub CLI
+        uses: cli/gh-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run alert grouping script
+        run: .github/scripts/dependabot-group-alerts.sh


### PR DESCRIPTION
## Issue

https://github.com/embabel/embabel-agent/issues/850

## Overview

Dependabot Vulnerability report comes with duplicate entries per  module (pom).  

Its time consuming to group entries by jar (artifact) and go over all related pages.

Automated vulnerability report generation with proper grouping.

##  Example
```

org.apache.tomcat.embed:tomcat-embed-core — GHSA-3p2h-wqq4-wf4h (1 unique alerts)
  Affected modules:
    - embabel-agent-mcpserver/pom.xml
    - embabel-agent-starters/embabel-agent-starter-mcpserver/pom.xml
  - Severity: medium | Apache Tomcat Denial of Service via invalid HTTP priority header
    ↪ Recommendation: Upgrade org.apache.tomcat.embed:tomcat-embed-core to a safe version (see advisory below)
    ↪ Advisory URL: https://github.com/advisories/GHSA-3p2h-wqq4-wf4h
```
##  Github Workflow

Added vulnerability report generation to workflow action


