### PR TITLE
Fix missing method.

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/Message.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/Message.kt
@@ -32,7 +32,13 @@ import java.time.Instant
 enum class MessageRole {
     USER,
     ASSISTANT,
-    SYSTEM
+    SYSTEM;
+
+    /**
+     * Human-readable name for this role, e.g. "User", "Assistant", "System".
+     */
+    val displayName: String
+        get() = name.lowercase().replaceFirstChar { it.uppercase() }
 }
 
 /**
@@ -101,7 +107,8 @@ sealed class BaseMessage(
     val isMultimodal: Boolean
         get() = parts.any { it !is TextPart }
 
-    val sender: String get() = name ?: role.name.lowercase().replaceFirstChar { it.uppercase() }
+    @Deprecated("Ambiguous: can be confused with the user who sent the message. Use role.displayName or name directly.", replaceWith = ReplaceWith("role.displayName"))
+    val sender: String get() = name ?: role.displayName
 }
 
 /**
@@ -129,7 +136,7 @@ class UserMessage : BaseMessage, UserContent {
     ) : this(parts = listOf(TextPart(content)), name = name, timestamp = timestamp)
 
     override fun toString(): String {
-        return "UserMessage(from='${sender}', content='${trim(content, 80, 10)}')"
+        return "UserMessage(from='${role.displayName}', content='${trim(content, 80, 10)}')"
     }
 }
 
@@ -154,7 +161,7 @@ open class AssistantMessage @JvmOverloads constructor(
 ), AssistantContent, AssetView {
 
     override fun toString(): String {
-        return "AssistantMessage(from='${sender}', content='${trim(content, 80, 10)}')"
+        return "AssistantMessage(from='${role.displayName}', content='${trim(content, 80, 10)}')"
     }
 
     companion object {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/console/ConsoleOutputChannel.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/console/ConsoleOutputChannel.kt
@@ -18,18 +18,9 @@ package com.embabel.chat.support.console
 import com.embabel.agent.api.channel.*
 import com.embabel.agent.spi.logging.ColorPalette
 import com.embabel.agent.spi.logging.DefaultColorPalette
-import com.embabel.chat.BaseMessage
 import com.embabel.chat.Message
 import com.embabel.common.util.color
 import org.apache.commons.text.WordUtils
-
-/**
- * Extension to get a display name for any Message.
- * Uses BaseMessage.sender if available, otherwise falls back to role name.
- */
-private val Message.displaySender: String
-    get() = (this as? BaseMessage)?.sender
-        ?: role.name.lowercase().replaceFirstChar { it.uppercase() }
 
 class ConsoleOutputChannel(
     private val colorPalette: ColorPalette = DefaultColorPalette(),
@@ -39,7 +30,7 @@ class ConsoleOutputChannel(
         when (event) {
             is MessageOutputChannelEvent -> {
                 val formattedResponse = WordUtils.wrap(
-                    "${event.message.displaySender}: ${event.message.content.color(colorPalette.color2)}",
+                    "${event.message.role.displayName}: ${event.message.content.color(colorPalette.color2)}",
                     140,
                 )
                 println(formattedResponse)

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/TerminalServices.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/TerminalServices.kt
@@ -28,7 +28,6 @@ import com.embabel.agent.shell.config.ShellProperties
 import com.embabel.agent.spi.logging.ColorPalette
 import com.embabel.agent.spi.logging.DefaultColorPalette
 import com.embabel.chat.AssistantMessage
-import com.embabel.chat.BaseMessage
 import com.embabel.chat.ChatSession
 import com.embabel.chat.Message
 import com.embabel.chat.UserMessage
@@ -48,12 +47,6 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import ch.qos.logback.classic.Logger as LogbackLogger
 
-/**
- * Extension to get a display name for any Message.
- */
-private val Message.displaySender: String
-    get() = (this as? BaseMessage)?.sender
-        ?: role.name.lowercase().replaceFirstChar { it.uppercase() }
 
 /**
  * Provide interaction and form support
@@ -253,7 +246,7 @@ class TerminalServices(
             when (event) {
                 is MessageOutputChannelEvent -> {
                     val formattedResponse = WordUtils.wrap(
-                        "${event.message.displaySender}: ${event.message.content.color(colorPalette.color2)}",
+                        "${event.message.role.displayName}: ${event.message.content.color(colorPalette.color2)}",
                         shellProperties.lineLength,
                     )
                     println(formattedResponse)


### PR DESCRIPTION

                                                                                                                                                      
 # Add MessageRole.displayName and deprecate BaseMessage.sender                                                                                        
                                                                                                                                                      
##  Summary

  - Add displayName property to MessageRole enum, returning a human-readable capitalized form (e.g. "User", "Assistant", "System")
  - Deprecate BaseMessage.sender — the name is ambiguous and easily confused with the actual user who sent the message
  - Migrate all internal usages of sender and the duplicated displaySender extension functions to use role.displayName

##  Changes

  - Message.kt: Add MessageRole.displayName, deprecate BaseMessage.sender, update UserMessage and AssistantMessage toString()
  - ConsoleOutputChannel.kt: Remove displaySender extension and BaseMessage import, use role.displayName
  - TerminalServices.kt: Remove displaySender extension and BaseMessage import, use role.displayName

## Dice App

The fix in Dice is then to use the new MessageRole convenience method. 