### PR TITLE
Better contextualName for span label

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
@@ -159,7 +159,7 @@ open class ToolLoopLlmOperations(
         val tools = interaction.tools
 
         val observation = Observation.createNotStarted("embabel.tool-loop", observationRegistry)
-            .contextualName("Tool Loop Execution")
+            .contextualName("embabel_agent")
 
         observation.start()
         val result = try {


### PR DESCRIPTION
This pull request makes a small change to the contextual naming used in application observations. The contextual name for tool loop execution has been updated to better reflect the service identity.

- Changed the contextual name in the `Observation.createNotStarted` call from `"Tool Loop Execution"` to `"embabel_agent"` in `ToolLoopLlmOperations.kt` for improved consistency and clarity.