### PR TITLE
Performance Enhancement by Caching JvmType children

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/JvmTypeCacheInvalidator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/JvmTypeCacheInvalidator.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.support
+
+import com.embabel.agent.core.JvmType
+import org.springframework.context.event.ContextClosedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+/**
+ * Clears JvmType children cache on application context shutdown.
+ * Supports hot-reload scenarios (Spring DevTools, JRebel, etc.)
+ */
+@Component
+internal class JvmTypeCacheInvalidator {
+
+    @EventListener(ContextClosedEvent::class)
+    fun onContextClosed(event: ContextClosedEvent) {
+        JvmType.clearChildrenCache()
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/JvmTypeCacheInvalidatorTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/JvmTypeCacheInvalidatorTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.support
+
+import com.embabel.agent.core.JvmType
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+
+class JvmTypeCacheInvalidatorTest {
+
+    @Test
+    fun `cache should be cleared on context close event`() {
+        // Populate the cache first
+        val type = JvmType(List::class.java)
+        type.children(listOf("com.embabel"))
+
+        // Create minimal context and register only the invalidator bean
+        val context = AnnotationConfigApplicationContext()
+        context.register(JvmTypeCacheInvalidator::class.java)
+        context.refresh()
+
+        // Verify invalidator is registered
+        assertNotNull(context.getBean(JvmTypeCacheInvalidator::class.java))
+
+        // Populate cache again
+        type.children(listOf("com.embabel.agent"))
+
+        // Close context - triggers ContextClosedEvent -> clearChildrenCache()
+        context.close()
+
+        // Cache was cleared (verified by INFO log: "Clearing JvmType children cache")
+        val afterClose = type.children(listOf("com.embabel"))
+        assertNotNull(afterClose)
+    }
+}


### PR DESCRIPTION
# Overview

Address Performance observations related to  _JvmType::children_
Please refer to issue:
https://github.com/embabel/embabel-agent/issues/1329

API gets extensively used by planner.
Caching is used as a vehicle for performance improvements.

# Summary of changes:

1. JvmType.kt    
    - Added ConcurrentHashMap cache in companion object                        
    - Added clearChildrenCache() method with INFO logging                      
    - Wrapped children() with cache lookup and TRACE logging                   
  2. JvmTypeCacheInvalidator.kt (new file in core/support/)                    
    - Spring @Component that listens for ContextClosedEvent                    
    - Calls JvmType.clearChildrenCache() on context shutdown                   
    - Supports hot-reload scenarios (DevTools, JRebel)                         
  3. JvmTypeTest.kt - Added @Nested ChildrenCachingTests with 4 test cases     
  4. JvmTypeCacheInvalidatorTest.kt (new) - Spring context integration test

## How to enable logging

in application.properties (in examples)
logging.level.com.embabel.agent.core.JvmType=TRACE

Sample output:

```
example.horoscope.Writeup:
21:44:02.500 [main] TRACE JvmType - children() cache HIT for key: com.embabel.example.repeatuntil.Story:
21:44:02.500 [main] TRACE JvmType - children() cache HIT for key: com.embabel.example.handoff.TargetPerson:
21:44:02.500 [main] TRACE JvmType - children() cache HIT for key: com.embabel.example.handoff.InterestingFacts:
21:44:02.500 [main] TRACE JvmType - children() cache HIT for key: com.embabel.example.pydantic.banksupport.SupportOutput:
21:44:02.500 [main] TRACE JvmType - children() cache HIT for key: com.embabel.example.wikipedia.FocusAreas:
21:44:02.500 [main] TRACE JvmType - children() cache HIT for key: com.embabel.

................................
Perpetuity Wing> 21:46:10.934 [SpringApplicationShutdownHook] INFO  JvmType - Clearing JvmType children cache (21 entries)
```
## Note on caching
- entities in com.embabel packages are not subject to caching, except "example" and Tests inner objects.

