### PR TITLE
Remove dependency to embabel-common-ai

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/pom.xml
@@ -52,12 +52,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.embabel.common</groupId>
-            <artifactId>embabel-common-test-ai</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test-internal</artifactId>
             <scope>test</scope>

--- a/embabel-agent-rag/embabel-agent-rag-core/pom.xml
+++ b/embabel-agent-rag/embabel-agent-rag-core/pom.xml
@@ -21,8 +21,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.embabel.common</groupId>
-            <artifactId>embabel-common-test-ai</artifactId>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-common</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/pom.xml
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/pom.xml
@@ -46,8 +46,8 @@
         
         <!-- Test dependencies - versions managed by parent -->
         <dependency>
-            <groupId>com.embabel.common</groupId>
-            <artifactId>embabel-common-test-ai</artifactId>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-common</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/embabel-agent-rag/pom.xml
+++ b/embabel-agent-rag/pom.xml
@@ -29,11 +29,6 @@
     <dependencies>
         <!-- Main Dependencies -->
         <dependency>
-            <groupId>com.embabel.common</groupId>
-            <artifactId>embabel-common-ai</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-api</artifactId>
         </dependency>


### PR DESCRIPTION
This pull request updates project dependencies to remove references to the old `embabel-common-ai` and `embabel-common-test-ai` modules and replaces them with newer or more appropriate modules under the `embabel-agent` group. These changes help streamline the dependency structure and ensure the use of up-to-date test and main libraries.

Dependency cleanup and replacement:

* Removed the `embabel-common-ai` dependency from `embabel-agent-rag/pom.xml` to eliminate unused or outdated main dependencies.
* Replaced the `embabel-common-test-ai` test dependency with `embabel-agent-test-common` in `embabel-agent-rag/embabel-agent-rag-core/pom.xml` and `embabel-agent-rag/embabel-agent-rag-pipeline/pom.xml` to use the updated test utility module. [[1]](diffhunk://#diff-a381c26252aee6e8dd265b218813ac1275a76fce1543289dfdd1b4033dd7c2f7L24-R25) [[2]](diffhunk://#diff-0f90b251a04e3edb3a3e69811ccc085ff6517fec0bdbeff425829b5933f8ff3aL49-R50)
* Removed the `embabel-common-test-ai` test dependency from `embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/pom.xml` to clean up unused or migrated test dependencies.