### PR TITLE
Remove test scoped dependency on RAG module from Platform Autoconfig

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/pom.xml
@@ -37,13 +37,6 @@
             <artifactId>spring-ai-autoconfigure-model-chat-client</artifactId>
         </dependency>
 
-        <!-- Test Dependencies -->
-        <dependency>
-            <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-rag-pipeline</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
 </project>

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/platform/AgentPlatformAutoConfigurationIT.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/platform/AgentPlatformAutoConfigurationIT.java
@@ -16,7 +16,6 @@
 package com.embabel.agent.autoconfigure.platform;
 
 import com.embabel.agent.api.event.AgenticEventListener;
-import com.embabel.agent.rag.service.RagService;
 import com.embabel.agent.spi.Ranker;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -46,9 +45,6 @@ class AgentPlatformAutoConfigurationIT {
     @Autowired
     private Ranker ranker;
 
-    @Autowired
-    private RagService defaultSpringVectorStore;
-
     @BeforeEach
     void setUp() {
     }
@@ -63,8 +59,6 @@ class AgentPlatformAutoConfigurationIT {
     public void testAutoConfiguredBeanPresence() {
         Assertions.assertNotNull(eventListener, "Event Listener should be Auto-Configured");
         Assertions.assertNotNull(ranker, "Ranker should be Auto-Configured");
-        Assertions.assertNotNull(defaultSpringVectorStore, "RagService should be Auto-Configured");
-
     }
 
 

--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/test/java/com/embabel/agent/config/annotation/EnableAgentsAnnotationIT.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/test/java/com/embabel/agent/config/annotation/EnableAgentsAnnotationIT.java
@@ -16,7 +16,6 @@
 package com.embabel.agent.config.annotation;
 
 import com.embabel.agent.api.event.AgenticEventListener;
-import com.embabel.agent.rag.service.RagService;
 import com.embabel.agent.spi.Ranker;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -66,9 +65,6 @@ class EnableAgentsAnnotationIT {
     @Autowired
     private Ranker ranker;
 
-    @Autowired
-    private RagService defaultSpringVectorStore;
-
     @Test
     @DisplayName("Should auto-configure all required agent platform beans")
     void testAutoConfiguredBeanPresence() {
@@ -81,9 +77,6 @@ class EnableAgentsAnnotationIT {
                 .as("Ranker should be auto-configured")
                 .isNotNull();
 
-        assertThat(defaultSpringVectorStore)
-                .as("RagService should be auto-configured")
-                .isNotNull();
     }
 
     @Test


### PR DESCRIPTION
This pull request removes the `RagService` dependency from the platform autoconfigure module's integration tests and its related test assertions. This simplifies the test setup by only verifying the presence of beans that are actually auto-configured by the platform.

**Test cleanup and simplification:**

* Removed the `embabel-agent-rag-pipeline` test dependency from the `pom.xml`, as its beans are no longer required for these integration tests.
* Removed all imports, field injections, and assertions related to `RagService` in both `AgentPlatformAutoConfigurationIT` and `EnableAgentsAnnotationIT` test classes. [[1]](diffhunk://#diff-7a0c47e09f2efb0f69df91221c6cba434ea79f0577ba7f8d0e8ce05a8a1cf383L19) [[2]](diffhunk://#diff-7a0c47e09f2efb0f69df91221c6cba434ea79f0577ba7f8d0e8ce05a8a1cf383L49-L51) [[3]](diffhunk://#diff-7a0c47e09f2efb0f69df91221c6cba434ea79f0577ba7f8d0e8ce05a8a1cf383L66-L67) [[4]](diffhunk://#diff-e43dfa2c90777fddb91b10ec136a46767019e77025a4c302e8b502186feeb1a3L19) [[5]](diffhunk://#diff-e43dfa2c90777fddb91b10ec136a46767019e77025a4c302e8b502186feeb1a3L69-L71) [[6]](diffhunk://#diff-e43dfa2c90777fddb91b10ec136a46767019e77025a4c302e8b502186feeb1a3L84-L86)