### PR TITLE
Prepare for 0.3.1 tag build

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.7</version>
+        <version>0.1.8</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.8-SNAPSHOT</version>
+        <version>0.1.8</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -15,7 +15,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <embabel-common.version>0.1.7-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.7</embabel-common.version>
         <netty.version>4.1.125.Final</netty.version>
     </properties>
 


### PR DESCRIPTION
This pull request updates project dependencies and parent references to use the latest stable releases instead of snapshot versions. The changes ensure that the project is built against finalized, stable versions of its parent and common dependencies.

Dependency and parent version updates:

* Updated the parent version in `pom.xml` from `0.1.8-SNAPSHOT` to the stable `0.1.8` release.
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.7-SNAPSHOT` to the stable `0.1.7` release.
* Updated the parent version in `embabel-agent-dependencies/pom.xml` from `0.1.7` to `0.1.8`.