### PR TITLE
Issue #405 Agent Observability

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/models/OpenAiCompatibleModelFactory.kt
@@ -24,6 +24,7 @@ import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.document.MetadataMode
 import org.springframework.ai.model.NoopApiKey
 import org.springframework.ai.model.SimpleApiKey
+import org.springframework.ai.model.tool.ToolCallingManager
 import org.springframework.ai.openai.OpenAiChatModel
 import org.springframework.ai.openai.OpenAiChatOptions
 import org.springframework.ai.openai.OpenAiEmbeddingModel
@@ -31,6 +32,8 @@ import org.springframework.ai.openai.OpenAiEmbeddingOptions
 import org.springframework.ai.openai.api.OpenAiApi
 import org.springframework.ai.retry.RetryUtils
 import org.springframework.retry.support.RetryTemplate
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
 import java.time.LocalDate
 
 /**
@@ -75,6 +78,15 @@ open class OpenAiCompatibleModelFactory(
             loggerFor<OpenAiModels>().info("Using custom OpenAI embeddings path: {}", embeddingsPath)
             builder.embeddingsPath(embeddingsPath)
         }
+
+        //add observation registry to rest and web client builders
+        builder
+            .restClientBuilder(RestClient.builder()
+                .observationRegistry(observationRegistry))
+        builder
+            .webClientBuilder(WebClient.builder()
+                .observationRegistry(observationRegistry))
+
         return builder.build()
     }
 
@@ -125,6 +137,10 @@ open class OpenAiCompatibleModelFactory(
                     .model(model)
                     .build()
             )
+            .toolCallingManager(
+                ToolCallingManager.builder()
+                    .observationRegistry(observationRegistry)
+                    .build())
             .openAiApi(openAiApi)
             .retryTemplate(retryTemplate)
             .observationRegistry(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -32,9 +32,11 @@ import com.fasterxml.jackson.databind.DatabindException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.micrometer.observation.ObservationRegistry
 import jakarta.annotation.PostConstruct
 import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.client.ResponseEntity
+import org.springframework.ai.chat.client.observation.DefaultChatClientObservationConvention
 import org.springframework.ai.chat.messages.SystemMessage
 import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.model.ChatResponse
@@ -71,6 +73,7 @@ internal class ChatClientLlmOperations(
     private val applicationContext: ApplicationContext? = null,
     autoLlmSelectionCriteriaResolver: AutoLlmSelectionCriteriaResolver = AutoLlmSelectionCriteriaResolver.DEFAULT,
     private val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
+    private val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
 ) : AbstractLlmOperations(toolDecorator, modelProvider, autoLlmSelectionCriteriaResolver) {
 
     @PostConstruct
@@ -368,7 +371,7 @@ internal class ChatClientLlmOperations(
         llm: Llm,
     ): ChatClient {
         return ChatClient
-            .builder(llm.model)
+            .builder(llm.model, observationRegistry, DefaultChatClientObservationConvention(),)
             .build()
     }
 

--- a/embabel-agent-api/src/main/resources/application-observability.yml
+++ b/embabel-agent-api/src/main/resources/application-observability.yml
@@ -1,37 +1,23 @@
+# Observability configuration for Spring AI with tracing and logging
+# This is a concern of the application, not the library and will be removed in future versions
 spring:
   ai:
     chat:
+      client:
+        observations:
+          log-prompt: false             # Enable ChatClient prompt logging
       observations:
-        enabled: true
-        log-prompt: true
-        log-completion: true
-        include-completion: true
-        include-prompt: true
-        include-error-logging: true
-    client:
-      observations:
-        log-prompt: true
-        log-completion: true
+        log-prompt: false               # Enable ChatModel prompt logging
+        log-completion: false           # Enable ChatModel response logging
+        include-error-logging: true     # Include error details
+# Observability and tracing configuration
 management:
   tracing:
     enabled: true
     sampling:
-      probability: 1.0
-  endpoints:
-    web:
-      exposure:
-        include: "*"
-  endpoint:
-    env:
-      show-values: always
-      show-details: always
-    health:
-      show-details: always
-  observations:
-    enabled: true
-    web:
-      response:
-        enabled: true
+      probability: 1.0                 # Sample 100% of traces (use 0.1 for production)
+
+  # Zipkin configuration
   zipkin:
     tracing:
       endpoint: http://localhost:9411/api/v2/spans

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/pom.xml
@@ -12,9 +12,21 @@
     <description>Spring Boot Auto-Configuration platform for Embabel Agent API</description>
 
     <dependencies>
+        <!-- Core API -->
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <!-- Spring AI Auto Configurations required for all models -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-chat-observation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
         </dependency>
 
         <!-- Move this one to a dedicated starter once ready-->


### PR DESCRIPTION
This pull request introduces enhanced observability and tracing support for the Embabel Agent API, focusing on integrating Spring AI's observation infrastructure and improving configuration flexibility. The changes ensure that chat models and clients are properly instrumented for metrics and tracing, and update configuration files and dependencies to support these features.

**Observability and Tracing Integration**

* Added support for passing `ObservationRegistry` to `RestClient` and `WebClient` builders in `OpenAiCompatibleModelFactory`, enabling instrumentation of HTTP clients used by AI models.
* Integrated `ToolCallingManager` with `ObservationRegistry` in the OpenAI model factory, ensuring tool calls are observed and traced.
* Updated `ChatClientLlmOperations` to accept and use an `ObservationRegistry`, passing it to the `ChatClient` builder for improved tracing and metrics. [[1]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200R35-R39) [[2]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200R76) [[3]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200L371-R374)

**Configuration and Dependency Updates**

* Refactored `application-observability.yml` to clarify and adjust logging, error, and tracing settings for chat models and clients, including Zipkin endpoint configuration for distributed tracing.
* Added required Spring AI auto-configuration dependencies for chat model and client observation to the platform auto-configure module, ensuring all models have observability support out-of-the-box.

These changes collectively improve the monitoring, debugging, and traceability of AI interactions within the application.