### PR TITLE
Make OpenAi model declarative

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -180,6 +180,8 @@ class AgentPlatformConfiguration(
         @Qualifier("dockerLocalModelsConfig") dockerLocalModelsConfig: Any?,
         @Autowired(required = false)
         @Qualifier("ollamaModelsConfig") ollamaModelsConfig: Any?,
+        @Autowired(required = false)
+        @Qualifier("openAiModelsConfig") openAiModelsConfig: Any?,
     ): ModelProvider {
 
         return ConfigurableModelProvider(

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoader.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.common.ai.autoconfig.AbstractYamlModelLoader
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadata
+import com.embabel.common.ai.autoconfig.LlmAutoConfigProvider
+import com.embabel.common.ai.model.PerTokenPricingModel
+import org.springframework.core.io.DefaultResourceLoader
+import org.springframework.core.io.ResourceLoader
+import java.time.LocalDate
+
+/**
+ * Container for OpenAI model definitions loaded from YAML.
+ *
+ * Implements [LlmAutoConfigProvider] to supply OpenAI-specific model metadata
+ * for auto-configuration purposes.
+ *
+ * @property models list of OpenAI LLM model definitions
+ * @property embeddingModels list of OpenAI embedding model definitions
+ */
+data class OpenAiModelDefinitions(
+    override val models: List<OpenAiModelDefinition> = emptyList(),
+    val embeddingModels: List<OpenAiEmbeddingModelDefinition> = emptyList()
+) : LlmAutoConfigProvider<OpenAiModelDefinition>
+
+/**
+ * OpenAI-specific LLM model definition.
+ *
+ * Implements [LlmAutoConfigMetadata] with OpenAI-specific features
+ * like temperature control and max tokens configuration.
+ *
+ * @property name the unique name of the model
+ * @property modelId the OpenAI API model identifier
+ * @property displayName optional human-readable name
+ * @property knowledgeCutoffDate optional knowledge cutoff date
+ * @property pricingModel optional per-token pricing information
+ * @property maxTokens maximum tokens for completion (default 16384)
+ * @property temperature sampling temperature (default 1.0)
+ * @property topP nucleus sampling parameter
+ * @property specialHandling optional special handling configuration (e.g., GPT-5 temperature)
+ */
+data class OpenAiModelDefinition(
+    override val name: String,
+    override val modelId: String,
+    override val displayName: String? = null,
+    override val knowledgeCutoffDate: LocalDate? = null,
+    override val pricingModel: PerTokenPricingModel? = null,
+    val maxTokens: Int = 16384,
+    val temperature: Double = 1.0,
+    val topP: Double? = null,
+    val specialHandling: SpecialHandlingConfiguration? = null,
+) : LlmAutoConfigMetadata
+
+/**
+ * Special handling configuration for models with unique requirements.
+ *
+ * @property supportsTemperature whether the model supports temperature adjustment
+ */
+data class SpecialHandlingConfiguration(
+    val supportsTemperature: Boolean = true
+)
+
+/**
+ * OpenAI embedding model definition.
+ *
+ * @property name the unique name of the model
+ * @property modelId the model identifier
+ * @property displayName optional human-readable name
+ * @property dimensions embedding vector dimensions
+ * @property pricingModel optional pricing for embeddings
+ */
+data class OpenAiEmbeddingModelDefinition(
+    val name: String,
+    val modelId: String,
+    val displayName: String? = null,
+    val dimensions: Int? = null,
+    val pricingModel: EmbeddingPricingModel? = null
+)
+
+/**
+ * Pricing model for embedding models.
+ *
+ * @property usdPer1mTokens cost per 1 million tokens (USD)
+ */
+data class EmbeddingPricingModel(
+    val usdPer1mTokens: Double
+)
+
+/**
+ * Loader for OpenAI model definitions from YAML configuration.
+ *
+ * Reads model metadata from the configured resource path (default: `classpath:models/openai-models.yml`)
+ * and deserializes it into [OpenAiModelDefinitions]. Validates loaded models to ensure data integrity.
+ *
+ * @property resourceLoader Spring resource loader for accessing classpath resources
+ * @property configPath path to the YAML configuration file
+ */
+class OpenAiModelLoader(
+    resourceLoader: ResourceLoader = DefaultResourceLoader(),
+    configPath: String = DEFAULT_CONFIG_PATH
+) : AbstractYamlModelLoader<OpenAiModelDefinitions>(resourceLoader, configPath) {
+
+    override fun getProviderClass() = OpenAiModelDefinitions::class
+
+    override fun createEmptyProvider() = OpenAiModelDefinitions()
+
+    override fun getProviderName() = "OpenAI"
+
+    override fun validateModels(provider: OpenAiModelDefinitions) {
+        // Validate LLM models
+        provider.models.forEach { model ->
+            validateCommonFields(model)
+            require(model.maxTokens > 0) { "Max tokens must be positive for model ${model.name}" }
+            require(model.temperature in 0.0..2.0) {
+                "Temperature must be between 0 and 2 for model ${model.name}"
+            }
+            model.topP?.let {
+                require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }
+            }
+        }
+
+        // Validate embedding models
+        provider.embeddingModels.forEach { model ->
+            require(model.name.isNotBlank()) { "Embedding model name cannot be blank" }
+            require(model.modelId.isNotBlank()) { "Embedding model ID cannot be blank" }
+            model.dimensions?.let {
+                require(it > 0) { "Dimensions must be positive for embedding model ${model.name}" }
+            }
+            model.pricingModel?.let {
+                require(it.usdPer1mTokens >= 0) {
+                    "Pricing must be non-negative for embedding model ${model.name}"
+                }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Default path to the OpenAI models YAML configuration file.
+         */
+        private const val DEFAULT_CONFIG_PATH = "classpath:models/openai-models.yml"
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
@@ -1,0 +1,113 @@
+# ============================================
+# openai-models.yml
+# ============================================
+# OpenAI and compatible models configuration
+
+models:
+  # ========================================
+  # GPT-5 FAMILY (Latest Generation)
+  # ========================================
+
+  # GPT-5 - Most capable model
+  - name: "gpt5"
+    model_id: "gpt-5"
+    display_name: "GPT-5"
+    knowledge_cutoff_date: "2024-10-01"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 1.25
+      usd_per1m_output_tokens: 10.0
+    special_handling:
+      supports_temperature: false  # GPT-5 uses fixed temperature
+
+  # GPT-5 Mini - Balanced performance and cost
+  - name: "gpt5mini"
+    model_id: "gpt-5-mini"
+    display_name: "GPT-5 Mini"
+    knowledge_cutoff_date: "2024-05-31"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 2.0
+    special_handling:
+      supports_temperature: false
+
+  # GPT-5 Nano - Ultra-fast and cost-effective
+  - name: "gpt5nano"
+    model_id: "gpt-5-nano"
+    display_name: "GPT-5 Nano"
+    knowledge_cutoff_date: "2024-05-31"
+    max_tokens: 8192
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 0.05
+      usd_per1m_output_tokens: 0.40
+    special_handling:
+      supports_temperature: false
+
+  # ========================================
+  # GPT-4.1 FAMILY
+  # ========================================
+
+  # GPT-4.1 - High capability model
+  - name: "gpt41"
+    model_id: "gpt-4.1"
+    display_name: "GPT-4.1"
+    knowledge_cutoff_date: "2024-08-06"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 2.0
+      usd_per1m_output_tokens: 8.0
+
+  # GPT-4.1 Mini - Smaller, faster variant
+  - name: "gpt41mini"
+    model_id: "gpt-4.1-mini"
+    display_name: "GPT-4.1 Mini"
+    knowledge_cutoff_date: "2024-07-18"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 0.40
+      usd_per1m_output_tokens: 1.6
+
+  # GPT-4.1 Nano - Most efficient variant
+  - name: "gpt41nano"
+    model_id: "gpt-4.1-nano"
+    display_name: "GPT-4.1 Nano"
+    knowledge_cutoff_date: "2024-08-06"
+    max_tokens: 8192
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 0.1
+      usd_per1m_output_tokens: 0.4
+
+# ========================================
+# EMBEDDING MODELS
+# ========================================
+embedding_models:
+  # Default text embedding model
+  - name: "text_embedding_3_large"
+    model_id: "text-embedding-3-large"
+    display_name: "Text Embedding 3 Large"
+    dimensions: 3072
+    pricing_model:
+      usd_per1m_tokens: 0.13
+
+  # Smaller embedding model
+  - name: "text_embedding_3_small"
+    model_id: "text-embedding-3-small"
+    display_name: "Text Embedding 3 Small"
+    dimensions: 1536
+    pricing_model:
+      usd_per1m_tokens: 0.02
+
+  # Legacy embedding model
+  - name: "text_embedding_ada_002"
+    model_id: "text-embedding-ada-002"
+    display_name: "Text Embedding Ada 002"
+    dimensions: 1536
+    pricing_model:
+      usd_per1m_tokens: 0.10

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
@@ -1,0 +1,528 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.DefaultResourceLoader
+import java.io.File
+import java.nio.file.Files
+
+class OpenAiModelLoaderTest {
+
+    @Test
+    fun `should load valid model definitions from default YAML file`() {
+        // Arrange
+        val loader = OpenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isNotEmpty(), "Should load at least one model")
+
+        // Verify first model has required fields
+        val firstModel = result.models.first()
+        assertNotNull(firstModel.name)
+        assertNotNull(firstModel.modelId)
+        assertTrue(firstModel.name.isNotBlank(), "Model name should not be blank")
+        assertTrue(firstModel.modelId.isNotBlank(), "Model ID should not be blank")
+    }
+
+    @Test
+    fun `should validate all loaded models have correct default values`() {
+        // Arrange
+        val loader = OpenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        result.models.forEach { model ->
+            // Verify defaults
+            assertTrue(model.maxTokens > 0, "Max tokens should be positive for ${model.name}")
+            assertTrue(model.temperature in 0.0..2.0, "Temperature should be in valid range for ${model.name}")
+
+            // Verify optional fields when present
+            model.topP?.let {
+                assertTrue(it in 0.0..1.0, "Top P should be between 0 and 1 for ${model.name}")
+            }
+        }
+    }
+
+    @Test
+    fun `should verify specific known models are loaded`() {
+        // Arrange
+        val loader = OpenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify some known OpenAI models are present
+        val modelNames = result.models.map { it.name }
+        assertTrue(modelNames.isNotEmpty(), "Should have loaded model names")
+
+        // Verify at least one model has pricing info
+        assertTrue(result.models.any { it.pricingModel != null },
+            "At least one model should have pricing information")
+    }
+
+    @Test
+    fun `should verify GPT-5 models have temperature handling configuration`() {
+        // Arrange
+        val loader = OpenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify GPT-5 models have special handling configured
+        val gpt5Models = result.models.filter { it.name.startsWith("gpt5") }
+        assertTrue(gpt5Models.isNotEmpty(), "Should have GPT-5 models")
+
+        gpt5Models.forEach { model ->
+            assertNotNull(model.specialHandling, "GPT-5 models should have special handling")
+            assertEquals(false, model.specialHandling?.supportsTemperature,
+                "GPT-5 models should not support temperature adjustment")
+        }
+    }
+
+    @Test
+    fun `should verify embedding models are loaded`() {
+        // Arrange
+        val loader = OpenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertTrue(result.embeddingModels.isNotEmpty(), "Should load at least one embedding model")
+
+        result.embeddingModels.forEach { embedding ->
+            assertNotNull(embedding.name)
+            assertNotNull(embedding.modelId)
+            assertNotNull(embedding.dimensions, "Dimensions should not be null for ${embedding.name}")
+            embedding.dimensions?.let { dims ->
+                assertTrue(dims > 0, "Dimensions should be positive for ${embedding.name}")
+            }
+            assertTrue(embedding.name.isNotBlank(), "Embedding name should not be blank")
+            assertTrue(embedding.modelId.isNotBlank(), "Embedding model ID should not be blank")
+        }
+    }
+
+    @Test
+    fun `should validate embedding model dimensions and pricing`() {
+        // Arrange
+        val loader = OpenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        result.embeddingModels.forEach { embedding ->
+            assertNotNull(embedding.dimensions, "Dimensions should not be null for ${embedding.name}")
+            embedding.dimensions?.let { dims ->
+                assertTrue(dims > 0, "Dimensions should be positive for ${embedding.name}")
+            }
+
+            embedding.pricingModel?.let { pricing ->
+                assertTrue(pricing.usdPer1mTokens >= 0.0,
+                    "Pricing should be non-negative for ${embedding.name}")
+            }
+        }
+    }
+
+    @Test
+    fun `should return empty definitions when file does not exist`() {
+        // Arrange
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "classpath:nonexistent-file.yml"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isEmpty(), "Should return empty list when file not found")
+        assertTrue(result.embeddingModels.isEmpty(), "Should return empty embedding list when file not found")
+    }
+
+    @Test
+    fun `should handle invalid YAML gracefully`() {
+        // Arrange
+        val tempFile = Files.createTempFile("invalid", ".yml").toFile()
+        tempFile.writeText("invalid: yaml: content: ][")
+        tempFile.deleteOnExit()
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isEmpty(), "Should return empty list on parse error")
+        assertTrue(result.embeddingModels.isEmpty(), "Should return empty embedding list on parse error")
+    }
+
+    @Test
+    fun `should validate model with invalid maxTokens`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: gpt-test
+                max_tokens: -100
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for negative maxTokens")
+    }
+
+    @Test
+    fun `should validate model with invalid temperature`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: gpt-test
+                temperature: 3.0
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for temperature out of range")
+    }
+
+    @Test
+    fun `should validate model with invalid topP`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: gpt-test
+                top_p: 1.5
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for topP out of range")
+    }
+
+    @Test
+    fun `should validate model with blank name`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: ""
+                model_id: gpt-test
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for blank name")
+    }
+
+    @Test
+    fun `should load valid model with all optional fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: gpt-test
+                display_name: Test Model
+                max_tokens: 4096
+                temperature: 0.7
+                top_p: 0.9
+                special_handling:
+                  supports_temperature: false
+                pricing_model:
+                  usd_per1m_input_tokens: 10.0
+                  usd_per1m_output_tokens: 20.0
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size)
+        val model = result.models.first()
+        assertEquals("test-model", model.name)
+        assertEquals("gpt-test", model.modelId)
+        assertEquals("Test Model", model.displayName)
+        assertEquals(4096, model.maxTokens)
+        assertEquals(0.7, model.temperature)
+        assertEquals(0.9, model.topP)
+        assertNotNull(model.specialHandling)
+        assertEquals(false, model.specialHandling?.supportsTemperature)
+        assertNotNull(model.pricingModel)
+        assertEquals(10.0, model.pricingModel?.usdPer1mInputTokens)
+        assertEquals(20.0, model.pricingModel?.usdPer1mOutputTokens)
+    }
+
+    @Test
+    fun `should load multiple models correctly`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: model-1
+                model_id: gpt-1
+                max_tokens: 2000
+              - name: model-2
+                model_id: gpt-2
+                max_tokens: 4000
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(2, result.models.size)
+        assertEquals("model-1", result.models[0].name)
+        assertEquals("model-2", result.models[1].name)
+        assertEquals(2000, result.models[0].maxTokens)
+        assertEquals(4000, result.models[1].maxTokens)
+    }
+
+    @Test
+    fun `should load model with minimal fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: minimal-model
+                model_id: gpt-minimal
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size)
+        val model = result.models.first()
+        assertEquals("minimal-model", model.name)
+        assertEquals("gpt-minimal", model.modelId)
+        assertNull(model.displayName)
+        assertEquals(16384, model.maxTokens) // Default value
+        assertEquals(1.0, model.temperature) // Default value
+        assertNull(model.topP)
+        assertNull(model.specialHandling)
+        assertNull(model.pricingModel)
+    }
+
+    @Test
+    fun `should validate embedding model with invalid dimensions`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            embedding_models:
+              - name: test-embedding
+                model_id: text-embedding-test
+                dimensions: -100
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.embeddingModels.isEmpty(), "Should fail validation for negative dimensions")
+    }
+
+    @Test
+    fun `should validate embedding model with blank name`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            embedding_models:
+              - name: ""
+                model_id: text-embedding-test
+                dimensions: 1536
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.embeddingModels.isEmpty(), "Should fail validation for blank name")
+    }
+
+    @Test
+    fun `should load valid embedding model with all fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            embedding_models:
+              - name: test-embedding
+                model_id: text-embedding-test
+                display_name: Test Embedding
+                dimensions: 1536
+                pricing_model:
+                  usd_per1m_tokens: 0.02
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.embeddingModels.size)
+        val embedding = result.embeddingModels.first()
+        assertEquals("test-embedding", embedding.name)
+        assertEquals("text-embedding-test", embedding.modelId)
+        assertEquals("Test Embedding", embedding.displayName)
+        assertEquals(1536, embedding.dimensions)
+        assertNotNull(embedding.pricingModel)
+        assertEquals(0.02, embedding.pricingModel?.usdPer1mTokens)
+    }
+
+    @Test
+    fun `should load multiple embedding models correctly`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            embedding_models:
+              - name: embedding-1
+                model_id: text-embedding-1
+                dimensions: 1536
+              - name: embedding-2
+                model_id: text-embedding-2
+                dimensions: 3072
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(2, result.embeddingModels.size)
+        assertEquals("embedding-1", result.embeddingModels[0].name)
+        assertEquals("embedding-2", result.embeddingModels[1].name)
+        assertEquals(1536, result.embeddingModels[0].dimensions)
+        assertEquals(3072, result.embeddingModels[1].dimensions)
+    }
+
+    @Test
+    fun `should load both LLM and embedding models from same file`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: llm-1
+                model_id: gpt-test-1
+                max_tokens: 4096
+              - name: llm-2
+                model_id: gpt-test-2
+                max_tokens: 8192
+            embedding_models:
+              - name: embedding-1
+                model_id: text-embedding-1
+                dimensions: 1536
+              - name: embedding-2
+                model_id: text-embedding-2
+                dimensions: 3072
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(2, result.models.size, "Should load 2 LLM models")
+        assertEquals(2, result.embeddingModels.size, "Should load 2 embedding models")
+    }
+
+    @Test
+    fun `should validate embedding model with invalid pricing`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            embedding_models:
+              - name: test-embedding
+                model_id: text-embedding-test
+                dimensions: 1536
+                pricing_model:
+                  usd_per1m_tokens: -0.5
+        """.trimIndent())
+
+        val loader = OpenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.embeddingModels.isEmpty(), "Should fail validation for negative pricing")
+    }
+
+    private fun createTempYamlFile(content: String): File {
+        val tempFile = Files.createTempFile("test-openai", ".yml").toFile()
+        tempFile.writeText(content)
+        tempFile.deleteOnExit()
+        return tempFile
+    }
+}


### PR DESCRIPTION
This pull request introduces a major refactor of OpenAI model configuration for the agent platform, moving from hardcoded model beans to a dynamic, YAML-driven autoconfiguration approach. OpenAI models and embeddings are now defined in a YAML file, loaded at startup, and registered as beans dynamically. This enables easier updates and additions of models without code changes, provides better validation, and aligns OpenAI configuration with the patterns used for other providers.

Key changes include:

**Dynamic Model Registration and Configuration**
- Replaced all hardcoded OpenAI model and embedding beans in `OpenAiModelsConfig` with a dynamic registration mechanism that loads model definitions from a YAML file at startup, using a new `OpenAiModelLoader` and `LlmAutoConfigMetadataLoader`. Beans are registered for each model and embedding found in the YAML. (`OpenAiModelsConfig.kt`, `OpenAiModelLoader.kt`, `openai-models.yml`) [[1]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daR81-R82) [[2]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL92-R185) [[3]](diffhunk://#diff-5f61e732feb51e70d5782f618e565372b215b0ed9d3d9278bbea054077818894R1-R157) [[4]](diffhunk://#diff-bb2de57ba57baddd2643e6a86359e1590cee73aa407b63989cad2fa7939efe86R1-R113)

**New Model Definition and Loader Classes**
- Added `OpenAiModelDefinitions`, `OpenAiModelDefinition`, `OpenAiEmbeddingModelDefinition`, and related classes to represent the structure of OpenAI models and embeddings, with validation logic to ensure correctness of loaded data. (`OpenAiModelLoader.kt`)

**YAML-based Model Metadata**
- Introduced `openai-models.yml`, a YAML file that defines all supported OpenAI models and embedding models, including their names, IDs, display names, token limits, pricing, and special handling flags. This makes model management more maintainable and extensible. (`openai-models.yml`)

**Options Converter Improvements**
- Added a new `StandardOpenAiOptionsConverter` for models that support all OpenAI parameters, and updated the logic to select the appropriate converter based on model features (e.g., GPT-5 models that do not support temperature adjustment). (`OpenAiModelsConfig.kt`)

**Spring Integration**
- Updated the main agent platform configuration to accept an optional `openAiModelsConfig` bean, supporting the new dynamic configuration. (`AgentPlatformConfiguration.kt`)

These changes make it much easier to add, remove, or update OpenAI models and embedding models by simply editing a YAML file, and reduce the risk of errors from manual bean management in code.