### PR TITLE
Fix: handleStuck() ignoring KILLED status causing infinite replan loop

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
@@ -269,6 +269,10 @@ abstract class AbstractAgentProcess(
         platformServices.eventListener.onProcessEvent(result)
         when (result.code) {
             StuckHandlingResultCode.REPLAN -> {
+                if (finished) {
+                    logger.info("Process {} is {} during stuck handling, will not replan", this.id, status)
+                    return
+                }
                 logger.info("Process {} unstuck and will replan: {}", this.id, result.message)
                 setStatus(AgentProcessStatusCode.RUNNING)
                 run()


### PR DESCRIPTION
**Fixes #1346**

- Guard `handleStuck()` REPLAN branch with `finished` check before overwriting status to RUNNING.
- Prevents infinite `handleStuck()` → `run()` recursion when process is killed during stuck handling.

**Test plan**
- [x] Added `kill during stuck handling prevents replan loop` unit test.
- [x] All 22 `SimpleAgentProcessTest` tests pass.