### PR TITLE
Update version to 0.1.6-SNAPSHOT in pom.xml

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.5</version>
+        <version>0.1.6-SNAPSHOT</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>


### PR DESCRIPTION
This pull request updates the parent dependency version in the `embabel-agent-dependencies/pom.xml` file to reference the latest snapshot.

Dependency management:

* Updated the parent artifact version from `0.1.5` to `0.1.6-SNAPSHOT` in `embabel-agent-dependencies/pom.xml` to use the most recent development version.