### PR TITLE
Prepare Release 0.3.3

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.10-SNAPSHOT</version>
+        <version>0.1.10</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.10-SNAPSHOT</version>
+        <version>0.1.10</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -15,7 +15,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <embabel-common.version>0.1.9-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.9</embabel-common.version>
         <netty.version>4.1.125.Final</netty.version>
     </properties>
 


### PR DESCRIPTION
This pull request updates version numbers in the Maven configuration files to move from snapshot (development) versions to stable release versions. This is a standard step when preparing for a release, ensuring that the project and its dependencies reference finalized, stable artifacts.

Dependency and parent version updates:

* Updated the parent POM version in `pom.xml` from `0.1.10-SNAPSHOT` to the stable `0.1.10`.
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.9-SNAPSHOT` to the stable `0.1.9`.
* Updated the parent POM version in `embabel-agent-dependencies/pom.xml` from `0.1.10-SNAPSHOT` to `0.1.10`.