### PR TITLE
Update Maven command in deploy-snapshots.yml

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         
-        run: mvn -U -P flatten-pom -DskipTests=true clean deploy
+        run: mvn -U -DskipTests=true clean deploy
 
       - name: Trigger examples repo workflow
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
Removed the 'flatten-pom' profile from the Maven command
This pull request makes a small update to the Maven deployment step in the GitHub Actions workflow. The change removes the use of the `flatten-pom` profile during the deploy command, likely to simplify the deployment process or resolve a related issue..