### PR TITLE
Update Maven command to include additional profiles

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn package
+        run: mvn -Phtml,pdf,dokka package
 
       - name: Extract version from pom.xml
         id: get_version


### PR DESCRIPTION
This pull request makes a minor update to the documentation deployment workflow, specifically changing the Maven build command to include additional profiles for generating HTML, PDF, and Dokka documentation outputs.

* Updated the Maven build step in `.github/workflows/deploy-docs.yml` to use the `-Phtml,pdf,dokka` profiles, ensuring that HTML, PDF, and Dokka documentation formats are generated during packaging.