### PR TITLE
Prepare for Release

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.6</version>
+        <version>0.1.7</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.7-SNAPSHOT</version>
+        <version>0.1.7</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -15,7 +15,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <embabel-common.version>0.1.6-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.6</embabel-common.version>
         <netty.version>4.1.125.Final</netty.version>
     </properties>
 


### PR DESCRIPTION
This pull request updates project dependencies and parent versions to their latest stable releases. These changes ensure the build uses stable versions instead of snapshot versions, which improves reliability and consistency across builds.

Dependency and parent version updates:

* Updated the parent version in `pom.xml` from `0.1.7-SNAPSHOT` to the stable `0.1.7`.
* Changed the `embabel-common.version` property in `pom.xml` from `0.1.6-SNAPSHOT` to the stable `0.1.6`.
* Updated the parent version in `embabel-agent-dependencies/pom.xml` from `0.1.6` to `0.1.7`.