### PR TITLE
Disable JGit file system cache in Windows Matrix build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Build and test
         env:
           SKIP_TESTCONTAINER_TESTS: true  # Do not run TestContainer Tests in Windows Matrix Build.
+          MAVEN_OPTS: "-Djgit.fs.cache.enabled=false"
         run: mvn -U -B test verify
       - name: Linux-specific setup and SonarCloud analysis
         if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
This pull request makes a minor update to the Maven build workflow configuration. The change disables the JGit filesystem cache during Maven builds, which can help prevent issues related to file system caching in certain environments.

* Added `MAVEN_OPTS: "-Djgit.fs.cache.enabled=false"` to the build environment in `.github/workflows/maven.yml` to disable JGit filesystem caching during Maven builds.