### PR TITLE
Update embabel-common version to 0.1.7-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <embabel-common.version>0.1.6</embabel-common.version>
+        <embabel-common.version>0.1.7-SNAPSHOT</embabel-common.version>
         <netty.version>4.1.125.Final</netty.version>
     </properties>
 


### PR DESCRIPTION
This pull request makes a minor update to the dependency version in the `pom.xml` file, bumping the `embabel-common` library from `0.1.6` to `0.1.7-SNAPSHOT`. This prepares the project to use the latest development version of the library.