### PR TITLE
Use OpenAi Converters from agent-openai module

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -23,11 +23,11 @@ import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadataLoader
 import com.embabel.common.ai.autoconfig.ProviderInitialization
 import com.embabel.common.ai.autoconfig.RegisteredModel
-import com.embabel.common.ai.model.*
+import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.ai.model.Llm
+import com.embabel.common.ai.model.PerTokenPricingModel
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
-import com.embabel.common.util.loggerFor
 import io.micrometer.observation.ObservationRegistry
-import org.springframework.ai.openai.OpenAiChatOptions
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory


### PR DESCRIPTION
This pull request refactors the handling of options converters for OpenAI models by removing the internal implementations of `Gpt5ChatOptionsConverter` and `StandardOpenAiOptionsConverter` from `OpenAiModelsConfig.kt` and instead importing them from another module. This change improves code organization and maintainability by centralizing the options converter logic.

**Refactoring and code organization:**

* Removed the internal implementations of `Gpt5ChatOptionsConverter` and `StandardOpenAiOptionsConverter` from `OpenAiModelsConfig.kt` and replaced them with imports from the `com.embabel.agent.openai` package. [[1]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daR19-R21) [[2]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL198-L233)