### PR TITLE
Add SCM details and repository URL

### DIFF
--- a/embabel-agent-starters/embabel-agent-starter-shell/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-shell/pom.xml
@@ -10,6 +10,14 @@
     <packaging>jar</packaging>
     <name>Embabel Agent Shell Starter</name>
     <description>Embabel Agent Starter Shell</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>v0.2.0</tag>
+    </scm>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This pull request adds project metadata to the `pom.xml` for the Embabel Agent Shell Starter. These changes help improve project documentation and integration with source control tools.

Project metadata improvements:

* Added a `<url>` element pointing to the project's GitHub repository in `pom.xml`.
* Added an `<scm>` section specifying the repository URL, connection details, developer connection, and the current tag version for source control management in `pom.xml`.Added SCM information and repository URL to pom.xml