### PR TITLE
Add embabel-agent-remote to BOM

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -140,6 +140,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-remote</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-shell</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
This pull request adds a new dependency to the project. The main change is the inclusion of the `embabel-agent-remote` library in the `embabel-agent-dependencies/pom.xml` file, allowing the project to use features provided by this module.

* Added `embabel-agent-remote` as a dependency in `embabel-agent-dependencies/pom.xml` to enable integration with remote agent functionalities.