### PR TITLE
Test LLM Streaming with Java

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiStreamingBuilderIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiStreamingBuilderIT.java
@@ -97,7 +97,7 @@ import static org.junit.jupiter.api.Assertions.*;
     }
 )
 @Import({StreamingTestConfig.class, AgentOpenAiAutoConfiguration.class})
-public class LLMOpenAiStreamingBuilderIT {
+class LLMOpenAiStreamingBuilderIT {
 
     private static final Logger logger = LoggerFactory.getLogger(LLMOpenAiStreamingBuilderIT.class);
 
@@ -160,7 +160,7 @@ public class LLMOpenAiStreamingBuilderIT {
         }
 
     @Test
-    public void realStreamingIntegrationWithReactiveCallbacks() {
+    void realStreamingIntegrationWithReactiveCallbacks() {
         // Enable Reactor debugging
         reactor.util.Loggers.useVerboseConsoleLoggers();
 
@@ -211,13 +211,6 @@ public class LLMOpenAiStreamingBuilderIT {
         assertNull(errorOccurred.get(), "Integration streaming should not produce errors");
         assertTrue(completionCalled.get(), "Integration stream should complete successfully");
         assertFalse(receivedEvents.isEmpty(), "Should receive object events");
-
-        // Verify we received object events
-        long objectEvents = receivedEvents.stream()
-            .filter(event -> event.startsWith("OBJECT:"))
-            .count();
-        // Note: Commenting out assertion as per original Kotlin test
-        // assertTrue(objectEvents > 0, "Should receive object events from integration streaming");
 
         logger.info("Integration streaming test completed successfully with {} total events", receivedEvents.size());
     }


### PR DESCRIPTION
# Overview

```promptRunner.asStreaming``` is extension function, defined in:

```
embabel-agent/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/streaming/StreamingPromptRunnerOperations.kt
```

There is no direct equivalent of extension function in java.

## Introduction of StreamingPromptRunnerBuilder

Please see test and advise whether syntax structurre is proper one.

As of now keeping in test-scope for assessment.