### PR TITLE
Update import for Ranking type

### DIFF
--- a/embabel-agent-observability/src/main/java/com/embabel/agent/observability/observation/EmbabelFullObservationEventListener.java
+++ b/embabel-agent-observability/src/main/java/com/embabel/agent/observability/observation/EmbabelFullObservationEventListener.java
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.observability.observation;
 
+import com.embabel.agent.api.common.ranking.Ranking;
 import com.embabel.agent.api.event.*;
 import com.embabel.agent.core.Action;
 import com.embabel.agent.core.AgentProcess;
@@ -26,7 +27,6 @@ import com.embabel.agent.event.RagResponseEvent;
 import com.embabel.agent.observability.ObservabilityProperties;
 import com.embabel.common.ai.model.LlmOptions;
 import com.embabel.agent.rag.pipeline.event.*;
-import com.embabel.agent.spi.Ranking;
 import com.embabel.plan.Plan;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;


### PR DESCRIPTION
This pull request makes a minor update to the `EmbabelFullObservationEventListener` class by changing the import statement for the `Ranking` class to use the correct package. This helps ensure that the correct `Ranking` implementation is referenced in the codebase. 

- Switched the import of `Ranking` from `com.embabel.agent.spi.Ranking` to `com.embabel.agent.api.common.ranking.Ranking` in `EmbabelFullObservationEventListener.java` to use the intended API version. [[1]](diffhunk://#diff-69e156d9da0ab2450a5a6a805ae12242b1abf1b09f803abe7ade65becb84eecfR18) [[2]](diffhunk://#diff-69e156d9da0ab2450a5a6a805ae12242b1abf1b09f803abe7ade65becb84eecfL29)