### PR TITLE
Property conventions for API Key configuration

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -73,13 +73,13 @@ class OpenAiProperties : RetryProperties {
 @EnableConfigurationProperties(OpenAiProperties::class)
 @ExcludeFromJacocoGeneratedReport(reason = "OpenAi configuration can't be unit tested")
 class OpenAiModelsConfig(
-    @Value("\${OPENAI_BASE_URL:#{null}}")
+    @Value("\${embabel.models.openai.base.url:\${OPENAI_BASE_URL:#{null}}}")
     baseUrl: String?,
-    @Value("\${OPENAI_API_KEY}")
+    @Value("\${embabel.models.openai.api-key:\${OPENAI_API_KEY}}")
     apiKey: String,
-    @Value("\${OPENAI_COMPLETIONS_PATH:#{null}}")
+    @Value("\${embabel.models.openai.completions:\${OPENAI_COMPLETIONS_PATH:#{null}}}")
     completionsPath: String?,
-    @Value("\${OPENAI_EMBEDDINGS_PATH:#{null}}")
+    @Value("\${embabel.models.openai.embeddings.path:\${OPENAI_EMBEDDINGS_PATH:#{null}}}")
     embeddingsPath: String?,
     observationRegistry: ObjectProvider<ObservationRegistry>,
     private val properties: OpenAiProperties,


### PR DESCRIPTION
This pull request updates the configuration property names for the OpenAI model integration, allowing the application to prioritize new, more descriptive property keys while maintaining backward compatibility with the previous environment variable names.

**Configuration improvements:**

* Updated `OpenAiModelsConfig` to use new property keys (e.g., `embabel.models.openai.base.url`, `embabel.models.openai.api-key`, etc.) with fallbacks to the old environment variables (e.g., `OPENAI_BASE_URL`, `OPENAI_API_KEY`). This makes configuration more consistent and flexible for different deployment environments.