### PR TITLE
Update Maven command to use flatten-pom profile

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -26,4 +26,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         
-        run: mvn -U -DskipTests=true clean deploy
+        run: mvn -U -P flatten-pom -DskipTests=true clean deploy


### PR DESCRIPTION
This pull request makes a minor update to the Maven deploy step in the GitHub Actions workflow, enabling the `flatten-pom` profile during deployment. This change ensures that the POM is flattened before deployment, which can help with dependency management and reproducibility.

* Updated the Maven deploy command in `.github/workflows/deploy-snapshots.yml` to use the `flatten-pom` profile for cleaner and more consistent POM files during deployment.