### PR TITLE
Issue/90: Implement concurrent action execution

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformProperties.kt
@@ -34,6 +34,7 @@ class AgentPlatformProperties {
      */
     var name: String = "embabel-default"
     var description: String = "Embabel Default Agent Platform"
+    var processType: ProcessType = ProcessType.SIMPLE
 
     /**
      * Platform behavior configurations
@@ -54,6 +55,14 @@ class AgentPlatformProperties {
     var sse: SseConfig = SseConfig()
     @field:NestedConfigurationProperty
     var test: TestConfig = TestConfig()
+
+    /**
+     * Agent Process Type
+     */
+    enum class ProcessType {
+        SIMPLE,
+        CONCURRENT
+    }
 
     /**
      * Agent scanning configuration

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/AgentProcessCallback.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/AgentProcessCallback.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core
+
+/**
+ * Callback interface for interleaving logic with the lifecycle of an AgentProcess and its actions.
+ *
+ * This is particularly useful for ConcurrentAgentProcess, where launched actions run in their own threads and may,
+ * for example, need a Spring Security context proliferated to the thread in which the action runs:
+ *
+ * ```kotlin
+ * @Component
+ * @Scope("prototype")
+ * class SecurityContextAgentProcessCallback : AgentProcessCallback {
+ *     var securityContext: SecurityContext? = null
+ *
+ *     override fun beforeActionLaunched(process: AgentProcess) {
+ *         securityContext = SecurityContextHolder.getContext()
+ *     }
+ *
+ *     override fun onActionLaunched(
+ *         process: AgentProcess,
+ *         action: Action,
+ *     ) {
+ *         securityContext?.let {
+ *             SecurityContextHolder.setContext(it)
+ *         }
+ *     }
+ *
+ *     override fun onActionCompleted(
+ *         process: AgentProcess,
+ *         action: Action,
+ *     ) {
+ *         SecurityContextHolder.clearContext()
+ *     }
+ * }
+ * ```
+ */
+interface AgentProcessCallback {
+    fun beforeActionLaunched(process: AgentProcess)
+    fun onActionLaunched(process: AgentProcess, action: Action)
+    fun onActionCompleted(process: AgentProcess, action: Action)
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcess.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.support
+
+
+import com.embabel.agent.api.common.PlatformServices
+import com.embabel.agent.core.*
+import com.embabel.plan.WorldState
+import com.embabel.plan.goap.GoapWorldState
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
+import java.time.Instant
+import kotlin.time.measureTime
+
+/**
+ * An AgentProcess that can execute multiple actions concurrently.
+ * With each invocation of formulateAndExecutePlan(), it will attempt to execute all
+ * actions that are currently achievable towards the plan.
+ */
+open class ConcurrentAgentProcess(
+    id: String,
+    parentId: String?,
+    agent: Agent,
+    processOptions: ProcessOptions,
+    blackboard: Blackboard,
+    platformServices: PlatformServices,
+    timestamp: Instant = Instant.now(),
+    val callbacks: List<AgentProcessCallback> = emptyList()
+) : SimpleAgentProcess(
+    id = id,
+    parentId = parentId,
+    agent = agent,
+    processOptions = processOptions,
+    blackboard = blackboard,
+    platformServices = platformServices,
+    timestamp = timestamp,
+    ) {
+    override fun formulateAndExecutePlan(worldState: WorldState): AgentProcess {
+        val plan = planner.bestValuePlanToAnyGoal(system = agent.planningSystem)
+        if (plan == null) {
+            return handlePlanNotFound(worldState)
+        }
+
+        logGoalInformation(plan)
+        _goal = plan.goal
+
+        if (plan.isComplete()) {
+            handleProcessCompletion(plan, worldState)
+        } else {
+            sendProcessRunningEvent(plan, worldState)
+
+            val achievableActions =
+                agent.actions.filter {
+                    plan.actions.contains(it) &&
+                            it.isAchievable(worldState as GoapWorldState)
+                }
+            val actions =
+                achievableActions.map { achievableAction ->
+                    agent.actions.singleOrNull { it.name == achievableAction.name }
+                        ?: error(
+                            "No unique action found for ${plan.actions.first().name} in ${agent.actions.map {
+                                it.name
+                            }}: Actions are\n${
+                                agent.actions.joinToString(
+                                    "\n",
+                                ) { it.name }
+                            }",
+                        )
+                }
+            val process = this
+            callbacks.forEach { it.beforeActionLaunched(process) }
+            val elapsed =
+                measureTime {
+                    logger.info("Executing ${actions.size} actions concurrently: \n${actions.map { it.name }}")
+                    val agentStatuses =
+                        actions
+                            .map { action ->
+                                platformServices.asyncer.async {
+                                    try {
+                                        callbacks.forEach { it.onActionLaunched(process, action) }
+                                        executeAction(action)
+                                    } finally {
+                                        callbacks.forEach { it.onActionCompleted(process, action) }
+                                    }
+                                }
+                            }.map { deferred ->
+                                runBlocking {
+                                    deferred.await()
+                                }
+                            }
+                    setStatus(actionStatusToAgentProcessStatus(agentStatuses))
+                }
+            logger.info("Executed ${actions.size} actions in $elapsed")
+        }
+        return this
+    }
+
+    protected fun actionStatusToAgentProcessStatus(actionStatuses: List<ActionStatus>): AgentProcessStatusCode =
+        when {
+            actionStatuses.any { it.status == ActionStatusCode.FAILED } -> {
+                logger.debug("❌ Process {} action {} failed", id, ActionStatusCode.FAILED)
+                AgentProcessStatusCode.FAILED
+            }
+
+            actionStatuses.any { it.status == ActionStatusCode.PAUSED } -> {
+                logger.debug("⏳ Process {} action {} paused", id, ActionStatusCode.PAUSED)
+                AgentProcessStatusCode.PAUSED
+            }
+            actionStatuses.any { it.status == ActionStatusCode.SUCCEEDED } -> {
+                logger.debug("Process {} action {} is running", id, ActionStatusCode.SUCCEEDED)
+                AgentProcessStatusCode.RUNNING
+            }
+            actionStatuses.any { it.status == ActionStatusCode.WAITING } -> {
+                logger.debug("⏳ Process {} action {} waiting", id, ActionStatusCode.WAITING)
+                AgentProcessStatusCode.WAITING
+            }
+            else -> {
+                error("Unexpected action statuses: $actionStatuses")
+            }
+        }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/SimpleAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/SimpleAgentProcess.kt
@@ -20,12 +20,13 @@ import com.embabel.agent.core.*
 import com.embabel.agent.event.AgentProcessPlanFormulatedEvent
 import com.embabel.agent.event.GoalAchievedEvent
 import com.embabel.common.util.indentLines
+import com.embabel.plan.Plan
 import com.embabel.plan.WorldState
 import com.embabel.plan.goap.AStarGoapPlanner
 import com.embabel.plan.goap.WorldStateDeterminer
 import java.time.Instant
 
-internal class SimpleAgentProcess(
+open class SimpleAgentProcess(
     id: String,
     parentId: String?,
     agent: Agent,
@@ -56,58 +57,75 @@ internal class SimpleAgentProcess(
         _llmInvocations.add(llmInvocation)
     }
 
-    override fun formulateAndExecutePlan(worldState: WorldState): AgentProcess {
-        val plan = planner.bestValuePlanToAnyGoal(system = agent.planningSystem)
-        if (plan == null) {
-            logger.info(
-                "❌ Process $id stuck\n" +
-                        """|No plan from:
+    protected fun handlePlanNotFound(worldState: WorldState): AgentProcess {
+        logger.info(
+            "❌ Process $id stuck\n" +
+                    """|No plan from:
                    |${worldState.infoString(verbose = true, indent = 1)}
                    |in:
                    |${agent.planningSystem.infoString(verbose = true, 1)}
                    |context:
                    |${blackboard.infoString(true, 1)}
                    |"""
-                            .trimMargin()
-                            .indentLines(1)
-            )
-            setStatus(AgentProcessStatusCode.STUCK)
-            return this
+                        .trimMargin()
+                        .indentLines(1)
+        )
+        setStatus(AgentProcessStatusCode.STUCK)
+        return this
         }
 
+    protected fun logGoalInformation(plan: Plan) {
         if (goal != null && goal?.name != plan.goal.name) {
             logger.info("Process {} goal changed: {} -> {}", this.id, goal?.name, plan.goal.name)
             require(processOptions.allowGoalChange) {
                 "Process ${this.id} goal changed from ${goal?.name} to ${plan.goal.name}, but allowGoalChange is false"
             }
         }
+    }
+
+    protected fun handleProcessCompletion(plan: Plan, worldState: WorldState) {
+        logger.debug(
+            "✅ Process {} completed, achieving goal {} in {} seconds",
+            this.id,
+            plan.goal.name,
+            this.runningTime.seconds,
+        )
+        platformServices.eventListener.onProcessEvent(
+            GoalAchievedEvent(
+                agentProcess = this,
+                worldState = worldState,
+                goal = plan.goal,
+            )
+        )
+        logger.debug("Final blackboard: {}", blackboard.infoString())
+        setStatus(AgentProcessStatusCode.COMPLETED)
+    }
+
+    protected fun sendProcessRunningEvent(plan: Plan, worldState: WorldState) {
+        platformServices.eventListener.onProcessEvent(
+            AgentProcessPlanFormulatedEvent(
+                agentProcess = this,
+                worldState = worldState,
+                plan = plan,
+            )
+        )
+        logger.debug("▶️ Process {} running: {}\n\tPlan: {}", id, worldState, plan.infoString())
+    }
+
+    override fun formulateAndExecutePlan(worldState: WorldState): AgentProcess {
+        val plan = planner.bestValuePlanToAnyGoal(system = agent.planningSystem)
+        if (plan == null) {
+            return handlePlanNotFound(worldState)
+        }
+
+        logGoalInformation(plan)
         _goal = plan.goal
 
         if (plan.isComplete()) {
-            logger.debug(
-                "✅ Process {} completed, achieving goal {} in {} seconds",
-                this.id,
-                plan.goal.name,
-                this.runningTime.seconds,
-            )
-            platformServices.eventListener.onProcessEvent(
-                GoalAchievedEvent(
-                    agentProcess = this,
-                    worldState = worldState,
-                    goal = plan.goal,
-                )
-            )
-            logger.debug("Final blackboard: {}", blackboard.infoString())
-            setStatus(AgentProcessStatusCode.COMPLETED)
+            handleProcessCompletion(plan, worldState)
         } else {
-            platformServices.eventListener.onProcessEvent(
-                AgentProcessPlanFormulatedEvent(
-                    agentProcess = this,
-                    worldState = worldState,
-                    plan = plan,
-                )
-            )
-            logger.debug("▶️ Process {} running: {}\n\tPlan: {}", id, worldState, plan.infoString())
+            sendProcessRunningEvent(plan, worldState)
+
             val agent = agent.actions.singleOrNull { it.name == plan.actions.first().name }
                 ?: error(
                     "No unique action found for ${plan.actions.first().name} in ${agent.actions.map { it.name }}: Actions are\n${

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/IntegrationTestUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/testing/integration/IntegrationTestUtils.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.testing.integration
 
 import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.channel.DevNullOutputChannel
+import com.embabel.agent.config.AgentPlatformProperties.ProcessType
 import com.embabel.agent.core.*
 import com.embabel.agent.core.support.DefaultAgentPlatform
 import com.embabel.agent.core.support.InMemoryBlackboard
@@ -56,6 +57,7 @@ object IntegrationTestUtils {
             toolGroupResolver = toolGroupResolver ?: RegistryToolGroupResolver("empty", emptyList()),
             name = "dummy-agent-platform",
             description = "Dummy Agent Platform for Integration Testing",
+            processType = ProcessType.SIMPLE,
             asyncer = ExecutorAsyncer(Executors.newSingleThreadExecutor()),
             objectMapper = jacksonObjectMapper(),
             outputChannel = DevNullOutputChannel,

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcessTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcessTest.kt
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.support
+
+import com.embabel.agent.api.annotation.AchievesGoal
+import com.embabel.agent.api.annotation.Action
+import com.embabel.agent.api.annotation.confirm
+import com.embabel.agent.api.annotation.support.AgentMetadataReader
+import com.embabel.agent.api.annotation.waitFor
+import com.embabel.agent.api.common.StuckHandler
+import com.embabel.agent.api.common.StuckHandlerResult
+import com.embabel.agent.api.common.StuckHandlingResultCode
+import com.embabel.agent.api.dsl.Frog
+import com.embabel.agent.api.dsl.agent
+import com.embabel.agent.api.dsl.evenMoreEvilWizard
+import com.embabel.agent.core.*
+import com.embabel.agent.core.hitl.ConfirmationRequest
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.domain.library.Person
+import com.embabel.agent.event.ObjectAddedEvent
+import com.embabel.agent.event.ObjectBoundEvent
+import com.embabel.agent.support.Dog
+import com.embabel.agent.support.SimpleTestAgent
+import com.embabel.agent.testing.common.EventSavingAgenticEventListener
+import com.embabel.agent.testing.integration.IntegrationTestUtils.dummyPlatformServices
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+
+class ConcurrentAgentProcessTest {
+
+    @Nested
+    inner class Serialization {
+
+        @Test
+        fun `should not be able to serialize AgentProcess`() {
+            val cap = ConcurrentAgentProcess(
+                id = "test",
+                agent = SimpleTestAgent,
+                processOptions = ProcessOptions(),
+                blackboard = InMemoryBlackboard(),
+                platformServices = dummyPlatformServices(),
+                parentId = null,
+            )
+            assertThrows<IOException> {
+                jacksonObjectMapper().writeValueAsString(cap)
+            }
+        }
+    }
+
+    @Nested
+    inner class Waiting {
+
+        @Test
+        fun `wait on tick for DSL agent`() {
+            waitOnTick(DslWaitingAgent)
+        }
+
+        @Test
+        fun `wait on run for DSL agent`() {
+            waitOnRun(DslWaitingAgent)
+        }
+
+        @Test
+        fun `wait on tick for annotation agent`() {
+            waitOnTick(AgentMetadataReader().createAgentMetadata(AnnotationWaitingAgent()) as Agent)
+        }
+
+        @Test
+        fun `wait on run for annotation agent`() {
+            waitOnRun(AgentMetadataReader().createAgentMetadata(AnnotationWaitingAgent()) as Agent)
+        }
+
+        private fun waitOnTick(agent: Agent) {
+            val dummyPlatformServices = dummyPlatformServices()
+            val blackboard = InMemoryBlackboard()
+            blackboard += UserInput("Rod")
+            val agentProcess = ConcurrentAgentProcess(
+                id = "test",
+                agent = agent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            val agentStatus = agentProcess.tick()
+            assertEquals(AgentProcessStatusCode.WAITING, agentStatus.status)
+            val confirmation = blackboard.lastResult()
+            assertTrue(confirmation is ConfirmationRequest<*>)
+        }
+
+        private fun waitOnRun(agent: Agent) {
+            val dummyPlatformServices = dummyPlatformServices()
+            val blackboard = InMemoryBlackboard()
+            blackboard += (IoBinding.DEFAULT_BINDING to UserInput("Rod"))
+            val agentProcess = ConcurrentAgentProcess(
+                id = "test",
+                agent = agent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            val agentStatus = agentProcess.run()
+            assertEquals(AgentProcessStatusCode.WAITING, agentStatus.status)
+        }
+    }
+
+    @Nested
+    inner class StuckHandling {
+
+        @Test
+        fun `expect stuck for DSL agent with no stuck handler`() {
+            val agentProcess = run(DslWaitingAgent)
+            assertEquals(AgentProcessStatusCode.STUCK, agentProcess.status)
+        }
+
+        @Test
+        fun `expect stuck for annotation agent with no stuck handler`() {
+            val agentProcess = run(AgentMetadataReader().createAgentMetadata(AnnotationWaitingAgent()) as Agent)
+            assertEquals(AgentProcessStatusCode.STUCK, agentProcess.status)
+        }
+
+        @Test
+        fun `expect unstuck for DSL agent with magic stuck handler`() {
+            unstick(DslWaitingAgent)
+        }
+
+        @Test
+        fun `expect unstuck for annotation agent with magic stuck handler`() {
+            unstick(AgentMetadataReader().createAgentMetadata(AnnotationWaitingAgent()) as Agent)
+        }
+
+        @Test
+        fun `agent implementing stuck handler unsticks itself`() {
+            val sua = SelfUnstickingAgent()
+            val agent = AgentMetadataReader().createAgentMetadata(sua) as Agent
+            val agentProcess = run(agent)
+            assertTrue(sua.called, "Stuck handler must have been called")
+            assertEquals(AgentProcessStatusCode.COMPLETED, agentProcess.status)
+            val last = agentProcess.lastResult()
+            assertEquals(
+                Frog("Duke"), last,
+                "Last result should be the dog added by the stuck handler. Poor Duke was turned into a frog."
+            )
+        }
+
+        private fun unstick(agent: Agent) {
+            var called = false
+            val stuckHandler = StuckHandler {
+                called = true
+                it.processContext.blackboard += UserInput("Rod")
+                StuckHandlerResult(
+                    message = "The magic unsticker unstuck the stuckness",
+                    handler = null,
+                    code = StuckHandlingResultCode.REPLAN,
+                    agentProcess = it,
+                )
+            }
+            val agentProcess = run(agent.copy(stuckHandler = stuckHandler))
+            assertTrue(called, "Stuck handler must have been called")
+            assertEquals(AgentProcessStatusCode.WAITING, agentProcess.status)
+        }
+
+
+        private fun run(agent: Agent): AgentProcess {
+            val dummyPlatformServices = dummyPlatformServices()
+            val blackboard = InMemoryBlackboard()
+            // Don't add anything to the blackboard
+            val agentProcess = ConcurrentAgentProcess(
+                id = "test",
+                agent = agent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            return agentProcess.run()
+        }
+
+    }
+
+    @Nested
+    inner class Binding {
+
+        @Test
+        fun adds() {
+            val ese = EventSavingAgenticEventListener()
+            val dummyPlatformServices = dummyPlatformServices(ese)
+            val blackboard = InMemoryBlackboard()
+            val agentProcess = ConcurrentAgentProcess(
+                id = "test",
+                agent = SimpleTestAgent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            val person = LocalPerson("John")
+            agentProcess += person
+            assertTrue(blackboard.objects.contains(person))
+        }
+
+        @Test
+        fun `emits add event`() {
+            val ese = EventSavingAgenticEventListener()
+            val dummyPlatformServices = dummyPlatformServices(ese)
+            val blackboard = InMemoryBlackboard()
+            val agentProcess = ConcurrentAgentProcess(
+                id = "test",
+                agent = SimpleTestAgent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            val person = LocalPerson("John")
+            agentProcess += person
+            val e = ese.processEvents.filterIsInstance<ObjectAddedEvent>().single()
+            assertEquals(person, e.value)
+        }
+
+        @Test
+        fun binds() {
+            val dummyPlatformServices = dummyPlatformServices()
+            val blackboard = InMemoryBlackboard()
+            val agentProcess = ConcurrentAgentProcess(
+                "test", agent = SimpleTestAgent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            val person = LocalPerson("John")
+            agentProcess += ("john" to person)
+            assertTrue(blackboard.objects.contains(person))
+            assertEquals(person, blackboard["john"])
+        }
+
+        @Test
+        fun `emits binding event`() {
+            val ese = EventSavingAgenticEventListener()
+            val dummyPlatformServices = dummyPlatformServices(ese)
+            val blackboard = InMemoryBlackboard()
+            val agentProcess = ConcurrentAgentProcess(
+                "test", agent = SimpleTestAgent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            val person = LocalPerson("John")
+            agentProcess += ("john" to person)
+            assertTrue(blackboard.objects.contains(person))
+            assertEquals(person, blackboard["john"])
+            assertEquals(1, ese.processEvents.size, "Should have 1 event")
+            val e = ese.processEvents.filterIsInstance<ObjectBoundEvent>().single()
+            assertEquals(person, e.value)
+            assertEquals("john", e.name)
+        }
+    }
+
+    @Nested
+    inner class ToolsStatsTest {
+
+        @Test
+        fun `no tools called`() {
+            val ese = EventSavingAgenticEventListener()
+            val dummyPlatformServices = dummyPlatformServices()
+            val blackboard = InMemoryBlackboard()
+            val agentProcess = ConcurrentAgentProcess(
+                "test", agent = SimpleTestAgent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            assertEquals(0, agentProcess.toolsStats.toolsStats.size, "No tools called yet")
+        }
+    }
+
+    @Nested
+    inner class Kill {
+
+        @Test
+        fun `cannot run killed process`() {
+            val dummyPlatformServices = dummyPlatformServices()
+            val blackboard = InMemoryBlackboard()
+            blackboard += UserInput("Rod")
+            val agentProcess = ConcurrentAgentProcess(
+                id = "test",
+                agent = evenMoreEvilWizard(),
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices,
+                parentId = null,
+            )
+            assertEquals(AgentProcessStatusCode.NOT_STARTED, agentProcess.status)
+            agentProcess.kill()
+            assertEquals(AgentProcessStatusCode.KILLED, agentProcess.status)
+            for (i in 0..10) {
+                val status = agentProcess.tick()
+                assertEquals(AgentProcessStatusCode.KILLED, status.status, "Process should remain killed")
+            }
+            for (i in 0..10) {
+                val status = agentProcess.run()
+                assertEquals(AgentProcessStatusCode.KILLED, status.status, "Process should remain killed")
+            }
+
+        }
+
+    }
+
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/DefaultAgentPlatformTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/DefaultAgentPlatformTest.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.core.support
 
 import com.embabel.agent.api.dsl.evenMoreEvilWizard
 import com.embabel.agent.channel.DevNullOutputChannel
+import com.embabel.agent.config.AgentPlatformProperties.ProcessType
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.Context
 import com.embabel.agent.core.ContextId
@@ -41,6 +42,7 @@ class DefaultAgentPlatformTest {
         return DefaultAgentPlatform(
             "name",
             "description",
+            processType = ProcessType.SIMPLE,
             mockk(),
             mockk(relaxed = true),
             l,


### PR DESCRIPTION
Adds a ConcurrentAgentProcess alongside the usual SimpleAgentProcess which can execute multiple actions concurrently. With each invocation of formulateAndExecutePlan(), it will attempt to execute all actions that are currently achievable towards the plan.

Using the existing DefaultAgentPlatform, consumers can opt into the ConcurrentAgentProcess with the`embabel.agent.platform.process-type: CONCURRENT` property.

Future improvements could include wiring in a custom CoroutineDispatcher (for example, to take advantage of virtual threads) and adding throttling/concurrency limits to the parallel actions.