### PR TITLE
Make Kotlin Reflection optional

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/FormBindingRequest.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/FormBindingRequest.kt
@@ -19,8 +19,8 @@ import com.embabel.agent.core.AgentProcess
 import com.embabel.common.util.loggerFor
 import com.embabel.ux.form.DefaultFormProcessor
 import com.embabel.ux.form.Form
-import com.embabel.ux.form.FormBinder
 import com.embabel.ux.form.FormSubmission
+import com.embabel.ux.form.bindTo
 import java.time.Instant
 import java.util.*
 
@@ -57,8 +57,7 @@ class FormBindingRequest<O : Any> @JvmOverloads constructor(
         if (!formSubmissionResult.valid) {
             throw IllegalStateException("Form submission is not valid: ${formSubmissionResult.validationErrors}")
         }
-        val formBinder = FormBinder(outputClass)
-        val boundInstance = formBinder.bind(formSubmissionResult)
+        val boundInstance = formSubmissionResult.bindTo(outputClass)
         return bind(boundInstance, agentProcess)
     }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/hitl/FormBindingRequestTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/hitl/FormBindingRequestTest.kt
@@ -35,7 +35,7 @@ class FormBindingRequestTest {
     private lateinit var processContext: ProcessContext
     private lateinit var form: Form
     private lateinit var formProcessor: DefaultFormProcessor
-    private lateinit var formBinder: FormBinder<TestData>
+    private lateinit var formBinder: KotlinFormBinder<TestData>
 
     @BeforeEach
     fun setUp() {
@@ -62,7 +62,7 @@ class FormBindingRequestTest {
         every { anyConstructed<DefaultFormProcessor>().processSubmission(any(), any()) } returns mockk(relaxed = true)
 
         formBinder = mockk()
-        mockkConstructor(FormBinder::class)
+        mockkConstructor(KotlinFormBinder::class)
     }
 
     @AfterEach
@@ -119,7 +119,7 @@ class FormBindingRequestTest {
             } returns submissionResult
 
             val testData = TestData("John Doe", "john@example.com")
-            every { anyConstructed<FormBinder<TestData>>().bind(submissionResult) } returns testData
+            every { anyConstructed<KotlinFormBinder<TestData>>().bind(submissionResult) } returns testData
 
             val result = request.onResponse(response, agentProcess)
 


### PR DESCRIPTION
This PR changes the Blackboard and FormBinder so that they no longer require kotlin-reflect to operate.
FormBinder has been turned into an interface, with a Java version and a Kotlin version

See: gh-946