### PR TITLE
Use spring.ai.mcp.server.type for ASYNC mode

### DIFF
--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/async/config/McpAsyncServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/async/config/McpAsyncServerConfiguration.kt
@@ -27,22 +27,20 @@ import org.springframework.ai.mcp.McpToolUtils
 import org.springframework.ai.tool.ToolCallbackProvider
 import org.springframework.ai.tool.method.MethodToolCallbackProvider
 import org.springframework.context.ConfigurableApplicationContext
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Conditional
-import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.*
+import org.springframework.core.type.AnnotatedTypeMetadata
 
 /**
  * Condition that checks if the MCP server is enabled and set to ASYNC mode.
  */
-class McpAsyncServerCondition : org.springframework.context.annotation.Condition {
+class McpAsyncServerCondition : Condition {
     override fun matches(
-        context: org.springframework.context.annotation.ConditionContext,
-        metadata: org.springframework.core.type.AnnotatedTypeMetadata,
+        context: ConditionContext,
+        metadata: AnnotatedTypeMetadata
     ): Boolean {
         val environment = context.environment
-        val enabled = environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false)
-        val type = environment.getProperty("embabel.agent.mcpserver.type", "SYNC")
-        return enabled && type == "ASYNC"
+        val type = environment.getProperty("spring.ai.mcp.server.type", "SYNC")
+        return type == "ASYNC"
     }
 }
 

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/async/support/PerGoalAsyncMcpToolExportCallbackPublisher.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/async/support/PerGoalAsyncMcpToolExportCallbackPublisher.kt
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Service
  */
 @Service
 @ConditionalOnProperty(
-    value = ["embabel.agent.mcpserver.type"],
+    value = ["spring.ai.mcp.server.type"],
     havingValue = "ASYNC",
     matchIfMissing = false,
 )

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/sync/config/McpSyncServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/sync/config/McpSyncServerConfiguration.kt
@@ -27,10 +27,8 @@ import org.springframework.ai.mcp.McpToolUtils
 import org.springframework.ai.tool.ToolCallbackProvider
 import org.springframework.ai.tool.method.MethodToolCallbackProvider
 import org.springframework.context.ConfigurableApplicationContext
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Condition
-import org.springframework.context.annotation.Conditional
-import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.*
+import org.springframework.core.type.AnnotatedTypeMetadata
 
 
 /**
@@ -49,13 +47,12 @@ class McpSyncServerCondition : Condition {
      * @return `true` if sync server should be enabled, otherwise `false`
      */
     override fun matches(
-        context: org.springframework.context.annotation.ConditionContext,
-        metadata: org.springframework.core.type.AnnotatedTypeMetadata,
+        context: ConditionContext,
+        metadata: AnnotatedTypeMetadata
     ): Boolean {
         val environment = context.environment
-        val enabled = environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false)
-        val type = environment.getProperty("embabel.agent.mcpserver.type", "SYNC")
-        return enabled && type == "SYNC"
+        val type = environment.getProperty("spring.ai.mcp.server.type", "SYNC")
+        return type == "SYNC"
     }
 }
 

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/sync/support/PerGoalMcpToolExportCallbackPublisher.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/sync/support/PerGoalMcpToolExportCallbackPublisher.kt
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Service
  */
 @Service
 @ConditionalOnProperty(
-    value = ["embabel.agent.mcpserver.type"],
+    value = ["spring.ai.mcp.server.type"],
     havingValue = "SYNC",
     matchIfMissing = true,
 )

--- a/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/config/McpServerConditionsTest.kt
+++ b/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/config/McpServerConditionsTest.kt
@@ -37,24 +37,9 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns true
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "SYNC"
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "SYNC"
 
         assertTrue(condition.matches(context, metadata))
-    }
-
-    @Test
-    fun `McpSyncServerCondition should not match when disabled`() {
-        val condition = McpSyncServerCondition()
-        val context = mockk<ConditionContext>()
-        val metadata = mockk<AnnotatedTypeMetadata>()
-        val environment = mockk<Environment>()
-
-        every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns false
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "SYNC"
-
-        assertFalse(condition.matches(context, metadata))
     }
 
     @Test
@@ -65,8 +50,7 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns true
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "ASYNC"
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "ASYNC"
 
         assertFalse(condition.matches(context, metadata))
     }
@@ -79,8 +63,7 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns true
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "SYNC" // Default value
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "SYNC" // Default value
 
         assertTrue(condition.matches(context, metadata))
     }
@@ -93,24 +76,9 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns true
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "ASYNC"
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "ASYNC"
 
         assertTrue(condition.matches(context, metadata))
-    }
-
-    @Test
-    fun `McpAsyncServerCondition should not match when disabled`() {
-        val condition = McpAsyncServerCondition()
-        val context = mockk<ConditionContext>()
-        val metadata = mockk<AnnotatedTypeMetadata>()
-        val environment = mockk<Environment>()
-
-        every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns false
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "ASYNC"
-
-        assertFalse(condition.matches(context, metadata))
     }
 
     @Test
@@ -121,8 +89,7 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns true
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "SYNC"
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "SYNC"
 
         assertFalse(condition.matches(context, metadata))
     }
@@ -135,8 +102,7 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns true
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "SYNC" // Default
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "SYNC" // Default
 
         assertFalse(condition.matches(context, metadata))
     }
@@ -169,13 +135,12 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns true
 
         // Test lowercase
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "sync"
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "sync"
         assertFalse(syncCondition.matches(context, metadata)) // Should be case sensitive
 
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "async"
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "async"
         assertFalse(asyncCondition.matches(context, metadata)) // Should be case sensitive
     }
 
@@ -188,8 +153,7 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns true
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "UNKNOWN"
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "UNKNOWN"
 
         assertFalse(syncCondition.matches(context, metadata))
         assertFalse(asyncCondition.matches(context, metadata))
@@ -203,11 +167,9 @@ class McpServerConditionsTest {
         val environment = mockk<Environment>()
 
         every { context.environment } returns environment
-        // When enabled property is not set, should default to false
-        every { environment.getProperty("embabel.agent.mcpserver.enabled", Boolean::class.java, false) } returns false
         // When type property is not set, should default to "SYNC"
-        every { environment.getProperty("embabel.agent.mcpserver.type", "SYNC") } returns "SYNC"
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "SYNC"
 
-        assertFalse(syncCondition.matches(context, metadata))
+        assertTrue(syncCondition.matches(context, metadata))
     }
 }


### PR DESCRIPTION
This pull request refactors the way the MCP server type is configured throughout the codebase, switching from the old property key `embabel.agent.mcpserver.type` to the new standardized property key `spring.ai.mcp.server.type`. It also simplifies the logic for enabling/disabling the sync and async server modes by removing the dependency on the `enabled` property, updating both the implementation and the related tests accordingly.

Configuration property refactor:

* Updated all references of the configuration property from `embabel.agent.mcpserver.type` to `spring.ai.mcp.server.type` in both sync and async server configuration classes, as well as in conditional annotations. [[1]](diffhunk://#diff-32e4b2c7e11785ce47d15ab63728c8d70aae54a0adc3a4b2642c7357b34b55d5L30-R43) [[2]](diffhunk://#diff-09304532f5088e41dcd61881b078a871a48394b2632f1d9bd67adba2be419fc0L30-R31) [[3]](diffhunk://#diff-7dbef22559ae4a55ff42cd5a97b96ffbcf2c63adb08df3dcbf92588cd190b019L44-R44) [[4]](diffhunk://#diff-d9f4e2638d0a062d4bbe21800c64a2312a7b5a231e4b811df02aba030346190dL44-R44)

Server mode enablement logic:

* Simplified the logic in `McpSyncServerCondition` and `McpAsyncServerCondition` to only check the server type property, removing the check for the `enabled` property. Now, the server mode is determined solely by the value of `spring.ai.mcp.server.type`. [[1]](diffhunk://#diff-32e4b2c7e11785ce47d15ab63728c8d70aae54a0adc3a4b2642c7357b34b55d5L30-R43) [[2]](diffhunk://#diff-09304532f5088e41dcd61881b078a871a48394b2632f1d9bd67adba2be419fc0L52-R55)

Test updates:

* Refactored tests in `McpServerConditionsTest` to align with the new property key and logic, removing tests for the deprecated `enabled` property and updating assertions to match the new behavior. [[1]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL40-L59) [[2]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL68-R53) [[3]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL82-R66) [[4]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL96-L115) [[5]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL124-R92) [[6]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL138-R105) [[7]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL172-R143) [[8]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL191-R156) [[9]](diffhunk://#diff-0935a5504be5de75e96e118d173767ba7b9b20e138cf2e42e1fe6c5f9f3682ecL206-R173)