### PR TITLE
doc: Fixes compilation error in example code in section 3.8.2.

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/types/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/types/page.adoc
@@ -106,8 +106,8 @@ For example:
 var story = context.ai()
     .withDefaultLlm()
     .withToolGroup(CoreToolGroups.WEB)
-    .withExample("A children's story", new Story("Once upon a time...")) // <1>
     .creating(Story.class)
+    .withExample("A children's story", new Story("Once upon a time...")) // <1>
     .fromPrompt("Create a story about: " + input.getContent());
 ----
 


### PR DESCRIPTION
Fixes compilation error in example code in section 3.8.2. `.withExample()` requires `.creating()` to be called first to get the right API returned.