### PR TITLE
Remove dependency on embabel-common-ai

### DIFF
--- a/embabel-agent-domain/pom.xml
+++ b/embabel-agent-domain/pom.xml
@@ -31,8 +31,13 @@
         </dependency>
 
         <dependency>
-            <groupId>com.embabel.common</groupId>
-            <artifactId>embabel-common-ai</artifactId>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This pull request makes a small update to the dependencies in the `embabel-agent-domain/pom.xml` file. The main change is updating a dependency to use the correct group and artifact, and adding a new Jackson module for Java 8 date/time support.

- Dependency updates:
  * Changed the dependency from `com.embabel.common:embabel-common-ai` to `com.embabel.agent:embabel-agent-common` to use the correct package.
  * Added the `com.fasterxml.jackson.datatype:jackson-datatype-jsr310` dependency to support Java 8 date/time types in Jackson.gent-common