### PR TITLE
Dependabot workflow fixes

### DIFF
--- a/.github/scripts/dependabot-group-alerts.sh
+++ b/.github/scripts/dependabot-group-alerts.sh
@@ -8,7 +8,7 @@ gh api repos/"$GITHUB_REPOSITORY"/dependabot/alerts \
   --paginate \
   --jq '.' > alerts.json
 
-# Group and format alerts
+# Group and format security alerts
 cat alerts.json | jq -s '
   add
   | group_by([.dependency.package.name, .security_advisory.ghsa_id])

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -25,6 +25,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
         run: |
-          export GH_TOKEN="$GH_TOKEN"
+          export GH_TOKEN="${{ secrets.DEPENDABOT_TOKEN }}"  # ✅ Injects secret directly
           bash .github/scripts/dependabot-group-alerts.sh
 

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -1,4 +1,4 @@
-Oname: Dependabot Insights
+name: Dependabot Insights
 
 on:
   workflow_dispatch:  # Manual trigger only

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -23,7 +23,7 @@ jobs:
       
       - name: Run alert grouping script
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
         run: |
           bash .github/scripts/dependabot-group-alerts.sh
 

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -22,4 +22,8 @@ jobs:
           sudo apt install -y gh
       
       - name: Run alert grouping script
-        run: .github/scripts/dependabot-group-alerts.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash .github/scripts/dependabot-group-alerts.sh
+

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -25,5 +25,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
         run: |
+          export GH_TOKEN="$GH_TOKEN"
           bash .github/scripts/dependabot-group-alerts.sh
 

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -20,14 +20,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y gh
-
-      - name: Authenticate GitHub CLI
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh auth login --with-token --hostname github.com
-
-      - name: Verify GitHub CLI Auth
-        run: gh auth status
-
+      
       - name: Run alert grouping script
         run: .github/scripts/dependabot-group-alerts.sh

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Authenticate GitHub CLI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh auth login --with-token <<< "$GH_TOKEN"
+        run: gh auth status
 
       - name: Verify GitHub CLI Auth
         run: gh auth status

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -1,4 +1,4 @@
-name: Dependabot Insights
+Oname: Dependabot Insights
 
 on:
   workflow_dispatch:  # Manual trigger only
@@ -23,8 +23,7 @@ jobs:
       
       - name: Run alert grouping script
         env:
-          GH_TOKEN: ${{ secrets.DEPENDABOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_REPO_TOKEN }}
         run: |
-          export GH_TOKEN="${{ secrets.DEPENDABOT_TOKEN }}"  # ✅ Injects secret directly
           bash .github/scripts/dependabot-group-alerts.sh
 

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -5,7 +5,7 @@ on:
 
 permissions:
   contents: read
-  security-events: read  # Required to access Dependabot alerts
+  security-events: read  # Required to access Dependabot alerts     
 
 jobs:
   generate-insights:

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -23,7 +23,7 @@ jobs:
       
       - name: Run alert grouping script
         env:
-          GH_TOKEN: ${{ secrets.DEPENDABOT_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_SECRET }}
         run: |
           bash .github/scripts/dependabot-group-alerts.sh
 

--- a/.github/workflows/dependabot-insights.yml
+++ b/.github/workflows/dependabot-insights.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Authenticate GitHub CLI
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh auth status
+        run: gh auth login --with-token --hostname github.com
 
       - name: Verify GitHub CLI Auth
         run: gh auth status


### PR DESCRIPTION
## Issue

https://github.com/embabel/embabel-agent/issues/850

## Overview

Dependabot Vulnerability report comes with duplicate entries per  module (pom).  

Its time consuming to group entries by jar (artifact) and go over all related pages.

Automated vulnerability report generation with proper grouping.

##  Example
```🔐 org.apache.tomcat.embed:tomcat-embed-core — GHSA-3p2h-wqq4-wf4h (1 unique alerts)
  Affected modules:
    - embabel-agent-mcpserver/pom.xml
    - embabel-agent-starters/embabel-agent-starter-mcpserver/pom.xml
  - Severity: medium | Apache Tomcat Denial of Service via invalid HTTP priority header
    ↪ Recommendation: Upgrade org.apache.tomcat.embed:tomcat-embed-core to a safe version (see advisory below)
    ↪ Advisory URL: https://github.com/advisories/GHSA-3p2h-wqq4-wf4h
```
##  Github Workflow

Added vulnerability report generation to workflow action

Workflow  employs ACTION-scoped secrets,  DEPENDABOT_SECRET.

