### PR TITLE
Disable GitReferenceTest on Windows due to CI Build Issues.

### DIFF
--- a/embabel-agent-code/src/test/kotlin/com/embabel/coding/tools/GitReferenceTest.kt
+++ b/embabel-agent-code/src/test/kotlin/com/embabel/coding/tools/GitReferenceTest.kt
@@ -24,11 +24,14 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisabledOnOs(OS.WINDOWS, disabledReason = "Windows file locking with Git pack files")
 class GitReferenceTest {
 
     private val repositoryReferenceProvider = RepositoryReferenceProvider()


### PR DESCRIPTION
This pull request introduces a minor update to the `GitReferenceTest` class to improve test reliability across operating systems. The test class is now disabled on Windows due to file locking issues with Git pack files.

* Testing reliability:
  * [`embabel-agent-code/src/test/kotlin/com/embabel/coding/tools/GitReferenceTest.kt`](diffhunk://#diff-b92a06bbbb1d7026df5e951fa0e12a5ed8696474380c29fdcd2cd2362f1d9879R27-R34): Added the `@DisabledOnOs(OS.WINDOWS, disabledReason = "Windows file locking with Git pack files")` annotation to prevent test failures on Windows environments.