### PR TITLE
Dedicated Jackson ObjectMapper

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
@@ -31,6 +31,7 @@ import com.embabel.common.textio.template.TemplateRenderer
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationContext
 import org.springframework.stereotype.Service
@@ -52,6 +53,7 @@ open class DefaultAgentPlatform(
     private val agentProcessRepository: AgentProcessRepository = InMemoryAgentProcessRepository(),
     private val operationScheduler: OperationScheduler = OperationScheduler.PRONTO,
     private val asyncer: Asyncer,
+    @param:Qualifier("embabelJacksonObjectMapper")
     private val objectMapper: ObjectMapper,
     private val outputChannel: OutputChannel,
     private val templateRenderer: TemplateRenderer,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -32,6 +32,7 @@ import com.embabel.common.textio.template.JinjavaTemplateRenderer
 import com.embabel.common.textio.template.TemplateRenderer
 import com.embabel.common.util.StringTransformer
 import com.embabel.common.util.loggerFor
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.observation.ObservationRegistry
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,6 +43,7 @@ import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
 import org.springframework.web.client.RestTemplate
 
 
@@ -102,6 +104,12 @@ class AgentPlatformConfiguration(
 
     @Bean
     fun restTemplate() = RestTemplate()
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["embabelJacksonObjectMapper"])
+    fun embabelJacksonObjectMapper(builder: Jackson2ObjectMapperBuilder): ObjectMapper {
+        return builder.createXmlMapper(false).build()
+    }
 
     @Bean
     fun ranker(


### PR DESCRIPTION
This PR ensures that Embabel configures its own Jackson ObjectMapper bean, registered under the name "embabelJacksonObjectMapper". Previously, we relied on the Spring's default ObjectMapper.