### PR TITLE
Update embabel-common to next dev version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <description>Parent POM for Embabel Agent Modules</description>
 
     <properties>
-        <embabel-common.version>0.1.4</embabel-common.version>
+        <embabel-common.version>0.1.5-SNAPSHOT</embabel-common.version>
         <!-- Netty version for security vulnerability fixes - duplicate from build-dependencies -->
         <netty.version>4.1.125.Final</netty.version>
     </properties>


### PR DESCRIPTION
This pull request updates the `embabel-common` dependency version in the Maven project configuration. The change ensures the project references the latest snapshot version of the shared library.

* Dependency update:
  * [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L17-R17): Updated the `embabel-common.version` property from `0.1.4` to `0.1.5-SNAPSHOT` to use the latest development version of the common library.