### PR TITLE
Fix self-invocation in ContextualPromptElementImpl  - Updated

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/ContextualPromptElement.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/ContextualPromptElement.kt
@@ -72,7 +72,7 @@ interface ContextualPromptElement : PromptElement {
             return ContextualPromptElementImpl(
                 role = role,
                 promptContributionLocation = location,
-                contribution = contribution,
+                contributionProvider  = contribution,
             )
         }
 


### PR DESCRIPTION
This pull request makes a minor refactor to the `ContextualPromptElement` implementation. The main change is renaming the `contribution` parameter and property to `contributionProvider` for improved clarity and consistency.

- Refactored the `ContextualPromptElementImpl` class and its factory method to rename the `contribution` parameter and property to `contributionProvider`, ensuring clearer intent and usage throughout the code.