### PR TITLE
Adding support for Mistral AI API.

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/MistralAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/MistralAiModels.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.models
+
+/**
+ * Provides constants for Mistral AI model identifiers.
+ * This class contains the latest model versions for models offered by Mistral AI.
+ */
+class MistralAiModels {
+
+	companion object {
+
+        const val PROVIDER = "Mistral AI"
+
+		const val MISTRAL_MEDIUM_31 = "mistral-medium-2508"
+
+        const val MISTRAL_SMALL_32 = "mistral-small-2506"
+
+        const val MINISTRAL_8B = "ministral-8b-2410"
+
+        const val MINISTRAL_3B = "ministral-3b-2410"
+
+        const val CODESTRAL = "codestral-2508"
+
+        const val DEVSTRAL_MEDIUM_10 = "devstral-medium-2507"
+
+        const val DEVSTRAL_SMALL_11 = "devstral-small-2507"
+
+        const val MISTRAL_LARGE_21 = "mistral-large-2411"
+	}
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -187,6 +187,8 @@ class AgentPlatformConfiguration(
         @Qualifier("openAiModelsConfig") openAiModelsConfig: Any?,
         @Autowired(required = false)
         @Qualifier("geminiModelsConfig") geminiModelsConfig: Any?,
+        @Autowired(required = false)
+        @Qualifier("mistralAiModelsConfig") mistralAiModelsConfig: Any?,
     ): ModelProvider {
 
         return ConfigurableModelProvider(

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.embabel.agent</groupId>
+		<artifactId>embabel-agent-autoconfigure</artifactId>
+		<version>0.3.1-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>embabel-agent-mistral-ai-autoconfigure</artifactId>
+	<packaging>jar</packaging>
+	<name>Embabel Agent Autoconfiguration Models MistralAI</name>
+	<description>MistralAI Models for Embabel Agent API</description>
+	<url>https://github.com/embabel/embabel-agent</url>
+
+	<scm>
+		<url>https://github.com/embabel/embabel-agent</url>
+		<connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+		<developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.embabel.agent</groupId>
+			<artifactId>embabel-agent-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-mistral-ai</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.embabel.agent</groupId>
+			<artifactId>embabel-agent-test-internal</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/mistralai/AgentMistralAiAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/mistralai/AgentMistralAiAutoConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.mistralai;
+
+import com.embabel.agent.config.models.mistralai.MistralAiModelsConfig;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Autoconfiguration for Mistral AI models in the Embabel Agent system.
+ * <p>
+ * This class serves as a Spring Boot autoconfiguration entry point that:
+ * - Imports the [MistralAIModelsConfig] configuration to dynamically register Mistral AI model beans
+ */
+@AutoConfiguration
+@AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
+@Import(MistralAiModelsConfig.class)
+public class AgentMistralAiAutoConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(AgentMistralAiAutoConfiguration.class);
+
+    @PostConstruct
+    public void logEvent() {
+        logger.info("AgentMistralAiAutoConfiguration about to proceed...");
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoader.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.mistralai
+
+import com.embabel.common.ai.autoconfig.AbstractYamlModelLoader
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadata
+import com.embabel.common.ai.autoconfig.LlmAutoConfigProvider
+import com.embabel.common.ai.model.PerTokenPricingModel
+import org.springframework.core.io.DefaultResourceLoader
+import org.springframework.core.io.ResourceLoader
+import java.time.LocalDate
+
+/**
+ * Container for Mistral AI model definitions loaded from YAML.
+ *
+ * Implements [LlmAutoConfigProvider] to supply Mistral AI-specific model metadata
+ * for auto-configuration purposes.
+ *
+ * @property models list of Mistral AI model definitions
+ */
+data class MistralAiModelDefinitions(
+	override val models: List<MistralAiModelDefinition> = emptyList()
+) : LlmAutoConfigProvider<MistralAiModelDefinition>
+
+/**
+ * Mistral AI-specific model definition.
+ *
+ * Implements [LlmAutoConfigMetadata] with Mistral AI-specific features
+ * like thinking mode and custom parameter defaults.
+ *
+ * @property name the unique name of the model
+ * @property modelId the Mistral AI API model identifier
+ * @property displayName optional human-readable name
+ * @property knowledgeCutoffDate optional knowledge cutoff date
+ * @property pricingModel optional per-token pricing information
+ * @property maxTokens maximum tokens for completion (default 8192)
+ * @property temperature sampling temperature (default 1.0)
+ * @property topP nucleus sampling parameter
+ */
+data class MistralAiModelDefinition(
+	override val name: String,
+	override val modelId: String,
+	override val displayName: String? = null,
+	override val knowledgeCutoffDate: LocalDate? = null,
+	override val pricingModel: PerTokenPricingModel? = null,
+	val maxTokens: Int = 32768,
+	val temperature: Double = 1.0,
+	val topP: Double? = null,
+) : LlmAutoConfigMetadata
+
+class MistralAiModelLoader(
+	resourceLoader: ResourceLoader = DefaultResourceLoader(),
+	configPath: String = DEFAULT_CONFIG_PATH
+) : AbstractYamlModelLoader<MistralAiModelDefinitions>(resourceLoader, configPath) {
+
+	override fun getProviderClass() = MistralAiModelDefinitions::class
+
+	override fun createEmptyProvider() = MistralAiModelDefinitions()
+
+	override fun getProviderName() = "Mistral AI"
+
+	override fun validateModels(provider: MistralAiModelDefinitions) {
+		provider.models.forEach { model ->
+			validateCommonFields(model)
+			require(model.maxTokens > 0) { "Max tokens must be positive for model ${model.name}" }
+            require(model.temperature in 0.0..2.0) {
+                "Temperature must be between 0 and 2 for model ${model.name}"
+            }
+			model.topP?.let {
+				require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }
+			}
+		}
+	}
+
+	companion object {
+		/**
+		 * Default path to the Anthropic models YAML configuration file.
+		 */
+		private const val DEFAULT_CONFIG_PATH = "classpath:models/mistral-ai-models.yml"
+	}
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelsConfig.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.mistralai
+
+import com.embabel.agent.api.models.MistralAiModels
+import com.embabel.agent.spi.common.RetryProperties
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadataLoader
+import com.embabel.common.ai.model.Llm
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.OptionsConverter
+import com.embabel.common.ai.model.PerTokenPricingModel
+import io.micrometer.observation.ObservationRegistry
+import jakarta.annotation.PostConstruct
+import org.slf4j.LoggerFactory
+import org.springframework.ai.mistralai.MistralAiChatModel
+import org.springframework.ai.mistralai.MistralAiChatOptions
+import org.springframework.ai.mistralai.api.MistralAiApi
+import org.springframework.ai.model.tool.ToolCallingManager
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * Configuration properties for Mistral AI models.
+ * These properties control retry behavior when calling Mistral AI APIs.
+ */
+@ConfigurationProperties(prefix = "embabel.agent.platform.models.mistralai")
+class MistralAiProperties : RetryProperties {
+	/**
+	 * Maximum number of attempts.
+	 */
+	override var maxAttempts: Int = 10
+
+	/**
+	 * Initial backoff interval (in milliseconds).
+	 */
+	override var backoffMillis: Long = 5_000L
+
+	/**
+	 * Backoff interval multiplier.
+	 */
+	override var backoffMultiplier: Double = 5.0
+
+	/**
+	 * Maximum backoff interval (in milliseconds).
+	 */
+	override var backoffMaxInterval: Long = 180_000L
+}
+
+/**
+ * Configuration for well-known MistralAI language and embedding models.
+ * Provides bean definitions for various models with their corresponding
+ * capabilities, knowledge cutoff dates, and pricing models.
+ */
+@Configuration(proxyBeanMethods = false)
+class MistralAiModelsConfig(
+	@param:Value("\${MISTRAL_BASE_URL:}")
+	private val baseUrl: String,
+	@param:Value("\${MISTRAL_API_KEY}")
+	private val apiKey: String,
+	private val properties: MistralAiProperties,
+	private val observationRegistry: ObjectProvider<ObservationRegistry>,
+	private val configurableBeanFactory: ConfigurableBeanFactory,
+	private val modelLoader: LlmAutoConfigMetadataLoader<MistralAiModelDefinitions> = MistralAiModelLoader(),
+) {
+	private val logger = LoggerFactory.getLogger(MistralAiModelsConfig::class.java)
+
+	init {
+		logger.info("Mistral AI models are available: {}", properties)
+	}
+
+	@PostConstruct
+	fun registerModelBeans() {
+		modelLoader
+			.loadAutoConfigMetadata().models.forEach { modelDef ->
+				try {
+					val llm = createMistralAiLlm(modelDef)
+
+					// Register as singleton bean with the configured bean name
+					configurableBeanFactory.registerSingleton(modelDef.name, llm)
+
+					logger.info(
+						"Registered Mistral AI model bean: {} -> {}",
+						modelDef.name, modelDef.modelId
+					)
+
+				} catch (e: Exception) {
+					logger.error(
+						"Failed to create model: {} ({})",
+						modelDef.name, modelDef.modelId, e
+					)
+					throw e
+				}
+			}
+	}
+
+	/**
+	 * Creates an individual Mistral AI model from configuration.
+	 */
+	private fun createMistralAiLlm(modelDef: MistralAiModelDefinition): Llm {
+		val chatModel = MistralAiChatModel
+			.builder()
+			.defaultOptions(createDefaultOptions(modelDef))
+			.mistralAiApi(createMistralAiApi())
+			.toolCallingManager(
+				ToolCallingManager.builder()
+					.observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+					.build()
+			)
+			.retryTemplate(properties.retryTemplate("mistral-ai-${modelDef.modelId}"))
+			.observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+			.build()
+
+		return Llm(
+			name = modelDef.modelId,
+			model = chatModel,
+			provider = MistralAiModels.PROVIDER,
+			optionsConverter = MistralAiOptionsConverter,
+			knowledgeCutoffDate = modelDef.knowledgeCutoffDate,
+			pricingModel = modelDef.pricingModel?.let {
+				PerTokenPricingModel(
+					usdPer1mInputTokens = it.usdPer1mInputTokens,
+					usdPer1mOutputTokens = it.usdPer1mOutputTokens,
+				)
+			}
+		)
+	}
+
+	/**
+	 * Creates default options for a model based on YAML configuration.
+	 */
+	private fun createDefaultOptions(modelDef: MistralAiModelDefinition): MistralAiChatOptions {
+		return MistralAiChatOptions.builder()
+			.model(modelDef.modelId)
+			.maxTokens(modelDef.maxTokens)
+			.temperature(modelDef.temperature)
+			.apply {
+				modelDef.topP?.let { topP(it) }
+			}
+			.build()
+	}
+
+	private fun createMistralAiApi(): MistralAiApi {
+		val builder = MistralAiApi.builder().apiKey(apiKey)
+		if (baseUrl.isNotBlank()) {
+			logger.info("Using custom Mistral AI base URL: {}", baseUrl)
+			builder.baseUrl(baseUrl)
+		}
+		// add observation registry to rest and web client builders
+		builder
+			.restClientBuilder(
+				RestClient.builder()
+					.observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+			)
+		builder
+			.webClientBuilder(
+				WebClient.builder()
+					.observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+			)
+
+		return builder.build()
+	}
+}
+
+object MistralAiOptionsConverter : OptionsConverter<MistralAiChatOptions> {
+
+	override fun convertOptions(options: LlmOptions): MistralAiChatOptions =
+		MistralAiChatOptions.builder()
+			.temperature(options.temperature)
+			.topP(options.topP)
+			.maxTokens(options.maxTokens)
+			.build()
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
@@ -1,0 +1,86 @@
+# ============================================
+# mistral-ai-models.yml
+# ============================================
+# Updated with latest Mistral AI models as of November 2025
+# Using official Mistral AI API aliases
+
+models:
+  - name: "mistral-medium-2508"
+    model_id: "mistral-medium-2508"
+    display_name: "Mistral Medium 3.1"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.4
+      usd_per1m_output_tokens: 2.0
+
+  - name: "ministral-3b-2410"
+    model_id: "ministral-3b-2410"
+    display_name: "Ministral 3B"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.04
+      usd_per1m_output_tokens: 0.04
+
+  - name: "mistral-small-2506"
+    model_id: "mistral-small-2506"
+    display_name: "Mistral Small 3.2"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.1
+      usd_per1m_output_tokens: 0.3
+
+  - name: "ministral-8b-2410"
+    model_id: "ministral-8b-2410"
+    display_name: "Ministral 8B"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.1
+      usd_per1m_output_tokens: 0.1
+
+  - name: "codestral-2508"
+    model_id: "codestral-2508"
+    display_name: "Codestral"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.3
+      usd_per1m_output_tokens: 0.9
+
+  - name: "devstral-small-2507"
+    model_id: "devstral-small-2507"
+    display_name: "Devstral Small 1.1"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.1
+      usd_per1m_output_tokens: 0.3
+
+  - name: "devstral-medium-2507"
+    model_id: "devstral-medium-2507"
+    display_name: "Devstral Medium 1.0"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.4
+      usd_per1m_output_tokens: 2.0
+
+  - name: "open-mistral-nemo-2407"
+    model_id: "open-mistral-nemo-2407"
+    display_name: "Mistral Nemo 12B"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.15
+      usd_per1m_output_tokens: 0.15
+
+  - name: "mistral-medium-2505"
+    model_id: "mistral-medium-2505"
+    display_name: "Mistral Medium 3"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 0.4
+      usd_per1m_output_tokens: 2.0
+
+  - name: "mistral-large-2411"
+    model_id: "mistral-large-2411"
+    display_name: "Mistral Large 2.1"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 2.0
+      usd_per1m_output_tokens: 6.0

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoaderTest.kt
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.mistralai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.DefaultResourceLoader
+import java.io.File
+import java.nio.file.Files
+
+class MistralAiModelLoaderTest {
+
+    @Test
+    fun `should load valid model definitions from default YAML file`() {
+        // Arrange
+        val loader = MistralAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isNotEmpty(), "Should load at least one model")
+
+        // Verify the first model has required fields
+        val firstModel = result.models.first()
+        assertNotNull(firstModel.name)
+        assertNotNull(firstModel.modelId)
+        assertTrue(firstModel.name.isNotBlank(), "Model name should not be blank")
+        assertTrue(firstModel.modelId.isNotBlank(), "Model ID should not be blank")
+    }
+
+    @Test
+    fun `should validate all loaded models have correct default values`() {
+        // Arrange
+        val loader = MistralAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        result.models.forEach { model ->
+            // Verify defaults
+            assertTrue(model.maxTokens > 0, "Max tokens should be positive for ${model.name}")
+            assertTrue(model.temperature in 0.0..2.0, "Temperature should be in valid range for ${model.name}")
+
+            // Verify optional fields when present
+            model.topP?.let {
+                assertTrue(it in 0.0..1.0, "Top P should be between 0 and 1 for ${model.name}")
+            }
+        }
+    }
+
+    @Test
+    fun `should verify specific known models are loaded`() {
+        // Arrange
+        val loader = MistralAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify some known Mistral AI models are present
+        val modelNames = result.models.map { it.name }
+        assertTrue(modelNames.isNotEmpty(), "Should have loaded model names")
+
+        // Verify at least one model has pricing info
+        assertTrue(result.models.any { it.pricingModel != null },
+            "At least one model should have pricing information")
+    }
+
+    @Test
+    fun `should return empty definitions when file does not exist`() {
+        // Arrange
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "classpath:nonexistent-file.yml"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isEmpty(), "Should return empty list when file not found")
+    }
+
+    @Test
+    fun `should handle invalid YAML gracefully`() {
+        // Arrange
+        val tempFile = Files.createTempFile("invalid", ".yml").toFile()
+        tempFile.writeText("invalid: yaml: content: ][")
+        tempFile.deleteOnExit()
+
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isEmpty(), "Should return empty list on parse error")
+    }
+
+    @Test
+    fun `should validate model with invalid maxTokens`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                max_tokens: -100
+        """.trimIndent())
+
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for negative maxTokens")
+    }
+
+    @Test
+    fun `should validate model with invalid temperature`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                temperature: 3.0
+        """.trimIndent())
+
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for temperature out of range")
+    }
+
+    @Test
+    fun `should validate model with invalid topP`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                top_p: 1.5
+        """.trimIndent())
+
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for topP out of range")
+    }
+
+    @Test
+    fun `should validate model with blank name`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: ""
+                model_id: test-id
+        """.trimIndent())
+
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for blank name")
+    }
+
+    @Test
+    fun `should load valid model with all optional fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: mistral-test
+                display_name: Test Model
+                max_tokens: 4096
+                temperature: 0.7
+                top_p: 0.9
+                pricing_model:
+                  usd_per1m_input_tokens: 10.0
+                  usd_per1m_output_tokens: 20.0
+        """.trimIndent())
+
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size)
+        val model = result.models.first()
+        assertEquals("test-model", model.name)
+        assertEquals("mistral-test", model.modelId)
+        assertEquals("Test Model", model.displayName)
+        assertEquals(4096, model.maxTokens)
+        assertEquals(0.7, model.temperature)
+        assertEquals(0.9, model.topP)
+        assertNotNull(model.pricingModel)
+        assertEquals(10.0, model.pricingModel?.usdPer1mInputTokens)
+        assertEquals(20.0, model.pricingModel?.usdPer1mOutputTokens)
+    }
+
+    @Test
+    fun `should load multiple models correctly`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: model-1
+                model_id: mistral-1
+                max_tokens: 2000
+              - name: model-2
+                model_id: mistral-2
+                max_tokens: 4000
+        """.trimIndent())
+
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(2, result.models.size)
+        assertEquals("model-1", result.models[0].name)
+        assertEquals("model-2", result.models[1].name)
+        assertEquals(2000, result.models[0].maxTokens)
+        assertEquals(4000, result.models[1].maxTokens)
+    }
+
+    @Test
+    fun `should load model with minimal fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: minimal-model
+                model_id: mistral-minimal
+        """.trimIndent())
+
+        val loader = MistralAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size)
+        val model = result.models.first()
+        assertEquals("minimal-model", model.name)
+        assertEquals("mistral-minimal", model.modelId)
+        assertNull(model.displayName)
+        assertEquals(32768, model.maxTokens) // Default value
+        assertEquals(1.0, model.temperature) // Default value
+        assertNull(model.topP)
+        assertNull(model.pricingModel)
+    }
+
+    private fun createTempYamlFile(content: String): File {
+        val tempFile = Files.createTempFile("test-mistral-ai", ".yml").toFile()
+        tempFile.writeText(content)
+        tempFile.deleteOnExit()
+        return tempFile
+    }
+}

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -31,6 +31,7 @@
         <module>models/embabel-agent-deepseek-autoconfigure</module>
         <module>models/embabel-agent-gemini-autoconfigure</module>
         <module>models/embabel-agent-google-genai-autoconfigure</module>
+        <module>models/embabel-agent-mistral-ai-autoconfigure</module>
     </modules>
 
     <build>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -122,6 +122,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-mistral-ai-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-eval</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -184,7 +190,7 @@
                 <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-anthropic</artifactId>
                 <version>${project.version}</version>
-            </dependency>            
+            </dependency>
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
@@ -213,6 +219,12 @@
             <dependency>
                 <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-google-genai</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-mistral-ai</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -187,6 +187,7 @@ Example `.env` file:
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 GEMINI_API_KEY=your_gemini_api_key_here
+MISTRAL_API_KEY=your_mistral_api_key_here
 ----
 
 ===== OpenAI Compatible (GPT-4, GPT-5, etc.)
@@ -283,3 +284,11 @@ embabel:
 <1> Set a Google GenAI model as the default LLM
 <2> Google GenAI specific configuration
 <3> API key can be set here or via environment variable `GOOGLE_API_KEY`
+
+===== Mistral AI
+
+* Required:
+- `MISTRAL_API_KEY`: API key for Mistral AI services
+* Optional:
+- `MISTRAL_BASE_URL`: base URL for Mistral AI API (default: `https://api.mistral.ai`)
+

--- a/embabel-agent-starters/embabel-agent-starter-mistral-ai/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-mistral-ai/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>0.3.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-starter-mistral-ai</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent MistralAI Starter</name>
+    <description>Embabel Agent MistralAI Starter</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-mistral-ai-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -33,6 +33,7 @@
         <module>embabel-agent-starter-deepseek</module>
         <module>embabel-agent-starter-gemini</module>
         <module>embabel-agent-starter-google-genai</module>
+        <module>embabel-agent-starter-mistral-ai</module>
         <module>embabel-agent-starter-a2a</module>
     </modules>
 


### PR DESCRIPTION
Hi.

As I live in Europe, I'd like to have a possibility to use European models from Mistral AI. Spring AI is supporting them already, Embabel was not, and because I want to write a few agents using Embabel, I though it would be a good exercise.

The implementation is following how other providers, like Google or Anthropic, are implemented. I must honestly say that I didn't follow your Dog Food Policy, for now because I couldn't use Mistral models.

Note:
* Magistral (thinking) models are not working yet, so not included.
* Cut-off dates are also not provided, I cannot find them anywhere.
* All models were queried through Embabel at least once.