### PR TITLE
Introduce ability to disable validation on PromptRunner

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
@@ -361,6 +361,12 @@ interface PromptRunner : LlmUse, PromptRunnerOperations {
     fun withPropertyFilter(filter: Predicate<String>): PromptRunner
 
     /**
+     * Set whether to validate created objects.
+     * @param validation `true` to validate created objects; `false` otherwise. Defaults to `true`.
+     */
+    fun withValidation(validation: Boolean = true): PromptRunner
+
+    /**
      * Create an object creator for the given output class.
      * Allows setting strongly typed examples.
      */

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/nested/ObjectCreator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/nested/ObjectCreator.kt
@@ -111,6 +111,17 @@ interface ObjectCreator<T> {
     fun withoutProperties(vararg properties: String): ObjectCreator<T> = withPropertyFilter { !properties.contains(it) }
 
     /**
+     * Set whether to validate created objects.
+     * @param validation `true` to validate created objects; `false` otherwise. Defaults to `true`.
+     */
+    fun withValidation(validation: Boolean = true): ObjectCreator<T>
+
+    /**
+     * Disables validation of created objects.
+     */
+    fun withoutValidation(): ObjectCreator<T> = withValidation(false)
+
+    /**
      * Create an object of the desired type using the given prompt and LLM options from context
      * (process context or implementing class).
      * Prompts are typically created within the scope of an

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/nested/support/PromptRunnerObjectCreator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/nested/support/PromptRunnerObjectCreator.kt
@@ -55,6 +55,14 @@ internal data class PromptRunnerObjectCreator<T>(
         )
     }
 
+    override fun withValidation(
+        validation: Boolean
+    ): ObjectCreator<T> {
+        return copy(
+            promptRunner = promptRunner.withValidation(validation)
+        )
+    }
+
     override fun fromMessages(
         messages: List<Message>,
     ): T {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextPromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextPromptRunner.kt
@@ -66,6 +66,7 @@ internal data class OperationContextPromptRunner(
     private val contextualPromptContributors: List<ContextualPromptElement>,
     override val generateExamples: Boolean?,
     override val propertyFilter: Predicate<String> = Predicate { true },
+    override val validation: Boolean = true,
     private val otherToolCallbacks: List<ToolCallback> = emptyList(),
 ) : StreamingPromptRunner {
 
@@ -138,6 +139,7 @@ internal data class OperationContextPromptRunner(
                 id = interactionId ?: idForPrompt(messages, outputClass),
                 generateExamples = generateExamples,
                 propertyFilter = propertyFilter,
+                validation = validation,
             ),
             outputClass = outputClass,
             agentProcess = context.processContext.agentProcess,
@@ -164,6 +166,7 @@ internal data class OperationContextPromptRunner(
                 id = interactionId ?: idForPrompt(messages, outputClass),
                 generateExamples = generateExamples,
                 propertyFilter = propertyFilter,
+                validation = validation,
             ),
             outputClass = outputClass,
             agentProcess = context.processContext.agentProcess,
@@ -287,6 +290,9 @@ internal data class OperationContextPromptRunner(
 
     override fun withPropertyFilter(filter: Predicate<String>): PromptRunner =
         copy(propertyFilter = this.propertyFilter.and(filter))
+
+    override fun withValidation(validation: Boolean): PromptRunner =
+        copy(validation = validation)
 
     override fun <T> creating(outputClass: Class<T>): ObjectCreator<T> {
         return PromptRunnerObjectCreator(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/LlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/LlmOperations.kt
@@ -49,6 +49,12 @@ interface LlmUse : PromptContributorConsumer, ToolGroupConsumer {
      */
     val propertyFilter: Predicate<String>
 
+    /**
+     * Whether to validate generated objects.
+     * Defaults to `true`; set to `false` to skip validation.
+     */
+    val validation: Boolean
+
 }
 
 /**
@@ -83,6 +89,7 @@ private data class LlmCallImpl(
     override val contextualPromptContributors: List<ContextualPromptElement> = emptyList(),
     override val generateExamples: Boolean = false,
     override val propertyFilter: Predicate<String> = Predicate { true },
+    override val validation: Boolean = true,
 ) : LlmCall
 
 /**
@@ -109,6 +116,7 @@ data class LlmInteraction(
     override val contextualPromptContributors: List<ContextualPromptElement> = emptyList(),
     override val generateExamples: Boolean? = null,
     override val propertyFilter: Predicate<String> = Predicate { true },
+    override val validation: Boolean = true,
 ) : LlmCall {
 
     override val name: String = id.value

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
@@ -59,6 +59,7 @@ data class FakePromptRunner(
     private val contextualPromptContributors: List<ContextualPromptElement>,
     override val generateExamples: Boolean?,
     override val propertyFilter: Predicate<String> = Predicate { true },
+    override val validation: Boolean = true,
     private val context: OperationContext,
     private val _llmInvocations: MutableList<LlmInvocation> = mutableListOf(),
     private val responses: MutableList<Any?> = mutableListOf(),
@@ -190,6 +191,9 @@ data class FakePromptRunner(
 
     override fun withPropertyFilter(filter: Predicate<String>): PromptRunner =
         copy(propertyFilter = this.propertyFilter.and(filter))
+
+    override fun withValidation(validation: Boolean): PromptRunner =
+        copy(validation = validation)
 
 
     private fun createLlmInteraction() =

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/thinking/ThinkingPromptRunnerOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/thinking/ThinkingPromptRunnerOperationsTest.kt
@@ -19,9 +19,9 @@ import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.common.support.OperationContextPromptRunner
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.chat.AssistantMessage
-import com.embabel.common.core.thinking.ThinkingResponse
 import com.embabel.common.core.thinking.ThinkingBlock
 import com.embabel.common.core.thinking.ThinkingException
+import com.embabel.common.core.thinking.ThinkingResponse
 import com.embabel.common.core.thinking.ThinkingTagType
 import io.mockk.every
 import io.mockk.mockk
@@ -169,6 +169,7 @@ class ThinkingPromptRunnerOperationsTest {
             override val promptContributors: List<com.embabel.common.ai.prompt.PromptContributor> = emptyList()
             override val generateExamples: Boolean? = null
             override val propertyFilter: java.util.function.Predicate<String> = java.util.function.Predicate { true }
+            override val validation: Boolean = true
 
             override fun <T> createObject(messages: List<com.embabel.chat.Message>, outputClass: Class<T>): T {
                 @Suppress("UNCHECKED_CAST")
@@ -237,6 +238,9 @@ class ThinkingPromptRunnerOperationsTest {
                 this
 
             override fun withPropertyFilter(filter: java.util.function.Predicate<String>): com.embabel.agent.api.common.PromptRunner =
+                this
+
+            override fun withValidation(validation: Boolean): com.embabel.agent.api.common.PromptRunner =
                 this
 
             override fun <T> creating(outputClass: Class<T>): com.embabel.agent.api.common.nested.ObjectCreator<T> {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -802,6 +802,40 @@ class ChatClientLlmOperationsTest {
 
             assertEquals(validHusky, createdDog, "Invalid response should have been corrected")
         }
+
+        @Test
+        fun `does not validate if interaction validation is set to false`() {
+            // Picky eater
+            data class BorderCollie(
+                val name: String,
+                @field:Pattern(regexp = "^mince$", message = "eats field must be 'mince'")
+                val eats: String,
+            )
+
+            val invalidHusky = BorderCollie("Husky", eats = "kibble")
+            val fakeChatModel = FakeChatModel(
+                jacksonObjectMapper().writeValueAsString(invalidHusky)
+            )
+            val prompt =
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+            val setup = createChatClientLlmOperations(
+                fakeChatModel = fakeChatModel,
+                dataBindingProperties = LlmDataBindingProperties(
+                    sendValidationInfo = true,
+                )
+            )
+            val createdDog = setup.llmOperations.createObject(
+                messages = listOf(UserMessage(prompt)),
+                interaction = LlmInteraction(
+                    id = InteractionId("id"), llm = LlmOptions(),
+                    validation = false
+                ),
+                outputClass = BorderCollie::class.java,
+                action = SimpleTestAgent.actions.first(),
+                agentProcess = setup.mockAgentProcess,
+            )
+            assertEquals(invalidHusky, createdDog, "Invalid response should have been corrected")
+        }
     }
 
 }


### PR DESCRIPTION
This PR introduces PromptRunner::withValidation, which allows the user to disable validation during object creation.

Closes: gh-991