### PR TITLE
Update Netty Client configuration section

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
@@ -390,6 +390,25 @@ From `NettyClientFactoryProperties` - configuration for the HTTP client used by 
 Embabel uses Reactor Netty as the HTTP client for improved performance and non-blocking I/O.
 This is particularly important for LLM API calls which can have long response times.
 
+====== Dependency Requirement
+
+To use the Netty client, you must manually add the following autoconfiguration dependency to your project:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-netty-client-autoconfigure</artifactId>
+</dependency>
+----
+
+For Gradle:
+
+[source,gradle]
+----
+implementation 'com.embabel.agent:embabel-agent-netty-client-autoconfigure'
+----
+
 [cols="3,2,1,4",options="header"]
 |===
 |Property |Type |Default |Description


### PR DESCRIPTION
This pull request updates the documentation for configuring the Netty HTTP client in Embabel. The main change is the addition of explicit instructions for adding the required Netty client autoconfiguration dependency to your project, with examples for both Maven and Gradle users.

Dependency management updates:

* Added a new section in `page.adoc` explaining that users must manually add the `embabel-agent-netty-client-autoconfigure` dependency to their project, including both Maven and Gradle examples.