### PR TITLE
Prepare 0.2.0

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.6-SNAPSHOT</version>
+        <version>0.1.6</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.6-SNAPSHOT</version>
+        <version>0.1.6</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -15,8 +15,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <embabel-common.version>0.1.5-SNAPSHOT</embabel-common.version>
-        <!-- Netty version for security vulnerability fixes - duplicate from build-dependencies -->
+        <embabel-common.version>0.1.5</embabel-common.version>
         <netty.version>4.1.125.Final</netty.version>
     </properties>
 


### PR DESCRIPTION
This pull request updates dependency versions in the Maven configuration files to use stable releases instead of snapshot versions. This change ensures that the project relies on finalized versions for improved stability and reproducibility.

Dependency version updates:

* Updated the parent version in `embabel-agent-dependencies/pom.xml` from `0.1.6-SNAPSHOT` to `0.1.6`.
* Updated the parent version in `pom.xml` from `0.1.6-SNAPSHOT` to `0.1.6`.
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.5-SNAPSHOT` to `0.1.5`.