### PR TITLE
Use aliases for Anthropic Models

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/resources/models/anthropic-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/resources/models/anthropic-models.yml
@@ -2,6 +2,7 @@
 # anthropic-models.yml
 # ============================================
 # Updated with latest Anthropic models as of October 2025
+# Using official Anthropic API aliases
 
 models:
   # ========================================
@@ -10,7 +11,7 @@ models:
 
   # Claude Sonnet 4.5 - Best coding model, flagship for general use
   - name: "claude_sonnet_45"
-    model_id: "claude-sonnet-4-5-20250929"
+    model_id: "claude-sonnet-4-5"
     display_name: "Claude Sonnet 4.5"
     knowledge_cutoff_date: "2025-01-01"
     max_tokens: 8192
@@ -20,7 +21,7 @@ models:
 
   # Claude Haiku 4.5 - Fast, cost-efficient with near-frontier performance
   - name: "claude_haiku_45"
-    model_id: "claude-haiku-4-5-20251015"
+    model_id: "claude-haiku-4-5"
     display_name: "Claude Haiku 4.5"
     knowledge_cutoff_date: "2025-02-01"
     max_tokens: 8192
@@ -34,7 +35,7 @@ models:
 
   # Claude Opus 4.1 - Most powerful for complex reasoning tasks
   - name: "claude_opus_41"
-    model_id: "claude-opus-4-1-20250805"
+    model_id: "claude-opus-4-1"
     display_name: "Claude Opus 4.1"
     knowledge_cutoff_date: "2025-01-01"
     max_tokens: 8192
@@ -44,7 +45,7 @@ models:
 
   # Claude Sonnet 4 - General purpose, large context window
   - name: "claude_sonnet_4"
-    model_id: "claude-sonnet-4-20250522"
+    model_id: "claude-sonnet-4-0"
     display_name: "Claude Sonnet 4"
     knowledge_cutoff_date: "2025-01-01"
     max_tokens: 8192
@@ -58,7 +59,7 @@ models:
 
   # Claude Opus 4.0 - Legacy flagship model
   - name: "claude_opus_40"
-    model_id: "claude-opus-4-20250514"
+    model_id: "claude-opus-4-0"
     display_name: "Claude Opus 4.0"
     knowledge_cutoff_date: "2025-03-31"
     max_tokens: 8192
@@ -68,7 +69,7 @@ models:
 
   # Claude 3.7 Sonnet - Hybrid reasoning model (being phased out)
   - name: "claude_sonnet_37"
-    model_id: "claude-3-7-sonnet-20250224"
+    model_id: "claude-3-7-sonnet-latest"
     display_name: "Claude 3.7 Sonnet"
     knowledge_cutoff_date: "2024-10-31"
     max_tokens: 8192
@@ -78,7 +79,7 @@ models:
 
   # Claude 3.5 Haiku - Legacy fast model (replaced by Haiku 4.5)
   - name: "claude_haiku_35"
-    model_id: "claude-3-5-haiku-20241022"
+    model_id: "claude-3-5-haiku-latest"
     display_name: "Claude 3.5 Haiku"
     knowledge_cutoff_date: "2024-10-22"
     max_tokens: 8192


### PR DESCRIPTION
This pull request updates the Anthropic model configuration in `anthropic-models.yml` to use the official API model aliases instead of version-specific model IDs. This change will make it easier to keep the configuration up-to-date and compatible with Anthropic's evolving API standards.

**Model configuration updates:**

* Updated all `model_id` fields to use Anthropic's official API aliases (e.g., `claude-sonnet-4-5`, `claude-haiku-4-5`) instead of hardcoded versioned IDs for all listed models. [[1]](diffhunk://#diff-7cbb771b68f5bb85fd84cdf702d1b9a5955d32d8aff34a27b6d53fe2faae6e4cL13-R14) [[2]](diffhunk://#diff-7cbb771b68f5bb85fd84cdf702d1b9a5955d32d8aff34a27b6d53fe2faae6e4cL23-R24) [[3]](diffhunk://#diff-7cbb771b68f5bb85fd84cdf702d1b9a5955d32d8aff34a27b6d53fe2faae6e4cL37-R38) [[4]](diffhunk://#diff-7cbb771b68f5bb85fd84cdf702d1b9a5955d32d8aff34a27b6d53fe2faae6e4cL47-R48) [[5]](diffhunk://#diff-7cbb771b68f5bb85fd84cdf702d1b9a5955d32d8aff34a27b6d53fe2faae6e4cL61-R62) [[6]](diffhunk://#diff-7cbb771b68f5bb85fd84cdf702d1b9a5955d32d8aff34a27b6d53fe2faae6e4cL71-R72) [[7]](diffhunk://#diff-7cbb771b68f5bb85fd84cdf702d1b9a5955d32d8aff34a27b6d53fe2faae6e4cL81-R82)
* Added a comment at the top of the file noting the switch to official Anthropic API aliases.