### PR TITLE
Fix: reset OTel context in @BeforeEach to prevent cross-test leakage on Windows.

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/observation/SpringObservationProofOfConceptTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/observation/SpringObservationProofOfConceptTest.java
@@ -58,9 +58,13 @@ class SpringObservationProofOfConceptTest {
     private OpenTelemetrySdk openTelemetry;
     private Tracer tracer;
     private ObservationRegistry observationRegistry;
+    private Scope otelRootScope;
 
     @BeforeEach
     void setUp() {
+        // Force clean OTel context to prevent cross-test context leakage
+        otelRootScope = Context.root().makeCurrent();
+
         // Create in-memory span exporter for testing
         spanExporter = InMemorySpanExporter.create();
 
@@ -96,6 +100,9 @@ class SpringObservationProofOfConceptTest {
     @AfterEach
     void tearDown() {
         spanExporter.reset();
+        if (otelRootScope != null) {
+            otelRootScope.close();
+        }
     }
 
     // Smoke test: observation creates a span through the handler


### PR DESCRIPTION
This pull request improves the reliability and isolation of tests involving OpenTelemetry context in the observability auto-configuration module. The main change is to ensure that each test starts with a clean OpenTelemetry context, preventing context leakage and interference between tests. This is achieved by explicitly resetting the OpenTelemetry root context at the beginning of each test and properly closing it after each test.

Test isolation and reliability improvements:

* Added explicit management of the OpenTelemetry root `Context` using a `Scope` (`otelRootScope`) in the test classes `EmbabelTracingObservationHandlerTest`, `ObservabilityToolCallbackIntegrationTest`, and `SpringObservationProofOfConceptTest` to ensure each test starts with a clean context and to prevent cross-test context leakage. [[1]](diffhunk://#diff-d785d74b09819a2af8655d15bc18162c8e95896fb0de41fb561b19acdd8a844aR64-R71) [[2]](diffhunk://#diff-e1d8a2b206cc569c9cd77f4dd213edfb5deaf13a9e68c634a3bf3880890582b9R88-R94) [[3]](diffhunk://#diff-9aa2c7b28a99e68fc905208fbd077d99f588d6f959896ed520d2b3fecf058bafR61-R67)
* In the `@BeforeEach` method of each test class, the root context is set as current before test execution, and in the `@AfterEach` method, the scope is closed to restore the previous context. [[1]](diffhunk://#diff-d785d74b09819a2af8655d15bc18162c8e95896fb0de41fb561b19acdd8a844aR108-R110) [[2]](diffhunk://#diff-e1d8a2b206cc569c9cd77f4dd213edfb5deaf13a9e68c634a3bf3880890582b9R142-R144) [[3]](diffhunk://#diff-9aa2c7b28a99e68fc905208fbd077d99f588d6f959896ed520d2b3fecf058bafR103-R105)
* Added necessary imports for `io.opentelemetry.context.Context` and `io.opentelemetry.context.Scope` in all affected test files. [[1]](diffhunk://#diff-d785d74b09819a2af8655d15bc18162c8e95896fb0de41fb561b19acdd8a844aR33-R34) [[2]](diffhunk://#diff-e1d8a2b206cc569c9cd77f4dd213edfb5deaf13a9e68c634a3bf3880890582b9R40-R41)