### PR TITLE
Issue #1096 - Wrong Tag Version

### DIFF
--- a/embabel-agent-starters/embabel-agent-starter-shell/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-shell/pom.xml
@@ -16,7 +16,7 @@
         <url>https://github.com/embabel/embabel-agent</url>
         <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
         <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
-        <tag>v0.2.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <dependencies>


### PR DESCRIPTION
This pull request makes a minor update to the Maven project configuration by changing the SCM tag from a specific version to reference the latest commit.

* Updated the `<tag>` value in `pom.xml` from `v0.2.0` to `HEAD`, so the SCM now points to the latest commit instead of a fixed version.