### PR TITLE
Decouple RAG component scan from Agent Platform

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/platform/ScanConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-platform-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/platform/ScanConfiguration.java
@@ -42,9 +42,7 @@ import org.springframework.context.annotation.Configuration;
                 "com.embabel.agent.spi",
                 "com.embabel.agent.test",
                 "com.embabel.agent.tools",
-                "com.embabel.agent.web",
-                //Scan RAG Packages, this one should be moved over to RAG Module later
-                "com.embabel.agent.rag",
+                "com.embabel.agent.web"
         }
 )
 @ComponentScan(
@@ -58,9 +56,7 @@ import org.springframework.context.annotation.Configuration;
                 "com.embabel.agent.spi",
                 "com.embabel.agent.test",
                 "com.embabel.agent.tools",
-                "com.embabel.agent.web",
-                //Scan RAG Packages, this one should be moved over to RAG Module later
-                "com.embabel.agent.rag",
+                "com.embabel.agent.web"
         }
 )
 @Configuration

--- a/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/AgentTestApplication.kt
+++ b/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/AgentTestApplication.kt
@@ -34,8 +34,7 @@ import org.springframework.context.annotation.ComponentScan
         "com.embabel.agent.shell",
         //Scan MCP Packages, this one should be moved over to MCP Module later
         "com.embabel.agent.mcpserver",
-        //Scan RAG Packages, this one should be moved over to RAG Module later
-        "com.embabel.agent.rag",
+
     ]
 )
 @ComponentScan(
@@ -55,8 +54,6 @@ import org.springframework.context.annotation.ComponentScan
         "com.embabel.agent.shell",
         //Scan MCP Packages, this one should be moved over to MCP Module later
         "com.embabel.agent.mcpserver",
-        //Scan RAG Packages, this one should be moved over to RAG Module later
-        "com.embabel.agent.rag",
     ]
 )
 class AgentTestApplication {}


### PR DESCRIPTION
This pull request removes the scanning of the `com.embabel.agent.rag` package from both the platform autoconfiguration and the test application. This change helps to decouple the RAG functionality from the core platform and test modules, likely in preparation for moving it to a separate module.

**Dependency and scanning configuration cleanup:**

* Removed `com.embabel.agent.rag` from the `@ComponentScan` base packages in `ScanConfiguration.java` to stop scanning RAG components in the platform autoconfigure module. [[1]](diffhunk://#diff-8e0859a035c110a0a9781c562dcaf6d6ace4506503126a81b5a5d961b8c1273fL45-R45) [[2]](diffhunk://#diff-8e0859a035c110a0a9781c562dcaf6d6ace4506503126a81b5a5d961b8c1273fL61-R59)
* Removed `com.embabel.agent.rag` from the `@ComponentScan` base packages in `AgentTestApplication.kt` to stop scanning RAG components in the test support module. [[1]](diffhunk://#diff-8298672910243737df94df586e9bf3db8483ec080fc0f3152b32730843e6b31aL37-R37) [[2]](diffhunk://#diff-8298672910243737df94df586e9bf3db8483ec080fc0f3152b32730843e6b31aL58-L59)