### PR TITLE
Make spring-webmvc optional in Embabel Frameworks

### DIFF
--- a/embabel-agent-a2a/pom.xml
+++ b/embabel-agent-a2a/pom.xml
@@ -29,6 +29,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/embabel-agent-autoconfigure/embabel-agent-a2a-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-a2a-autoconfigure/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/embabel-agent-autoconfigure/embabel-agent-shell-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-shell-autoconfigure/pom.xml
@@ -33,6 +33,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/pom.xml
@@ -34,6 +34,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/embabel-agent-test-support/embabel-agent-test-internal/pom.xml
+++ b/embabel-agent-test-support/embabel-agent-test-internal/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This pull request updates several Maven project files to mark the `spring-webmvc` dependency as optional. This change helps clarify that `spring-webmvc` is not a required dependency for consumers of these modules, which can reduce unnecessary transitive dependencies in downstream projects.

Dependency management improvements:

* Marked the `spring-webmvc` dependency as optional in the following `pom.xml` files to prevent it from being a required transitive dependency:
  * `embabel-agent-a2a/pom.xml`
  * `embabel-agent-autoconfigure/embabel-agent-a2a-autoconfigure/pom.xml`
  * `embabel-agent-autoconfigure/embabel-agent-shell-autoconfigure/pom.xml`
  * `embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/pom.xml`
  * `embabel-agent-test-support/embabel-agent-test-internal/pom.xml`