### PR TITLE
Update User Guide copyright year to 2026

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/index.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/index.adoc
@@ -18,7 +18,7 @@ ifdef::backend-html5[]
 
 Embabel Agent Release: {embabel-agent-version}
 
-(C) 2024-2025 Embabel
+(C) 2024-2026 Embabel
 
 endif::backend-html5[]
 


### PR DESCRIPTION
This pull request updates the copyright year in the documentation.

* Documentation update:
  * [`embabel-agent-docs/src/main/asciidoc/index.adoc`](diffhunk://#diff-77b60ec9d3cf061c1bb72ba3d6f0563c6d70baabe306440a6a34371468dd8e9cL21-R21): Changed copyright year from 2025 to 2026.