### PR TITLE
Add ToolCallingManager Observability support

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModels.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModels.kt
@@ -204,6 +204,8 @@ class BedrockModels(
         .timeout(connectionProperties.timeout)
         .defaultOptions(ToolCallingChatOptions.builder().model(model).build())
         .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+        .toolCallingManager(ToolCallingManager.builder()
+            .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP }).build())
         .bedrockRuntimeClient(bedrockRuntimeClient.getIfAvailable())
         .bedrockRuntimeAsyncClient(bedrockRuntimeAsyncClient.getIfAvailable())
         .build()


### PR DESCRIPTION
This pull request introduces an update to the `BedrockModels` class to enhance tool-calling capabilities. The main change is the addition of a `ToolCallingManager` to the builder configuration, which improves the integration and observability of tool-calling operations.

Tool-calling integration:

* Added a `ToolCallingManager` to the `BedrockModels` builder, including observation registry configuration for improved monitoring of tool-calling operations.