### PR TITLE
Architectural Diagrams addition to User Guide

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/agent-platform/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/agent-platform/page.adoc
@@ -4,3 +4,10 @@
 An `AgentPlatform` provides the ability to run agents in a specific environment.
 This is an SPI interface, so multiple implementations are possible.
 
+
+[graphviz, embabel_agent_platform_model.dot, png]
+----
+include::../diagrams/architecture/embabel_agent_platform_model.dot[]
+----
+
+

--- a/embabel-agent-docs/src/main/asciidoc/reference/agent-process/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/agent-process/page.adoc
@@ -21,3 +21,10 @@ Allows fine grained control over logging prompts, LLM returns and detailed plann
 This is useful to avoid rate limiting.
 
 
+[graphviz, embabel_execution_context.dot, png]
+----
+include::../diagrams/architecture/embabel_execution_context.dot[]
+----
+
+
+

--- a/embabel-agent-docs/src/main/asciidoc/reference/architecture/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/architecture/page.adoc
@@ -1,2 +1,13 @@
 [[reference.architecture]]
 === Embabel Architecture
+
+Please refer to architectural diagrams in sections:
+
+<<reference.planners>>
+
+<<reference.agent-platform>>
+
+<<reference.agent-process>>
+
+
+

--- a/embabel-agent-docs/src/main/asciidoc/reference/diagrams/architecture/embabel_agent_platform_model.dot
+++ b/embabel-agent-docs/src/main/asciidoc/reference/diagrams/architecture/embabel_agent_platform_model.dot
@@ -1,0 +1,71 @@
+digraph AgentPlatformModel {
+    // Node styling - matching original diagram
+    node [shape=box, style="filled,rounded", fontname="Arial", margin=0.2];
+    edge [fontname="Arial", fontsize=10];
+    
+    // Core platform components
+    AgentPlatform [fillcolor=lightblue, label="AgentPlatform\n(Runtime deployment)"];
+    Agent [fillcolor=lightgreen, label="Agent\n(Immutable agent description)"];
+    AgentScope [fillcolor=lightyellow, label="AgentScope\n(Actions, goals, conditions)"];
+    AgentProcess [fillcolor=lightcoral, label="AgentProcess\n(Single agent run)"];
+    
+    // Programming model - annotations
+    AgentAnnotation [fillcolor=pink, label="@Agent\n(Component annotation)"];
+    ActionAnnotation [fillcolor=lightgrey, label="@action\n(Method annotation)"];
+    ConditionAnnotation [fillcolor=lightcyan, label="@condition\n(Method annotation)"];
+    CapabilitiesAnnotation [fillcolor=lavender, label="@AgentCapabilities\n(Shared capabilities)"];
+    
+    // Configuration
+    ProcessOptions [fillcolor=lightpink, label="ProcessOptions\n(Runtime configuration)"];
+    
+    // Status tracking
+    ProcessStatus [fillcolor=lightsteelblue, label="ProcessStatus\n(Runtime state)"];
+    
+    // Domain types
+    DataDictionary [fillcolor=lightsalmon, label="DataDictionary\n(Type registry)"];
+    DomainType [fillcolor=lightseagreen, label="DomainType\n(Type representation)"];
+    
+    // Core components from planning system
+    Action [fillcolor=lightblue, label="Action\n(Executable step)"];
+    Condition [fillcolor=lightgreen, label="Condition\n(Named predicate)"];
+    Goal [fillcolor=pink, label="Goal\n(Desired end state)"];
+    
+    // Core relationships
+    AgentPlatform -> Agent [label="deploys"];
+    AgentPlatform -> AgentProcess [label="creates"];
+    Agent -> AgentScope [label="implements"];
+    AgentProcess -> ProcessStatus [label="tracks"];
+    AgentProcess -> ProcessOptions [label="configured by"];
+    
+    // Programming model relationships  
+    AgentAnnotation -> Agent [label="defines"];
+    ActionAnnotation -> Action [label="creates"];
+    ConditionAnnotation -> Condition [label="creates"];
+    CapabilitiesAnnotation -> AgentScope [label="contributes to"];
+    
+    // Compositional relationships - Agent composed of Actions/Goals/Conditions
+    Agent -> Action [label="composed of", style="bold"];
+    Agent -> Goal [label="composed of", style="bold"];
+    Agent -> Condition [label="composed of", style="bold"];
+    
+    // AgentScope composition
+    AgentScope -> Action [label="contains", style="dashed"];
+    AgentScope -> Goal [label="contains", style="dashed"];
+    AgentScope -> Condition [label="contains", style="dashed"];
+    
+    // Action-Condition relationships
+    Action -> Condition [label="has pre/post conditions"];
+    
+    // Configuration relationships
+    ProcessOptions -> AgentProcess [label="configures"];
+    
+    // Schema relationships - inheritance/implementation
+    AgentScope -> DataDictionary [label="implements", style="dashed"];
+    Agent -> DataDictionary [label="implements", style="dashed"];
+    AgentPlatform -> DataDictionary [label="implements", style="dashed"];
+    DataDictionary -> DomainType [label="contains"];
+    
+    // Additional platform relationships
+    AgentPlatform -> AgentScope [label="acts as superset", style="dashed"];
+    ProcessStatus -> AgentProcess [label="reports on", dir="back", style="dashed"];
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/diagrams/architecture/embabel_execution_context.dot
+++ b/embabel-agent-docs/src/main/asciidoc/reference/diagrams/architecture/embabel_execution_context.dot
@@ -1,0 +1,73 @@
+digraph ExecutionContext {
+    // Simple layout improvements
+    ranksep=1.0;
+    nodesep=0.8;
+    
+    // Node styling - matching original diagram  
+    node [shape=box, style="filled,rounded", fontname="Arial", margin=0.3, fontsize=12];
+    edge [fontname="Arial", fontsize=11];
+    
+    // Core context and LLM layer - grouped together
+    {rank=same; ProcessContext; OperationContext; LlmOperations;}
+    ProcessContext [fillcolor=lightblue, label="ProcessContext\n(Process-scoped services)"];
+    OperationContext [fillcolor=lightgreen, label="OperationContext\n(Operation execution context)"];
+    LlmOperations [fillcolor=lightgrey, label="LlmOperations\n(LLM backend services)"];
+    
+    // Secondary context layer
+    ActionContext [fillcolor=lightyellow, label="ActionContext\n(Action-specific context)"];
+    
+    // LLM configuration  
+    PromptRunner [fillcolor=lightcoral, label="PromptRunner\n(LLM interaction API)"];
+    LlmOptions [fillcolor=lightcyan, label="LlmOptions\n(Model configuration)"];
+    
+    // Thinking capability
+    ThinkingPromptRunnerOperations [fillcolor=lightsteelblue, label="ThinkingPromptRunnerOperations\n(Thinking-aware operations)"];
+    ThinkingResponse [fillcolor=lightpink, label="ThinkingResponse\n(Result + thinking blocks)"];
+    
+    // Tool system
+    ToolGroup [fillcolor=pink, label="ToolGroup\n(Coherent tool set)"];
+    ToolGroupRequirement [fillcolor=lavender, label="ToolGroupRequirement\n(Tool dependency)"];
+    ToolObject [fillcolor=wheat, label="ToolObject\n(@Tool annotated object)"];
+    
+    // State and data flow
+    Blackboard [fillcolor=lightsalmon, label="Blackboard\n(Shared state store)"];
+    IoBinding [fillcolor=lightseagreen, label="IoBinding\n(Input/output binding)"];
+    
+    // Prompt system
+    PromptContributor [fillcolor=lavender, label="PromptContributor\n(Prompt element)"];
+    Message [fillcolor=lightsteelblue, label="Message\n(Conversation element)"];
+    
+    // Context hierarchy relationships
+    ProcessContext -> OperationContext [label="provides"];
+    OperationContext -> ActionContext [label="specializes to"];
+    
+    // LLM integration relationships
+    OperationContext -> PromptRunner [label="creates"];
+    ActionContext -> PromptRunner [label="enhances"];
+    PromptRunner -> LlmOperations [label="delegates to"];
+    PromptRunner -> LlmOptions [label="configured by"];
+    
+    // Thinking integration
+    PromptRunner -> ThinkingPromptRunnerOperations [label="withThinking()"];
+    ThinkingPromptRunnerOperations -> ThinkingResponse [label="returns"];
+    
+    // Tool integration relationships
+    PromptRunner -> ToolGroup [label="with tool groups"];
+    PromptRunner -> ToolObject [label="with tool objects"];
+    ActionContext -> ToolGroupRequirement [label="declares"];
+    ToolGroupRequirement -> ToolGroup [label="requires"];
+    
+    // State and data relationships
+    OperationContext -> Blackboard [label="accesses"];
+    ActionContext -> Blackboard [label="reads/writes"];
+    Blackboard -> IoBinding [label="stores via"];
+    
+    // Prompt construction relationships
+    PromptRunner -> PromptContributor [label="with contributors"];
+    PromptRunner -> Message [label="with messages"];
+    
+    // Additional flow relationships
+    ProcessContext -> LlmOperations [label="provides", style="dashed"];
+    ActionContext -> ToolObject [label="creates from domain objects", style="dashed"];
+    OperationContext -> IoBinding [label="manages", style="dashed"];
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/diagrams/architecture/embabel_planning_system.dot
+++ b/embabel-agent-docs/src/main/asciidoc/reference/diagrams/architecture/embabel_planning_system.dot
@@ -1,0 +1,46 @@
+digraph PlanningSystem {
+    // Node styling
+    node [shape=box, style="filled,rounded", fontname="Arial", margin=0.2, fontsize=12];
+    edge [fontname="Arial", fontsize=11];
+    
+    // Key components
+    Action [fillcolor=lightblue, label="Action\n(Core executable unit)"];
+    Condition [fillcolor=lightgreen, label="Condition\n(Named predicate)"];
+    Blackboard [fillcolor=lightyellow, label="Blackboard\n(Shared memory system)"];
+    WorldState [fillcolor=lightcoral, label="WorldState\n(System conditions map)"];
+    Plan [fillcolor=lightgrey, label="Plan\n(Sequence of Actions)"];
+    Goal [fillcolor=pink, label="Goal\n(Desired end state)"];
+    Planner [fillcolor=lightcyan, label="Planner\n(GOAP / Utility)"];
+    PlanningSystem [fillcolor=lavender, label="PlanningSystem\n(Actions + Goals + Conditions)"];
+    IoBinding [fillcolor=lightpink, label="IoBinding\n(Input/output binding)"];
+    
+    // Relationships
+    Action -> Condition [label="has preconditions"];
+    Action -> WorldState [label="produces effects on"];
+    Action -> Blackboard [label="reads from/writes to"];
+    Action -> IoBinding [label="defines inputs/outputs via"];
+    
+    Condition -> WorldState [label="evaluated against"];
+    
+    Goal -> Condition [label="defined by"];
+    
+    Blackboard -> WorldState [label="determines"];
+    
+    WorldState -> Planner [label="informs"];
+    
+    Planner -> Plan [label="creates"];
+    Planner -> Action [label="selects"];
+    Planner -> Goal [label="satisfies"];
+    
+    Plan -> Action [label="contains sequence of"];
+    Plan -> Goal [label="achieves"];
+    
+    PlanningSystem -> Action [label="contains available"];
+    PlanningSystem -> Goal [label="contains possible"];
+    PlanningSystem -> Planner [label="used by"];
+    
+    // Additional relationships
+    Blackboard -> Condition [label="stores state for", style="dashed"];
+    WorldState -> Action [label="determines achievability of", style="dashed"];
+    Action -> Plan [label="executed according to", dir="back", style="dashed"];
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/planners/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/planners/page.adoc
@@ -675,3 +675,9 @@ Both `SupervisorInvocation` and <<reference.tools__agentic-tools,AgenticTool>> p
 
 Use `AgenticTool` when you need a tool that internally orchestrates other tools.
 Use `SupervisorInvocation` when you need a complete workflow that produces a typed result with full blackboard state management.
+
+
+[graphviz, embabel_planning_system.dot, png]
+----
+include::../diagrams/architecture/embabel_planning_system.dot[]
+----


### PR DESCRIPTION
## Overview

Diagrams additions: 
Sections:  Planners, Agent Platform, Agent Process

Please refer to issue:
https://github.com/embabel/embabel-agent/issues/40

## Implementation

Diagrams got generated using Graphiz in ".dot"-format.

Syntax on inclusion into Asciidoc:
```
[graphviz, embabel_planning_system.dot, png]
----
include::../diagrams/architecture/embabel_planning_system.dot[]
----
```


Maven does include proper diagram plugin:

```

                            <groupId>org.asciidoctor</groupId>
                            <artifactId>asciidoctorj-diagram</artifactId>
                            <version>${asciidoctorj.diagram.version}</version>

```

We need to test whether this works properly in Github build.

In order to render diagrams in Intellij  **Kroki** should be enabled:

<img width="1062" height="465" alt="image" src="https://github.com/user-attachments/assets/7d4ea5ad-e36f-4933-a30a-eb3b646681ed" />

### Note on Rendering

if auto-rendering from .dot file is not working properly,  will switch to 2-step process on generating svg / png from .dot file