### PR TITLE
Replace RestTemplate with RestClient

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -44,7 +44,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
-import org.springframework.web.client.RestTemplate
 
 
 /**
@@ -101,9 +100,6 @@ class AgentPlatformConfiguration(
     @Bean
     @ConditionalOnMissingBean(ColorPalette::class)
     fun defaultColorPalette(): ColorPalette = DefaultColorPalette()
-
-    @Bean
-    fun restTemplate() = RestTemplate()
 
     @Bean
     @ConditionalOnMissingBean(name = ["embabelJacksonObjectMapper"])


### PR DESCRIPTION
This PR replaces the RestTemplate usage in AgentChatClient with RestClient.
It also removes the RestTemplate bean configured in AgentPlatformConfiguration, as it does not appear to be used anywhere.

See: gh-1003