### PR TITLE
Add embabel-agent-domain module

### DIFF
--- a/embabel-agent-domain/pom.xml
+++ b/embabel-agent-domain/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-parent</artifactId>
+        <version>0.3.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-domain</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Domain Types</name>
+    <description>Embabel Agent Domain Types</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.common</groupId>
+            <artifactId>embabel-common-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.common</groupId>
+            <artifactId>embabel-common-util</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.common</groupId>
+            <artifactId>embabel-common-ai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/io/SystemOutput.kt
+++ b/embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/io/SystemOutput.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.domain.io
+
+import com.embabel.common.core.types.Timestamped
+import java.io.File
+import java.time.Instant
+
+interface SystemOutput : Timestamped
+
+data class FileArtifact(
+    val file: File,
+    override val timestamp: Instant = Instant.now(),
+) : SystemOutput {
+
+    constructor(directory: String, outputFile: String) : this(File(directory, outputFile))
+}

--- a/embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/io/UserInput.kt
+++ b/embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/io/UserInput.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.domain.io
+
+import com.embabel.agent.domain.library.HasContent
+import com.embabel.common.core.types.Timestamped
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import java.time.Instant
+
+interface SystemInput : Timestamped
+
+/**
+ * Superinterface for all inputs that come from users
+ * This can be useful to drive guardrails
+ */
+interface UserContent : HasContent, Timestamped
+
+/**
+ * Superinterface for all inputs that come from AI assistants
+ * This can be useful to drive guardrails
+ */
+interface AssistantContent : HasContent, Timestamped
+
+/**
+ * Special class that represents a single user input
+ * Starting point for many flows.
+ */
+@JsonIgnoreProperties(value = ["timestamp"], allowGetters = true)
+data class UserInput(
+    @get:JsonPropertyDescription("user input")
+    override val content: String,
+    override val timestamp: Instant = Instant.now(),
+) : SystemInput, UserContent {
+
+    // For Java
+    constructor (content: String) : this(content, Instant.now())
+}

--- a/embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/library/Content.kt
+++ b/embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/library/Content.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.domain.library
+
+import com.embabel.common.ai.prompt.PromptContributor
+import com.embabel.common.core.types.Timestamped
+
+
+/**
+ * Interface when an object has a single important text component.
+ */
+interface HasContent {
+
+    /**
+     * Content associated with this object.
+     */
+    val content: String
+}

--- a/embabel-agent-domain/src/test/kotlin/com/embabel/agent/domain/io/UserInputSerializationTest.kt
+++ b/embabel-agent-domain/src/test/kotlin/com/embabel/agent/domain/io/UserInputSerializationTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.domain.io
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import org.junit.Test
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import kotlin.test.assertEquals
+
+class UserInputSerializationTest {
+
+    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    @Test
+    fun `can deserialize`() {
+        val content = "Hello, world!"
+        val json = """
+            { "content": "$content" }
+        """.trimIndent()
+        val userInput = objectMapper.readValue(json, UserInput::class.java)
+        assertEquals(content, userInput.content)
+    }
+
+}


### PR DESCRIPTION
This pull request introduces the initial domain module for the Embabel Agent, establishing foundational types and interfaces for handling user input, system output, and content representation. It also sets up the project's Maven configuration and includes a basic test for serialization.

**Domain Model Foundations:**

* Added `UserInput`, `SystemInput`, `UserContent`, and `AssistantContent` interfaces and data classes in `UserInput.kt`, providing a structure for representing user and assistant inputs, as well as system-level inputs. (`embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/io/UserInput.kt`)
* Introduced `SystemOutput` interface and `FileArtifact` data class in `SystemOutput.kt` to represent outputs, particularly file-based artifacts, with timestamping. (`embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/io/SystemOutput.kt`)
* Defined the `HasContent` interface in `Content.kt` for objects encapsulating a primary text component, supporting consistent content handling across domain types. (`embabel-agent-domain/src/main/kotlin/com/embabel/agent/domain/library/Content.kt`)

**Project Configuration and Testing:**

* Added a new Maven module with a `pom.xml` specifying dependencies, build plugins, and project metadata for the domain layer. (`embabel-agent-domain/pom.xml`)
* Implemented a unit test for verifying JSON deserialization of the `UserInput` class, ensuring correct serialization logic. (`embabel-agent-domain/src/test/kotlin/com/embabel/agent/domain/io/UserInputSerializationTest.kt`)