### PR TITLE
Document OpenAI custom models setup

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -264,6 +264,20 @@ MISTRAL_API_KEY=your_mistral_api_key_here
 - `OPENAI_COMPLETIONS_PATH`: custom path for completions endpoint (default: `/v1/completions`)
 - `OPENAI_EMBEDDINGS_PATH`: custom path for embeddings endpoint (default: `/v1/embeddings`)
 
+===== OpenAi Custom
+- `OPENAI_CUSTOM_MODELS`: comma-separated list of custom model names to register (useful for OpenAI-compatible providers like Groq, Together AI, etc.)
+
+When using `OPENAI_CUSTOM_MODELS`, set `EMBABEL_MODELS_DEFAULT_LLM` to specify which model to use as the default.
+
+Example for using Groq:
+
+[source,bash]
+----
+export OPENAI_CUSTOM_BASE_URL="https://api.groq.com/openai/v1"
+export OPENAI_CUSTOM_API_KEY="your-groq-api-key"
+export OPENAI_CUSTOM_MODELS="llama-3.3-70b-versatile,mixtral-8x7b-32768"
+export EMBABEL_MODELS_DEFAULT_LLM="llama-3.3-70b-versatile"
+----
 ===== Anthropic (Claude 3.x, etc.)
 
 * Required:


### PR DESCRIPTION
This pull request adds documentation for configuring custom OpenAI-compatible models, making it easier to use providers like Groq and Together AI. The new section explains how to register custom models and set a default model.

Configuration documentation improvements:

* Added a section describing the `OPENAI_CUSTOM_MODELS` environment variable, allowing users to register custom model names for OpenAI-compatible providers.
* Provided instructions and an example for setting up Groq as a custom provider, including usage of `OPENAI_CUSTOM_BASE_URL`, `OPENAI_CUSTOM_API_KEY`, `OPENAI_CUSTOM_MODELS`, and `EMBABEL_MODELS_DEFAULT_LLM`.Added instructions for using custom OpenAI models and provided an example for Groq integration.