### PR TITLE
Enable Common Properties Loader

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/platform/AgentPlatformAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/platform/AgentPlatformAutoConfiguration.java
@@ -23,12 +23,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.Import;
+import com.embabel.common.core.config.CommonPlatformPropertiesLoader;
+
 
 /**
  * Bootstraps Agent Platform Configuration, Tools Configuration, and Rag Service Configuration
  */
 @AutoConfiguration
-@Import({ScanConfiguration.class, AgentPlatformConfiguration.class, ToolGroupsConfiguration.class,})
+@Import({CommonPlatformPropertiesLoader.class, ScanConfiguration.class, AgentPlatformConfiguration.class, ToolGroupsConfiguration.class,})
 public class AgentPlatformAutoConfiguration {
     final private static Logger logger = LoggerFactory.getLogger(AgentPlatformAutoConfiguration.class);
 


### PR DESCRIPTION
# Overview

Common Platform Properties Loader (in "commons" repo)  allows to load platform / application properties cross jars, using classpath wildcard syntax:

```@Configuration
@PropertySource("classpath*:embabel-platform.properties")
@PropertySource("classpath*:embabel-application.properties")
@Order(Ordered.HIGHEST_PRECEDENCE)
class CommonPlatformPropertiesLoader ......
```

Artifact got activated in agent platform auto-configuration.

Please refer to issue:  https://github.com/embabel/embabel-agent/issues/865

