### PR TITLE
Personality should be of type String

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingThemes.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingThemes.java
@@ -20,7 +20,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "embabel.agent.platform.logging")
 record LoggingPersonalityProperties(
-        LoggingThemes personality
+        String personality
 ) {
 }
 


### PR DESCRIPTION
This pull request makes a small but important change to the `LoggingPersonalityProperties` record, updating the type of the `personality` property from the enum `LoggingThemes` to a `String`. This change increases flexibility in how the personality is specified in configuration.

* Changed the type of the `personality` property in the `LoggingPersonalityProperties` record from `LoggingThemes` to `String` to allow for more flexible configuration.