### PR TITLE
Prepare 0.3.2

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.8</version>
+        <version>0.1.9</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.9-SNAPSHOT</version>
+        <version>0.1.9</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -15,7 +15,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <embabel-common.version>0.1.8-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.8</embabel-common.version>
         <netty.version>4.1.125.Final</netty.version>
     </properties>
 


### PR DESCRIPTION
This pull request updates project dependencies and parent versions from snapshot or previous releases to stable release versions. The changes are primarily related to version management in Maven configuration files.

Dependency and parent version updates:

* Updated the parent version in `pom.xml` from `0.1.9-SNAPSHOT` to the stable `0.1.9`.
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.8-SNAPSHOT` to `0.1.8`.
* Updated the parent version in `embabel-agent-dependencies/pom.xml` from `0.1.8` to `0.1.9`.