### PR TITLE
Convert @Tool back to @LlmTool in UnifiedBanner

### DIFF
--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/AbstractMcpServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/AbstractMcpServerConfiguration.kt
@@ -319,7 +319,8 @@ class UnifiedBannerTool(private val serverInfo: ServerInfo) {
      *
      * @return a map containing banner details
      */
-    @Tool(
+    @LlmTool(
+        name = "helloBanner",
         description = "Display a welcome banner with server information"
     )
     fun helloBanner(): Map<String, Any> {

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/async/config/McpAsyncServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/async/config/McpAsyncServerConfiguration.kt
@@ -15,6 +15,8 @@
  */
 package com.embabel.agent.mcpserver.async.config
 
+import com.embabel.agent.api.common.ToolObject
+import com.embabel.agent.core.support.safelyGetToolCallbacksFrom
 import com.embabel.agent.mcpserver.*
 import com.embabel.agent.mcpserver.async.AsyncServerStrategy
 import com.embabel.agent.mcpserver.async.McpAsyncPromptPublisher
@@ -25,7 +27,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.ai.mcp.McpToolUtils
 import org.springframework.ai.tool.ToolCallbackProvider
-import org.springframework.ai.tool.method.MethodToolCallbackProvider
 import org.springframework.beans.factory.getBean
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.context.ConfigurableApplicationContext
@@ -86,9 +87,11 @@ class McpAsyncServerConfiguration(
      * @return a `ToolCallbackProvider` for the async server banner tool
      */
     override fun createBannerTool(): ToolCallbackProvider {
-        return MethodToolCallbackProvider.builder()
-            .toolObjects(UnifiedBannerTool(serverInfo))
-            .build()
+        return ToolCallbackProvider.from(
+            safelyGetToolCallbacksFrom(
+                ToolObject.from(UnifiedBannerTool(serverInfo))
+            )
+        )
     }
 
     /**

--- a/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/sync/config/McpSyncServerConfiguration.kt
+++ b/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/sync/config/McpSyncServerConfiguration.kt
@@ -15,6 +15,8 @@
  */
 package com.embabel.agent.mcpserver.sync.config
 
+import com.embabel.agent.api.common.ToolObject
+import com.embabel.agent.core.support.safelyGetToolCallbacksFrom
 import com.embabel.agent.mcpserver.*
 import com.embabel.agent.mcpserver.domain.McpExecutionMode
 import com.embabel.agent.mcpserver.sync.McpPromptPublisher
@@ -25,7 +27,6 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.ai.mcp.McpToolUtils
 import org.springframework.ai.tool.ToolCallbackProvider
-import org.springframework.ai.tool.method.MethodToolCallbackProvider
 import org.springframework.beans.factory.getBean
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.context.ConfigurableApplicationContext
@@ -103,9 +104,11 @@ class McpSyncServerConfiguration(
      * @return a `ToolCallbackProvider` for the banner tool
      */
     override fun createBannerTool(): ToolCallbackProvider {
-        return MethodToolCallbackProvider.builder()
-            .toolObjects(UnifiedBannerTool(serverInfo))
-            .build()
+        return ToolCallbackProvider.from(
+            safelyGetToolCallbacksFrom(
+                ToolObject.from(UnifiedBannerTool(serverInfo))
+            )
+        )
     }
 
     /**


### PR DESCRIPTION
This pull request updates how the banner tool is registered and invoked in both the async and sync server configurations. The main goal is to standardize tool registration by using the new `ToolObject` and `safelyGetToolCallbacksFrom` utilities, and to update the annotation for the banner tool method.

Tool registration and callback handling:

* Replaced usage of `MethodToolCallbackProvider` with a new pattern that uses `ToolObject.from` and `safelyGetToolCallbacksFrom` to register the `UnifiedBannerTool` in both `McpAsyncServerConfiguration` and `McpSyncServerConfiguration`. This change streamlines and unifies tool callback registration. [[1]](diffhunk://#diff-32e4b2c7e11785ce47d15ab63728c8d70aae54a0adc3a4b2642c7357b34b55d5L89-R94) [[2]](diffhunk://#diff-09304532f5088e41dcd61881b078a871a48394b2632f1d9bd67adba2be419fc0L106-R111)
* Added imports for `ToolObject` and `safelyGetToolCallbacksFrom` in both server configuration files to support the new registration approach. [[1]](diffhunk://#diff-32e4b2c7e11785ce47d15ab63728c8d70aae54a0adc3a4b2642c7357b34b55d5R18-R19) [[2]](diffhunk://#diff-09304532f5088e41dcd61881b078a871a48394b2632f1d9bd67adba2be419fc0R18-R19)
* Removed the now-unused import of `MethodToolCallbackProvider` from both configuration files. [[1]](diffhunk://#diff-32e4b2c7e11785ce47d15ab63728c8d70aae54a0adc3a4b2642c7357b34b55d5L28) [[2]](diffhunk://#diff-09304532f5088e41dcd61881b078a871a48394b2632f1d9bd67adba2be419fc0L28)

Annotation and naming update:

* Updated the annotation on the `helloBanner` method in `UnifiedBannerTool` from `@Tool` to `@LlmTool`, and explicitly set the tool name to `"helloBanner"` for clarity and consistency with the new registration approach.