### PR TITLE
Remove A2A packages from global component scan

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/platform/ScanConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/platform/ScanConfiguration.java
@@ -47,8 +47,6 @@ import org.springframework.context.annotation.Configuration;
                 "com.embabel.agent.shell",
                 //Scan MCP Packages, this one should be moved over to MCP Module later
                 "com.embabel.agent.mcpserver",
-                //Scan A2A Packages, this one should be moved over to A2A Module later
-                "com.embabel.agent.a2a",
                 //Scan RAG Packages, this one should be moved over to RAG Module later
                 "com.embabel.agent.rag",
         }
@@ -69,8 +67,6 @@ import org.springframework.context.annotation.Configuration;
                 "com.embabel.agent.shell",
                 //Scan MCP Packages, this one should be moved over to MCP Module later
                 "com.embabel.agent.mcpserver",
-                //Scan A2A Packages, this one should be moved over to A2A Module later
-                "com.embabel.agent.a2a",
                 //Scan RAG Packages, this one should be moved over to RAG Module later
                 "com.embabel.agent.rag",
         }

--- a/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/AgentTestApplication.kt
+++ b/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/AgentTestApplication.kt
@@ -34,8 +34,6 @@ import org.springframework.context.annotation.ComponentScan
         "com.embabel.agent.shell",
         //Scan MCP Packages, this one should be moved over to MCP Module later
         "com.embabel.agent.mcpserver",
-        //Scan A2A Packages, this one should be moved over to A2A Module later
-        "com.embabel.agent.a2a",
         //Scan RAG Packages, this one should be moved over to RAG Module later
         "com.embabel.agent.rag",
     ]
@@ -57,8 +55,6 @@ import org.springframework.context.annotation.ComponentScan
         "com.embabel.agent.shell",
         //Scan MCP Packages, this one should be moved over to MCP Module later
         "com.embabel.agent.mcpserver",
-        //Scan A2A Packages, this one should be moved over to A2A Module later
-        "com.embabel.agent.a2a",
         //Scan RAG Packages, this one should be moved over to RAG Module later
         "com.embabel.agent.rag",
     ]


### PR DESCRIPTION
This pull request removes the scanning of the `com.embabel.agent.a2a` package from the component scan configuration in both the main platform autoconfigure module and the internal test support module. This means that A2A-related components will no longer be automatically discovered or registered by Spring in these contexts.

Component scan configuration updates:

* Removed the `com.embabel.agent.a2a` package from the `ScanConfiguration.java` file in the platform autoconfigure module, so A2A components are no longer included in the main application context. [[1]](diffhunk://#diff-8e0859a035c110a0a9781c562dcaf6d6ace4506503126a81b5a5d961b8c1273fL50-L51) [[2]](diffhunk://#diff-8e0859a035c110a0a9781c562dcaf6d6ace4506503126a81b5a5d961b8c1273fL72-L73)
* Removed the `com.embabel.agent.a2a` package from the `AgentTestApplication.kt` file in the test internal support module, so A2A components are no longer included in test application contexts. [[1]](diffhunk://#diff-8298672910243737df94df586e9bf3db8483ec080fc0f3152b32730843e6b31aL37-L38) [[2]](diffhunk://#diff-8298672910243737df94df586e9bf3db8483ec080fc0f3152b32730843e6b31aL60-L61)