### PR TITLE
Add OpenAi apiKey validation

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -44,6 +44,26 @@ import org.springframework.context.annotation.Configuration
 @ConfigurationProperties(prefix = "embabel.agent.platform.models.openai")
 class OpenAiProperties : RetryProperties {
     /**
+     * Base URL for OpenAI API requests.
+     */
+    var baseUrl: String? = null
+
+    /**
+     * API key for authenticating with OpenAI services.
+     */
+    var apiKey: String? = null
+
+    /**
+     * Path to completions endpoint or configuration.
+     */
+    var completions: String? = null
+
+    /**
+     * Path to embeddings endpoint or configuration.
+     */
+    var embeddingsPath: String? = null
+
+    /**
      *  Maximum number of attempts.
      */
     override var maxAttempts: Int = 10
@@ -73,23 +93,24 @@ class OpenAiProperties : RetryProperties {
 @EnableConfigurationProperties(OpenAiProperties::class)
 @ExcludeFromJacocoGeneratedReport(reason = "OpenAi configuration can't be unit tested")
 class OpenAiModelsConfig(
-    @Value("\${embabel.models.openai.base.url:\${OPENAI_BASE_URL:#{null}}}")
-    baseUrl: String?,
-    @Value("\${embabel.models.openai.api-key:\${OPENAI_API_KEY}}")
-    apiKey: String,
-    @Value("\${embabel.models.openai.completions:\${OPENAI_COMPLETIONS_PATH:#{null}}}")
-    completionsPath: String?,
-    @Value("\${embabel.models.openai.embeddings.path:\${OPENAI_EMBEDDINGS_PATH:#{null}}}")
-    embeddingsPath: String?,
+    @Value("\${OPENAI_BASE_URL:#{null}}")
+    envBaseUrl: String?,
+    @Value("\${OPENAI_API_KEY:#{null}}")
+    envApiKey: String?,
+    @Value("\${OPENAI_COMPLETIONS_PATH:#{null}}")
+    envCompletionsPath: String?,
+    @Value("\${OPENAI_EMBEDDINGS_PATH:#{null}}")
+    envEmbeddingsPath: String?,
     observationRegistry: ObjectProvider<ObservationRegistry>,
     private val properties: OpenAiProperties,
     private val configurableBeanFactory: ConfigurableBeanFactory,
     private val modelLoader: LlmAutoConfigMetadataLoader<OpenAiModelDefinitions> = OpenAiModelLoader(),
 ) : OpenAiCompatibleModelFactory(
-    baseUrl = baseUrl,
-    apiKey = apiKey,
-    completionsPath = completionsPath,
-    embeddingsPath = embeddingsPath,
+    baseUrl = envBaseUrl ?: properties.baseUrl,
+    apiKey = envApiKey ?: properties.apiKey
+        ?: error("OpenAI API key required: set OPENAI_API_KEY env var or embabel.agent.platform.models.openai.api-key"),
+    completionsPath = envCompletionsPath ?: properties.completions,
+    embeddingsPath = envEmbeddingsPath ?: properties.embeddingsPath,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP }
 ) {
 


### PR DESCRIPTION
This pull request refactors the configuration of OpenAI model properties to improve flexibility and environment variable support. The main change is to prioritize environment variables for configuration, falling back to values from the new `OpenAiProperties` class if not set, and to add new fields to this class for easier property management.

**Configuration improvements:**

* Added new fields to the `OpenAiProperties` class for `baseUrl`, `apiKey`, `completions`, and `embeddingsPath`, allowing these properties to be set via configuration files.
* Refactored the `OpenAiModelsConfig` constructor to first check environment variables (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, etc.), and fall back to the corresponding values in `OpenAiProperties` if the environment variables are not set. This makes configuration more robust and flexible.
* Improved error handling for the API key by throwing an error if neither the environment variable nor the property is set, ensuring that required credentials are always provided.