### PR TITLE
Discussion Piece: Allow env based openAI compatibilty.

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/CustomModelParsingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/CustomModelParsingTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024-2025 Embabel Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for custom model parsing logic used in OpenAiModelsConfig.
+ * This validates the parsing of the OPENAI_CUSTOM_MODELS environment variable.
+ */
+class CustomModelParsingTest {
+
+    @Test
+    fun `should parse single custom model`() {
+        val customModels = "llama-3.3-70b-versatile"
+        val result = parseCustomModels(customModels)
+
+        assertEquals(1, result.size)
+        assertEquals("llama-3.3-70b-versatile", result[0])
+    }
+
+    @Test
+    fun `should parse multiple custom models`() {
+        val customModels = "llama-3.3-70b-versatile,mixtral-8x7b-32768,gemma2-9b-it"
+        val result = parseCustomModels(customModels)
+
+        assertEquals(3, result.size)
+        assertEquals("llama-3.3-70b-versatile", result[0])
+        assertEquals("mixtral-8x7b-32768", result[1])
+        assertEquals("gemma2-9b-it", result[2])
+    }
+
+    @Test
+    fun `should trim whitespace from model names`() {
+        val customModels = "  llama-3.3-70b-versatile  ,  mixtral-8x7b-32768  "
+        val result = parseCustomModels(customModels)
+
+        assertEquals(2, result.size)
+        assertEquals("llama-3.3-70b-versatile", result[0])
+        assertEquals("mixtral-8x7b-32768", result[1])
+    }
+
+    @Test
+    fun `should filter out blank entries`() {
+        val customModels = "llama-3.3-70b-versatile,,  ,mixtral-8x7b-32768"
+        val result = parseCustomModels(customModels)
+
+        assertEquals(2, result.size)
+        assertEquals("llama-3.3-70b-versatile", result[0])
+        assertEquals("mixtral-8x7b-32768", result[1])
+    }
+
+    @Test
+    fun `should return empty list for null input`() {
+        val result = parseCustomModels(null)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `should return empty list for blank input`() {
+        val result = parseCustomModels("   ")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `should return empty list for only commas`() {
+        val result = parseCustomModels(",,,")
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `should handle model names with special characters`() {
+        val customModels = "openai/gpt-oss-120b,meta-llama/llama-3.3-70b"
+        val result = parseCustomModels(customModels)
+
+        assertEquals(2, result.size)
+        assertEquals("openai/gpt-oss-120b", result[0])
+        assertEquals("meta-llama/llama-3.3-70b", result[1])
+    }
+
+    /**
+     * Replicates the parsing logic from OpenAiModelsConfig for testing.
+     */
+    private fun parseCustomModels(customModels: String?): List<String> {
+        return customModels
+            ?.split(",")
+            ?.map { it.trim() }
+            ?.filter { it.isNotBlank() }
+            ?: emptyList()
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -198,6 +198,19 @@ MISTRAL_API_KEY=your_mistral_api_key_here
 - `OPENAI_BASE_URL`: base URL of the OpenAI deployment (for Azure AI use `https://{resource-name}.openai.azure.com/openai`)
 - `OPENAI_COMPLETIONS_PATH`: custom path for completions endpoint (default: `/v1/completions`)
 - `OPENAI_EMBEDDINGS_PATH`: custom path for embeddings endpoint (default: `/v1/embeddings`)
+- `OPENAI_CUSTOM_MODELS`: comma-separated list of custom model names to register (useful for OpenAI-compatible providers like Groq, Together AI, etc.)
+
+When using `OPENAI_CUSTOM_MODELS`, set `EMBABEL_MODELS_DEFAULT_LLM` to specify which model to use as the default.
+
+Example for using Groq:
+
+[source,bash]
+----
+export OPENAI_BASE_URL="https://api.groq.com/openai/v1"
+export OPENAI_API_KEY="your-groq-api-key"
+export OPENAI_CUSTOM_MODELS="llama-3.3-70b-versatile,mixtral-8x7b-32768"
+export EMBABEL_MODELS_DEFAULT_LLM="llama-3.3-70b-versatile"
+----
 
 ===== Anthropic (Claude 3.x, etc.)
 


### PR DESCRIPTION
# Problem Statement

Long tail LLM providers have a unique value proposition that gives them a portion of the market without being mainstream. For this reason, rather than offer their own API they use OpenAI as the lingua di franco compatibility layer. 

Embabel handles this well, allowing registration of a bean. But what about: 

* Pre-packaged agents (eg in docker hub) where users want to use an openAI compatible LLM, but don't have access to the code. 
* Other situations where it makes sense to have a purely properties based approach. 

# Proposed Solution 

Most of the pieces are in place already to offer this. However there is a registry of possible openAI models to use. We need to be able to plug in the long-tail vendor's model on the fly, so Embabel can hook it up. 

We can do that something like (in this pr):

```bash
export OPENAI_BASE_URL="https://api.groq.com/openai/"
export OPENAI_API_KEY="GROQ_KEY"
export OPENAI_CUSTOM_MODELS="llama-3.3-70b-versatile,mixtral-8x7b-32768,openai/gpt-oss-120b"
export EMBABEL_MODELS_DEFAULT_LLM="llama-3.3-70b-versatile"
```

I used this approach to spin up the hub powered by models provided by Groq. (Not the flashiest of models, but Groq lets them run blisteringly fast). 