### PR TITLE
Add Kdoc to Properties classes and fix some bugs

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformProperties.kt
@@ -30,9 +30,13 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty
 @ConfigurationProperties("embabel.agent.platform")
 class AgentPlatformProperties {
     /**
-     * Core platform identity
+     * Core platform identity name
      */
     var name: String = "embabel-default"
+
+    /**
+     * Platform description
+     */
     var description: String = "Embabel Default Agent Platform"
 
     /**
@@ -40,18 +44,25 @@ class AgentPlatformProperties {
      */
     @field:NestedConfigurationProperty
     var scanning: ScanningConfig = ScanningConfig()
+
     @field:NestedConfigurationProperty
     var ranking: RankingConfig = RankingConfig()
+
     @field:NestedConfigurationProperty
     var llmOperations: LlmOperationsConfig = LlmOperationsConfig()
+
     @field:NestedConfigurationProperty
     var processIdGeneration: ProcessIdGenerationConfig = ProcessIdGenerationConfig()
+
     @field:NestedConfigurationProperty
     var autonomy: AutonomyConfig = AutonomyConfig()
+
     @field:NestedConfigurationProperty
     var models: ModelsConfig = ModelsConfig()
+
     @field:NestedConfigurationProperty
     var sse: SseConfig = SseConfig()
+
     @field:NestedConfigurationProperty
     var test: TestConfig = TestConfig()
 
@@ -59,7 +70,14 @@ class AgentPlatformProperties {
      * Agent scanning configuration
      */
     class ScanningConfig {
+        /**
+         *  Whether to auto register beans with @Agent and @Agentic annotation
+         */
         var annotation: Boolean = true
+
+        /**
+         * Whether to auto register as agents Spring beans of type Agent
+         */
         var bean: Boolean = false
     }
 
@@ -67,19 +85,40 @@ class AgentPlatformProperties {
      * Ranking configuration with retry logic
      */
     class RankingConfig {
+        /**
+         * Name of the LLM to use for ranking, or null to use auto selection
+         */
         var llm: String? = null
+
+        /**
+         * Maximum number of attempts to retry ranking
+         */
         var maxAttempts: Int = 5
+
+        /**
+         * Initial backoff time in milliseconds
+         */
         var backoffMillis: Long = 100L
+
+        /**
+         * Multiplier for backoff time
+         */
         var backoffMultiplier: Double = 5.0
+
+        /**
+         * Maximum backoff time in milliseconds
+         */
         var backoffMaxInterval: Long = 180000L
     }
 
     /**
      * LLM operations configuration
      */
+    @ConfigurationProperties(prefix = "embabel.agent.platform.llm-operations")
     class LlmOperationsConfig {
         @field:NestedConfigurationProperty
         var prompts: PromptsConfig = PromptsConfig()
+
         @field:NestedConfigurationProperty
         var dataBinding: DataBindingConfig = DataBindingConfig()
 
@@ -87,7 +126,14 @@ class AgentPlatformProperties {
          * Prompt configuration
          */
         class PromptsConfig {
+            /**
+             * Template for "maybe" prompt, enabling failure result when LLM lacks information
+             */
             var maybePromptTemplate: String = "maybe_prompt_contribution"
+
+            /**
+             * Whether to generate examples by default
+             */
             var generateExamplesByDefault: Boolean = true
         }
 
@@ -95,7 +141,14 @@ class AgentPlatformProperties {
          * Data binding retry configuration
          */
         class DataBindingConfig {
+            /**
+             * Maximum retry attempts for data binding
+             */
             var maxAttempts: Int = 10
+
+            /**
+             * Fixed backoff time in milliseconds between retries
+             */
             var fixedBackoffMillis: Long = 30L
         }
     }
@@ -103,25 +156,43 @@ class AgentPlatformProperties {
     /**
      * Process ID generation configuration
      */
+    @ConfigurationProperties("embabel.agent.platform.process-id-generation")
     class ProcessIdGenerationConfig {
+        /**
+         * Whether to include version in process ID generation
+         */
         var includeVersion: Boolean = false
+
+        /**
+         * Whether to include agent name in process ID generation
+         */
         var includeAgentName: Boolean = false
     }
 
     /**
      * Autonomy thresholds configuration
      */
+    @ConfigurationProperties("embabel.agent.platform.autonomy")
     class AutonomyConfig {
+        /**
+         * Confidence threshold for agent operations
+         */
         var agentConfidenceCutOff: Double = 0.6
+
+        /**
+         * Confidence threshold for goal achievement
+         */
         var goalConfidenceCutOff: Double = 0.6
     }
 
     /**
      * Model provider integration configurations
      */
+    @ConfigurationProperties("embabel.agent.platform.models")
     class ModelsConfig {
         @field:NestedConfigurationProperty
         var anthropic: AnthropicConfig = AnthropicConfig()
+
         @field:NestedConfigurationProperty
         var openai: OpenAiConfig = OpenAiConfig()
 
@@ -129,9 +200,24 @@ class AgentPlatformProperties {
          * Anthropic provider retry configuration
          */
         class AnthropicConfig {
+            /**
+             * Maximum retry attempts
+             */
             var maxAttempts: Int = 10
+
+            /**
+             * Initial backoff time in milliseconds
+             */
             var backoffMillis: Long = 5000L
+
+            /**
+             * Backoff multiplier
+             */
             var backoffMultiplier: Double = 5.0
+
+            /**
+             * Maximum backoff interval in milliseconds
+             */
             var backoffMaxInterval: Long = 180000L
         }
 
@@ -139,9 +225,24 @@ class AgentPlatformProperties {
          * OpenAI provider retry configuration
          */
         class OpenAiConfig {
+            /**
+             * Maximum retry attempts
+             */
             var maxAttempts: Int = 10
+
+            /**
+             * Initial backoff time in milliseconds
+             */
             var backoffMillis: Long = 5000L
+
+            /**
+             * Backoff multiplier
+             */
             var backoffMultiplier: Double = 5.0
+
+            /**
+             * Maximum backoff interval in milliseconds
+             */
             var backoffMaxInterval: Long = 180000L
         }
     }
@@ -149,15 +250,27 @@ class AgentPlatformProperties {
     /**
      * Server-sent events configuration
      */
+    @ConfigurationProperties("embabel.agent.platform.sse")
     class SseConfig {
+        /**
+         * Maximum buffer size for SSE
+         */
         var maxBufferSize: Int = 100
+
+        /**
+         * Maximum number of process buffers
+         */
         var maxProcessBuffers: Int = 1000
     }
 
     /**
      * Test configuration
      */
+    @ConfigurationProperties("embabel.agent.platform.test")
     class TestConfig {
+        /**
+         * Whether to enable mock mode for testing
+         */
         var mockMode: Boolean = true
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/ToolGroupsConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/ToolGroupsConfiguration.kt
@@ -45,13 +45,22 @@ data class GroupConfig(
 
 /**
  * Configuration for ToolGroups when MCP is available
- * @param includes map of tool group names to list of tool names to include
- * @param excludes list of tool names to exclude from all tool groups
  */
 @ConfigurationProperties(prefix = "embabel.agent.platform.tools")
 class ToolGroupsProperties {
+    /**
+     * Map of tool group names to list of tool names to include
+     */
     var includes: Map<String, GroupConfig> = emptyMap()
+
+    /**
+     * List of tool names to exclude from all tool groups
+     */
     var excludes: List<String> = emptyList()
+
+    /**
+     * The version of tool groups
+     */
     var version: String = Semver().value
 }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/migration/DeprecatedPropertyScanner.kt
@@ -222,6 +222,9 @@ class DeprecatedPropertyScanner(
         put("embabel.llm-operations.data-binding.max-attempts", "embabel.agent.platform.llm-operations.data-binding.max-attempts")
         put("embabel.llm-operations.data-binding.fixed-backoff-millis", "embabel.agent.platform.llm-operations.data-binding.fixed-backoff-millis")
         put("embabel.llm-operations.prompts.template", "embabel.agent.platform.llm-operations.prompts.template")
+        put("embabel.llm-operations.prompts.maybe-prompt-template", "embabel.agent.platform.llm-operations.prompts.maybe-prompt-template")
+        put("embabel.llm-operations.prompts.generate-examples-by-default", "embabel.agent.platform.llm-operations.prompts.generate-examples-by-default")
+        put("embabel.llm-operations.prompts.default-timeout", "embabel.agent.platform.llm-operations.prompts.default-timeout")
         put("embabel.autonomy.agent-confidence-cut-off", "embabel.agent.platform.autonomy.agent-confidence-cut-off")
         put("embabel.autonomy.goal-confidence-cut-off", "embabel.agent.platform.autonomy.goal-confidence-cut-off")
         put("embabel.sse.max-buffer-size", "embabel.agent.platform.sse.max-buffer-size")
@@ -248,8 +251,16 @@ class DeprecatedPropertyScanner(
         put("embabel.models.bedrock.models.input-price", "embabel.agent.models.bedrock.models.input-price")
         put("embabel.models.bedrock.models.output-price", "embabel.agent.models.bedrock.models.output-price")
 
-        // discord prefix
+        // Discord configurations
         put("embabel.discord.token", "embabel.agent.discord.token")
+
+        // Shell configurations
+        put("embabel.shell.line-length", "embabel.agent.shell.line-length")
+        put("embabel.shell.chat.bind-conversation", "embabel.agent.shell.chat.bind-conversation")
+        put("embabel.shell.chat.model", "embabel.agent.shell.chat.model")
+        put("embabel.shell.chat.confirm-goals", "embabel.agent.shell.chat.confirm-goals")
+        put("embabel.shell.chat.multi-goal", "embabel.agent.shell.chat.multi-goal")
+        put("embabel.shell.chat.temperature", "embabel.agent.shell.chat.temperature")
 
         // Specific platform feature migrations
         put("embabel.agent.enable-scanning", "embabel.agent.platform.scanning.annotation")
@@ -260,6 +271,8 @@ class DeprecatedPropertyScanner(
         // @ConfigurationProperties prefix migrations
         put("embabel.anthropic", "embabel.agent.platform.models.anthropic")
         put("embabel.openai", "embabel.agent.platform.models.openai")
+        put("embabel.docker.models", "embabel.agent.platform.models.docker")
+        put("embabel.models.bedrock", "embabel.agent.models.bedrock")
         put("embabel.llm-operations", "embabel.agent.platform.llm-operations")
         put("embabel.llm-operations.data-binding", "embabel.agent.platform.llm-operations.data-binding")
         put("embabel.llm-operations.prompts", "embabel.agent.platform.llm-operations.prompts")
@@ -268,6 +281,7 @@ class DeprecatedPropertyScanner(
         put("embabel.process-id-generation", "embabel.agent.platform.process-id-generation")
         put("embabel.agent-platform.ranking", "embabel.agent.platform.ranking")
         put("embabel.agent-platform.scanning", "embabel.agent.platform.scanning")
+        put("embabel.shell", "embabel.agent.shell")
     }
 
     /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/deployment/AgentScanningProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/deployment/AgentScanningProperties.kt
@@ -19,14 +19,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 /**
  * Scanning configuration
- * @param annotation whether to auto register beans with
- * @Agent and @Agentic annotation
- * @param bean whether to auto register agents
- * from Agent beans
  * @see com.embabel.agent.api.annotation.Agent
  */
 @ConfigurationProperties("embabel.agent.platform.scanning")
 data class AgentScanningProperties(
+    /**
+     * Whether to auto register beans with @Agent and @Agentic annotation
+     */
     val annotation: Boolean = true,
+    /**
+     * Whether to auto register agents from Agent beans
+     */
     val bean: Boolean = false,
 )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -32,7 +32,14 @@ import java.time.Duration
 class LlmDataBindingProperties : RetryTemplateProvider {
     private val logger = LoggerFactory.getLogger(LlmDataBindingProperties::class.java)
 
+    /**
+     * Maximum retry attempts for data binding
+     */
     override var maxAttempts: Int = 10
+
+    /**
+     * Fixed backoff time in milliseconds between retries
+     */
     var fixedBackoffMillis: Long = 30L
 
     override fun retryTemplate(name: String): RetryTemplate {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmOperationsPromptsProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmOperationsPromptsProperties.kt
@@ -20,13 +20,21 @@ import java.time.Duration
 
 /**
  * Properties for the ChatClientLlmOperations operations
- * @param maybePromptTemplate template to use for the "maybe" prompt, which
- *  * can enable a failure result if the LLM does not have enough information to
- *  * create the desired output structure.
  */
 @ConfigurationProperties(prefix = "embabel.agent.platform.llm-operations.prompts")
 class LlmOperationsPromptsProperties {
+    /**
+     * Template to use for the "maybe" prompt, which can enable a failure result if the LLM does not have enough information to create the desired output structure
+     */
     var maybePromptTemplate: String = "maybe_prompt_contribution"
+
+    /**
+     * Whether to generate examples by default
+     */
     var generateExamplesByDefault: Boolean = true
+
+    /**
+     * Default timeout for operations
+     */
     var defaultTimeout: Duration = Duration.ofSeconds(60)
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/agent/AgentPlatformChatSession.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/agent/AgentPlatformChatSession.kt
@@ -33,17 +33,33 @@ import com.embabel.chat.support.InMemoryConversation
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.util.loggerFor
 
-
 /**
  * Configuration for the chat session
- * @param confirmGoals Whether to confirm goals with the user before proceeding
- * @param bindConversation Whether to bind the conversation to the chat session
  */
 class ChatConfig {
+    /**
+     * Whether to confirm goals with the user before proceeding
+     */
     var confirmGoals: Boolean = true
+
+    /**
+     * Whether to bind the conversation to the chat session
+     */
     var bindConversation: Boolean = false
+
+    /**
+     * Whether to allow multiple goals to be selected and accomplished.
+     */
     var multiGoal: Boolean = false
+
+    /**
+     * Model used in the chat session
+     */
     var model: String = OpenAiModels.GPT_41_MINI
+
+    /**
+     * The temperature to use when generating responses
+     */
     var temperature: Double? = null
 
     /**

--- a/embabel-agent-api/src/main/resources/agent-application.properties
+++ b/embabel-agent-api/src/main/resources/agent-application.properties
@@ -49,7 +49,7 @@ management.tracing.enabled=false
 #embabel.process-id-generation.include-version=false
 
 # LLM Operations
-embabel.llm-operations.prompts.generate-examples-by-default=true
+embabel.agent.platform.llm-operations.prompts.generate-examples-by-default=true
 
 # Models
 embabel.models.default-llm=gpt-4.1-mini

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModels.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModels.kt
@@ -55,7 +55,7 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient
 @ConfigurationProperties(prefix = "embabel.agent.models.bedrock")
 class BedrockProperties {
     /**
-     * List of LLM provider by Bedrock
+     * List of Bedrock models to configure
      */
     @NestedConfigurationProperty
     var models: List<BedrockModelProperties> = emptyList()
@@ -69,10 +69,18 @@ class BedrockModelProperties {
     var name: String = ""
 
     /**
-     * model's knowledge cutoff date
+     * Model's knowledge cutoff date
      */
     var knowledgeCutoff: String = ""
+
+    /**
+     * Input token price
+     */
     var inputPrice: Double = 0.0
+
+    /**
+     * Output token price
+     */
     var outputPrice: Double = 0.0
 }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/docker/DockerLocalModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/docker/DockerLocalModelsConfig.kt
@@ -36,7 +36,6 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
-import org.springframework.core.env.Environment
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
@@ -70,7 +69,7 @@ class DockerRetryProperties : RetryProperties {
 @ConfigurationProperties(prefix = "embabel.agent.models.docker")
 class DockerConnectionProperties {
     /**
-     * The base url for docker
+     * Base URL for Docker model endpoint
      */
     var baseUrl: String = "http://localhost:12434/engines"
 }

--- a/embabel-agent-shell/pom.xml
+++ b/embabel-agent-shell/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.embabel.agent</groupId>
@@ -36,6 +37,23 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>kapt</id>
+                        <goals>
+                            <goal>kapt</goal>
+                        </goals>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>org.springframework.boot</groupId>
+                                    <artifactId>spring-boot-configuration-processor</artifactId>
+                                    <version>${spring-boot.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
#  Main changes
This PR fix and supplement some remaining issues 

### Add Kdoc to the class annotated with @ConfigurationProperties.
- AgentPlatformProperties
- ToolGroupsProperties
- AgentScanningProperties
- LlmDataBindingProperties
- LlmOperationsPromptsProperties
- ChatConfig
- BedrockProperties
- DockerLocalModelsConfig.kt

### Add `@field:NestedConfigurationProperty` to the field of object type in AgentPlatformProperties class. 
 For fields of object type, it is necessary to add the nested configuration annotation. If this annotation is missing, auto completion will not be available during configuration.

### Add a `kapt` execution to Maven build to enable annotation processing  in `embabel-agent-shell/pom.xml`
ShellProperties cannot generate `spring-configuration-metadata.json` because `kapt` is missing.

### Add exactPropertyMappings In `DeprecatedPropertyScanner.kt`

```
 // System properties consolidation
 put("embabel.llm-operations.prompts.maybe-prompt-template", "embabel.agent.platform.llm-operations.prompts.maybe-prompt-template")
 put("embabel.llm-operations.prompts.generate-examples-by-default", "embabel.agent.platform.llm-operations.prompts.generate-examples-by-default")
 put("embabel.llm-operations.prompts.default-timeout", "embabel.agent.platform.llm-operations.prompts.default-timeout")

 // Shell configurations
 put("embabel.shell.line-length", "embabel.agent.shell.line-length")
 put("embabel.shell.chat.bind-conversation", "embabel.agent.shell.chat.bind-conversation")
 put("embabel.shell.chat.model", "embabel.agent.shell.chat.model")
 put("embabel.shell.chat.confirm-goals", "embabel.agent.shell.chat.confirm-goals")
 put("embabel.shell.chat.multi-goal", "embabel.agent.shell.chat.multi-goal")
 put("embabel.shell.chat.temperature", "embabel.agent.shell.chat.temperature")

 // @ConfigurationProperties prefix migrations
 put("embabel.openai", "embabel.agent.platform.models.openai")
 put("embabel.docker.models", "embabel.agent.platform.models.docker")
 put("embabel.shell", "embabel.agent.shell")
```

### Fix LLM Operations in agent-application.properties file
change `embabel.llm-operations.prompts.generate-examples-by-default=true` to `embabel.agent.platform.llm-operations.prompts.generate-examples-by-default=true`


