### PR TITLE
Reduce Log level to Debug

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolGroupsConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolGroupsConfiguration.kt
@@ -108,7 +108,7 @@ class OnMcpConnectionCondition : Condition {
 
             val exists = environment.containsProperty(stdioKey) || environment.containsProperty(sseKey)
 
-            logger.info("MCP connection '{}': exists={}", connectionName, exists)
+            logger.debug("MCP connection '{}': exists={}", connectionName, exists)
             connectionName to exists
         }
 


### PR DESCRIPTION
This pull request makes a minor change to the logging level in the `ToolGroupsConfiguration.kt` file. The log statement for MCP connection existence has been changed from `info` to `debug` level, reducing log verbosity in production environments.

* Changed logging level from `info` to `debug` for MCP connection existence checks in `OnMcpConnectionCondition`.