### PR TITLE
Make required dependencies optional

### DIFF
--- a/embabel-agent-a2a/pom.xml
+++ b/embabel-agent-a2a/pom.xml
@@ -25,8 +25,18 @@
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-api</artifactId>
         </dependency>
-        
-   
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+
+
         <!-- SLF4J for logging -->
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -25,11 +25,13 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -56,6 +58,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Kotlin Dependencies -->
@@ -88,6 +91,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/embabel-agent-rag/embabel-agent-rag-neo/pom.xml
+++ b/embabel-agent-rag/embabel-agent-rag-neo/pom.xml
@@ -38,6 +38,18 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>neo4j</artifactId>
             <scope>test</scope>

--- a/embabel-agent-shell/pom.xml
+++ b/embabel-agent-shell/pom.xml
@@ -31,6 +31,12 @@
             <artifactId>spring-shell-starter</artifactId>
         </dependency>
 
+        <!-- Apache Commons -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>com.embabel.agent</groupId>

--- a/embabel-agent-starters/embabel-agent-starter-shell/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-shell/pom.xml
@@ -32,6 +32,11 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
This PR changes the embabel-agent-api POM to make several required dependencies optional or give them test scope, as they are non-essential.

Some of the same dependencies are introduced in other modules, as they are need for either the main or test sources, and no longer transitively resolved:

- embabel-agent-a2a: spring-webmvc and servlet API added
- embabel-agent-rag-neo: spring-webmvc and servlet API added with test scope
- embabel-agent-shell: commons-text added
- embabel-agent-starter-shell: spring-boot-starter-logging added, as it makes sense for shell applications to have logging by default

Closes: gh-1050