### PR TITLE
Model Provider name should start with capital letter

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/DeepSeekModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/DeepSeekModels.kt
@@ -26,6 +26,6 @@ class DeepSeekModels {
         const val DEEPSEEK_CHAT = "deepseek-chat";
         const val DEEPSEEK_REASONER = "deepseek-reasoner";
 
-        const val PROVIDER = "deepseek";
+        const val PROVIDER = "Deepseek";
     }
 }


### PR DESCRIPTION
This pull request makes a minor update to the `DeepSeekModels` class by standardizing the casing of the provider name constant.

* Changed the value of the `PROVIDER` constant from `"deepseek"` to `"Deepseek"` in `DeepSeekModels.kt` to ensure consistent casing.