### PR TITLE
Add workflow step to trigger examples repo

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -33,3 +33,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         
         run: mvn -U -P flatten-pom -DskipTests=true clean deploy
+
+      - name: Trigger examples repo workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: embabel/embabel-agent-examples
+          event-type: agent-snapshots-deployed


### PR DESCRIPTION
This pull request adds an automation step to the deployment workflow. After deploying Maven snapshots, it now triggers a workflow in the `embabel-agent-examples` repository to notify that new agent snapshots have been deployed.

**Workflow automation:**

* Added a step to the `.github/workflows/deploy-snapshots.yml` file that uses the `peter-evans/repository-dispatch` action to trigger the `agent-snapshots-deployed` event in the `embabel/embabel-agent-examples` repository after a successful deployment.