### PR TITLE
Make LoggingTheme user level configuration

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/colossus/ColossusColorPalette.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/colossus/ColossusColorPalette.kt
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "colossus"
 )
 object ColossusColorPalette : ColorPalette {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/colossus/ColossusLoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/colossus/ColossusLoggingAgenticEventListener.kt
@@ -41,7 +41,7 @@ import org.springframework.stereotype.Service
  */
 @Service
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "colossus"
 )
 class ColossusLoggingAgenticEventListener : LoggingAgenticEventListener(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/hitchhiker/HitchhikerColorPalette.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/hitchhiker/HitchhikerColorPalette.kt
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "hitchhiker"
 )
 object HitchhikerColorPalette : ColorPalette {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/hitchhiker/HitchhikerLoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/hitchhiker/HitchhikerLoggingAgenticEventListener.kt
@@ -55,7 +55,7 @@ fun highlight(text: String) = "<$text>".color(HitchhikerColorPalette.BABEL_GREEN
  */
 @Service
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "hitchhiker"
 )
 class HitchhikerLoggingAgenticEventListener : LoggingAgenticEventListener(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/montypython/MontyPythonColorPalette.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/montypython/MontyPythonColorPalette.kt
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "montypython"
 )
 object MontyPythonColorPalette : ColorPalette {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/montypython/MontyPythonLoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/montypython/MontyPythonLoggingAgenticEventListener.kt
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "montypython"
 )
 class MontyPythonLoggingAgenticEventListener : LoggingAgenticEventListener(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/severance/LumonColorPalette.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/severance/LumonColorPalette.kt
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "severance"
 )
 object LumonColorPalette : ColorPalette {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/severance/SeveranceLoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/severance/SeveranceLoggingAgenticEventListener.kt
@@ -76,7 +76,7 @@ const val BANNER_CHAR = "."
  */
 @Service
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "severance"
 )
 class SeveranceLoggingAgenticEventListener : LoggingAgenticEventListener(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/starwars/StarWarsColorPalette.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/starwars/StarWarsColorPalette.kt
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "starwars"
 )
 object StarWarsColorPalette : ColorPalette {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/starwars/StarWarsLoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/starwars/StarWarsLoggingAgenticEventListener.kt
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component
  */
 @Component
 @ConditionalOnProperty(
-    name = ["embabel.agent.platform.logging.personality"],
+    name = ["embabel.agent.logging.personality"],
     havingValue = "starwars"
 )
 class StarWarsLoggingAgenticEventListener : LoggingAgenticEventListener(

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingThemes.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/LoggingThemes.java
@@ -18,7 +18,7 @@ package com.embabel.agent.config.annotation;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "embabel.agent.platform.logging")
+@ConfigurationProperties(prefix = "embabel.agent.logging")
 record LoggingPersonalityProperties(
         String personality
 ) {

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/config/annotation/spi/EnvironmentPostProcessor.java
@@ -78,7 +78,7 @@ import java.util.Set;
  */
 public class EnvironmentPostProcessor implements org.springframework.boot.env.EnvironmentPostProcessor, Ordered {
 
-    public static final String LOGGING_THEME_PROPERTY = "embabel.agent.platform.logging.personality";
+    public static final String LOGGING_THEME_PROPERTY = "embabel.agent.logging.personality";
 
     private final Logger logger = LoggerFactory.getLogger(EnvironmentPostProcessor.class);
 

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,7 +1,7 @@
 {
   "hints": [
     {
-      "name": "embabel.agent.platform.logging.personality",
+      "name": "embabel.agent.logging.personality",
       "values": [
         { "value": "starwars", "description": "Star Wars themed logging messages" },
         { "value": "severance", "description": "Severance themed logging messages. Praise Kier" },

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/colossus/ColossusPromptProvider.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/colossus/ColossusPromptProvider.kt
@@ -22,7 +22,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
-@ConditionalOnProperty(name = ["embabel.agent.platform.logging.personality"], havingValue = "colossus")
+@ConditionalOnProperty(name = ["embabel.agent.logging.personality"], havingValue = "colossus")
 class ColossusPromptProvider : MessageGeneratorPromptProvider(
     color = ColossusColorPalette.PANEL,
     prompt = "Colossus",

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/hitchhiker/HitchhikerPromptProvider.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/hitchhiker/HitchhikerPromptProvider.kt
@@ -45,7 +45,7 @@ val GuideEntries = listOf(
 )
 
 @Component
-@ConditionalOnProperty(name = ["embabel.agent.platform.logging.personality"], havingValue = "hitchhiker")
+@ConditionalOnProperty(name = ["embabel.agent.logging.personality"], havingValue = "hitchhiker")
 class HitchhikerPromptProvider : MessageGeneratorPromptProvider(
     color = HitchhikerColorPalette.BABEL_GREEN,
     prompt = GuideEntries.random(),

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/montypython/MontyPythonPromptProvider.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/montypython/MontyPythonPromptProvider.kt
@@ -22,7 +22,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
-@ConditionalOnProperty(name = ["embabel.agent.platform.logging.personality"], havingValue = "montypython")
+@ConditionalOnProperty(name = ["embabel.agent.logging.personality"], havingValue = "montypython")
 class MontyPythonPromptProvider : MessageGeneratorPromptProvider(
     color = MontyPythonColorPalette.BRIGHT_RED,
     prompt = "pythons",

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/severance/SeverancePromptProvider.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/severance/SeverancePromptProvider.kt
@@ -35,7 +35,7 @@ val LumonDepartments = listOf(
 )
 
 @Component
-@ConditionalOnProperty(name = ["embabel.agent.platform.logging.personality"], havingValue = "severance")
+@ConditionalOnProperty(name = ["embabel.agent.logging.personality"], havingValue = "severance")
 class SeverancePromptProvider : MessageGeneratorPromptProvider(
     color = LumonColorPalette.MEMBRANE,
     prompt = LumonDepartments.random(),

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/starwars/StarwarsPromptProvider.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/personality/starwars/StarwarsPromptProvider.kt
@@ -22,7 +22,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
-@ConditionalOnProperty(name = ["embabel.agent.platform.logging.personality"], havingValue = "starwars")
+@ConditionalOnProperty(name = ["embabel.agent.logging.personality"], havingValue = "starwars")
 class StarWarsPromptProvider : MessageGeneratorPromptProvider(
     color = StarWarsColorPalette.YELLOW_ACCENT,
     prompt = "starwars",


### PR DESCRIPTION
This pull request updates the configuration property name used to select logging personalities throughout the codebase. The property has been renamed from `embabel.agent.platform.logging.personality` to `embabel.agent.logging.personality` for consistency and simplicity. This change affects both Java and Kotlin files, as well as configuration metadata.

**Configuration property renaming:**

* Updated all `@ConditionalOnProperty` annotations in Kotlin agent personality classes to use `embabel.agent.logging.personality` instead of the old property name. This affects color palette, event listener, and prompt provider classes for Colossus, Hitchhiker, Monty Python, Severance, and Star Wars personalities. [[1]](diffhunk://#diff-62726080d550bc389e3234877d3948dce253a3d72aebc7392666ac57dae13c35L24-R24) [[2]](diffhunk://#diff-df1fbfe55fcb87b5525ff460bb1d6b332b3b7debb378b16f27ad56f12b221ecaL44-R44) [[3]](diffhunk://#diff-9db771554b5459efca34078e52d289e5f0d0ea32824455ec076edc62e860bb1cL24-R24) [[4]](diffhunk://#diff-dae7a739bda54e84ed372db923177c886a5784d2aebba9d11bffc01f30c9894cL58-R58) [[5]](diffhunk://#diff-740cc240b637a79dd4db5ff1d0c0fb867169a87cb94f53653d87ff06204c57daL24-R24) [[6]](diffhunk://#diff-6c9b75b71d55d5a1152c1df69f66b108d601df23dc21d884ae96b2314ef99985L30-R30) [[7]](diffhunk://#diff-661f0de99a952b46f132e9e90096a0a5be102285a82249a67e3f4d13f7e343d6L24-R24) [[8]](diffhunk://#diff-143d47b9fa6f6fb1efb1243fcbc072f4a98e28bc8643a935edda56b309620cc8L79-R79) [[9]](diffhunk://#diff-9a797b85d9ffe5c082ca1c05b04b16f5587f963be550aa318afa59daafaed535L24-R24) [[10]](diffhunk://#diff-fd894501b4a2b49185f4e7ee59a6bef811a5cb15d3f3ae7e6d48ae86c34ad8c2L31-R31) [[11]](diffhunk://#diff-e64e574e81d31bb48dfa8156120b43126c2c9a25a9331479dbd9b5611b2aec46L25-R25) [[12]](diffhunk://#diff-61fce3c55732e7b5fe0436d0284d86e99a780183c3746627c5bbc27d11a415a1L48-R48) [[13]](diffhunk://#diff-3b012236a45462ecc31f3ae910347a337151ba319f85a22b0f5da5ebf0668be3L25-R25) [[14]](diffhunk://#diff-482fcd16156be27e9dd4c0becff6917be8960b7f699d38b16f8da5a9a4742fe6L38-R38) [[15]](diffhunk://#diff-f79dea8f2afc93263b241880cc932ef97edd32461520cd44d001ba15774d6349L25-R25)

* Changed the property prefix in the `LoggingPersonalityProperties` record annotation in `LoggingThemes.java` to the new property name.

* Updated the static property name reference in `EnvironmentPostProcessor.java` to match the new property name.

* Modified the configuration metadata in `additional-spring-configuration-metadata.json` to reflect the new property name.

These changes ensure that all modules consistently use the new property name for configuring logging personalities, reducing confusion and potential misconfiguration.