### PR TITLE
Fixes #1228

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -95,24 +95,22 @@ class OpenAiProperties : RetryProperties {
 @EnableConfigurationProperties(OpenAiProperties::class)
 @ExcludeFromJacocoGeneratedReport(reason = "OpenAi configuration can't be unit tested")
 class OpenAiModelsConfig(
-    @Value("\${OPENAI_BASE_URL:#{null}}")
-    envBaseUrl: String?,
-    @Value("\${OPENAI_API_KEY:#{null}}")
-    envApiKey: String?,
-    @Value("\${OPENAI_COMPLETIONS_PATH:#{null}}")
-    envCompletionsPath: String?,
-    @Value("\${OPENAI_EMBEDDINGS_PATH:#{null}}")
-    envEmbeddingsPath: String?,
+    @param:Value("\${OPENAI_BASE_URL:#{null}}")
+    private val envBaseUrl: String?,
+    @param:Value("\${OPENAI_API_KEY:#{null}}")
+    private val envApiKey: String?,
+    @param:Value("\${OPENAI_COMPLETIONS_PATH:#{null}}")
+    private val envCompletionsPath: String?,
+    @param:Value("\${OPENAI_EMBEDDINGS_PATH:#{null}}")
+    private val envEmbeddingsPath: String?,
     observationRegistry: ObjectProvider<ObservationRegistry>,
-    @Qualifier("aiModelHttpRequestFactory")
-    requestFactory: ObjectProvider<ClientHttpRequestFactory>,
+    @Qualifier("aiModelHttpRequestFactory") requestFactory: ObjectProvider<ClientHttpRequestFactory>,
     private val properties: OpenAiProperties,
     private val configurableBeanFactory: ConfigurableBeanFactory,
     private val modelLoader: LlmAutoConfigMetadataLoader<OpenAiModelDefinitions> = OpenAiModelLoader(),
 ) : OpenAiCompatibleModelFactory(
     baseUrl = envBaseUrl ?: properties.baseUrl,
-    apiKey = envApiKey ?: properties.apiKey
-    ?: error("OpenAI API key required: set OPENAI_API_KEY env var or embabel.agent.platform.models.openai.api-key"),
+    apiKey = envApiKey ?: properties.apiKey ?: error("OpenAI API key required: set OPENAI_API_KEY env var or embabel.agent.platform.models.openai.api-key"),
     completionsPath = envCompletionsPath ?: properties.completions,
     embeddingsPath = envEmbeddingsPath ?: properties.embeddingsPath,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
@@ -135,13 +133,11 @@ class OpenAiModelsConfig(
                     configurableBeanFactory.registerSingleton(modelDef.name, llm)
                     add(RegisteredModel(beanName = modelDef.name, modelId = modelDef.modelId))
                     logger.info(
-                        "Registered OpenAI model bean: {} -> {}",
-                        modelDef.name, modelDef.modelId
+                        "Registered OpenAI model bean: {} -> {}", modelDef.name, modelDef.modelId
                     )
                 } catch (e: Exception) {
                     logger.error(
-                        "Failed to create model: {} ({})",
-                        modelDef.name, modelDef.modelId, e
+                        "Failed to create model: {} ({})", modelDef.name, modelDef.modelId, e
                     )
                     throw e
                 }
@@ -156,13 +152,11 @@ class OpenAiModelsConfig(
                     configurableBeanFactory.registerSingleton(embeddingDef.name, embeddingService)
                     add(RegisteredModel(beanName = embeddingDef.name, modelId = embeddingDef.modelId))
                     logger.info(
-                        "Registered OpenAI embedding model bean: {} -> {}",
-                        embeddingDef.name, embeddingDef.modelId
+                        "Registered OpenAI embedding model bean: {} -> {}", embeddingDef.name, embeddingDef.modelId
                     )
                 } catch (e: Exception) {
                     logger.error(
-                        "Failed to create embedding model: {} ({})",
-                        embeddingDef.name, embeddingDef.modelId, e
+                        "Failed to create embedding model: {} ({})", embeddingDef.name, embeddingDef.modelId, e
                     )
                     throw e
                 }
@@ -189,8 +183,7 @@ class OpenAiModelsConfig(
         }
 
         val chatModel = chatModelOf(
-            model = modelDef.modelId,
-            retryTemplate = properties.retryTemplate(modelDef.modelId)
+            model = modelDef.modelId, retryTemplate = properties.retryTemplate(modelDef.modelId)
         )
 
         // Create pricing model if present


### PR DESCRIPTION
This pull request improves the configuration flexibility and consistency for multiple model providers (Anthropic, DeepSeek, Gemini, Mistral AI, OpenAI, and OpenAI Custom) by allowing both environment variables and configuration properties to be used for specifying API keys and base URLs. It also introduces better error handling for missing API keys and minor code cleanups.

Key changes include:

**Configuration Flexibility and Consistency:**
- Added `baseUrl` and `apiKey` fields to the properties classes for Anthropic, DeepSeek, Gemini, Mistral AI, and OpenAI Custom, allowing these values to be set via configuration properties as well as environment variables. (`AnthropicModelsConfig.kt`, `DeepSeekModelsConfig.kt`, `GeminiModelsConfig.kt`, `MistralAiModelsConfig.kt`, `OpenAiCustomModelsConfig.kt`) [[1]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9R58-R67) [[2]](diffhunk://#diff-04cd9d09b045f18977108fb11a2fc5a552ad255338b3709dd6a35f643fca1c8bR48-R57) [[3]](diffhunk://#diff-8996e33691059952c6c03c60e4dd85bfa7f03f058b08e6a0d7a664148a7ad611R46-R55) [[4]](diffhunk://#diff-2f53e1e66fa129636f8d92238f424e877d49f1f58dfdab7a87ab979c4872661fR49-R58) [[5]](diffhunk://#diff-6c3a04ab41828ffc87cb301c978c7f79cfed9fe9dc2e24110c52b86d84b62011R42-R56)
- Updated configuration classes to prioritize environment variables, then fall back to configuration properties, and finally provide clear error messages if required API keys are missing. (`AnthropicModelsConfig.kt`, `DeepSeekModelsConfig.kt`, `GeminiModelsConfig.kt`, `MistralAiModelsConfig.kt`, `OpenAiCustomModelsConfig.kt`, `OpenAiModelsConfig.kt`) [[1]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9L89-R102) [[2]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9R112-R115) [[3]](diffhunk://#diff-04cd9d09b045f18977108fb11a2fc5a552ad255338b3709dd6a35f643fca1c8bL78-R100) [[4]](diffhunk://#diff-8996e33691059952c6c03c60e4dd85bfa7f03f058b08e6a0d7a664148a7ad611L79-R99) [[5]](diffhunk://#diff-2f53e1e66fa129636f8d92238f424e877d49f1f58dfdab7a87ab979c4872661fL78-R102) [[6]](diffhunk://#diff-6c3a04ab41828ffc87cb301c978c7f79cfed9fe9dc2e24110c52b86d84b62011L85-R119) [[7]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL98-R113)

**Default Values and Null Handling:**
- Improved handling of optional `baseUrl` fields by checking for null or blank values before using them, ensuring that defaults are only overridden when appropriate. (`AnthropicModelsConfig.kt`, `DeepSeekModelsConfig.kt`, `MistralAiModelsConfig.kt`) [[1]](diffhunk://#diff-4f7c226141776851900f74dc01a8c57ff8a9a3b38d3602addea57731d98ae5b9L233-R247) [[2]](diffhunk://#diff-04cd9d09b045f18977108fb11a2fc5a552ad255338b3709dd6a35f643fca1c8bL155-R169) [[3]](diffhunk://#diff-2f53e1e66fa129636f8d92238f424e877d49f1f58dfdab7a87ab979c4872661fL174-R188)
- For Gemini, introduced a `DEFAULT_BASE_URL` constant and fallback logic. (`GeminiModelsConfig.kt`)

**OpenAI and OpenAI Custom Enhancements:**
- Standardized the way environment variables are injected and used, aligning with the approach used for other providers. (`OpenAiModelsConfig.kt`, `OpenAiCustomModelsConfig.kt`) [[1]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL98-R113) [[2]](diffhunk://#diff-6c3a04ab41828ffc87cb301c978c7f79cfed9fe9dc2e24110c52b86d84b62011L85-R119)
- Allowed custom model IDs for OpenAI Custom to be set via either environment variable or configuration property. (`OpenAiCustomModelsConfig.kt`) [[1]](diffhunk://#diff-6c3a04ab41828ffc87cb301c978c7f79cfed9fe9dc2e24110c52b86d84b62011R42-R56) [[2]](diffhunk://#diff-6c3a04ab41828ffc87cb301c978c7f79cfed9fe9dc2e24110c52b86d84b62011L85-R119)

**Minor Code Cleanups:**
- Streamlined logger statements for better readability and consistency. (`OpenAiModelsConfig.kt`) [[1]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL138-R140) [[2]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL159-R159) [[3]](diffhunk://#diff-3d381c30ef4652440c3d0b6cecc7aa532cba73bf7c21d3ae4fcad83ca641d4daL192-R186)

These improvements make the configuration more robust, user-friendly, and consistent across all supported providers.