### PR TITLE
Align version with snapshots as 0.1.11-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.10</version>
+        <version>0.1.11-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>


### PR DESCRIPTION
# Overview

set build-parent version to 0.1.11-SNAPSHOT in order to test jinjava high vulnerability (upgrade to v 2.8.3).

see results below:

```
mvn dependency:tree|grep jinjava
[INFO] |  \- com.hubspot.jinjava:jinjava:jar:2.8.3:compile
[INFO] |  |  \- com.hubspot.jinjava:jinjava:jar:2.8.3:compile
```