### PR TITLE
Update Unified Banner Tool with @Tool annotation

### DIFF
--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/AbstractMcpServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/AbstractMcpServerConfiguration.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.mcpserver.domain.ToolSpecification
 import com.embabel.agent.spi.support.AgentScanningBeanPostProcessorEvent
 import org.slf4j.Logger
 import org.springframework.ai.tool.ToolCallbackProvider
+import org.springframework.ai.tool.annotation.Tool
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.event.EventListener
 import reactor.core.publisher.Flux
@@ -318,7 +319,7 @@ class UnifiedBannerTool(private val serverInfo: ServerInfo) {
      *
      * @return a map containing banner details
      */
-    @LlmTool(
+    @Tool(
         description = "Display a welcome banner with server information"
     )
     fun helloBanner(): Map<String, Any> {


### PR DESCRIPTION
This pull request updates the annotation used for the `helloBanner` method to align with the latest conventions and imports in the codebase.

Annotation update for tool methods:

* Replaced the `@LlmTool` annotation with the `@Tool` annotation for the `helloBanner` method in the `UnifiedBannerTool` class to ensure compatibility with the current tooling framework.

The following code would not work, unless @Tool annotation is used:

<img width="687" height="131" alt="image" src="https://github.com/user-attachments/assets/8086c202-dedc-460e-b854-2d64d715db42" />