### PR TITLE
Normalize path separators in DirectoryTextSearch

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearch.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearch.kt
@@ -25,6 +25,7 @@ import com.embabel.common.core.types.TextSimilaritySearchRequest
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.invariantSeparatorsPathString
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.name
 import kotlin.io.path.pathString
@@ -233,7 +234,7 @@ class DirectoryTextSearch @JvmOverloads constructor(
     }
 
     private fun relativePath(path: Path): String {
-        return rootPath.relativize(path).pathString
+        return rootPath.relativize(path).invariantSeparatorsPathString
     }
 
     /**
@@ -274,7 +275,7 @@ class DirectoryTextSearch @JvmOverloads constructor(
     ): List<Chunk> {
         val relativePath = relativePath(filePath)
         val baseMetadata = mapOf(
-            "file_path" to filePath.pathString,
+            "file_path" to filePath.invariantSeparatorsPathString,
             "relative_path" to relativePath,
             "file_name" to filePath.name,
             "source" to "directory:$directory",


### PR DESCRIPTION
This pull request updates how file paths are handled in the `DirectoryTextSearch` service to ensure consistent path formatting across different operating systems. The main change is the switch from using `pathString` to `invariantSeparatorsPathString`, which standardizes path separators and helps avoid issues when running on various platforms.

**Path handling improvements:**

* Changed the implementation of the `relativePath` function to use `invariantSeparatorsPathString` instead of `pathString`, ensuring consistent path separators in relative paths.
* Updated the metadata for file chunks to use `invariantSeparatorsPathString` for the `file_path` entry, improving cross-platform compatibility.
* Added the import for `invariantSeparatorsPathString` from `kotlin.io.path` to support the new path formatting.