### PR TITLE
Update Maven profile for documentation build

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -Phtml,pdf,dokka package
+        run: mvn -Pguide-html,dokka package
 
       - name: Extract version from pom.xml
         id: get_version


### PR DESCRIPTION
This pull request makes a small update to the documentation deployment workflow, specifically changing the Maven build profiles used during the package step.

* The Maven command in `.github/workflows/deploy-docs.yml` was updated to use the `guide-html` and `dokka` profiles instead of the previous `html`, `pdf`, and `dokka` profiles.