### PR TITLE
Add license header to a2a autoconfiguration registration

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-a2a-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/embabel-agent-a2a-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,16 @@
+#
+# Copyright 2025-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 com.embabel.agent.autoconfigure.a2a.AgentA2AAutoConfiguration


### PR DESCRIPTION
This pull request adds a copyright and licensing header to the `org.springframework.boot.autoconfigure.AutoConfiguration.imports` resource file. This ensures proper attribution and compliance with the Apache License for the file.

* Added an Apache License header with copyright information to the `embabel-agent-a2a-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` file.