### PR TITLE
Fix docs formatting

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/invoking/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/invoking/page.adoc
@@ -671,3 +671,4 @@ try {
     logger.info("Goal not approved: {}", e.getReason());
     return requiresApprovalResponse();
 }
+----


### PR DESCRIPTION
<img width="3824" height="1912" alt="Screenshot From 2026-02-03 11-34-54" src="https://github.com/user-attachments/assets/0668a4d8-4d11-45b0-b834-addae3dd01d4" />

Current docs are missing a closing tag, everything after is broken