### PR TITLE
Remove JUnit Dependencies

### DIFF
--- a/embabel-agent-test-support/embabel-agent-test-internal/pom.xml
+++ b/embabel-agent-test-support/embabel-agent-test-internal/pom.xml
@@ -18,7 +18,7 @@
         </dependency>
         
         <!-- Test framework dependencies with compile scope needed for main code (test support utilities) -->
-        <dependency>
+        <!--<dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>compile</scope>
@@ -28,7 +28,7 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit5</artifactId>
             <scope>compile</scope>
-        </dependency>
+        </dependency>-->
     </dependencies> 
 
 </project>


### PR DESCRIPTION
Comment out the junit-jupiter-api and kotlin-test-junit5 dependencies in pom.xml until IntelliJ issues is resolved.