### PR TITLE
Update guide with Ollama starter

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
@@ -12,7 +12,6 @@ Example:
 @SpringBootApplication
 @EnableAgents(
     loggingTheme = LoggingThemes.STAR_WARS,
-    localModels = { "docker" },
     mcpClients = { "docker" }
 )
 class MyAgentApplication {
@@ -26,7 +25,19 @@ This is a normal Spring Boot application class.
 You can add other Spring Boot annotations as needed.
 `@EnableAgents` enables the agent framework.
 It allows you to specify a logging theme (optional) and well-known sources of local models and MCP tools.
-In this case we're using Docker as a source of local models and MCP tools.
+In this case we're using Docker as a source of MCP tools.
+
+Add the following dependency to your `pom.xml` to include the Ollama model provider starter:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-ollama</artifactId>
+</dependency>
+----
+
+Other providers such as OpenAI, Anthropic, AWS Bedrock, Docker Models, etc. can be added similarly by including their respective starter dependencies.
 
 ==== Configuration Properties
 


### PR DESCRIPTION
This pull request updates the documentation for agent configuration in `embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc`, clarifying the use of Docker and providing instructions for adding model provider dependencies. The most important changes are grouped below:

**Clarification of Docker usage:**

* Updated the example and explanation to indicate that Docker is now used only as a source of MCP tools, not local models. [[1]](diffhunk://#diff-dd772560e82fd3c9e9e8bd18de9a0920d3e886be0a64cb3dad9df7d7c7451076L15) [[2]](diffhunk://#diff-dd772560e82fd3c9e9e8bd18de9a0920d3e886be0a64cb3dad9df7d7c7451076L29-R40)

**Model provider dependency instructions:**

* Added instructions for including the Ollama model provider starter dependency in `pom.xml`, with an example XML snippet.
* Noted that other providers (OpenAI, Anthropic, AWS Bedrock, Docker Models, etc.) can be added by including their respective starter dependencies.