### PR TITLE
Improve FakePromptRunner#createObject(List<Message>, Class<T>)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
@@ -16,13 +16,11 @@
 package com.embabel.agent.test.unit
 
 import com.embabel.agent.api.common.*
-import com.embabel.agent.api.validation.guardrails.GuardRail
-import com.embabel.agent.api.common.nested.ObjectCreator
-import com.embabel.agent.api.common.nested.TemplateOperations
 import com.embabel.agent.api.common.support.DelegatingCreating
 import com.embabel.agent.api.common.support.DelegatingRendering
 import com.embabel.agent.api.common.support.PromptExecutionDelegate
 import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.api.validation.guardrails.GuardRail
 import com.embabel.agent.core.ToolGroup
 import com.embabel.agent.core.ToolGroupRequirement
 import com.embabel.agent.core.support.LlmInteraction
@@ -325,7 +323,12 @@ data class FakePromptRunner(
         messages: List<Message>,
         outputClass: Class<T>,
     ): T {
-        return createObject(prompt = messages.joinToString(), outputClass = outputClass)
+        _llmInvocations += LlmInvocation(
+            interaction = createLlmInteraction(),
+            messages = messages,
+            method = Method.CREATE_OBJECT,
+        )
+        return getResponse(outputClass)!!
     }
 
     override fun evaluateCondition(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/test/unit/FakePromptRunnerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/test/unit/FakePromptRunnerTest.kt
@@ -383,6 +383,44 @@ class FakePromptRunnerTest {
 
             assertEquals(expectedIntent, result)
         }
+
+        @Test
+        fun `createObjectIfPossible with messages returns expected object`() {
+            val context = FakeOperationContext.create()
+            val expectedIntent = TestUserIntent("query", "User question")
+            context.expectResponse(expectedIntent)
+
+            val messages = listOf(
+                com.embabel.chat.UserMessage("What is the weather?"),
+                com.embabel.chat.UserMessage("I need to know for tomorrow")
+            )
+
+            val result = context.ai().withDefaultLlm().createObjectIfPossible(messages, TestUserIntent::class.java)
+
+            assertEquals(expectedIntent, result)
+            assertEquals(1, context.llmInvocations.size)
+            assertEquals(Method.CREATE_OBJECT_IF_POSSIBLE, context.llmInvocations[0].method)
+            assertEquals(messages, context.llmInvocations[0].messages)
+        }
+
+        @Test
+        fun `createObjectIfPossible with messages returns null when expected`() {
+            val context = FakeOperationContext.create()
+            context.expectResponse(null)
+
+            val messages = listOf(
+                com.embabel.chat.UserMessage("Unclear request"),
+                com.embabel.chat.UserMessage("Very ambiguous")
+            )
+
+            val result = context.ai().withDefaultLlm().createObjectIfPossible(messages, TestUserIntent::class.java)
+
+            assertNull(result)
+            assertEquals(1, context.llmInvocations.size)
+            assertEquals(Method.CREATE_OBJECT_IF_POSSIBLE, context.llmInvocations[0].method)
+            assertEquals(messages, context.llmInvocations[0].messages)
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
This PR improves the `FakePromptRunner#createObject(List<Message>, Class<T>)` method so that it
 retains the list of messages.

 Closes gh-1312