### PR TITLE
Polishing AnthropicModelsConfig.kt

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
@@ -16,7 +16,6 @@
 package com.embabel.agent.config.models.anthropic
 
 import com.embabel.agent.api.models.AnthropicModels
-import com.embabel.agent.api.models.OpenAiModels
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadataLoader
 import com.embabel.common.ai.autoconfig.ProviderInitialization
@@ -41,7 +40,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.ClientHttpRequestFactory
-import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestClient
 import org.springframework.web.reactive.function.client.WebClient
 import java.time.LocalDate
@@ -111,7 +109,7 @@ class AnthropicModelsConfig(
 
     private val baseUrl: String? = envBaseUrl ?: properties.baseUrl
     private val apiKey: String = envApiKey ?: properties.apiKey
-        ?: error("Anthropic API key required: set ANTHROPIC_API_KEY env var or embabel.agent.platform.models.anthropic.api-key")
+    ?: error("Anthropic API key required: set ANTHROPIC_API_KEY env var or embabel.agent.platform.models.anthropic.api-key")
 
     init {
         logger.info("Anthropic models are available: {}", properties)


### PR DESCRIPTION
This pull request makes minor cleanup changes to the import statements in the `AnthropicModelsConfig.kt` file, removing unused imports to keep the codebase tidy and easier to maintain.

- Removed unused imports:
  - `OpenAiModels` from `com.embabel.agent.api.models`
  - `SimpleClientHttpRequestFactory` from `org.springframework.http.client`