### PR TITLE
Fix KotlinReflectionInternalError for Java records

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/TypeBasedInputSchema.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/TypeBasedInputSchema.kt
@@ -86,6 +86,11 @@ class TypeBasedInputSchema(
         val required = mutableListOf<String>()
 
         try {
+            // Skip Kotlin reflection for Java records - go straight to fallback
+            if (type.isRecord) {
+                throw UnsupportedOperationException("Java records require fallback reflection")
+            }
+
             val kClass = type.kotlin
             for (prop in kClass.memberProperties) {
                 val propName = prop.name
@@ -130,6 +135,11 @@ class TypeBasedInputSchema(
         val params = mutableListOf<Tool.Parameter>()
 
         try {
+            // Skip Kotlin reflection for Java records - go straight to fallback
+            if (type.isRecord) {
+                throw UnsupportedOperationException("Java records require fallback reflection")
+            }
+
             val kClass = type.kotlin
             for (prop in kClass.memberProperties) {
                 val propType = (prop.returnType.javaType as? Class<*>) ?: Any::class.java


### PR DESCRIPTION
This pull request updates the `TypeBasedInputSchema` class to improve compatibility with Java records. The main change is to bypass Kotlin reflection for Java record types, ensuring the code falls back to a more appropriate reflection mechanism for these cases.

Reflection handling improvements:

* Updated both the `getJsonSchema` and `getParameters` logic in `TypeBasedInputSchema.kt` to detect Java record types using `type.isRecord` and explicitly skip Kotlin reflection for them, throwing an exception to trigger fallback reflection instead. [[1]](diffhunk://#diff-748e164c9958037e6fad2b5473f0bf3117856d1f779a42c3b51cd049806dbc07R89-R93) [[2]](diffhunk://#diff-748e164c9958037e6fad2b5473f0bf3117856d1f779a42c3b51cd049806dbc07R138-R142)