### PR TITLE
Update the tool name when Agent is exposed as a tool

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/agent/PerGoalToolCallbackFactory.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/agent/PerGoalToolCallbackFactory.kt
@@ -138,7 +138,7 @@ class PerGoalToolCallbackFactory(
         return goal.export.startingInputTypes.map { inputType ->
             GoalToolCallback(
                 autonomy = autonomy,
-                name = "${inputType.simpleName}_$goalName",
+                name = goalName,
                 description = goal.description,
                 goal = goal,
                 inputType = inputType,


### PR DESCRIPTION
Do not include the input's type class name as part of the final tool name. Using input's type class name as part of the tool name can lead to verbose names and it easily might exceed some limits when MPC server is added in Claude or somewhere else. 