### PR TITLE
ObservationRegistry is optional. Default to NOOP

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/config/AgentPlatformConfiguration.kt
@@ -33,6 +33,7 @@ import com.embabel.common.textio.template.TemplateRenderer
 import com.embabel.common.util.StringTransformer
 import com.embabel.common.util.loggerFor
 import io.micrometer.observation.ObservationRegistry
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -63,7 +64,7 @@ class AgentPlatformConfiguration(
     @Bean
     fun toolDecorator(
         toolGroupResolver: ToolGroupResolver,
-        observationRegistry: ObservationRegistry,
+        observationRegistry: ObjectProvider<ObservationRegistry>,
     ): ToolDecorator {
         loggerFor<AgentPlatformConfiguration>().info(
             "Creating default ToolDecorator with toolGroupResolver: {}, observationRegistry: {}",
@@ -72,7 +73,7 @@ class AgentPlatformConfiguration(
         )
         return DefaultToolDecorator(
             toolGroupResolver = toolGroupResolver,
-            observationRegistry = observationRegistry,
+            observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
             outputTransformer = StringTransformer(),
         )
     }

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
@@ -28,6 +28,7 @@ import org.springframework.ai.anthropic.AnthropicChatModel
 import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.anthropic.api.AnthropicApi
 import org.springframework.ai.model.tool.ToolCallingManager
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -80,7 +81,7 @@ class AnthropicModelsConfig(
     @param:Value("\${ANTHROPIC_API_KEY}")
     private val apiKey: String,
     private val properties: AnthropicProperties,
-    private val observationRegistry: ObservationRegistry,
+    private val observationRegistry: ObjectProvider<ObservationRegistry>,
 ) {
     private val logger = LoggerFactory.getLogger(AnthropicModelsConfig::class.java)
 
@@ -142,10 +143,10 @@ class AnthropicModelsConfig(
             .anthropicApi(createAnthropicApi())
             .toolCallingManager(
                 ToolCallingManager.builder()
-                    .observationRegistry(observationRegistry)
+                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
                     .build())
             .retryTemplate(properties.retryTemplate("anthropic-$name"))
-            .observationRegistry(observationRegistry)
+            .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
             .build()
 
         return Llm(
@@ -166,10 +167,10 @@ class AnthropicModelsConfig(
         //add observation registry to rest and web client builders
         builder
             .restClientBuilder(RestClient.builder()
-                .observationRegistry(observationRegistry))
+                .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP }))
         builder
             .webClientBuilder(WebClient.builder()
-                .observationRegistry(observationRegistry))
+                .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP }))
 
         return builder.build()
     }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -23,6 +23,7 @@ import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import com.embabel.common.util.loggerFor
 import io.micrometer.observation.ObservationRegistry
 import org.springframework.ai.openai.OpenAiChatOptions
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Bean
@@ -74,14 +75,14 @@ class OpenAiModelsConfig(
     completionsPath: String?,
     @Value("\${OPENAI_EMBEDDINGS_PATH:#{null}}")
     embeddingsPath: String?,
-    observationRegistry: ObservationRegistry,
+    observationRegistry: ObjectProvider<ObservationRegistry>,
     private val properties: OpenAiProperties,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = baseUrl,
     apiKey = apiKey,
     completionsPath = completionsPath,
     embeddingsPath = embeddingsPath,
-    observationRegistry = observationRegistry
+    observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP }
 ) {
 
     init {


### PR DESCRIPTION
This pull request refactors how `ObservationRegistry` dependencies are handled in several configuration classes, improving flexibility and robustness in bean instantiation. The most significant change is replacing direct injection of `ObservationRegistry` with `ObjectProvider<ObservationRegistry>`, allowing for safer retrieval and fallback to `ObservationRegistry.NOOP` when a unique instance is not available.

### Dependency Injection Improvements

* Changed constructor parameters in `AgentPlatformConfiguration`, `AnthropicModelsConfig`, and `OpenAiModelsConfig` to use `ObjectProvider<ObservationRegistry>` instead of direct injection of `ObservationRegistry`, enabling conditional retrieval and fallback. [[1]](diffhunk://#diff-011525aa6875443a79e643130d2093ea1fe528e7a7440f96123623107d476b8fL66-R67) [[2]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9L83-R84) [[3]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL77-R85)

* Updated instantiation logic to use `observationRegistry.getIfUnique { ObservationRegistry.NOOP }`, ensuring a default no-operation registry is used if no unique registry bean is present. This affects the creation of `ToolDecorator`, Anthropic model beans, and OpenAI model beans. [[1]](diffhunk://#diff-011525aa6875443a79e643130d2093ea1fe528e7a7440f96123623107d476b8fL75-R76) [[2]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9L145-R149) [[3]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL77-R85)

### Configuration Consistency

* Applied the same fallback logic (`getIfUnique { ObservationRegistry.NOOP }`) to REST and WebClient builders in `AnthropicModelsConfig`, ensuring consistent observation registry handling across HTTP clients.

### Imports

* Added necessary import statements for `ObjectProvider` in affected files to support the new dependency injection pattern. [[1]](diffhunk://#diff-011525aa6875443a79e643130d2093ea1fe528e7a7440f96123623107d476b8fR36) [[2]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9R31) [[3]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daR26)