### PR TITLE
Add paragraph on how to configure logging themes

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
@@ -10,10 +10,6 @@ Example:
 [source,java]
 ----
 @SpringBootApplication
-@EnableAgents(
-    loggingTheme = LoggingThemes.STAR_WARS,
-    mcpClients = { "docker" }
-)
 class MyAgentApplication {
     public static void main(String[] args) {
         SpringApplication.run(MyAgentApplication.class, args);
@@ -23,10 +19,6 @@ class MyAgentApplication {
 
 This is a normal Spring Boot application class.
 You can add other Spring Boot annotations as needed.
-`@EnableAgents` enables the agent framework.
-It allows you to specify a logging theme (optional) and well-known sources of local models and MCP tools.
-In this case we're using Docker as a source of MCP tools.
-
 Add the following dependency to your `pom.xml` to include the Ollama model provider starter:
 
 [source,xml]
@@ -114,6 +106,52 @@ From `AgentPlatformProperties` - unified configuration for all agent platform pr
 |Platform description
 
 |===
+
+===== Logging Personality
+
+Configuration for agent logging output style and theming.
+
+[cols="3,2,1,4",options="header"]
+|===
+|Property |Type |Default |Description
+
+|`embabel.agent.logging.personality`
+|String
+|_(none)_
+|Themed logging messages to add personality to agent output
+
+|===
+
+.Available Personality Values
+[cols="2,5",options="header"]
+|===
+|Value |Description
+
+|`starwars`
+|Star Wars themed logging messages
+
+|`severance`
+|Severance themed logging messages. Praise Kier
+
+|`colossus`
+|Colossus: The Forbin Project themed messages
+
+|`hitchhiker`
+|Hitchhiker's Guide to the Galaxy themed messages
+
+|`montypython`
+|Monty Python themed logging messages
+
+|===
+
+.Example Configuration
+[source,yaml]
+----
+embabel:
+  agent:
+    logging:
+      personality: hitchhiker
+----
 
 ===== Agent Scanning
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -113,23 +113,14 @@ You can also configure logging via a `logback-spring.xml` file if you have more 
 See the https://docs.spring.io/spring-boot/reference/features/logging.html[Spring Boot Logging] reference.
 
 By default, many Embabel examples use personality-based logging experiences such as Star Wars.
-You can disable this via the `@EnableAgents` annotation on your main application class:
+You can disable this by updating application.properties accordingly.
 
-[source,java]
+[source,text]
 ----
-@SpringBootApplication
-@ConfigurationPropertiesScan
-@EnableAgents(
-        loggingTheme = LoggingThemes.STAR_WARS
-)
-class MyAwesomeApplication {
-    public static void main(String[] args) {
-        SpringApplication.run(GuideApplication.class, args);
-    }
-}
+embabel.agent.logging.personality=severance
 ----
 
-Remove the `loggingTheme` attribute to disable personality-based logging.
+Remove the `embabel.agent.logging.personality` key to disable personality-based logging.
 
 As all logging results from listening to events via an `AgenticEventListener`, you can also easily create your own customized logging.
 


### PR DESCRIPTION
This pull request updates the documentation for configuring agent logging personalities in Embabel, shifting from annotation-based configuration to property-based configuration. It clarifies how to enable, disable, and customize personality-based logging using the `embabel.agent.logging.personality` property in your configuration files. The changes also provide detailed documentation on available personality values and example configurations.

**Configuration documentation updates:**

* Removed references to the `@EnableAgents` annotation and its attributes for configuring logging personality and MCP tool sources, reflecting a move to property-based configuration (`embabel.agent.logging.personality`). [[1]](diffhunk://#diff-dd772560e82fd3c9e9e8bd18de9a0920d3e886be0a64cb3dad9df7d7c7451076L13-L16) [[2]](diffhunk://#diff-dd772560e82fd3c9e9e8bd18de9a0920d3e886be0a64cb3dad9df7d7c7451076L26-L29)
* Added a new section detailing the `embabel.agent.logging.personality` property, including a table of available values (e.g., `starwars`, `severance`, `colossus`, `hitchhiker`, `montypython`) and example YAML configuration.

**How to enable/disable personality-based logging:**

* Updated instructions to disable personality-based logging by removing the `embabel.agent.logging.personality` property, instead of modifying annotations.
* Provided updated code/configuration examples for enabling or disabling logging personalities using properties files.Removed EnableAgent references as this is not longer required