### PR TITLE
Remove dependencies on webmvc and servlet-api

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-shell-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-shell-autoconfigure/pom.xml
@@ -26,16 +26,6 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-webmvc</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>
         </dependency>


### PR DESCRIPTION
This pull request makes a small change to the dependencies in the `embabel-agent-shell-autoconfigure/pom.xml` file, specifically by removing unused servlet and Spring Web MVC dependencies. This helps keep the project dependencies minimal and reduces potential maintenance overhead.