### PR TITLE
Fix #1203

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AsyncConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AsyncConfiguration.kt
@@ -17,11 +17,13 @@ package com.embabel.agent.spi.config.spring
 
 import com.embabel.agent.api.common.Asyncer
 import com.embabel.agent.spi.support.ExecutorAsyncer
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 @Configuration
 class AsyncConfiguration {
@@ -29,8 +31,11 @@ class AsyncConfiguration {
     @Bean
     fun asyncer(
         @Qualifier(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
-        executor: Executor,
+        executorProvider: ObjectProvider<Executor>,
     ): Asyncer {
+        val executor = executorProvider.getIfAvailable {
+            Executors.newCachedThreadPool() // default fallback
+        }
         return ExecutorAsyncer(executor)
     }
 }


### PR DESCRIPTION
This pull request updates the way the `Asyncer` bean is configured in `AsyncConfiguration`. Instead of requiring an `Executor` bean to always be present, it now uses an `ObjectProvider<Executor>` to allow for a fallback executor if none is available. This increases the robustness and flexibility of the bean configuration.

Dependency injection improvement:

* The `asyncer` bean method in `AsyncConfiguration` now uses `ObjectProvider<Executor>` to retrieve the executor, providing a default `Executors.newCachedThreadPool()` if none is available. This prevents failures when the expected executor bean is not present and makes the configuration more resilient.