### PR TITLE
Polishing Maven Pom for Tests

### DIFF
--- a/embabel-agent-test-support/embabel-agent-test-internal/pom.xml
+++ b/embabel-agent-test-support/embabel-agent-test-internal/pom.xml
@@ -16,19 +16,6 @@
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test</artifactId>
         </dependency>
-        
-        <!-- Test framework dependencies with compile scope needed for main code (test support utilities) -->
-        <!--<dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit5</artifactId>
-            <scope>compile</scope>
-        </dependency>-->
     </dependencies> 
 
 </project>


### PR DESCRIPTION
This pull request makes a minor cleanup to the `pom.xml` file by removing commented-out test framework dependencies that are no longer needed.

* Removed commented-out dependencies for `junit-jupiter-api` and `kotlin-test-junit5` from `embabel-agent-test-internal/pom.xml` to clean up the file.