### PR TITLE
Update legal entity name

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/index.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/index.adoc
@@ -18,7 +18,7 @@ ifdef::backend-html5[]
 
 Embabel Agent Release: {embabel-agent-version}
 
-(C) 2024-2026 Embabel
+(C) 2024-2026 Embabel Pty, Ltd
 
 endif::backend-html5[]
 


### PR DESCRIPTION
This pull request makes a minor update to the copyright notice in the documentation, specifying the company name as "Embabel Pty, Ltd" instead of just "Embabel".