### PR TITLE
Fix missing Tools Group Resolution and Tool Decorator in Streaming mode

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/streaming/StreamingLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/streaming/StreamingLlmOperations.kt
@@ -144,28 +144,36 @@ interface StreamingLlmOperations {
     ): Flux<StreamingEvent<O>>
 
     /**
-     * Low level streaming transform, not necessarily aware of platform.
-     * Streams text chunks as they arrive from the LLM without platform mediation.
+     * Low level streaming transform with optional platform context.
+     * Streams text chunks as they arrive from the LLM.
+     * When agentProcess is provided, tools are resolved from ToolGroups and decorated.
      *
      * @param messages messages in the conversation so far
      * @param interaction The LLM call options
      * @param llmRequestEvent Event already published for this request if one has been
+     * @param agentProcess Optional agent process for tool resolution and decoration
+     * @param action Optional action context for tool decoration
      * @return Flux of text chunks as they arrive from the LLM
      */
     fun doTransformStream(
         messages: List<Message>,
         interaction: LlmInteraction,
         llmRequestEvent: LlmRequestEvent<String>?,
+        agentProcess: AgentProcess? = null,
+        action: Action? = null,
     ): Flux<String>
 
     /**
-     * Low level object streaming transform, not necessarily aware of platform.
+     * Low level object streaming transform with optional platform context.
      * Streams typed objects as they are parsed from JSONL response.
+     * When agentProcess is provided, tools are resolved from ToolGroups and decorated.
      *
      * @param messages messages in the conversation so far
      * @param interaction The LLM call options
      * @param outputClass Class of the output objects
      * @param llmRequestEvent Event already published for this request if one has been
+     * @param agentProcess Optional agent process for tool resolution and decoration
+     * @param action Optional action context for tool decoration
      * @return Flux of typed objects as they are parsed from the response
      */
     fun <O> doTransformObjectStream(
@@ -173,16 +181,21 @@ interface StreamingLlmOperations {
         interaction: LlmInteraction,
         outputClass: Class<O>,
         llmRequestEvent: LlmRequestEvent<O>?,
+        agentProcess: AgentProcess? = null,
+        action: Action? = null,
     ): Flux<O>
 
     /**
-     * Low level mixed content streaming transform, not necessarily aware of platform.
+     * Low level mixed content streaming transform with optional platform context.
      * Streams both typed objects and thinking content from mixed JSONL response.
+     * When agentProcess is provided, tools are resolved from ToolGroups and decorated.
      *
      * @param messages messages in the conversation so far
      * @param interaction The LLM call options
      * @param outputClass Class of the output objects
      * @param llmRequestEvent Event already published for this request if one has been
+     * @param agentProcess Optional agent process for tool resolution and decoration
+     * @param action Optional action context for tool decoration
      * @return Flux of StreamingEvent objects containing either objects or thinking content
      */
     fun <O> doTransformObjectStreamWithThinking(
@@ -190,5 +203,7 @@ interface StreamingLlmOperations {
         interaction: LlmInteraction,
         outputClass: Class<O>,
         llmRequestEvent: LlmRequestEvent<O>?,
+        agentProcess: AgentProcess? = null,
+        action: Action? = null,
     ): Flux<StreamingEvent<O>>
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolResolutionHelper.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolResolutionHelper.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support
+
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.core.Action
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.support.LlmInteraction
+import com.embabel.agent.spi.ToolDecorator
+
+/**
+ * Utility for resolving ToolGroups and decorating tools.
+ * Provides consistent tool resolution across streaming, thinking, and standard LLM operations.
+ */
+object ToolResolutionHelper {
+
+    /**
+     * Resolves ToolGroups from the interaction and decorates all tools.
+     *
+     * @param interaction LLM interaction containing tools and tool groups
+     * @param agentProcess Process context for accessing toolGroupResolver
+     * @param action Optional action context for decoration
+     * @param toolDecorator Decorator to make tools platform-aware
+     * @return List of resolved and decorated tools
+     */
+    fun resolveAndDecorate(
+        interaction: LlmInteraction,
+        agentProcess: AgentProcess?,
+        action: Action?,
+        toolDecorator: ToolDecorator,
+    ): List<Tool> {
+        if (agentProcess == null) {
+            return interaction.tools
+        }
+        val toolGroupResolver = agentProcess.processContext.platformServices.agentPlatform.toolGroupResolver
+        val resolvedTools = interaction.resolveTools(toolGroupResolver)
+        return resolvedTools.map { tool ->
+            toolDecorator.decorate(tool, agentProcess, action, interaction.llm)
+        }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -16,6 +16,9 @@
 package com.embabel.agent.spi.support.springai
 
 import com.embabel.agent.api.event.LlmRequestEvent
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.core.Action
+import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.core.support.toEmbabelUsage
 import com.embabel.agent.spi.AutoLlmSelectionCriteriaResolver
@@ -26,6 +29,7 @@ import com.embabel.agent.spi.support.LlmDataBindingProperties
 import com.embabel.agent.spi.support.LlmOperationsPromptsProperties
 import com.embabel.agent.spi.support.OutputConverter
 import com.embabel.agent.spi.support.ToolLoopLlmOperations
+import com.embabel.agent.spi.support.ToolResolutionHelper
 import com.embabel.agent.spi.support.guardrails.validateAssistantResponse
 import com.embabel.agent.spi.support.guardrails.validateUserInput
 import com.embabel.agent.spi.validation.DefaultValidationPromptGenerator
@@ -1017,6 +1021,26 @@ internal class ChatClientLlmOperations(
             }
         }
     }
+
+    // ====================================
+    // TOOL RESOLUTION
+    // ====================================
+
+    /**
+     * Resolves ToolGroups and decorates all tools for streaming operations.
+     * Convenience wrapper around [ToolResolutionHelper.resolveAndDecorate].
+     * When agentProcess is null, returns interaction.tools without decoration.
+     */
+    internal fun resolveAndDecorateTools(
+        interaction: LlmInteraction,
+        agentProcess: AgentProcess?,
+        action: Action?,
+    ): List<Tool> = ToolResolutionHelper.resolveAndDecorate(
+        interaction = interaction,
+        agentProcess = agentProcess,
+        action = action,
+        toolDecorator = toolDecorator,
+    )
 }
 
 /**

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolResolutionHelperTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolResolutionHelperTest.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support
+
+import com.embabel.agent.api.common.InteractionId
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.core.Action
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.support.LlmInteraction
+import com.embabel.agent.spi.ToolDecorator
+import com.embabel.common.ai.model.LlmOptions
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [ToolResolutionHelper].
+ * Verifies tool resolution from interactions and decoration via ToolDecorator.
+ */
+class ToolResolutionHelperTest {
+
+    private lateinit var mockAgentProcess: AgentProcess
+    private lateinit var mockProcessContext: ProcessContext
+    private lateinit var mockAction: Action
+    private lateinit var mockToolDecorator: ToolDecorator
+
+    @BeforeEach
+    fun setUp() {
+        mockAgentProcess = mockk(relaxed = true)
+        mockProcessContext = mockk(relaxed = true)
+        mockAction = mockk(relaxed = true)
+        mockToolDecorator = mockk(relaxed = true)
+
+        every { mockAgentProcess.processContext } returns mockProcessContext
+        every { mockProcessContext.platformServices.agentPlatform.toolGroupResolver } returns
+            RegistryToolGroupResolver("test", emptyList())
+    }
+
+    private fun createMockTool(name: String): Tool {
+        val definition = mockk<Tool.Definition>(relaxed = true)
+        every { definition.name } returns name
+        val tool = mockk<Tool>(relaxed = true)
+        every { tool.definition } returns definition
+        return tool
+    }
+
+    @Test
+    fun `should resolve tools from interaction`() {
+        // Given
+        val tool1 = createMockTool("tool1")
+        val tool2 = createMockTool("tool2")
+        val interaction = LlmInteraction(
+            id = InteractionId("test"),
+            tools = listOf(tool1, tool2),
+        )
+        every { mockToolDecorator.decorate(any(), any(), any(), any()) } answers { firstArg() }
+
+        // When
+        val result = ToolResolutionHelper.resolveAndDecorate(
+            interaction, mockAgentProcess, mockAction, mockToolDecorator
+        )
+
+        // Then
+        assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `should decorate each resolved tool`() {
+        // Given
+        val tool1 = createMockTool("tool1")
+        val tool2 = createMockTool("tool2")
+        val interaction = LlmInteraction(
+            id = InteractionId("test"),
+            tools = listOf(tool1, tool2),
+        )
+        every { mockToolDecorator.decorate(any(), any(), any(), any()) } answers { firstArg() }
+
+        // When
+        ToolResolutionHelper.resolveAndDecorate(
+            interaction, mockAgentProcess, mockAction, mockToolDecorator
+        )
+
+        // Then
+        verify { mockToolDecorator.decorate(tool1, mockAgentProcess, mockAction, any()) }
+        verify { mockToolDecorator.decorate(tool2, mockAgentProcess, mockAction, any()) }
+    }
+
+    @Test
+    fun `should pass llmOptions to decorator`() {
+        // Given
+        val tool = createMockTool("tool1")
+        val llmOptions = LlmOptions()
+        val interaction = LlmInteraction(
+            id = InteractionId("test"),
+            tools = listOf(tool),
+            llm = llmOptions,
+        )
+        every { mockToolDecorator.decorate(any(), any(), any(), any()) } answers { firstArg() }
+
+        // When
+        ToolResolutionHelper.resolveAndDecorate(
+            interaction, mockAgentProcess, mockAction, mockToolDecorator
+        )
+
+        // Then
+        verify { mockToolDecorator.decorate(tool, mockAgentProcess, mockAction, llmOptions) }
+    }
+
+    @Test
+    fun `should handle null action`() {
+        // Given
+        val tool = createMockTool("tool1")
+        val interaction = LlmInteraction(
+            id = InteractionId("test"),
+            tools = listOf(tool),
+        )
+        every { mockToolDecorator.decorate(any(), any(), any(), any()) } answers { firstArg() }
+
+        // When
+        val result = ToolResolutionHelper.resolveAndDecorate(
+            interaction, mockAgentProcess, null, mockToolDecorator
+        )
+
+        // Then
+        assertEquals(1, result.size)
+        verify { mockToolDecorator.decorate(tool, mockAgentProcess, null, any()) }
+    }
+
+    @Test
+    fun `should return empty list when no tools`() {
+        // Given
+        val interaction = LlmInteraction(id = InteractionId("test"))
+
+        // When
+        val result = ToolResolutionHelper.resolveAndDecorate(
+            interaction, mockAgentProcess, mockAction, mockToolDecorator
+        )
+
+        // Then
+        assertTrue(result.isEmpty())
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/LLMAnthropicStreamingBuilderIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/LLMAnthropicStreamingBuilderIT.java
@@ -166,8 +166,8 @@ class LLMAnthropicStreamingBuilderIT {
         reactor.util.Loggers.useVerboseConsoleLoggers();
 
         // Given: Use the existing streaming test LLM (configured as "best")
-        PromptRunner runner = ai.withLlm("claude-sonnet-4-5");
-               // .withToolObject(Tooling.class);
+        PromptRunner runner = ai.withLlm("claude-sonnet-4-5")
+                             .withToolObject(Tooling.class);
         assertTrue(runner.supportsStreaming(), "Test LLM should support streaming");
 
         // When: Subscribe with real reactive callbacks using builder pattern


### PR DESCRIPTION
# Overview

please refer to issue:

https://github.com/embabel/embabel-agent/issues/1363:

"Feature gap between StreamingChatClientOperations and AbstractLlmOperations"

## Changes in PR:

* added helper class ToolResolutionHelper
* added wrapper in ChatClientLLMOperatiios to invoke utility
* updated Streaming interfaces and Implementation to pass action and AgentProcess
* Implementation resolves tool groups and decorate tools