### PR TITLE
fix #1285: Expose streamingLlmOperations.generateStream

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/streaming/StreamingPromptRunnerOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/streaming/StreamingPromptRunnerOperations.kt
@@ -61,6 +61,13 @@ interface StreamingPromptRunnerOperations : StreamingCapability {
      * @return Flux emitting StreamingEvent instances for objects and thinking
      */
     fun <T> createObjectStreamWithThinking(itemClass: Class<T>): Flux<StreamingEvent<T>>
+
+    /**
+     * Generate a reactive stream of text chunks as they arrive from the LLM.
+     *
+     * @return Flux emitting text chunks as they arrive from the LLM
+     */
+    fun generateStream(): Flux<String>
 }
 
 /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingOperations.kt
@@ -34,6 +34,10 @@ internal data class DelegatingStreamingOperations(
     override fun withMessages(messages: List<Message>): StreamingPromptRunnerOperations =
         copy(delegate = delegate.withMessages((messages)))
 
+    override fun generateStream(): Flux<String> {
+        return delegate.generateStream()
+    }
+
     override fun <T> createObjectStream(itemClass: Class<T>): Flux<T> =
         delegate.createObjectStream(itemClass)
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
@@ -262,6 +262,18 @@ internal data class OperationContextDelegate(
         return StreamingCapabilityDetector.supportsStreaming(llmOperations, this.llm)
     }
 
+    override fun generateStream(): Flux<String> {
+        val llmOperations = context.agentPlatform().platformServices.llmOperations as ChatClientLlmOperations
+        val streamingLlmOperations = StreamingChatClientOperations(llmOperations)
+
+        return streamingLlmOperations.generateStream(
+            messages = messages,
+            interaction = streamingInteraction(),
+            agentProcess = context.processContext.agentProcess,
+            action = action,
+        )
+    }
+
     override fun <T> createObjectStream(itemClass: Class<T>): Flux<T> {
         val llmOperations = context.agentPlatform().platformServices.llmOperations as ChatClientLlmOperations
         val streamingLlmOperations = StreamingChatClientOperations(llmOperations)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/PromptExecutionDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/PromptExecutionDelegate.kt
@@ -101,6 +101,8 @@ internal interface PromptExecutionDelegate : LlmUse {
 
     fun supportsStreaming(): Boolean
 
+    fun generateStream(): Flux<String>
+
     fun <T> createObjectStream(itemClass: Class<T>): Flux<T>
 
     fun <T> createObjectStreamWithThinking(itemClass: Class<T>): Flux<StreamingEvent<T>>

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
@@ -220,6 +220,10 @@ data class FakePromptRunner(
 
         override fun supportsStreaming(): Boolean = false
 
+        override fun generateStream(): Flux<String> {
+            TODO("Not yet implemented")
+        }
+
         override fun <T> createObjectStream(itemClass: Class<T>): Flux<T> {
             TODO("Not yet implemented")
         }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingOperationsTest.kt
@@ -80,6 +80,25 @@ class DelegatingStreamingOperationsTest {
     }
 
     @Nested
+    inner class GenerateStreamTest {
+
+        @Test
+        fun `should delegate to delegate generateStream`() {
+            val mockStream = Flux.just("test")
+
+            every { mockDelegate.generateStream() } returns mockStream
+
+            val operations = createStreamingOperations()
+            val result = operations.generateStream()
+
+            verify { mockDelegate.generateStream() }
+
+            val firstItem = result.blockFirst()
+            assertEquals("test", firstItem)
+        }
+    }
+
+    @Nested
     inner class CreateObjectStreamTest {
 
         @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/streaming/StreamingPromptRunnerOperationsImpl.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/streaming/StreamingPromptRunnerOperationsImpl.kt
@@ -60,6 +60,15 @@ internal class StreamingPromptRunnerOperationsImpl(
         return copy(messages = messages)
     }
 
+    override fun generateStream(): Flux<String> {
+        return streamingLlmOperations.generateStream(
+            messages = messages,
+            interaction = interaction,
+            agentProcess = agentProcess,
+            action = action
+        )
+    }
+
     override fun <T> createObjectStream(itemClass: Class<T>): Flux<T> {
         return streamingLlmOperations.createObjectStream(
             messages = messages,

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/streaming/StreamingPromptRunnerOperationsImplTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/streaming/StreamingPromptRunnerOperationsImplTest.kt
@@ -80,6 +80,31 @@ class StreamingPromptRunnerOperationsImplTest {
     }
 
     @Test
+    fun `should delegate generateStream to StreamingLlmOperations`() {
+        // Given
+        val mockStream = Flux.just("test")
+        every {
+            mockStreamingLlmOperations.generateStream(
+                eq(initialMessages), any(), mockAgentProcess, mockAction
+            )
+        } returns mockStream
+
+        // When
+        val result = streamingOperations.generateStream()
+
+        // Then
+        verify {
+            mockStreamingLlmOperations.generateStream(
+                initialMessages, mockInteraction, mockAgentProcess, mockAction
+            )
+        }
+
+        // Simple verification - get first item from stream
+        val firstItem = result.blockFirst()
+        assertEquals("test", firstItem)
+    }
+
+    @Test
     fun `should delegate createObjectStream to StreamingLlmOperations`() {
         // Given
         val outputClass = TestItem::class.java

--- a/embabel-agent-docs/src/main/asciidoc/reference/streaming/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/streaming/page.adoc
@@ -3,8 +3,8 @@
 
 Developer can choose piping data from LLM gradually, using Embabel streaming capabilities.
 
-Streams include LLM reasoning events, so-called "thinking", and stream of objects.
-This feature is well aligned with Embabel focus on object-oriented programming model
+In addition to streaming the raw text output from the LLM, Embabel streams can also include LLM reasoning events, so-called "thinking", and stream of objects created by the LLM.
+This feature is well aligned with Embabel focus on object-oriented programming model.
 
 ==== Concepts
 
@@ -13,7 +13,7 @@ This feature is well aligned with Embabel focus on object-oriented programming m
 - Spring Reactive Programming Support for Spring AI ChatClient as underlying infrastructure
 - All reactive callbacks, such as _doOnNext_, _doOnComplete_, etc. are at developer's disposal
 
-==== Example - Simple Streaming with Callbacks
+==== Example - Simple Thinking and Object Streaming with Callbacks
 [source,java]
 ----
 
@@ -44,6 +44,41 @@ This feature is well aligned with Embabel focus on object-oriented programming m
                         receivedEvents.add("OBJECT: " + obj.getName());
                         logger.info("Integration test received object: {}", obj.getName());
                     }
+                })
+                .doOnError(error -> {
+                    errorOccurred.set(error);
+                    logger.error("Integration test stream error: {}", error.getMessage());
+                })
+                .doOnComplete(() -> {
+                    completionCalled.set(true);
+                    logger.info("Integration test stream completed successfully");
+                })
+                .blockLast(Duration.ofSeconds(6000));
+----
+
+==== Example - Simple Raw Text Streaming with Callbacks
+[source,java]
+----
+
+        PromptRunner runner = ai.withLlm("qwen3:latest");
+
+        String prompt = "What is the highest building in Paris?";
+
+        // Use StreamingPromptBuilder instead of Kotlin extension function
+        Flux<String> results = new StreamingPromptRunnerBuilder(runner)
+                .withStreaming()
+                .withPrompt(prompt)
+                .generateStream();
+
+        // Subscribe with real reactive callbacks using builder pattern
+        results
+                .timeout(Duration.ofSeconds(150))
+                .doOnSubscribe(subscription -> {
+                    logger.info("Stream subscription started");
+                })
+                .doOnNext(content -> {
+                        receivedTextChunks.add(content);
+                        logger.info("Integration test received text chunk: {}", content);
                 })
                 .doOnError(error -> {
                     errorOccurred.set(error);


### PR DESCRIPTION
fix #1285: 

This PR exposes `StreamingLlmOperations.generateStream` on the `StreamingPromptRunnerOperations` interface to enable streaming of the raw LLM output string in case of a plain conversation (as opposed to object creation). Also adds this capability to the documentation.

Left the implementation in `FakePromptRunner` with a TODO as it was done for the `createObjectStream` methods.