### PR TITLE
fix: Wrap non-JSON tool responses for Gemini compatibility

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MatryoshkaTool.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MatryoshkaTool.kt
@@ -560,6 +560,18 @@ interface MatryoshkaTool : Tool {
 }
 
 /**
+ * Returns a JSON-formatted tool response listing enabled tools.
+ * JSON format ensures compatibility with LLM providers that require
+ * valid JSON in tool responses (e.g. Google Gemini).
+ */
+private fun enabledToolsJson(toolNames: List<String>): Tool.Result {
+    val toolNamesJson = toolNames.joinToString(", ") { "\"$it\"" }
+    return Tool.Result.text(
+        """{"enabled_tools_count": ${toolNames.size}, "enabled_tools": [$toolNamesJson]}"""
+    )
+}
+
+/**
  * Simple implementation that exposes all inner tools.
  */
 private class SimpleMatryoshkaTool(
@@ -571,9 +583,7 @@ private class SimpleMatryoshkaTool(
 
     override fun call(input: String): Tool.Result {
         val toolNames = innerTools.map { it.definition.name }
-        return Tool.Result.text(
-            "Enabled ${innerTools.size} tools: ${toolNames.joinToString(", ")}"
-        )
+        return enabledToolsJson(toolNames)
     }
 }
 
@@ -593,8 +603,6 @@ private class SelectableMatryoshkaTool(
     override fun call(input: String): Tool.Result {
         val selected = selectTools(input)
         val toolNames = selected.map { it.definition.name }
-        return Tool.Result.text(
-            "Enabled ${selected.size} tools: ${toolNames.joinToString(", ")}"
-        )
+        return enabledToolsJson(toolNames)
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/MatryoshkaToolTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/MatryoshkaToolTest.kt
@@ -64,7 +64,7 @@ class MatryoshkaToolTest {
         }
 
         @Test
-        fun `call returns message listing enabled tools`() {
+        fun `call returns JSON message listing enabled tools`() {
             val innerTool1 = MockTool("tool_a", "Tool A") { Tool.Result.text("a") }
             val innerTool2 = MockTool("tool_b", "Tool B") { Tool.Result.text("b") }
 
@@ -78,9 +78,10 @@ class MatryoshkaToolTest {
 
             assertTrue(result is Tool.Result.Text)
             val text = (result as Tool.Result.Text).content
-            assertTrue(text.contains("2 tools"))
-            assertTrue(text.contains("tool_a"))
-            assertTrue(text.contains("tool_b"))
+            val json = objectMapper.readTree(text)
+            assertEquals(2, json["enabled_tools_count"].intValue())
+            val toolNames = json["enabled_tools"].map { it.textValue() }
+            assertEquals(listOf("tool_a", "tool_b"), toolNames)
         }
 
         @Test
@@ -282,7 +283,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "outer",
                     toolInput = "{}",
-                    result = "Enabled 1 tools: inner",
+                    result = """{"enabled_tools_count": 1, "enabled_tools": ["inner"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -316,7 +317,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "persistent",
                     toolInput = "{}",
-                    result = "Enabled 1 tools: inner",
+                    result = """{"enabled_tools_count": 1, "enabled_tools": ["inner"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -353,7 +354,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "selector",
                     toolInput = """{"pick": "one"}""",
-                    result = "Enabled 1 tools: tool1",
+                    result = """{"enabled_tools_count": 1, "enabled_tools": ["tool1"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -383,7 +384,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "empty",
                     toolInput = "{}",
-                    result = "Enabled 0 tools:",
+                    result = """{"enabled_tools_count": 0, "enabled_tools": []}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -413,7 +414,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "composer_stats",
                     toolInput = "{}",
-                    result = "Enabled 2 tools: count, getValues",
+                    result = """{"enabled_tools_count": 2, "enabled_tools": ["count", "getValues"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -445,7 +446,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "composer_stats",
                     toolInput = "{}",
-                    result = "Enabled 2 tools: count, getValues",
+                    result = """{"enabled_tools_count": 2, "enabled_tools": ["count", "getValues"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -481,7 +482,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "composer_stats",
                     toolInput = "{}",
-                    result = "Enabled 2 tools: count, getValues",
+                    result = """{"enabled_tools_count": 2, "enabled_tools": ["count", "getValues"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -520,7 +521,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "empty",
                     toolInput = "{}",
-                    result = "Enabled 0 tools:",
+                    result = """{"enabled_tools_count": 0, "enabled_tools": []}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -550,7 +551,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "spotify_search",
                     toolInput = "{}",
-                    result = "Enabled 2 tools: vector_search, text_search",
+                    result = """{"enabled_tools_count": 2, "enabled_tools": ["vector_search", "text_search"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -588,7 +589,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "music_search",
                     toolInput = "{}",
-                    result = "Enabled 2 tools",
+                    result = """{"enabled_tools_count": 2, "enabled_tools": ["vector_search", "text_search"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -625,7 +626,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "no_notes",
                     toolInput = "{}",
-                    result = "Enabled 1 tool",
+                    result = """{"enabled_tools_count": 1, "enabled_tools": ["tool1"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -695,7 +696,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "outer",
                     toolInput = "{}",
-                    result = "Enabled 1 tools: inner",
+                    result = """{"enabled_tools_count": 1, "enabled_tools": ["inner"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,
@@ -936,7 +937,7 @@ class MatryoshkaToolTest {
                 lastToolCall = ToolCallResult(
                     toolName = "music_search",
                     toolInput = "{}",
-                    result = "Enabled 2 tools",
+                    result = """{"enabled_tools_count": 2, "enabled_tools": ["vectorSearch", "textSearch"]}""",
                     resultObject = null,
                 ),
                 iterationCount = 1,

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/MessageConversionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/MessageConversionTest.kt
@@ -209,6 +209,62 @@ class MessageConversionTest {
             assertThat(response.name()).isEqualTo("get_weather")
             assertThat(response.responseData()).isEqualTo("""{"temperature": 72}""")
         }
+
+        @Test
+        fun `tool result with plain text content is wrapped as JSON`() {
+            val message = ToolResultMessage(
+                toolCallId = "call-1",
+                toolName = "search",
+                content = "2 results: HBNB Services - Technical Blockchain Advisor"
+            )
+
+            val springAiMessage = message.toSpringAiMessage() as ToolResponseMessage
+            val responseData = springAiMessage.responses[0].responseData()
+
+            assertThat(responseData).startsWith("{")
+            assertThat(responseData).contains("\"result\"")
+            assertThat(responseData).contains("2 results: HBNB Services - Technical Blockchain Advisor")
+        }
+
+        @Test
+        fun `tool result with valid JSON object content is preserved`() {
+            val message = ToolResultMessage(
+                toolCallId = "call-1",
+                toolName = "get_count",
+                content = """{"count": 5}"""
+            )
+
+            val springAiMessage = message.toSpringAiMessage() as ToolResponseMessage
+
+            assertThat(springAiMessage.responses[0].responseData()).isEqualTo("""{"count": 5}""")
+        }
+
+        @Test
+        fun `tool result with valid JSON array content is preserved`() {
+            val message = ToolResultMessage(
+                toolCallId = "call-1",
+                toolName = "get_items",
+                content = """[1, 2, 3]"""
+            )
+
+            val springAiMessage = message.toSpringAiMessage() as ToolResponseMessage
+
+            assertThat(springAiMessage.responses[0].responseData()).isEqualTo("""[1, 2, 3]""")
+        }
+
+        @Test
+        fun `tool result with whitespace-only content is wrapped as JSON`() {
+            val message = ToolResultMessage(
+                toolCallId = "call-1",
+                toolName = "no_result",
+                content = " "
+            )
+
+            val springAiMessage = message.toSpringAiMessage() as ToolResponseMessage
+            val responseData = springAiMessage.responses[0].responseData()
+
+            assertThat(responseData).isEqualTo("""{"result":" "}""")
+        }
     }
 
     @Nested


### PR DESCRIPTION
https://github.com/embabel/embabel-agent/issues/1391

###   Summary

  Google GenAI (Gemini) requires tool responses (FunctionResponse.response) to be valid JSON objects. When a tool returns a plain text string, Spring AI's GoogleGenAiChatModel.parseJsonToMap() either:

  1. Crashes with a JsonParseException - for MatryoshkaTool responses that return plain text like "Enabled 4 tools: ..."
  2. Silently drops the content - for RAG/search tools returning plain text results, causing the LLM to hallucinate 

  The same tools work correctly with OpenAI, which accepts plain text in tool response content fields.

###   Root cause

  All tool results flow through messageConverters.kt before being sent to the LLM. The textContent was passed as-is to ToolResponseMessage.ToolResponse.responseData without ensuring it's valid JSON. 

Most tools worked "by luck" because MethodTool.convertResult() serializes non-String return types to JSON via Jackson only tools returning a raw String (or implementing Tool directly like MatryoshkaTool) were affected.

### Fix

  - messageConverters.kt: Added ensureJson() extension function that wraps non-JSON tool response text in {"result": "..."} before sending to the LLM. 
  - JSON objects and arrays are preserved as-is. This acts as a safety net at the single conversion point all tools pass through.
  - MatryoshkaTool.kt: Changed SimpleMatryoshkaTool.call() and SelectableMatryoshkaTool.call() to return structured JSON ({"enabled_tools_count": N, "enabled_tools": [...]}) instead of plain text, via a shared enabledToolsJson() helper.

### Test plan

  - MessageConversionTest: new tests covering plain text wrapping, JSON object/array preservation, and whitespace handling
  - MatryoshkaToolTest: All assertions updated to verify JSON format responses
  - Manual verification with https://github.com/embabel/ragbot + Google GenAI to confirm no more JsonParseException and no hallucination