### PR TITLE
Declarative Anthropic LLM(s)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -169,6 +169,8 @@ class AgentPlatformConfiguration(
         applicationContext: ApplicationContext,
         properties: ConfigurableModelProviderProperties,
         @Autowired(required = false)
+        @Qualifier("anthropicModelsConfig") anthropicModelsConfig: Any?,
+        @Autowired(required = false)
         @Qualifier("dockerLocalModelsConfig") dockerLocalModelsConfig: Any?,
         @Autowired(required = false)
         @Qualifier("ollamaModelsConfig") ollamaModelsConfig: Any?,

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelLoader.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.anthropic
+
+import com.embabel.common.ai.autoconfig.AbstractYamlModelLoader
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadata
+import com.embabel.common.ai.autoconfig.LlmAutoConfigProvider
+import com.embabel.common.ai.model.PerTokenPricingModel
+import org.springframework.core.io.DefaultResourceLoader
+import org.springframework.core.io.ResourceLoader
+import java.time.LocalDate
+
+/**
+ * Container for Anthropic model definitions loaded from YAML.
+ *
+ * Implements [LlmAutoConfigProvider] to supply Anthropic-specific model metadata
+ * for auto-configuration purposes.
+ *
+ * @property models list of Anthropic model definitions
+ */
+data class AnthropicModelDefinitions(
+    override val models: List<AnthropicModelDefinition> = emptyList()
+) : LlmAutoConfigProvider<AnthropicModelDefinition>
+
+/**
+ * Anthropic-specific model definition.
+ *
+ * Implements [LlmAutoConfigMetadata] with Anthropic-specific features
+ * like thinking mode and custom parameter defaults.
+ *
+ * @property name the unique name of the model
+ * @property modelId the Anthropic API model identifier
+ * @property displayName optional human-readable name
+ * @property knowledgeCutoffDate optional knowledge cutoff date
+ * @property pricingModel optional per-token pricing information
+ * @property maxTokens maximum tokens for completion (default 8192)
+ * @property temperature sampling temperature (default 1.0)
+ * @property topP nucleus sampling parameter
+ * @property topK top-k sampling parameter
+ * @property thinking optional thinking mode configuration
+ */
+data class AnthropicModelDefinition(
+    override val name: String,
+    override val modelId: String,
+    override val displayName: String? = null,
+    override val knowledgeCutoffDate: LocalDate? = null,
+    override val pricingModel: PerTokenPricingModel? = null,
+    val maxTokens: Int = 8192,
+    val temperature: Double = 1.0,
+    val topP: Double? = null,
+    val topK: Int? = null,
+    val thinking: ThinkingConfiguration? = null,
+) : LlmAutoConfigMetadata
+
+/**
+ * Configuration for Anthropic's extended thinking mode.
+ *
+ * @property tokenBudget maximum tokens allocated for thinking
+ */
+data class ThinkingConfiguration(
+    val tokenBudget: Int? = null
+)
+
+/**
+ * Loader for Anthropic model definitions from YAML configuration.
+ *
+ * Reads model metadata from the configured resource path (default: `classpath:models/anthropic-models.yml`)
+ * and deserializes it into [AnthropicModelDefinitions]. Validates loaded models to ensure data integrity.
+ *
+ * @property resourceLoader Spring resource loader for accessing classpath resources
+ * @property configPath path to the YAML configuration file
+ */
+class AnthropicModelLoader(
+    resourceLoader: ResourceLoader = DefaultResourceLoader(),
+    configPath: String = DEFAULT_CONFIG_PATH
+) : AbstractYamlModelLoader<AnthropicModelDefinitions>(resourceLoader, configPath) {
+
+    override fun getProviderClass() = AnthropicModelDefinitions::class
+
+    override fun createEmptyProvider() = AnthropicModelDefinitions()
+
+    override fun getProviderName() = "Anthropic"
+
+    override fun validateModels(provider: AnthropicModelDefinitions) {
+        provider.models.forEach { model ->
+            validateCommonFields(model)
+            require(model.maxTokens > 0) { "Max tokens must be positive for model ${model.name}" }
+            require(model.temperature in 0.0..2.0) {
+                "Temperature must be between 0 and 2 for model ${model.name}"
+            }
+            model.topP?.let {
+                require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }
+            }
+            model.topK?.let {
+                require(it > 0) { "Top K must be positive for model ${model.name}" }
+            }
+            model.thinking?.tokenBudget?.let {
+                require(it > 0) { "Thinking token budget must be positive for model ${model.name}" }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Default path to the Anthropic models YAML configuration file.
+         */
+        private const val DEFAULT_CONFIG_PATH = "classpath:models/anthropic-models.yml"
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/resources/models/anthropic-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/resources/models/anthropic-models.yml
@@ -1,0 +1,87 @@
+# ============================================
+# anthropic-models.yml
+# ============================================
+# Updated with latest Anthropic models as of October 2025
+
+models:
+  # ========================================
+  # CLAUDE 4.5 FAMILY (Latest Generation)
+  # ========================================
+
+  # Claude Sonnet 4.5 - Best coding model, flagship for general use
+  - name: "claude_sonnet_45"
+    model_id: "claude-sonnet-4-5-20250929"
+    display_name: "Claude Sonnet 4.5"
+    knowledge_cutoff_date: "2025-01-01"
+    max_tokens: 8192
+    pricing_model:
+      usd_per1m_input_tokens: 3.0
+      usd_per1m_output_tokens: 15.0
+
+  # Claude Haiku 4.5 - Fast, cost-efficient with near-frontier performance
+  - name: "claude_haiku_45"
+    model_id: "claude-haiku-4-5-20251015"
+    display_name: "Claude Haiku 4.5"
+    knowledge_cutoff_date: "2025-02-01"
+    max_tokens: 8192
+    pricing_model:
+      usd_per1m_input_tokens: 1.0
+      usd_per1m_output_tokens: 5.0
+
+  # ========================================
+  # CLAUDE 4 FAMILY (Current Generation)
+  # ========================================
+
+  # Claude Opus 4.1 - Most powerful for complex reasoning tasks
+  - name: "claude_opus_41"
+    model_id: "claude-opus-4-1-20250805"
+    display_name: "Claude Opus 4.1"
+    knowledge_cutoff_date: "2025-01-01"
+    max_tokens: 8192
+    pricing_model:
+      usd_per1m_input_tokens: 15.0
+      usd_per1m_output_tokens: 75.0
+
+  # Claude Sonnet 4 - General purpose, large context window
+  - name: "claude_sonnet_4"
+    model_id: "claude-sonnet-4-20250522"
+    display_name: "Claude Sonnet 4"
+    knowledge_cutoff_date: "2025-01-01"
+    max_tokens: 8192
+    pricing_model:
+      usd_per1m_input_tokens: 3.0
+      usd_per1m_output_tokens: 15.0
+
+  # ========================================
+  # LEGACY MODELS (For Backward Compatibility)
+  # ========================================
+
+  # Claude Opus 4.0 - Legacy flagship model
+  - name: "claude_opus_40"
+    model_id: "claude-opus-4-20250514"
+    display_name: "Claude Opus 4.0"
+    knowledge_cutoff_date: "2025-03-31"
+    max_tokens: 8192
+    pricing_model:
+      usd_per1m_input_tokens: 15.0
+      usd_per1m_output_tokens: 75.0
+
+  # Claude 3.7 Sonnet - Hybrid reasoning model (being phased out)
+  - name: "claude_sonnet_37"
+    model_id: "claude-3-7-sonnet-20250224"
+    display_name: "Claude 3.7 Sonnet"
+    knowledge_cutoff_date: "2024-10-31"
+    max_tokens: 8192
+    pricing_model:
+      usd_per1m_input_tokens: 3.0
+      usd_per1m_output_tokens: 15.0
+
+  # Claude 3.5 Haiku - Legacy fast model (replaced by Haiku 4.5)
+  - name: "claude_haiku_35"
+    model_id: "claude-3-5-haiku-20241022"
+    display_name: "Claude 3.5 Haiku"
+    knowledge_cutoff_date: "2024-10-22"
+    max_tokens: 8192
+    pricing_model:
+      usd_per1m_input_tokens: 0.80
+      usd_per1m_output_tokens: 4.0

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelLoaderTest.kt
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.anthropic
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.DefaultResourceLoader
+import java.io.File
+import java.nio.file.Files
+
+class AnthropicModelLoaderTest {
+
+    @Test
+    fun `should load valid model definitions from default YAML file`() {
+        // Arrange
+        val loader = AnthropicModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isNotEmpty(), "Should load at least one model")
+
+        // Verify first model has required fields
+        val firstModel = result.models.first()
+        assertNotNull(firstModel.name)
+        assertNotNull(firstModel.modelId)
+        assertTrue(firstModel.name.isNotBlank(), "Model name should not be blank")
+        assertTrue(firstModel.modelId.isNotBlank(), "Model ID should not be blank")
+    }
+
+    @Test
+    fun `should validate all loaded models have correct default values`() {
+        // Arrange
+        val loader = AnthropicModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        result.models.forEach { model ->
+            // Verify defaults
+            assertTrue(model.maxTokens > 0, "Max tokens should be positive for ${model.name}")
+            assertTrue(model.temperature in 0.0..2.0, "Temperature should be in valid range for ${model.name}")
+
+            // Verify optional fields when present
+            model.topP?.let {
+                assertTrue(it in 0.0..1.0, "Top P should be between 0 and 1 for ${model.name}")
+            }
+            model.topK?.let {
+                assertTrue(it > 0, "Top K should be positive for ${model.name}")
+            }
+            model.thinking?.tokenBudget?.let {
+                assertTrue(it > 0, "Thinking token budget should be positive for ${model.name}")
+            }
+        }
+    }
+
+    @Test
+    fun `should verify specific known models are loaded`() {
+        // Arrange
+        val loader = AnthropicModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify some known Anthropic models are present
+        val modelNames = result.models.map { it.name }
+        assertTrue(modelNames.isNotEmpty(), "Should have loaded model names")
+
+        // Verify at least one model has pricing info
+        assertTrue(result.models.any { it.pricingModel != null },
+            "At least one model should have pricing information")
+    }
+
+    @Test
+    fun `should return empty definitions when file does not exist`() {
+        // Arrange
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "classpath:nonexistent-file.yml"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isEmpty(), "Should return empty list when file not found")
+    }
+
+    @Test
+    fun `should handle invalid YAML gracefully`() {
+        // Arrange
+        val tempFile = Files.createTempFile("invalid", ".yml").toFile()
+        tempFile.writeText("invalid: yaml: content: ][")
+        tempFile.deleteOnExit()
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isEmpty(), "Should return empty list on parse error")
+    }
+
+    @Test
+    fun `should validate model with invalid maxTokens`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                max_tokens: -100
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for negative maxTokens")
+    }
+
+    @Test
+    fun `should validate model with invalid temperature`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                temperature: 3.0
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for temperature out of range")
+    }
+
+    @Test
+    fun `should validate model with invalid topP`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                top_p: 1.5
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for topP out of range")
+    }
+
+    @Test
+    fun `should validate model with blank name`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: ""
+                model_id: test-id
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for blank name")
+    }
+
+    @Test
+    fun `should load valid model with all optional fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: claude-test
+                display_name: Test Model
+                max_tokens: 4096
+                temperature: 0.7
+                top_p: 0.9
+                top_k: 50
+                thinking:
+                  token_budget: 1000
+                pricing_model:
+                  usd_per1m_input_tokens: 10.0
+                  usd_per1m_output_tokens: 20.0
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size)
+        val model = result.models.first()
+        assertEquals("test-model", model.name)
+        assertEquals("claude-test", model.modelId)
+        assertEquals("Test Model", model.displayName)
+        assertEquals(4096, model.maxTokens)
+        assertEquals(0.7, model.temperature)
+        assertEquals(0.9, model.topP)
+        assertEquals(50, model.topK)
+        assertNotNull(model.thinking)
+        assertEquals(1000, model.thinking?.tokenBudget)
+        assertNotNull(model.pricingModel)
+        assertEquals(10.0, model.pricingModel?.usdPer1mInputTokens)
+        assertEquals(20.0, model.pricingModel?.usdPer1mOutputTokens)
+    }
+
+    @Test
+    fun `should load multiple models correctly`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: model-1
+                model_id: claude-1
+                max_tokens: 2000
+              - name: model-2
+                model_id: claude-2
+                max_tokens: 4000
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(2, result.models.size)
+        assertEquals("model-1", result.models[0].name)
+        assertEquals("model-2", result.models[1].name)
+        assertEquals(2000, result.models[0].maxTokens)
+        assertEquals(4000, result.models[1].maxTokens)
+    }
+
+    @Test
+    fun `should validate model with invalid topK`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                top_k: -5
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for negative topK")
+    }
+
+    @Test
+    fun `should validate model with invalid thinking token budget`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                thinking:
+                  token_budget: -1000
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for negative thinking token budget")
+    }
+
+    @Test
+    fun `should load model with minimal fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: minimal-model
+                model_id: claude-minimal
+        """.trimIndent())
+
+        val loader = AnthropicModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size)
+        val model = result.models.first()
+        assertEquals("minimal-model", model.name)
+        assertEquals("claude-minimal", model.modelId)
+        assertNull(model.displayName)
+        assertEquals(8192, model.maxTokens) // Default value
+        assertEquals(1.0, model.temperature) // Default value
+        assertNull(model.topP)
+        assertNull(model.topK)
+        assertNull(model.thinking)
+        assertNull(model.pricingModel)
+    }
+
+    private fun createTempYamlFile(content: String): File {
+        val tempFile = Files.createTempFile("test-anthropic", ".yml").toFile()
+        tempFile.writeText(content)
+        tempFile.deleteOnExit()
+        return tempFile
+    }
+}


### PR DESCRIPTION
This pull request modernizes the Anthropic model integration by introducing dynamic model configuration via YAML, enabling easier updates and additions of Anthropic models without code changes. The previous hardcoded bean definitions for each model are replaced with a loader and registry mechanism that reads model metadata from a YAML file and registers each model as a Spring bean at runtime. This makes the system more maintainable and scalable as new models are released.

**Dynamic Anthropic model configuration:**

* Added `AnthropicModelLoader` and supporting data classes to load model definitions from a YAML file, including validation for key parameters. (`AnthropicModelLoader.kt`)
* Introduced `anthropic-models.yml` with up-to-date Anthropic model definitions, supporting both current and legacy models with pricing, cutoff dates, and other metadata. (`anthropic-models.yml`)

**Spring bean registration and configuration:**

* Replaced individual hardcoded Anthropic model beans with a `@PostConstruct` method that registers each model as a bean using the loaded YAML configuration. (`AnthropicModelsConfig.kt`)
* Updated constructor and dependencies in `AgentPlatformConfiguration` and `AnthropicModelsConfig` to support dynamic configuration and bean registration. (`AgentPlatformConfiguration.kt`, `AnthropicModelsConfig.kt`) [[1]](diffhunk://#diff-5ed0dfe15541660e463d02167ac28e42bb2a260c9cf3bad49b08625987d3f5eaR172-R173) [[2]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9R20-L34)

**Model options and features:**

* Model options such as temperature, top-p, top-k, and "thinking mode" are now configurable per model via YAML and applied when instantiating each model bean. (`AnthropicModelsConfig.kt`, `AnthropicModelLoader.kt`) [[1]](diffhunk://#diff-e5c79f8dfa96553ed4fd74a08465f6c9213309dd20a82453604c9f2bc97f673fR1-R122) [[2]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9R87-R181)