### PR TITLE
Fixes #1300

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -93,8 +93,8 @@ internal class ChatClientLlmOperations(
     private val applicationContext: ApplicationContext? = null,
     autoLlmSelectionCriteriaResolver: AutoLlmSelectionCriteriaResolver = AutoLlmSelectionCriteriaResolver.DEFAULT,
     objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
-    private val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
-    private val customizers: List<ChatClientCustomizer> = emptyList()
+    observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
+    private val customizers: List<ChatClientCustomizer> = emptyList(),
 ) : ToolLoopLlmOperations(
     toolDecorator = toolDecorator,
     modelProvider = modelProvider,
@@ -104,6 +104,7 @@ internal class ChatClientLlmOperations(
     autoLlmSelectionCriteriaResolver = autoLlmSelectionCriteriaResolver,
     promptsProperties = llmOperationsPromptsProperties,
     objectMapper = objectMapper,
+    observationRegistry = observationRegistry,
 ) {
 
     @PostConstruct


### PR DESCRIPTION
This pull request adds distributed tracing support to the tool loop execution flow by integrating Micrometer's `Observation` API. The main focus is on enabling observability for LLM operations by starting and stopping observations around the tool loop execution. The changes also ensure that the `ObservationRegistry` is properly passed through the class hierarchy.

Observability and tracing integration:

* Added `ObservationRegistry` as a parameter to the `ToolLoopLlmOperations` constructor and stored it as a protected property.
* Wrapped the execution of `toolLoop.execute` in an `Observation`, starting and stopping the observation to enable distributed tracing for tool loop executions.
* Updated the class documentation and imports to reflect the use of `ObservationRegistry` and Micrometer Observation. [[1]](diffhunk://#diff-bb18beec019821cad86b7d9d33af7bf42699564e8e5c398804f93660fbb30090R40-R41) [[2]](diffhunk://#diff-bb18beec019821cad86b7d9d33af7bf42699564e8e5c398804f93660fbb30090R82)

Class hierarchy updates:

* Ensured that `observationRegistry` is passed from `ChatClientLlmOperations` to the base class `ToolLoopLlmOperations`, maintaining consistent tracing support throughout the LLM operations stack. [[1]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200L96-R97) [[2]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200R107)