### PR TITLE
Fix self-invocation in ContextualPromptElementImpl

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/ContextualPromptElement.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/ContextualPromptElement.kt
@@ -80,12 +80,12 @@ interface ContextualPromptElement : PromptElement {
 }
 
 private data class ContextualPromptElementImpl(
-    private val contribution: (OperationContext) -> String,
+    private val contributionProvider: (OperationContext) -> String,
     override val role: String? = null,
     override val promptContributionLocation: PromptContributionLocation = PromptContributionLocation.BEGINNING,
 ) : ContextualPromptElement {
 
     override fun contribution(context: OperationContext): String =
-        contribution(context)
+        contributionProvider(context)
 
 }


### PR DESCRIPTION
The contribution override in ContextualPromptElementImpl recursively calls itself resulting in a StackOverflowException.