### PR TITLE
Fix: Merge consecutive ToolResponseMessages for Gemini parallel tool call

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmMessageSender.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmMessageSender.kt
@@ -49,7 +49,7 @@ internal class SpringAiLlmMessageSender(
         tools: List<Tool>,
     ): LlmMessageResponse {
         // Convert Embabel messages to Spring AI messages
-        val springAiMessages = messages.map { it.toSpringAiMessage() }
+        val springAiMessages = messages.map { it.toSpringAiMessage() }.mergeConsecutiveToolResponses()
 
         // Convert Embabel tools to Spring AI tool callbacks using existing adapter
         val toolCallbacks = tools.toSpringToolCallbacks()


### PR DESCRIPTION
  ## Summary       

https://github.com/embabel/embabel-agent/issues/1383                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                     
  - Fix Google Gemini models failing with parallel tool calls (`400: number of function response parts must equal function call parts`)                                                                                                                                                                                                                                              
  - Added `mergeConsecutiveToolResponses()` in `messageConverters.kt` to group consecutive `ToolResponseMessage` entries into a single message                                                                                                                                                                                                                                       
  - Applied the merge in `SpringAiLlmMessageSender` after message conversion                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                     
  **Root cause:** Each `ToolResultMessage` was converted to a separate `ToolResponseMessage`. Gemini requires all function responses for a single tool-calling turn to be in one message. OpenAI/Anthropic are not affected.                                                                                                                                                         

  ## Changes

  - **`messageConverters.kt`** — Added `mergeConsecutiveToolResponses()` extension function
  - **`SpringAiLlmMessageSender.kt`** — Applied the merge after converting messages
  - **`MessageConversionTest.kt`** — Added 6 unit tests

  ## Open question

  Could this merging behavior cause issues with other existing Embabel tools (e.g. tools that rely on individual `ToolResponseMessage` ordering, or tools with side effects that depend on being processed one at a time)? The merge only affects the Spring AI message layer sent to the LLM provider — tool execution itself is unchanged — but this should be investigated to confirm there are no unexpected interactions with the broader tool ecosystem.

  ## Test plan

  - [x] New `MergeConsecutiveToolResponsesTests` (6 tests)
  - [x] Existing `SpringAiLlmMessageSenderTest`
  - [x] Existing `ToolLoopTest`
  - [x] Manual testing against Gemini models with actions triggering parallel tool calls