### PR TITLE
Reorder Maven command for deployment

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         
-        run: mvn clean -U -DskipTests=true deploy
+        run: mvn -U -DskipTests=true clean deploy


### PR DESCRIPTION
This pull request makes a minor update to the Maven deployment command in the GitHub Actions workflow. The order of the `mvn` command arguments has been adjusted for consistency with standard Maven practices.