### PR TITLE
Change Maven command to include 'clean' step

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         
-        run: mvn -U -DskipTests=true deploy
+        run: mvn clean -U -DskipTests=true deploy


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow. The Maven deploy command in `.github/workflows/deploy-snapshots.yml` now includes the `clean` phase to ensure the build directory is cleared before deployment.