### PR TITLE
Add workflow_run trigger for deployment

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -4,12 +4,18 @@ name: Deploy Snapshots
 
 on:
   workflow_dispatch:  # Enables manual triggering
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+    branches:
+      - main
 
 jobs:
   build-and-deploy:
 
     runs-on: ubuntu-latest
-
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 21


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy-snapshots.yml` workflow to automate deployments when the "Build" workflow completes successfully on the `main` branch, in addition to allowing manual triggers. The workflow now only runs if triggered manually or if the "Build" workflow run was successful.

Workflow automation improvements:

* Added a `workflow_run` trigger so the deployment workflow is automatically triggered when the "Build" workflow completes successfully on the `main` branch.
* Updated the job condition to ensure the deployment only runs for manual triggers or successful "Build" workflow runs.