### PR TITLE
Remove blank line from top of pom.xml

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/embabel-agent-starters/embabel-agent-starter-lmstudio/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-lmstudio/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This pull request makes minor formatting changes by removing an extra blank line at the top of two Maven `pom.xml` files. There is no impact on functionality or dependencies.