### PR TITLE
Update LMStudioModelsConfig to differentiate and register embeddings LLMs

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfigTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfigTest.kt
@@ -78,9 +78,9 @@ class LmStudioModelsConfigTest {
         // Given
         val jsonResponse = """
             {
-              "data": [
-                { "id": "model-1" },
-                { "id": "user/model-2" }
+              "models": [
+                { "key": "model-1" ,"type": "llm"},
+                { "key": "user/model-2", "type": "embedding"}
               ]
             }
         """.trimIndent()
@@ -100,6 +100,7 @@ class LmStudioModelsConfigTest {
         verify {
             mockBeanFactory.registerSingleton("lmStudioModel-model-1", any())
             mockBeanFactory.registerSingleton("lmStudioModel-user-model-2", any())
+
         }
     }
 
@@ -144,8 +145,8 @@ class LmStudioModelsConfigTest {
         // Given
         val jsonResponse = """
             {
-              "data": [
-                { "id": "Organization/Model:Name" }
+              "models": [
+                { "key": "Organization/Model:Name","type": "llm" }
               ]
             }
         """.trimIndent()
@@ -167,4 +168,5 @@ class LmStudioModelsConfigTest {
             mockBeanFactory.registerSingleton("lmStudioModel-organization-model-name", any())
         }
     }
+
 }


### PR DESCRIPTION
This pull request updates the `LMStudioModelsConfig` to properly differentiate between and register language models (LLMs) and embeddings. This ensures more accurate model configuration and management.

I found that that LMStudio does have an API that properly sends lot of metadata about models it has : 

/api/v1/models

```

{
    "models": [
        {
            "display_name": "Nomic Embed Text v1.5",
            "format": "gguf",
            "key": "nomic-ai/text-embedding-nomic-embed-text-v1.5",
            "loaded_instances": [],
            "max_context_length": 2048,
            "params_string": null,
            "publisher": "nomic-ai",
            "quantization": {
                "bits_per_weight": 4,
                "name": "Q4_K_M"
            },
            "size_bytes": 84106624,
            "type": "embedding"
        },
```

vs the raw barebone  /v1/models of openai : 

```
{
    "data": [
        {
            "id": "nomic-ai/text-embedding-nomic-embed-text-v1.5",
            "object": "model",
            "owned_by": "organization_owner"
        },
```

This way I could properly load embedding models on my embabel application using lmstudio : 


```
22:56:33.199 [main] INFO  OpenAiModels - Using custom OpenAI base URL: http://localhost:1234
22:56:33.300 [main] INFO  LmStudioModelsConfig - Attempting to fetch models from: http://localhost:1234/api/v1/models
22:56:33.344 [main] INFO  LmStudioModelsConfig - Discovered 10 LM Studio models: [ModelData(key=nomic-ai/text-embedding-nomic-embed-text-v1.5, type=embedding), ModelData(key=s3dev-ai/text-embedding-nomic-embed-text-v1.5, type=embedding), ModelData(key=mistralai_ministral-3-14b-instruct-2512-mlx, type=llm), ModelData(key=liquid/lfm2.5-1.2b, type=llm), ModelData(key=ministral-3-8b-reasoning-2512, type=llm), ModelData(key=functiongemma-270m-it, type=llm), ModelData(key=mistralai/ministral-3-14b-reasoning, type=llm), ModelData(key=zai-org/glm-4.6v-flash, type=llm), ModelData(key=text-embedding-qwen3-0.6b-text-embedding, type=embedding), ModelData(key=qwen3-8b-mlx, type=llm)]
22:56:33.351 [main] INFO  LmStudioModelsConfig - LM Studio: Initialized 7 LLM(s) and 3 embedding(s)
22:56:33.355 [main] INFO  ConfigurableModelProvider - Default LLM: qwen3-8b-mlx
Available LLMs:
        name: functiongemma-270m-it, provider: LM Studio
        name: liquid/lfm2.5-1.2b, provider: LM Studio
        name: ministral-3-8b-reasoning-2512, provider: LM Studio
        name: mistralai/ministral-3-14b-reasoning, provider: LM Studio
        name: mistralai_ministral-3-14b-instruct-2512-mlx, provider: LM Studio
        name: qwen3-8b-mlx, provider: LM Studio
        name: zai-org/glm-4.6v-flash, provider: LM Studio
Default embedding service: s3dev-ai/text-embedding-nomic-embed-text-v1.5
Available embedding services:
        name: nomic-ai/text-embedding-nomic-embed-text-v1.5, provider: LM Studio
        name: s3dev-ai/text-embedding-nomic-embed-text-v1.5, provider: LM Studio
        name: text-embedding-qwen3-0.6b-text-embedding, provider: LM Studio
```

I just use the custom /api endpoint to retrieve model info, the other endpoints remain unchanged

Hope it solves #1287 