### PR TITLE
Additional ArchUnit Tests

### DIFF
--- a/embabel-agent-api/src/test/kotlin/architecture/ArchitectureRules.kt
+++ b/embabel-agent-api/src/test/kotlin/architecture/ArchitectureRules.kt
@@ -19,7 +19,8 @@ import com.tngtech.archunit.core.importer.ImportOption
 import com.tngtech.archunit.core.importer.Location
 import com.tngtech.archunit.junit.AnalyzeClasses
 import com.tngtech.archunit.junit.ArchTest
-import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses
+import com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices
 import org.junit.jupiter.api.Tag
 
 
@@ -40,14 +41,25 @@ import org.junit.jupiter.api.Tag
 class ArchitectureRules {
 
     @ArchTest
-    val noPackageCycles = SlicesRuleDefinition.slices()
+    val noPackageCycles = slices()
         .matching("com.embabel.agent.(*)..")
         .should().beFreeOfCycles()
 
     @ArchTest
-    val noClassCycles = SlicesRuleDefinition.slices()
+    val noClassCycles = slices()
         .matching("com.embabel.agent.(*)")
         .should().beFreeOfCycles()
+
+    @ArchTest
+    val coreShouldNotDependOnApi =
+        noClasses().that().resideInAPackage("..core..")
+            .should().dependOnClassesThat().resideInAPackage("..api..")
+
+    @ArchTest
+    val apiShouldNotDependOnSpi =
+        noClasses().that().resideInAPackage("..api..")
+            .should().dependOnClassesThat().resideInAPackage("..spi..")
+
 }
 
 class ExcludeExperimentalOption : ImportOption {


### PR DESCRIPTION
This PR introduces two additional ArchUnit tests:

- com.embabel.agent.core should not depend on com.embabel.agent.api
- com.embabel.agent.api should not depend on com.embabel.agent.spi