### PR TITLE
Introduce navigation on entity proxies

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/NamedEntityInvocationHandler.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/NamedEntityInvocationHandler.kt
@@ -15,18 +15,37 @@
  */
 package com.embabel.agent.rag.model
 
+import com.embabel.agent.rag.service.RetrievableIdentifier
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
 
 /**
  * InvocationHandler that backs a [NamedEntity] instance with a property map.
+ *
+ * Supports lazy relationship navigation when a [RelationshipNavigator] is provided
+ * and methods are annotated with [@Semantics][Semantics].
+ *
+ * @param properties the entity's properties (id, name, description, etc.)
+ * @param metadata the entity's metadata
+ * @param labels the entity's labels
+ * @param entityData the backing entity data
+ * @param navigator optional navigator for relationship traversal
+ * @param interfaces the interfaces this proxy implements (for determining return types)
  */
 internal class NamedEntityInvocationHandler(
     private val properties: Map<String, Any?>,
     private val metadata: Map<String, Any?>,
     private val labels: Set<String>,
     private val entityData: NamedEntityData,
+    private val navigator: RelationshipNavigator? = null,
+    private val interfaces: Array<out Class<*>> = emptyArray(),
 ) : InvocationHandler {
+
+    // Cache for lazy-loaded relationships
+    private val relationshipCache = mutableMapOf<String, Any?>()
 
     override fun invoke(proxy: Any, method: Method, args: Array<out Any>?): Any? {
         return when (val methodName = method.name) {
@@ -57,20 +76,160 @@ internal class NamedEntityInvocationHandler(
 
             "propertiesToPersist" -> entityData.propertiesToPersist()
 
-            // Kotlin property getter pattern: getXxx() -> property "xxx"
+            // Check for relationship navigation, property getter, or default method
+            else -> handlePropertyOrRelationship(proxy, method, methodName, args)
+        }
+    }
+
+    private fun handlePropertyOrRelationship(
+        proxy: Any,
+        method: Method,
+        methodName: String,
+        args: Array<out Any>?,
+    ): Any? {
+        // Check for @Relationship annotation
+        val relationship = findRelationshipAnnotation(method)
+        if (relationship != null && navigator != null) {
+            return handleRelationship(method, relationship)
+        }
+
+        // Standard property getter handling
+        if (methodName.startsWith("get") && methodName.length > 3 && args.isNullOrEmpty()) {
+            val propertyName = methodName.substring(3).replaceFirstChar { it.lowercase() }
+            return properties[propertyName]
+        } else if (methodName.startsWith("is") && methodName.length > 2 && args.isNullOrEmpty()) {
+            // Boolean property: isXxx() -> property "xxx" or "isXxx"
+            val propertyName = methodName.substring(2).replaceFirstChar { it.lowercase() }
+            return properties[propertyName] ?: properties[methodName]
+        }
+
+        // Check for default interface method (business logic methods)
+        if (method.isDefault) {
+            return invokeDefaultMethod(proxy, method, args)
+        }
+
+        // Try direct property lookup
+        return properties[methodName]
+    }
+
+    /**
+     * Invoke a default interface method using MethodHandles.
+     * This allows business logic methods defined in interfaces to work correctly.
+     */
+    private fun invokeDefaultMethod(proxy: Any, method: Method, args: Array<out Any>?): Any? {
+        val declaringClass = method.declaringClass
+        val lookup = MethodHandles.privateLookupIn(declaringClass, MethodHandles.lookup())
+        val methodHandle = lookup.findSpecial(
+            declaringClass,
+            method.name,
+            MethodType.methodType(method.returnType, method.parameterTypes),
+            declaringClass
+        )
+        return if (args.isNullOrEmpty()) {
+            methodHandle.bindTo(proxy).invokeWithArguments()
+        } else {
+            methodHandle.bindTo(proxy).invokeWithArguments(*args)
+        }
+    }
+
+    /**
+     * Find the @Relationship annotation on this method, checking all implemented interfaces.
+     */
+    private fun findRelationshipAnnotation(method: Method): Relationship? {
+        // Check method directly
+        method.getAnnotation(Relationship::class.java)?.let { return it }
+
+        // Check interfaces for the same method signature
+        for (iface in interfaces) {
+            try {
+                val ifaceMethod = iface.getMethod(method.name, *method.parameterTypes)
+                ifaceMethod.getAnnotation(Relationship::class.java)?.let { return it }
+            } catch (_: NoSuchMethodException) {
+                // Method not found in this interface, continue
+            }
+        }
+        return null
+    }
+
+    private fun handleRelationship(method: Method, relationship: Relationship): Any? {
+        // Derive relationship name if not specified
+        val relationshipName = relationship.name.ifEmpty { deriveRelationshipName(method.name) }
+        val cacheKey = "$relationshipName:${relationship.direction}"
+
+        // Return cached value if available
+        relationshipCache[cacheKey]?.let { return it }
+
+        val entityId = properties["id"] as? String ?: return null
+        val entityType = labels.firstOrNull() ?: "Entity"
+        val source = RetrievableIdentifier(id = entityId, type = entityType)
+        val relatedEntities = navigator!!.findRelated(
+            source,
+            relationshipName,
+            relationship.direction
+        )
+
+        val result = hydrateRelationshipResult(method, relatedEntities)
+        relationshipCache[cacheKey] = result
+        return result
+    }
+
+    /**
+     * Hydrate relationship results to the appropriate return type.
+     * Handles: single entity (T?), collection (List<T>), etc.
+     */
+    private fun hydrateRelationshipResult(method: Method, entities: List<NamedEntityData>): Any? {
+        val returnType = method.returnType
+
+        // Determine target entity type
+        val targetType = extractTargetType(method)
+
+        return when {
+            // Collection type (List, Set, Collection, etc.)
+            Collection::class.java.isAssignableFrom(returnType) -> {
+                entities.mapNotNull { it.toInstanceOrNull(targetType) }
+            }
+            // Single entity (nullable)
             else -> {
-                if (methodName.startsWith("get") && methodName.length > 3 && args.isNullOrEmpty()) {
-                    val propertyName = methodName.substring(3).replaceFirstChar { it.lowercase() }
-                    properties[propertyName]
-                } else if (methodName.startsWith("is") && methodName.length > 2 && args.isNullOrEmpty()) {
-                    // Boolean property: isXxx() -> property "xxx" or "isXxx"
-                    val propertyName = methodName.substring(2).replaceFirstChar { it.lowercase() }
-                    properties[propertyName] ?: properties[methodName]
-                } else {
-                    // Try direct property lookup
-                    properties[methodName]
+                entities.firstOrNull()?.toInstanceOrNull(targetType)
+            }
+        }
+    }
+
+    /**
+     * Extract the target entity type from the method return type.
+     * For List<Person>, extracts Person.
+     * For Company?, extracts Company.
+     */
+    private fun extractTargetType(method: Method): Class<out NamedEntity>? {
+        val returnType = method.returnType
+
+        // For collections, get the generic type parameter
+        if (Collection::class.java.isAssignableFrom(returnType)) {
+            val genericType = method.genericReturnType
+            if (genericType is ParameterizedType) {
+                val typeArg = genericType.actualTypeArguments.firstOrNull()
+                if (typeArg is Class<*> && NamedEntity::class.java.isAssignableFrom(typeArg)) {
+                    @Suppress("UNCHECKED_CAST")
+                    return typeArg as Class<out NamedEntity>
                 }
             }
+            return null
+        }
+
+        // For single types
+        if (NamedEntity::class.java.isAssignableFrom(returnType)) {
+            @Suppress("UNCHECKED_CAST")
+            return returnType as Class<out NamedEntity>
+        }
+        return null
+    }
+
+    private fun NamedEntityData.toInstanceOrNull(targetType: Class<out NamedEntity>?): NamedEntity? {
+        if (targetType == null) return null
+        return try {
+            toInstance(targetType)
+        } catch (_: Exception) {
+            null
         }
     }
 }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/Relationship.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/Relationship.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model
+
+/**
+ * Marks a getter method as navigating a relationship to another entity.
+ *
+ * When applied to a getter on a [NamedEntity] interface, the dynamic proxy
+ * will use the repository to lazily load the related entity/entities.
+ *
+ * Example:
+ * ```kotlin
+ * interface Person : NamedEntity {
+ *     val name: String
+ *
+ *     @Relationship  // Defaults to "HAS_EMPLOYER"
+ *     fun getEmployer(): Company?
+ *
+ *     @Relationship("OWNS")  // Explicit name
+ *     fun getPets(): List<Pet>
+ *
+ *     @Relationship(direction = RelationshipDirection.INCOMING)  // "HAS_DIRECT_REPORTS"
+ *     fun getDirectReports(): List<Person>
+ * }
+ * ```
+ *
+ * @property name The relationship type/name (e.g., "EMPLOYED_BY", "OWNS").
+ *                If empty, defaults to `HAS_` + property name in UPPER_SNAKE_CASE.
+ *                For example, `getEmployer()` -> "HAS_EMPLOYER", `getPets()` -> "HAS_PETS".
+ * @property direction The direction of relationship traversal. Defaults to [RelationshipDirection.OUTGOING].
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Relationship(
+    val name: String = "",
+    val direction: RelationshipDirection = RelationshipDirection.OUTGOING,
+)
+
+/**
+ * Direction of relationship traversal.
+ */
+enum class RelationshipDirection {
+    /** Traverse outgoing relationships (this entity → target entity) */
+    OUTGOING,
+    /** Traverse incoming relationships (target entity → this entity) */
+    INCOMING,
+    /** Traverse both directions */
+    BOTH
+}
+
+/**
+ * Derives the default relationship name from a method name.
+ *
+ * Converts getter method names to HAS_UPPER_SNAKE_CASE format:
+ * - `getEmployer` -> "HAS_EMPLOYER"
+ * - `getPets` -> "HAS_PETS"
+ * - `getDirectReports` -> "HAS_DIRECT_REPORTS"
+ */
+fun deriveRelationshipName(methodName: String): String {
+    val propertyName = when {
+        methodName.startsWith("get") && methodName.length > 3 ->
+            methodName.substring(3)
+        methodName.startsWith("is") && methodName.length > 2 ->
+            methodName.substring(2)
+        else -> methodName
+    }
+    return "HAS_" + propertyName.toUpperSnakeCase()
+}
+
+/**
+ * Converts a camelCase or PascalCase string to UPPER_SNAKE_CASE.
+ */
+private fun String.toUpperSnakeCase(): String {
+    return this.replace(Regex("([a-z])([A-Z])")) { "${it.groupValues[1]}_${it.groupValues[2]}" }
+        .uppercase()
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/RelationshipNavigator.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/RelationshipNavigator.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model
+
+import com.embabel.agent.rag.service.RetrievableIdentifier
+
+/**
+ * Provides relationship navigation capability for [NamedEntityInvocationHandler].
+ *
+ * This interface is implemented by repositories that support relationship traversal.
+ * It allows the invocation handler to lazily load related entities when a method
+ * annotated with `@Relationship` is invoked.
+ */
+interface RelationshipNavigator {
+    /**
+     * Find entities related to the given entity via a named relationship.
+     *
+     * @param source identifier for the source entity (id + type)
+     * @param relationshipName the relationship type/name
+     * @param direction the direction of traversal
+     * @return list of related entity data
+     */
+    fun findRelated(
+        source: RetrievableIdentifier,
+        relationshipName: String,
+        direction: RelationshipDirection,
+    ): List<NamedEntityData>
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaAddressEntity.java
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaAddressEntity.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model;
+
+/**
+ * Java interface for testing - represents an address entity.
+ */
+public interface JavaAddressEntity extends NamedEntity {
+    String getStreet();
+    String getCity();
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaCompanyEntity.java
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaCompanyEntity.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model;
+
+/**
+ * Java interface for testing - represents a company entity.
+ */
+public interface JavaCompanyEntity extends NamedEntity {
+    String getIndustry();
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaInterfaceRelationshipTest.java
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaInterfaceRelationshipTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model;
+
+import com.embabel.agent.rag.service.RetrievableIdentifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests relationship navigation and business logic methods using Java interfaces.
+ */
+public class JavaInterfaceRelationshipTest {
+
+    private TestNavigator navigator;
+
+    @BeforeEach
+    void setUp() {
+        navigator = new TestNavigator();
+    }
+
+    private NamedEntityData createAddress(String id, String street, String city) {
+        Set<String> labels = new HashSet<>();
+        labels.add("JavaAddressEntity");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("street", street);
+        properties.put("city", city);
+        return new SimpleNamedEntityData(
+            id,
+            null,
+            street + ", " + city,
+            "Address",
+            labels,
+            properties,
+            new HashMap<>(),
+            null
+        );
+    }
+
+    private NamedEntityData createCompany(String id, String name, String industry) {
+        Set<String> labels = new HashSet<>();
+        labels.add("JavaCompanyEntity");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("industry", industry);
+        return new SimpleNamedEntityData(
+            id,
+            null,
+            name,
+            "A company",
+            labels,
+            properties,
+            new HashMap<>(),
+            null
+        );
+    }
+
+    private NamedEntityData createPerson(String id, String name, int age) {
+        Set<String> labels = new HashSet<>();
+        labels.add("JavaPersonEntity");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("age", age);
+        return new SimpleNamedEntityData(
+            id,
+            null,
+            name,
+            "A person",
+            labels,
+            properties,
+            new HashMap<>(),
+            null
+        );
+    }
+
+    @Test
+    void nullableRelationshipReturnsNullWhenNoRelatedEntity() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        JavaPersonEntity person = personData.toInstance(navigator, JavaPersonEntity.class);
+
+        // getEmployer() returns nullable type - should return null without error
+        JavaCompanyEntity employer = person.getEmployer();
+        assertNull(employer);
+    }
+
+    @Test
+    void collectionRelationshipReturnsEmptyListWhenNoRelatedEntities() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        JavaPersonEntity person = personData.toInstance(navigator, JavaPersonEntity.class);
+
+        // getAddresses() returns List - should return empty list without error
+        List<JavaAddressEntity> addresses = person.getAddresses();
+        assertNotNull(addresses);
+        assertTrue(addresses.isEmpty());
+    }
+
+    @Test
+    void relationshipGetterReturnsList() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        NamedEntityData address1 = createAddress("a1", "123 Main St", "Springfield");
+        NamedEntityData address2 = createAddress("a2", "456 Oak Ave", "Shelbyville");
+
+        navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address1);
+        navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address2);
+
+        JavaPersonEntity person = personData.toInstance(navigator, JavaPersonEntity.class);
+
+        List<JavaAddressEntity> addresses = person.getAddresses();
+        assertEquals(2, addresses.size());
+        assertEquals("123 Main St", addresses.get(0).getStreet());
+        assertEquals("456 Oak Ave", addresses.get(1).getStreet());
+    }
+
+    @Test
+    void relationshipGetterReturnsSingleEntity() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        NamedEntityData company = createCompany("c1", "Acme Corp", "Technology");
+
+        navigator.addRelationship("p1", "HAS_EMPLOYER", RelationshipDirection.OUTGOING, company);
+
+        JavaPersonEntity person = personData.toInstance(navigator, JavaPersonEntity.class);
+
+        JavaCompanyEntity employer = person.getEmployer();
+        assertNotNull(employer);
+        assertEquals("Acme Corp", employer.getName());
+        assertEquals("Technology", employer.getIndustry());
+    }
+
+    @Test
+    void businessLogicMethodInvokesRelationshipMethod() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        NamedEntityData address1 = createAddress("a1", "123 Main St", "Springfield");
+        NamedEntityData address2 = createAddress("a2", "456 Oak Ave", "Shelbyville");
+
+        navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address1);
+        navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address2);
+
+        JavaPersonEntity person = personData.toInstance(navigator, JavaPersonEntity.class);
+
+        // addressHistory() internally calls getAddresses()
+        String history = person.addressHistory();
+        assertEquals("123 Main St, Springfield -> 456 Oak Ave, Shelbyville", history);
+    }
+
+    @Test
+    void businessLogicMethodWithSingleRelationship() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        NamedEntityData company = createCompany("c1", "Acme Corp", "Technology");
+
+        navigator.addRelationship("p1", "HAS_EMPLOYER", RelationshipDirection.OUTGOING, company);
+
+        JavaPersonEntity person = personData.toInstance(navigator, JavaPersonEntity.class);
+
+        // employerName() internally calls getEmployer()
+        String name = person.employerName();
+        assertEquals("Acme Corp", name);
+    }
+
+    @Test
+    void businessLogicMethodHandlesNullRelationship() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        JavaPersonEntity person = personData.toInstance(navigator, JavaPersonEntity.class);
+
+        // employerName() with no employer
+        String name = person.employerName();
+        assertEquals("Unemployed", name);
+    }
+
+    @Test
+    void scalarPropertiesWork() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        JavaPersonEntity person = personData.toInstance(navigator, JavaPersonEntity.class);
+
+        assertEquals("p1", person.getId());
+        assertEquals("John", person.getName());
+        assertEquals(30, person.getAge());
+    }
+
+    /**
+     * Test navigator implementation for testing.
+     */
+    static class TestNavigator implements RelationshipNavigator {
+        private final Map<String, Map<String, List<NamedEntityData>>> relationships = new HashMap<>();
+
+        void addRelationship(
+            String entityId,
+            String relationshipName,
+            RelationshipDirection direction,
+            NamedEntityData target
+        ) {
+            String key = entityId + ":" + relationshipName + ":" + direction;
+            relationships
+                .computeIfAbsent(key, k -> new HashMap<>())
+                .computeIfAbsent(relationshipName, k -> new ArrayList<>())
+                .add(target);
+        }
+
+        @Override
+        public List<NamedEntityData> findRelated(
+            RetrievableIdentifier source,
+            String relationshipName,
+            RelationshipDirection direction
+        ) {
+            String key = source.getId() + ":" + relationshipName + ":" + direction;
+            Map<String, List<NamedEntityData>> rels = relationships.get(key);
+            if (rels == null) {
+                return List.of();
+            }
+            List<NamedEntityData> result = rels.get(relationshipName);
+            return result != null ? result : List.of();
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaPersonEntity.java
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaPersonEntity.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Java interface for testing relationship navigation and business logic methods.
+ */
+public interface JavaPersonEntity extends NamedEntity {
+
+    int getAge();
+
+    @Relationship(name = "HAS_ADDRESS")
+    List<JavaAddressEntity> getAddresses();
+
+    @Relationship  // Defaults to HAS_EMPLOYER
+    JavaCompanyEntity getEmployer();
+
+    /**
+     * Business logic method that invokes relationship method.
+     */
+    default String addressHistory() {
+        List<JavaAddressEntity> addresses = getAddresses();
+        return addresses.stream()
+                .map(a -> a.getStreet() + ", " + a.getCity())
+                .collect(Collectors.joining(" -> "));
+    }
+
+    /**
+     * Business logic method using single relationship.
+     */
+    default String employerName() {
+        JavaCompanyEntity employer = getEmployer();
+        return employer != null ? employer.getName() : "Unemployed";
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/service/JavaRepositoryRelationshipNavigationTest.java
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/service/JavaRepositoryRelationshipNavigationTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.service;
+
+import com.embabel.agent.core.DataDictionary;
+import com.embabel.agent.rag.model.*;
+import com.embabel.agent.rag.service.support.InMemoryNamedEntityDataRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that relationship navigation works correctly when entities are loaded
+ * via the repository's findById method.
+ */
+public class JavaRepositoryRelationshipNavigationTest {
+
+    private InMemoryNamedEntityDataRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        DataDictionary dataDictionary = DataDictionary.fromClasses(
+            JavaPersonEntity.class,
+            JavaAddressEntity.class,
+            JavaCompanyEntity.class
+        );
+        repository = new InMemoryNamedEntityDataRepository(dataDictionary);
+    }
+
+    private NamedEntityData createAddress(String id, String street, String city) {
+        Set<String> labels = new HashSet<>();
+        labels.add("JavaAddressEntity");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("street", street);
+        properties.put("city", city);
+        return new SimpleNamedEntityData(
+            id,
+            null,
+            street + ", " + city,
+            "Address",
+            labels,
+            properties,
+            new HashMap<>(),
+            null
+        );
+    }
+
+    private NamedEntityData createCompany(String id, String name, String industry) {
+        Set<String> labels = new HashSet<>();
+        labels.add("JavaCompanyEntity");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("industry", industry);
+        return new SimpleNamedEntityData(
+            id,
+            null,
+            name,
+            "A company",
+            labels,
+            properties,
+            new HashMap<>(),
+            null
+        );
+    }
+
+    private NamedEntityData createPerson(String id, String name, int age) {
+        Set<String> labels = new HashSet<>();
+        labels.add("JavaPersonEntity");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("age", age);
+        return new SimpleNamedEntityData(
+            id,
+            null,
+            name,
+            "A person",
+            labels,
+            properties,
+            new HashMap<>(),
+            null
+        );
+    }
+
+    @Test
+    void relationshipNavigationWorksViaRepositoryFindById() {
+        // Create and save entities
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        NamedEntityData address1 = createAddress("a1", "123 Main St", "Springfield");
+        NamedEntityData address2 = createAddress("a2", "456 Oak Ave", "Shelbyville");
+
+        repository.save(personData);
+        repository.save(address1);
+        repository.save(address2);
+
+        // Create relationships
+        repository.createRelationship(
+            new RetrievableIdentifier("p1", "JavaPersonEntity"),
+            new RetrievableIdentifier("a1", "JavaAddressEntity"),
+            new RelationshipData("HAS_ADDRESS", Map.of())
+        );
+        repository.createRelationship(
+            new RetrievableIdentifier("p1", "JavaPersonEntity"),
+            new RetrievableIdentifier("a2", "JavaAddressEntity"),
+            new RelationshipData("HAS_ADDRESS", Map.of())
+        );
+
+        // Load person via repository - should have navigator attached
+        JavaPersonEntity person = repository.findById("p1", JavaPersonEntity.class);
+        assertNotNull(person);
+
+        // Navigate relationship - should work!
+        List<JavaAddressEntity> addresses = person.getAddresses();
+        assertNotNull(addresses, "Relationship collection should not be null");
+        assertEquals(2, addresses.size(), "Should have 2 addresses");
+        assertEquals("123 Main St", addresses.get(0).getStreet());
+        assertEquals("456 Oak Ave", addresses.get(1).getStreet());
+    }
+
+    @Test
+    void singleRelationshipNavigationWorksViaRepository() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        NamedEntityData company = createCompany("c1", "Acme Corp", "Technology");
+
+        repository.save(personData);
+        repository.save(company);
+
+        repository.createRelationship(
+            new RetrievableIdentifier("p1", "JavaPersonEntity"),
+            new RetrievableIdentifier("c1", "JavaCompanyEntity"),
+            new RelationshipData("HAS_EMPLOYER", Map.of())
+        );
+
+        JavaPersonEntity person = repository.findById("p1", JavaPersonEntity.class);
+        assertNotNull(person);
+
+        JavaCompanyEntity employer = person.getEmployer();
+        assertNotNull(employer, "Single relationship should not be null when target exists");
+        assertEquals("Acme Corp", employer.getName());
+        assertEquals("Technology", employer.getIndustry());
+    }
+
+    @Test
+    void emptyCollectionRelationshipReturnsEmptyListNotNull() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        repository.save(personData);
+
+        JavaPersonEntity person = repository.findById("p1", JavaPersonEntity.class);
+        assertNotNull(person);
+
+        // No addresses were created, should return empty list, not null
+        List<JavaAddressEntity> addresses = person.getAddresses();
+        assertNotNull(addresses, "Empty relationship should return empty list, not null");
+        assertTrue(addresses.isEmpty(), "Should be empty");
+    }
+
+    @Test
+    void nullableSingleRelationshipReturnsNull() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        repository.save(personData);
+
+        JavaPersonEntity person = repository.findById("p1", JavaPersonEntity.class);
+        assertNotNull(person);
+
+        // No employer was set
+        JavaCompanyEntity employer = person.getEmployer();
+        assertNull(employer, "Nullable relationship with no target should return null");
+    }
+
+    @Test
+    void businessLogicMethodWorksWithRelationshipNavigation() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        NamedEntityData address1 = createAddress("a1", "123 Main St", "Springfield");
+        NamedEntityData address2 = createAddress("a2", "456 Oak Ave", "Shelbyville");
+
+        repository.save(personData);
+        repository.save(address1);
+        repository.save(address2);
+
+        repository.createRelationship(
+            new RetrievableIdentifier("p1", "JavaPersonEntity"),
+            new RetrievableIdentifier("a1", "JavaAddressEntity"),
+            new RelationshipData("HAS_ADDRESS", Map.of())
+        );
+        repository.createRelationship(
+            new RetrievableIdentifier("p1", "JavaPersonEntity"),
+            new RetrievableIdentifier("a2", "JavaAddressEntity"),
+            new RelationshipData("HAS_ADDRESS", Map.of())
+        );
+
+        JavaPersonEntity person = repository.findById("p1", JavaPersonEntity.class);
+        assertNotNull(person);
+
+        // Business logic method that internally calls getAddresses()
+        String history = person.addressHistory();
+        assertEquals("123 Main St, Springfield -> 456 Oak Ave, Shelbyville", history);
+    }
+
+    @Test
+    void businessLogicMethodHandlesNullRelationship() {
+        NamedEntityData personData = createPerson("p1", "John", 30);
+        repository.save(personData);
+
+        JavaPersonEntity person = repository.findById("p1", JavaPersonEntity.class);
+        assertNotNull(person);
+
+        // employerName() with no employer should return "Unemployed"
+        String name = person.employerName();
+        assertEquals("Unemployed", name);
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/NamedEntityInvocationHandlerTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/NamedEntityInvocationHandlerTest.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model
+
+import com.embabel.agent.rag.service.RetrievableIdentifier
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class NamedEntityInvocationHandlerTest {
+
+    // Test interfaces
+    interface Address : NamedEntity {
+        val street: String
+        val city: String
+    }
+
+    interface Person : NamedEntity {
+        val age: Int
+
+        @Relationship("HAS_ADDRESS")
+        fun getAddresses(): List<Address>
+
+        @Relationship  // Defaults to "HAS_EMPLOYER"
+        fun getEmployer(): Company?
+
+        /**
+         * Business logic method that invokes relationship methods.
+         * This should NOT be proxied as a property/relationship.
+         */
+        fun addressHistory(): String {
+            val addresses = getAddresses()
+            return addresses.joinToString(" -> ") { "${it.street}, ${it.city}" }
+        }
+
+        /**
+         * Another business logic method using a single relationship.
+         */
+        fun employerName(): String {
+            return getEmployer()?.name ?: "Unemployed"
+        }
+    }
+
+    interface Company : NamedEntity {
+        val industry: String
+    }
+
+    // Test navigator that returns mock data
+    class TestNavigator : RelationshipNavigator {
+        val relationships = mutableMapOf<String, MutableMap<String, MutableList<NamedEntityData>>>()
+
+        fun addRelationship(
+            entityId: String,
+            relationshipName: String,
+            direction: RelationshipDirection,
+            target: NamedEntityData,
+        ) {
+            val key = "$entityId:$relationshipName:$direction"
+            relationships.getOrPut(key) { mutableMapOf() }
+                .getOrPut(relationshipName) { mutableListOf() }
+                .add(target)
+        }
+
+        override fun findRelated(
+            source: RetrievableIdentifier,
+            relationshipName: String,
+            direction: RelationshipDirection,
+        ): List<NamedEntityData> {
+            val key = "${source.id}:$relationshipName:$direction"
+            return relationships[key]?.get(relationshipName) ?: emptyList()
+        }
+    }
+
+    private lateinit var navigator: TestNavigator
+
+    @BeforeEach
+    fun setUp() {
+        navigator = TestNavigator()
+    }
+
+    private fun createAddress(id: String, street: String, city: String): NamedEntityData =
+        SimpleNamedEntityData(
+            id = id,
+            name = "$street, $city",
+            description = "Address",
+            labels = setOf("Address"),
+            properties = mapOf("street" to street, "city" to city),
+        )
+
+    private fun createCompany(id: String, name: String, industry: String): NamedEntityData =
+        SimpleNamedEntityData(
+            id = id,
+            name = name,
+            description = "A company",
+            labels = setOf("Company"),
+            properties = mapOf("industry" to industry),
+        )
+
+    private fun createPerson(id: String, name: String, age: Int): NamedEntityData =
+        SimpleNamedEntityData(
+            id = id,
+            name = name,
+            description = "A person",
+            labels = setOf("Person"),
+            properties = mapOf("age" to age),
+        )
+
+    @Nested
+    inner class RelationshipNavigationTest {
+
+        @Test
+        fun `relationship getter returns list of related entities`() {
+            val personData = createPerson("p1", "John", 30)
+            val address1 = createAddress("a1", "123 Main St", "Springfield")
+            val address2 = createAddress("a2", "456 Oak Ave", "Shelbyville")
+
+            navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address1)
+            navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address2)
+
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            val addresses = person.getAddresses()
+            assertEquals(2, addresses.size)
+            assertEquals("123 Main St", addresses[0].street)
+            assertEquals("456 Oak Ave", addresses[1].street)
+        }
+
+        @Test
+        fun `nullable relationship returns null when no related entity exists`() {
+            val personData = createPerson("p1", "John", 30)
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            // getEmployer() returns Company? (nullable) - should return null without error
+            val employer = person.getEmployer()
+            assertNull(employer)
+        }
+
+        @Test
+        fun `collection relationship returns empty list when no related entities exist`() {
+            val personData = createPerson("p1", "John", 30)
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            // getAddresses() returns List<Address> - should return empty list without error
+            val addresses = person.getAddresses()
+            assertNotNull(addresses)
+            assertTrue(addresses.isEmpty())
+        }
+
+        @Test
+        fun `relationship getter returns single entity`() {
+            val personData = createPerson("p1", "John", 30)
+            val company = createCompany("c1", "Acme Corp", "Technology")
+
+            navigator.addRelationship("p1", "HAS_EMPLOYER", RelationshipDirection.OUTGOING, company)
+
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            val employer = person.getEmployer()
+            assertNotNull(employer)
+            assertEquals("Acme Corp", employer?.name)
+            assertEquals("Technology", employer?.industry)
+        }
+
+        @Test
+        fun `default relationship name derived from method name`() {
+            val personData = createPerson("p1", "John", 30)
+            val company = createCompany("c1", "Acme Corp", "Technology")
+
+            // Note: Using default name "HAS_EMPLOYER" derived from getEmployer()
+            navigator.addRelationship("p1", "HAS_EMPLOYER", RelationshipDirection.OUTGOING, company)
+
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            val employer = person.getEmployer()
+            assertNotNull(employer)
+            assertEquals("Acme Corp", employer?.name)
+        }
+
+        @Test
+        fun `relationships are cached after first load`() {
+            val personData = createPerson("p1", "John", 30)
+            val address1 = createAddress("a1", "123 Main St", "Springfield")
+
+            navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address1)
+
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            // First call
+            val addresses1 = person.getAddresses()
+            assertEquals(1, addresses1.size)
+
+            // Add another address to navigator (simulating external change)
+            val address2 = createAddress("a2", "456 Oak Ave", "Shelbyville")
+            navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address2)
+
+            // Second call should return cached result
+            val addresses2 = person.getAddresses()
+            assertEquals(1, addresses2.size) // Still 1, cached
+        }
+    }
+
+    @Nested
+    inner class BusinessLogicMethodTest {
+
+        @Test
+        fun `business logic method can invoke relationship methods`() {
+            val personData = createPerson("p1", "John", 30)
+            val address1 = createAddress("a1", "123 Main St", "Springfield")
+            val address2 = createAddress("a2", "456 Oak Ave", "Shelbyville")
+
+            navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address1)
+            navigator.addRelationship("p1", "HAS_ADDRESS", RelationshipDirection.OUTGOING, address2)
+
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            // addressHistory() internally calls getAddresses()
+            val history = person.addressHistory()
+            assertEquals("123 Main St, Springfield -> 456 Oak Ave, Shelbyville", history)
+        }
+
+        @Test
+        fun `business logic method handles empty relationships`() {
+            val personData = createPerson("p1", "John", 30)
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            // addressHistory() with no addresses
+            val history = person.addressHistory()
+            assertEquals("", history)
+        }
+
+        @Test
+        fun `business logic method using single relationship`() {
+            val personData = createPerson("p1", "John", 30)
+            val company = createCompany("c1", "Acme Corp", "Technology")
+
+            navigator.addRelationship("p1", "HAS_EMPLOYER", RelationshipDirection.OUTGOING, company)
+
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            // employerName() internally calls getEmployer()
+            val name = person.employerName()
+            assertEquals("Acme Corp", name)
+        }
+
+        @Test
+        fun `business logic method handles null relationship`() {
+            val personData = createPerson("p1", "John", 30)
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            // employerName() with no employer
+            val name = person.employerName()
+            assertEquals("Unemployed", name)
+        }
+    }
+
+    @Nested
+    inner class PropertyAccessTest {
+
+        @Test
+        fun `scalar properties still work with navigator`() {
+            val personData = createPerson("p1", "John", 30)
+            val person = personData.toInstance<Person>(navigator, Person::class.java)
+
+            assertEquals("p1", person.id)
+            assertEquals("John", person.name)
+            assertEquals(30, person.age)
+        }
+    }
+
+    @Nested
+    inner class DeriveRelationshipNameTest {
+
+        @Test
+        fun `derives name from getter method`() {
+            assertEquals("HAS_EMPLOYER", deriveRelationshipName("getEmployer"))
+            assertEquals("HAS_PETS", deriveRelationshipName("getPets"))
+            assertEquals("HAS_ADDRESSES", deriveRelationshipName("getAddresses"))
+        }
+
+        @Test
+        fun `handles camelCase to UPPER_SNAKE_CASE`() {
+            assertEquals("HAS_DIRECT_REPORTS", deriveRelationshipName("getDirectReports"))
+            assertEquals("HAS_HOME_ADDRESS", deriveRelationshipName("getHomeAddress"))
+        }
+
+        @Test
+        fun `handles is prefix for boolean-style names`() {
+            assertEquals("HAS_ACTIVE", deriveRelationshipName("isActive"))
+        }
+    }
+
+    // Java interface tests are in JavaInterfaceRelationshipTest.java
+}


### PR DESCRIPTION
Allow navigation on entity proxies backed by a `NamedEntityDataRepository`