### PR TITLE
Update comment

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -163,8 +163,7 @@ class AgentPlatformConfiguration(
      *
      * @param applicationContext the Spring application context used to discover model beans
      * @param properties configuration properties for the model provider
-     * @param dockerLocalModelsConfig optional marker bean for docker-local models auto-configuration
-     * @param ollamaModelsConfig optional marker bean for Ollama models auto-configuration
+     * @param providerInitialization list of provider initializations for dynamic model ingestion
      * @return a configured [ModelProvider] instance that exposes discovered LLMs and embedding services
      */
     @Bean(name = ["modelProvider"])


### PR DESCRIPTION
This pull request updates the documentation for the `AgentPlatformConfiguration` class to better reflect the current parameters used for model provider configuration. The main change is to update the KDoc comment to replace outdated parameter descriptions with the current approach for dynamic model ingestion.

Documentation update:

* Updated the KDoc for the `modelProvider` bean in `AgentPlatformConfiguration.kt` to remove references to `dockerLocalModelsConfig` and `ollamaModelsConfig`, and instead document the `providerInitialization` parameter for dynamic model ingestion.