### PR TITLE
Add Web dependencies for Tests

### DIFF
--- a/embabel-agent-test-support/embabel-agent-test-internal/pom.xml
+++ b/embabel-agent-test-support/embabel-agent-test-internal/pom.xml
@@ -35,6 +35,16 @@
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test-domain</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
     </dependencies> 
 
 </project>


### PR DESCRIPTION
This pull request adds new dependencies to the `embabel-agent-test-internal` module to support web and servlet functionality.

Dependency additions:

* Added `spring-webmvc` as a dependency to enable Spring MVC features.
* Added `jakarta.servlet-api` as a dependency to provide servlet API support.