### PR TITLE
Support configuration auto completion and consolidate/clean up Configuration Properties

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -192,6 +192,21 @@
                             </sourceDirs>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>kapt</id>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-configuration-processor</artifactId>
+                                    <version>${spring-boot.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformProperties.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
 
 /**
  * Unified configuration for all agent platform properties.
@@ -27,124 +28,136 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * @since 1.x
  */
 @ConfigurationProperties("embabel.agent.platform")
-data class AgentPlatformProperties(
+class AgentPlatformProperties {
     /**
      * Core platform identity
      */
-    val name: String = "embabel-default",
-    val description: String = "Embabel Default Agent Platform",
+    var name: String = "embabel-default"
+    var description: String = "Embabel Default Agent Platform"
 
     /**
      * Platform behavior configurations
      */
-    val scanning: ScanningConfig = ScanningConfig(),
-    val ranking: RankingConfig = RankingConfig(),
-    val llmOperations: LlmOperationsConfig = LlmOperationsConfig(),
-    val processIdGeneration: ProcessIdGenerationConfig = ProcessIdGenerationConfig(),
-    val autonomy: AutonomyConfig = AutonomyConfig(),
-    val models: ModelsConfig = ModelsConfig(),
-    val sse: SseConfig = SseConfig(),
-    val test: TestConfig = TestConfig()
-) {
+    @field:NestedConfigurationProperty
+    var scanning: ScanningConfig = ScanningConfig()
+    @field:NestedConfigurationProperty
+    var ranking: RankingConfig = RankingConfig()
+    @field:NestedConfigurationProperty
+    var llmOperations: LlmOperationsConfig = LlmOperationsConfig()
+    @field:NestedConfigurationProperty
+    var processIdGeneration: ProcessIdGenerationConfig = ProcessIdGenerationConfig()
+    @field:NestedConfigurationProperty
+    var autonomy: AutonomyConfig = AutonomyConfig()
+    @field:NestedConfigurationProperty
+    var models: ModelsConfig = ModelsConfig()
+    @field:NestedConfigurationProperty
+    var sse: SseConfig = SseConfig()
+    @field:NestedConfigurationProperty
+    var test: TestConfig = TestConfig()
+
     /**
      * Agent scanning configuration
      */
-    data class ScanningConfig(
-        val annotation: Boolean = true,
-        val bean: Boolean = false
-    )
+    class ScanningConfig {
+        var annotation: Boolean = true
+        var bean: Boolean = false
+    }
 
     /**
      * Ranking configuration with retry logic
      */
-    data class RankingConfig(
-        val llm: String? = null,
-        val maxAttempts: Int = 5,
-        val backoffMillis: Long = 100L,
-        val backoffMultiplier: Double = 5.0,
-        val backoffMaxInterval: Long = 180000L
-    )
+    class RankingConfig {
+        var llm: String? = null
+        var maxAttempts: Int = 5
+        var backoffMillis: Long = 100L
+        var backoffMultiplier: Double = 5.0
+        var backoffMaxInterval: Long = 180000L
+    }
 
     /**
      * LLM operations configuration
      */
-    data class LlmOperationsConfig(
-        val prompts: PromptsConfig = PromptsConfig(),
-        val dataBinding: DataBindingConfig = DataBindingConfig()
-    ) {
+    class LlmOperationsConfig {
+        @field:NestedConfigurationProperty
+        var prompts: PromptsConfig = PromptsConfig()
+        @field:NestedConfigurationProperty
+        var dataBinding: DataBindingConfig = DataBindingConfig()
+
         /**
          * Prompt configuration
          */
-        data class PromptsConfig(
-            val maybePromptTemplate: String = "maybe_prompt_contribution",
-            val generateExamplesByDefault: Boolean = true
-        )
+        class PromptsConfig {
+            var maybePromptTemplate: String = "maybe_prompt_contribution"
+            var generateExamplesByDefault: Boolean = true
+        }
 
         /**
          * Data binding retry configuration
          */
-        data class DataBindingConfig(
-            val maxAttempts: Int = 10,
-            val fixedBackoffMillis: Long = 30L
-        )
+        class DataBindingConfig {
+            var maxAttempts: Int = 10
+            var fixedBackoffMillis: Long = 30L
+        }
     }
 
     /**
      * Process ID generation configuration
      */
-    data class ProcessIdGenerationConfig(
-        val includeVersion: Boolean = false,
-        val includeAgentName: Boolean = false
-    )
+    class ProcessIdGenerationConfig {
+        var includeVersion: Boolean = false
+        var includeAgentName: Boolean = false
+    }
 
     /**
      * Autonomy thresholds configuration
      */
-    data class AutonomyConfig(
-        val agentConfidenceCutOff: Double = 0.6,
-        val goalConfidenceCutOff: Double = 0.6
-    )
+    class AutonomyConfig {
+        var agentConfidenceCutOff: Double = 0.6
+        var goalConfidenceCutOff: Double = 0.6
+    }
 
     /**
      * Model provider integration configurations
      */
-    data class ModelsConfig(
-        val anthropic: AnthropicConfig = AnthropicConfig(),
-        val openai: OpenAiConfig = OpenAiConfig()
-    ) {
+    class ModelsConfig {
+        @field:NestedConfigurationProperty
+        var anthropic: AnthropicConfig = AnthropicConfig()
+        @field:NestedConfigurationProperty
+        var openai: OpenAiConfig = OpenAiConfig()
+
         /**
          * Anthropic provider retry configuration
          */
-        data class AnthropicConfig(
-            val maxAttempts: Int = 10,
-            val backoffMillis: Long = 5000L,
-            val backoffMultiplier: Double = 5.0,
-            val backoffMaxInterval: Long = 180000L
-        )
+        class AnthropicConfig {
+            var maxAttempts: Int = 10
+            var backoffMillis: Long = 5000L
+            var backoffMultiplier: Double = 5.0
+            var backoffMaxInterval: Long = 180000L
+        }
 
         /**
          * OpenAI provider retry configuration
          */
-        data class OpenAiConfig(
-            val maxAttempts: Int = 10,
-            val backoffMillis: Long = 5000L,
-            val backoffMultiplier: Double = 5.0,
-            val backoffMaxInterval: Long = 180000L
-        )
+        class OpenAiConfig {
+            var maxAttempts: Int = 10
+            var backoffMillis: Long = 5000L
+            var backoffMultiplier: Double = 5.0
+            var backoffMaxInterval: Long = 180000L
+        }
     }
 
     /**
      * Server-sent events configuration
      */
-    data class SseConfig(
-        val maxBufferSize: Int = 100,
-        val maxProcessBuffers: Int = 1000
-    )
+    class SseConfig {
+        var maxBufferSize: Int = 100
+        var maxProcessBuffers: Int = 1000
+    }
 
     /**
      * Test configuration
      */
-    data class TestConfig(
-        val mockMode: Boolean = true
-    )
+    class TestConfig {
+        var mockMode: Boolean = true
+    }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/ContextRepositoryProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/ContextRepositoryProperties.kt
@@ -21,11 +21,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * Configuration properties for the agent process repository.
  */
 @ConfigurationProperties("embabel.agent.platform.context-repository")
-data class ContextRepositoryProperties(
+class ContextRepositoryProperties {
     /**
      * Maximum number of contexts to keep in memory.
      * When this limit is exceeded, the oldest processes will be evicted.
      * Default is 1000.
      */
-    val windowSize: Int = 1000,
-)
+    var windowSize: Int = 1000
+
+    companion object {
+        operator fun invoke(windowSize: Int): ContextRepositoryProperties =
+            ContextRepositoryProperties().apply { this.windowSize = windowSize }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/ProcessRepositoryProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/ProcessRepositoryProperties.kt
@@ -21,11 +21,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * Configuration properties for the agent process repository.
  */
 @ConfigurationProperties("embabel.agent.platform.process-repository")
-data class ProcessRepositoryProperties(
+class ProcessRepositoryProperties {
     /**
      * Maximum number of agent processes to keep in memory.
      * When this limit is exceeded, the oldest processes will be evicted.
      * Default is 1000.
      */
-    val windowSize: Int = 1000,
-)
+    var windowSize: Int = 1000
+
+    companion object {
+        operator fun invoke(windowSize: Int): ProcessRepositoryProperties {
+            return ProcessRepositoryProperties().apply {
+                this.windowSize = windowSize
+            }
+        }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/ToolGroupsConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/ToolGroupsConfiguration.kt
@@ -49,11 +49,11 @@ data class GroupConfig(
  * @param excludes list of tool names to exclude from all tool groups
  */
 @ConfigurationProperties(prefix = "embabel.agent.platform.tools")
-data class ToolGroupsProperties(
-    val includes: Map<String, GroupConfig> = emptyMap(),
-    val excludes: List<String> = emptyList(),
-    val version: String = Semver().value,
-)
+class ToolGroupsProperties {
+    var includes: Map<String, GroupConfig> = emptyMap()
+    var excludes: List<String> = emptyList()
+    var version: String = Semver().value
+}
 
 @Configuration
 @EnableConfigurationProperties(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanner.kt
@@ -238,6 +238,18 @@ class DeprecatedPropertyScanner(
         put("embabel.openai.backoff-millis", "embabel.agent.platform.models.openai.backoff-millis")
         put("embabel.openai.backoff-multiplier", "embabel.agent.platform.models.openai.backoff-multiplier")
         put("embabel.openai.backoff-max-interval", "embabel.agent.platform.models.openai.backoff-max-interval")
+        put("embabel.docker.models.max-attempts", "embabel.agent.platform.models.docker.max-attempts")
+        put("embabel.docker.models.backoff-millis", "embabel.agent.platform.models.docker.backoff-millis")
+        put("embabel.docker.models.backoff-multiplier", "embabel.agent.platform.models.docker.backoff-multiplier")
+        put("embabel.docker.models.backoff-max-interval", "embabel.agent.platform.models.docker.backoff-max-interval")
+        put("embabel.docker.models.base-url", "embabel.agent.models.docker.base-url")
+        put("embabel.models.bedrock.models.name", "embabel.agent.models.bedrock.models.name")
+        put("embabel.models.bedrock.models.knowledge-cutoff", "embabel.agent.models.bedrock.models.knowledge-cutoff")
+        put("embabel.models.bedrock.models.input-price", "embabel.agent.models.bedrock.models.input-price")
+        put("embabel.models.bedrock.models.output-price", "embabel.agent.models.bedrock.models.output-price")
+
+        // discord prefix
+        put("embabel.discord.token", "embabel.agent.discord.token")
 
         // Specific platform feature migrations
         put("embabel.agent.enable-scanning", "embabel.agent.platform.scanning.annotation")

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanningConfig.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanningConfig.kt
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory
     havingValue = "true",
     matchIfMissing = false
 )
-data class DeprecatedPropertyScanningConfig(
+class DeprecatedPropertyScanningConfig {
     /**
      * Base packages to scan for deprecated conditional annotations.
      * Defaults to actual Embabel packages while excluding framework internals.
@@ -113,31 +113,31 @@ data class DeprecatedPropertyScanningConfig(
     var includePackages: List<String> = listOf(
         "com.embabel.agent",
         "com.embabel.agent.shell"
-    ),
+    )
 
     /**
      * Package prefixes to exclude from scanning.
      * Uses a comprehensive strategy that excludes common framework and library packages
      * while allowing configuration override for custom environments.
      */
-    var excludePackages: List<String> = defaultExcludePackages(),
+    var excludePackages: List<String> = defaultExcludePackages()
 
     /**
      * Additional user-specific packages to exclude.
      * Allows runtime customization without modifying the default exclusion list.
      */
-    var additionalExcludes: List<String> = emptyList(),
+    var additionalExcludes: List<String> = emptyList()
 
     /**
      * Whether to use classpath-based detection to automatically exclude JAR-based packages.
      * When enabled, packages from JAR files are automatically excluded from scanning.
      */
-    var autoExcludeJarPackages: Boolean = false,
+    var autoExcludeJarPackages: Boolean = false
 
     /**
      * Maximum depth for package scanning to prevent excessive recursion.
      */
-    var maxScanDepth: Int = 10,
+    var maxScanDepth: Int = 10
 
     /**
      * Whether scanning is enabled.
@@ -145,7 +145,6 @@ data class DeprecatedPropertyScanningConfig(
      * Set to `true` to activate comprehensive migration detection and warnings.
      */
     var enabled: Boolean = false
-) {
 
     private val logger = LoggerFactory.getLogger(DeprecatedPropertyScanningConfig::class.java)
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyWarningConfig.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyWarningConfig.kt
@@ -69,7 +69,7 @@ import org.springframework.context.annotation.Configuration
     havingValue = "true",
     matchIfMissing = true
 )
-data class DeprecatedPropertyWarningConfig(
+class DeprecatedPropertyWarningConfig {
     /**
      * Whether to enable individual warning logging.
      * **Enabled by default** for maximum visibility during migration periods.
@@ -77,4 +77,12 @@ data class DeprecatedPropertyWarningConfig(
      * When false, only aggregated summary is logged.
      */
     var individualLogging: Boolean = true
-)
+
+    companion object {
+        operator fun invoke(individualLogging: Boolean): DeprecatedPropertyWarningConfig {
+            return DeprecatedPropertyWarningConfig().apply {
+                this.individualLogging = individualLogging
+            }
+        }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/deployment/AgentScanningProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/deployment/AgentScanningProperties.kt
@@ -26,7 +26,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * @see com.embabel.agent.api.annotation.Agent
  */
 @ConfigurationProperties("embabel.agent.platform.scanning")
-data class AgentScanningProperties(
-    val annotation: Boolean = true,
-    val bean: Boolean = false,
-)
+class AgentScanningProperties {
+    var annotation: Boolean = true
+    var bean: Boolean = false
+
+
+    companion object {
+        operator fun invoke(annotation: Boolean, bean: Boolean): AgentScanningProperties {
+            return AgentScanningProperties().apply {
+                this.annotation = annotation
+                this.bean = bean
+            }
+        }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/rag/RagServiceEnhancerProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/rag/RagServiceEnhancerProperties.kt
@@ -19,8 +19,8 @@ import com.embabel.common.ai.model.LlmOptions
 import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "embabel.agent.rag")
-data class RagServiceEnhancerProperties(
-    val compressionLlm: LlmOptions = LlmOptions.withAutoLlm(),
-    val rerankingLlm: LlmOptions = LlmOptions.withAutoLlm(),
-    val maxConcurrency: Int = 12,
-)
+class RagServiceEnhancerProperties {
+    var compressionLlm: LlmOptions = LlmOptions.withAutoLlm()
+    var rerankingLlm: LlmOptions = LlmOptions.withAutoLlm()
+    var maxConcurrency: Int = 12
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -28,12 +28,12 @@ import java.time.Duration
  * We want to be more forgiving with data binding. This
  * can be important for smaller models.
  */
-@ConfigurationProperties(prefix = "embabel.llm-operations.data-binding")
-data class LlmDataBindingProperties(
-    override val maxAttempts: Int = 10,
-    val fixedBackoffMillis: Long = 30L,
-) : RetryTemplateProvider {
+@ConfigurationProperties(prefix = "embabel.agent.platform.llm-operations.data-binding")
+class LlmDataBindingProperties : RetryTemplateProvider {
     private val logger = LoggerFactory.getLogger(LlmDataBindingProperties::class.java)
+
+    override var maxAttempts: Int = 10
+    var fixedBackoffMillis: Long = 30L
 
     override fun retryTemplate(name: String): RetryTemplate {
         return RetryTemplate.builder()

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmOperationsPromptsProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmOperationsPromptsProperties.kt
@@ -24,9 +24,9 @@ import java.time.Duration
  *  * can enable a failure result if the LLM does not have enough information to
  *  * create the desired output structure.
  */
-@ConfigurationProperties(prefix = "embabel.llm-operations.prompts")
-data class LlmOperationsPromptsProperties(
-    val maybePromptTemplate: String = "maybe_prompt_contribution",
-    val generateExamplesByDefault: Boolean = true,
-    val defaultTimeout: Duration = Duration.ofSeconds(60),
-)
+@ConfigurationProperties(prefix = "embabel.agent.platform.llm-operations.prompts")
+class LlmOperationsPromptsProperties {
+    var maybePromptTemplate: String = "maybe_prompt_contribution"
+    var generateExamplesByDefault: Boolean = true
+    var defaultTimeout: Duration = Duration.ofSeconds(60)
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/AgentPlatformTestExtensions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/AgentPlatformTestExtensions.kt
@@ -33,11 +33,11 @@ fun forAutonomyTesting(
     agentConfidenceCutOff: Double? = null,
     goalConfidenceCutOff: Double? = null
 ): AutonomyProperties {
-    val autonomyConfig = AgentPlatformProperties.AutonomyConfig(
-        agentConfidenceCutOff = agentConfidenceCutOff ?: 0.6,
-        goalConfidenceCutOff = goalConfidenceCutOff ?: 0.6
-    )
-    val testPlatformProperties = AgentPlatformProperties(autonomy = autonomyConfig)
+    val autonomyConfig = AgentPlatformProperties.AutonomyConfig()
+    autonomyConfig.agentConfidenceCutOff = agentConfidenceCutOff ?: 0.6
+    autonomyConfig.goalConfidenceCutOff = goalConfidenceCutOff ?: 0.6
+    val testPlatformProperties = AgentPlatformProperties()
+    testPlatformProperties.autonomy = autonomyConfig
     return AutonomyProperties(testPlatformProperties)
 }
 
@@ -49,10 +49,10 @@ fun forProcessIdGenerationTesting(
     includeAgentName: Boolean? = null,
     includeVersion: Boolean? = null
 ): DefaultProcessIdGeneratorProperties {
-    val processIdConfig = AgentPlatformProperties.ProcessIdGenerationConfig(
-        includeAgentName = includeAgentName ?: false,
-        includeVersion = includeVersion ?: false
-    )
-    val testPlatformProperties = AgentPlatformProperties(processIdGeneration = processIdConfig)
+    val processIdConfig = AgentPlatformProperties.ProcessIdGenerationConfig()
+    processIdConfig.includeAgentName = includeAgentName ?: false
+    processIdConfig.includeVersion = includeVersion ?: false
+    val testPlatformProperties = AgentPlatformProperties()
+    testPlatformProperties.processIdGeneration = processIdConfig
     return DefaultProcessIdGeneratorProperties(testPlatformProperties)
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/agent/AgentPlatformChatSession.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/agent/AgentPlatformChatSession.kt
@@ -39,13 +39,12 @@ import com.embabel.common.util.loggerFor
  * @param confirmGoals Whether to confirm goals with the user before proceeding
  * @param bindConversation Whether to bind the conversation to the chat session
  */
-data class ChatConfig(
-    val confirmGoals: Boolean = true,
-    val bindConversation: Boolean = false,
-    val multiGoal: Boolean = false,
-    val model: String = OpenAiModels.GPT_41_MINI,
-    val temperature: Double? = null,
-) {
+class ChatConfig {
+    var confirmGoals: Boolean = true
+    var bindConversation: Boolean = false
+    var multiGoal: Boolean = false
+    var model: String = OpenAiModels.GPT_41_MINI
+    var temperature: Double? = null
 
     /**
      * Options for the LLM used in the chat session

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModels.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModels.kt
@@ -52,7 +52,7 @@ import software.amazon.awssdk.regions.providers.AwsRegionProvider
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient
 
-@ConfigurationProperties(prefix = "embabel.models.bedrock")
+@ConfigurationProperties(prefix = "embabel.agent.models.bedrock")
 class BedrockProperties {
     /**
      * List of LLM provider by Bedrock
@@ -61,7 +61,7 @@ class BedrockProperties {
     var models: List<BedrockModelProperties> = emptyList()
 }
 
-@ConfigurationProperties(prefix = "embabel.models.bedrock.models")
+@ConfigurationProperties(prefix = "embabel.agent.models.bedrock.models")
 class BedrockModelProperties {
     /**
      * Name of the LLM, such as "gpt-3.5-turbo"

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/resources/application-bedrock.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/resources/application-bedrock.yml
@@ -13,81 +13,82 @@ spring:
         session-token: ${AWS_SESSION_TOKEN:}
 
 embabel:
-  models:
-    bedrock:
-      models:
+  agent:
+    models:
+      bedrock:
+        models:
         # US region
-        - name: us.anthropic.claude-3-5-sonnet-20240620-v1:0
-          knowledge-cutoff: 2024-04-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: us.anthropic.claude-3-5-sonnet-20241022-v2:0
-          knowledge-cutoff: 2024-07-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: us.anthropic.claude-3-5-haiku-20241022-v1:0
-          knowledge-cutoff: 2024-07-01
-          input-price: 0.8
-          output-price: 4.0
-        - name: us.anthropic.claude-3-7-sonnet-20250219-v1:0
-          knowledge-cutoff: 2024-10-31
-          input-price: 3.0
-          output-price: 15.0
-        - name: us.anthropic.claude-sonnet-4-20250514-v1:0
-          knowledge-cutoff: 2025-03-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: us.anthropic.claude-opus-4-20250514-v1:0
-          knowledge-cutoff: 2025-03-01
-          input-price: 15.0
-          output-price: 75.0
-        # EU region
-        - name: eu.anthropic.claude-3-5-sonnet-20240620-v1:0
-          knowledge-cutoff: 2024-04-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: eu.anthropic.claude-3-5-sonnet-20241022-v2:0
-          knowledge-cutoff: 2024-07-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: eu.anthropic.claude-3-5-haiku-20241022-v1:0
-          knowledge-cutoff: 2024-07-01
-          input-price: 0.8
-          output-price: 4.0
-        - name: eu.anthropic.claude-3-7-sonnet-20250219-v1:0
-          knowledge-cutoff: 2024-10-31
-          input-price: 3.0
-          output-price: 15.0
-        - name: eu.anthropic.claude-sonnet-4-20250514-v1:0
-          knowledge-cutoff: 2025-03-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: eu.anthropic.claude-opus-4-20250514-v1:0
-          knowledge-cutoff: 2025-03-01
-          input-price: 15.0
-          output-price: 75.0
-        # APAC region
-        - name: apac.anthropic.claude-3-5-sonnet-20240620-v1:0
-          knowledge-cutoff: 2024-04-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: apac.anthropic.claude-3-5-sonnet-20241022-v2:0
-          knowledge-cutoff: 2024-07-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: apac.anthropic.claude-3-5-haiku-20241022-v1:0
-          knowledge-cutoff: 2024-07-01
-          input-price: 0.8
-          output-price: 4.0
-        - name: apac.anthropic.claude-3-7-sonnet-20250219-v1:0
-          knowledge-cutoff: 2024-10-31
-          input-price: 3.0
-          output-price: 15.0
-        - name: apac.anthropic.claude-sonnet-4-20250514-v1:0
-          knowledge-cutoff: 2025-03-01
-          input-price: 3.0
-          output-price: 15.0
-        - name: apac.anthropic.claude-opus-4-20250514-v1:0
-          knowledge-cutoff: 2025-03-01
-          input-price: 15.0
-          output-price: 75.0
+          - name: us.anthropic.claude-3-5-sonnet-20240620-v1:0
+            knowledge-cutoff: 2024-04-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: us.anthropic.claude-3-5-sonnet-20241022-v2:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: us.anthropic.claude-3-5-haiku-20241022-v1:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 0.8
+            output-price: 4.0
+          - name: us.anthropic.claude-3-7-sonnet-20250219-v1:0
+            knowledge-cutoff: 2024-10-31
+            input-price: 3.0
+            output-price: 15.0
+          - name: us.anthropic.claude-sonnet-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: us.anthropic.claude-opus-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 15.0
+            output-price: 75.0
+          # EU region
+          - name: eu.anthropic.claude-3-5-sonnet-20240620-v1:0
+            knowledge-cutoff: 2024-04-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: eu.anthropic.claude-3-5-sonnet-20241022-v2:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: eu.anthropic.claude-3-5-haiku-20241022-v1:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 0.8
+            output-price: 4.0
+          - name: eu.anthropic.claude-3-7-sonnet-20250219-v1:0
+            knowledge-cutoff: 2024-10-31
+            input-price: 3.0
+            output-price: 15.0
+          - name: eu.anthropic.claude-sonnet-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: eu.anthropic.claude-opus-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 15.0
+            output-price: 75.0
+          # APAC region
+          - name: apac.anthropic.claude-3-5-sonnet-20240620-v1:0
+            knowledge-cutoff: 2024-04-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: apac.anthropic.claude-3-5-sonnet-20241022-v2:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: apac.anthropic.claude-3-5-haiku-20241022-v1:0
+            knowledge-cutoff: 2024-07-01
+            input-price: 0.8
+            output-price: 4.0
+          - name: apac.anthropic.claude-3-7-sonnet-20250219-v1:0
+            knowledge-cutoff: 2024-10-31
+            input-price: 3.0
+            output-price: 15.0
+          - name: apac.anthropic.claude-sonnet-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 3.0
+            output-price: 15.0
+          - name: apac.anthropic.claude-opus-4-20250514-v1:0
+            knowledge-cutoff: 2025-03-01
+            input-price: 15.0
+            output-price: 75.0

--- a/embabel-agent-discord/pom.xml
+++ b/embabel-agent-discord/pom.xml
@@ -38,6 +38,23 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>kapt</id>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-configuration-processor</artifactId>
+                                    <version>${spring-boot.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/embabel-agent-discord/src/main/kotlin/com/embabel/agent/discord/DiscordConfiguration.kt
+++ b/embabel-agent-discord/src/main/kotlin/com/embabel/agent/discord/DiscordConfiguration.kt
@@ -26,12 +26,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
-@ConfigurationProperties(prefix = "embabel.discord")
-data class DiscordConfigProperties(
-    val token: String? = null,
-)
+@ConfigurationProperties(prefix = "embabel.agent.discord")
+class DiscordConfigProperties {
+    var token: String? = null
+}
 
-const val TOKEN_KEY = "embabel.discord.token"
+const val TOKEN_KEY = "embabel.agent.discord.token"
 
 /**
  * Adds all event listeners defined in the context to JDA builder

--- a/embabel-agent-rag/embabel-agent-rag-neo/src/main/kotlin/com/embabel/agent/rag/neo/ogm/NeoRagServiceProperties.kt
+++ b/embabel-agent-rag/embabel-agent-rag-neo/src/main/kotlin/com/embabel/agent/rag/neo/ogm/NeoRagServiceProperties.kt
@@ -24,22 +24,22 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * @param ogmPackages the packages to scan for Neo4j OGM entities. Defaults to none
  */
 @ConfigurationProperties(prefix = "embabel.agent.rag.neo")
-data class NeoRagServiceProperties(
-    val uri: String = "bolt://localhost:7687",
-    val username: String = "neo4j",
-    internal val password: String,
+class NeoRagServiceProperties : ContentChunker.Config {
+    var uri: String = "bolt://localhost:7687"
+    var username: String = "neo4j"
+    internal var password: String = ""
 
-    val chunkNodeName: String = "Chunk",
-    val entityNodeName: String = "Entity",
-    val name: String = "OgmRagService",
-    val description: String = "RAG service using Neo4j OGM for querying and embedding",
-    val contentElementIndex: String = "embabel-content-index",
-    val entityIndex: String = "embabel-entity-index",
-    val contentElementFullTextIndex: String = "embabel-content-fulltext-index",
-    val entityFullTextIndex: String = "embabel-entity-fulltext-index",
+    var chunkNodeName: String = "Chunk"
+    var entityNodeName: String = "Entity"
+    var name: String = "OgmRagService"
+    var description: String = "RAG service using Neo4j OGM for querying and embedding"
+    var contentElementIndex: String = "embabel-content-index"
+    var entityIndex: String = "embabel-entity-index"
+    var contentElementFullTextIndex: String = "embabel-content-fulltext-index"
+    var entityFullTextIndex: String = "embabel-entity-fulltext-index"
 
     // Empty packages causes a strange failure within Neo4j OGM
-    val ogmPackages: List<String> = listOf("not.a.real.package"),
-    override val maxChunkSize: Int = 1500,
-    override val overlapSize: Int = 200,
-) : ContentChunker.Config
+    var ogmPackages: List<String> = listOf("not.a.real.package")
+    override var maxChunkSize: Int = 1500
+    override var overlapSize: Int = 200
+}

--- a/embabel-agent-rag/pom.xml
+++ b/embabel-agent-rag/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.embabel.agent</groupId>
@@ -42,6 +43,23 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>kapt</id>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-configuration-processor</artifactId>
+                                    <version>${spring-boot.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/config/ShellProperties.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/config/ShellProperties.kt
@@ -17,9 +17,11 @@ package com.embabel.agent.shell.config
 
 import com.embabel.chat.agent.ChatConfig
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
 
-@ConfigurationProperties(prefix = "embabel.shell")
-data class ShellProperties(
-    val lineLength: Int = 140,
-    val chat: ChatConfig = ChatConfig(),
-)
+@ConfigurationProperties(prefix = "embabel.agent.shell")
+class ShellProperties {
+    var lineLength: Int = 140
+    @field:NestedConfigurationProperty
+    var chat: ChatConfig = ChatConfig()
+}

--- a/embabel-agent-starters/embabel-agent-starter-shell/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-shell/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.embabel.agent</groupId>
@@ -20,6 +21,12 @@
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-shell</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 </project>

--- a/embabel-agent-starters/embabel-agent-starter-shell/src/main/java/com/embabel/agent/starter/shell/AgentShellStarterProperties.java
+++ b/embabel-agent-starters/embabel-agent-starter-shell/src/main/java/com/embabel/agent/starter/shell/AgentShellStarterProperties.java
@@ -38,8 +38,8 @@ import javax.validation.constraints.Pattern;
  *
  * @since 1.1
  */
-@ConfigurationProperties(prefix = "embabel.agent.shell")
 @Validated
+@ConfigurationProperties(prefix = "embabel.agent.shell")
 public class AgentShellStarterProperties {
 
     /**


### PR DESCRIPTION
# Overview
This pr support all @ConfigurationProperties classes auto completion and consolidate / clean-up Configuration Properties.
I greatly appreciate @igordayen`s direction [#845 #899 ] .

The most significant changes involve enhancing annotation processing support in the Maven build and refactoring the class with @ConfigurationProperties annotation.

# Build process improvements:
Added a kapt execution to Maven build  to enable annotation processing, specifically including the spring-boot-configuration-processor for improved Spring Boot configuration metadata generation.
- embabel-agent-api/pom.xml
- embabel-agent-discord/pom.xml
- embabel-agent-rag/pom.xml

In embabel-agent-starter-shell module add  spring-boot-configuration-processor  in pom, because of it Java class, do not need kapt.

# Configuration model refactoring:

## AgentPlatformProperties

1. Refactored the AgentPlatformProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).

 2. Add @field:NestedConfigurationProperty on Object field.
## ContextRepositoryProperties

1. Refactored the ContextRepositoryProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).
2. Add companion object to make object creation easier
## ProcessRepositoryProperties
1. Refactored the ProcessRepositoryProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).
2. Add companion object to make object creation easier
## ToolGroupsProperties
1. Refactored the ToolGroupsProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).

## AgentScanningProperties

1. Refactored the AgentScanningProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).
2. Add companion object to make object creation easier.

## RagServiceEnhancerProperties

1. Refactored the RagServiceEnhancerProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val)

## LlmOperationsPromptsProperties

1. Refactored the LlmOperationsPromptsProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).
2. The @ConfigurationProperties annotation prefix change `embabel.llm-operations.prompts` to `embabel.agent.platform.llm-operations.prompts`

## LlmDataBindingProperties

1. Refactored the LlmDataBindingProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).
2. The @ConfigurationProperties annotation prefix change `embabel.llm-operations.data-binding` to `embabel.agent.platform.llm-operations.data-binding`.

## DeprecatedPropertyScanningConfig

1. Refactored the DeprecatedPropertyScanningConfig type from a data class to a class, change the constructor properties to class properties.

## DeprecatedPropertyWarningConfig

1. Refactored the DeprecatedPropertyWarningConfig type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).
2. Add companion object to make object creation easier.

## ShellProperties

1. Refactored the ShellProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).
2. The @ConfigurationProperties annotation prefix change `embabel.shell` to `embabel.agent.shell`.

## DiscordConfigProperties

1. Refactored the DiscordConfigProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val).
2. The @ConfigurationProperties annotation prefix change `embabel.discord` to `embabel.agent.discord`.
3. The const val TOKEN_KEY change value from "embabel.discord.token" to "embabel.agent.discord.token".

## NeoRagServiceProperties

1. Refactored the NeoRagServiceProperties type from a data class to a class, change the constructor properties to class properties, and use mutable (var) properties instead of immutable (val)

## AgentShellStarterProperties
1. reordered annotations  @Validated

## BedrockProperties
1. The @ConfigurationProperties annotation prefix change `embabel.models.bedrock` to `embabel.agent.models.bedrock`.
2. fix application-bedrock configuration.

## DockerProperties
The DockerProperties class has been split into DockerRetryProperties (Platform Properties) and DockerConnectionProperties(Application Properties).

@ConfigurationProperties("embabel.agent.platform.models.docker")
class DockerRetryProperties : RetryProperties {
override var maxAttempts: Int = 10
override var backoffMillis: Long = 5000L
override var backoffMultiplier: Double = 5.0
override var backoffMaxInterval: Long = 180000L
}

@ConfigurationProperties("embabel.agent.models.docker")
class DockerConnectionProperties {
var baseUrl: String = "http://localhost:12434/engines"
}
# Other changes;
   put("embabel.docker.models.max-attempts", "embabel.agent.platform.models.docker.max-attempts")
   put("embabel.docker.models.backoff-millis", "embabel.agent.platform.models.docker.backoff-millis")
   put("embabel.docker.models.backoff-multiplier", "embabel.agent.platform.models.docker.backoff-multiplier")
   put("embabel.docker.models.backoff-max-interval", "embabel.agent.platform.models.docker.backoff-max-interval")
   put("embabel.docker.models.base-url", "embabel.agent.models.docker.base-url")
   put("embabel.models.bedrock.models.name", "embabel.agent.models.bedrock.models.name")
   put("embabel.models.bedrock.models.knowledge-cutoff", "embabel.agent.models.bedrock.models.knowledge-cutoff")
   put("embabel.models.bedrock.models.input-price", "embabel.agent.models.bedrock.models.input-price")
   put("embabel.models.bedrock.models.output-price", "embabel.agent.models.bedrock.models.output-price")

 added to the exactPropertyMappings attribute in the DeprecatedPropertyScanner class.
