### PR TITLE
Add embabel-agent-mvcstarter

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -308,6 +308,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-webmvc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-test</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/embabel-agent-starters/embabel-agent-starter-webmvc/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-webmvc/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>0.3.4-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-starter-webmvc</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent WebMvc Starter</name>
+    <description>Embabel Agent Starter with MVC Controllers</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <!-- Base Starter -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter</artifactId>
+        </dependency>
+
+        <!--  Web dependencies -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-webmvc</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -37,6 +37,7 @@
         <module>embabel-agent-starter-google-genai</module>
         <module>embabel-agent-starter-mistral-ai</module>
         <module>embabel-agent-starter-a2a</module>
+        <module>embabel-agent-starter-webmvc</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This pull request introduces a new starter module for WebMVC support in the Embabel Agent project. The main changes involve adding the new `embabel-agent-starter-webmvc` module and wiring it into the project's dependency and module management.

**New WebMVC starter module:**

* Added a new Maven module `embabel-agent-starter-webmvc` under `embabel-agent-starters`, including its own `pom.xml` with dependencies on `embabel-agent-starter` and `embabel-agent-webmvc`.
* Registered the new module in the parent `embabel-agent-starters/pom.xml` to ensure it is built as part of the multi-module project.

**Dependency updates:**

* Added `embabel-agent-starter-webmvc` as a dependency in `embabel-agent-dependencies/pom.xml` to make it available for downstream projects.