### PR TITLE
Add starter for embabel-agent-openai-compatible models

### DIFF
--- a/embabel-agent-starters/embabel-agent-starter-openai-compatible/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-openai-compatible/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>0.3.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-starter-openai-compatible</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent OpenAI Compatible Starter</name>
+    <description>Embabel Agent OpenAI Compatible Starter</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-openai-compatible-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
This pull request adds a new Maven project configuration for the OpenAI-compatible agent starter. The new `pom.xml` file sets up project metadata, parent linkage, and dependencies required for building the OpenAI-compatible starter module.

Project setup:

* Added a new `pom.xml` for the `embabel-agent-starter-openai-compatible` module, specifying its parent project, artifact information, and project metadata.

Dependencies:

* Declared dependencies on `embabel-agent-platform-autoconfigure` and `embabel-agent-openai-compatible-autoconfigure` to ensure the starter module includes necessary autoconfiguration features.