### PR TITLE
Move LlmOperations to core.internal package

### DIFF
--- a/embabel-agent-a2a/src/test/kotlin/com/embabel/agent/a2a/server/config/FakeAiConfiguration.kt
+++ b/embabel-agent-a2a/src/test/kotlin/com/embabel/agent/a2a/server/config/FakeAiConfiguration.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.a2a.server.config
 
-import com.embabel.agent.spi.LlmOperations
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.agent.test.integration.DummyObjectCreatingLlmOperations

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PlatformServices.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PlatformServices.kt
@@ -21,7 +21,7 @@ import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.core.expression.LogicalExpressionParser
-import com.embabel.agent.spi.LlmOperations
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.spi.OperationScheduler
 import com.embabel.chat.ConversationFactoryProvider
 import com.embabel.common.ai.model.ModelProvider

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
@@ -47,7 +47,7 @@ import kotlin.reflect.KProperty1
  * generateText or other LLM invocation methods.
  * Thus, a PromptRunner can be reused within an action implementation.
  * A contextual facade to LlmOperations.
- * @see com.embabel.agent.spi.LlmOperations
+ * @see com.embabel.agent.core.internal.LlmOperations
  */
 interface PromptRunner : LlmUse, PromptRunnerOperations {
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
@@ -15,21 +15,17 @@
  */
 package com.embabel.agent.api.common.support
 
-import com.embabel.agent.api.common.ActionContext
-import com.embabel.agent.api.common.AgentImage
-import com.embabel.agent.api.common.ContextualPromptElement
-import com.embabel.agent.api.common.InteractionId
-import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.api.common.*
 import com.embabel.agent.api.common.support.streaming.StreamingCapabilityDetector
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolObject
 import com.embabel.agent.api.validation.guardrails.GuardRail
 import com.embabel.agent.core.ToolGroup
 import com.embabel.agent.core.ToolGroupRequirement
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.core.support.safelyGetTools
 import com.embabel.agent.experimental.primitive.Determination
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.agent.spi.support.springai.streaming.StreamingChatClientOperations
 import com.embabel.chat.AssistantMessage

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/PromptExecutionDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/PromptExecutionDelegate.kt
@@ -23,8 +23,8 @@ import com.embabel.agent.api.tool.ToolObject
 import com.embabel.agent.api.validation.guardrails.GuardRail
 import com.embabel.agent.core.ToolGroup
 import com.embabel.agent.core.ToolGroupRequirement
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmUse
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.chat.AssistantMessage
 import com.embabel.chat.Message
 import com.embabel.common.ai.model.LlmOptions

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/streaming/StreamingCapabilityDetector.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/streaming/StreamingCapabilityDetector.kt
@@ -17,8 +17,8 @@ package com.embabel.agent.api.common.support.streaming
 
 import com.embabel.agent.api.common.InteractionId
 import com.embabel.agent.api.common.support.streaming.StreamingCapabilityDetector.supportsStreaming
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.common.ai.model.LlmOptions

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessContext.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessContext.kt
@@ -19,7 +19,7 @@ import com.embabel.agent.api.channel.OutputChannel
 import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.api.event.MulticastAgenticEventListener
-import com.embabel.agent.spi.LlmOperations
+import com.embabel.agent.core.internal.LlmOperations
 
 /**
  * Process state and services. Created by the platform,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/internal/LlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/internal/LlmOperations.kt
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.spi
+
+package com.embabel.agent.core.internal
 
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.core.Action
@@ -23,6 +24,7 @@ import com.embabel.agent.core.support.InvalidLlmReturnTypeException
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.chat.Message
 import com.embabel.chat.UserMessage
+import org.jetbrains.annotations.ApiStatus
 
 /**
  * Wraps LLM operations.
@@ -34,6 +36,7 @@ import com.embabel.chat.UserMessage
  * and emitting events.
  * @see com.embabel.agent.api.common.PromptRunner
  */
+@ApiStatus.Internal
 interface LlmOperations {
 
     /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.api.event.AgentProcessCreationEvent
 import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.*
 import com.embabel.agent.core.expression.LogicalExpressionParser
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.spi.*
 import com.embabel.agent.spi.config.spring.AgentPlatformProperties
 import com.embabel.agent.spi.support.DefaultPlannerFactory

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -21,6 +21,7 @@ import com.embabel.agent.api.common.ranking.Ranker
 import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.core.ToolGroup
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.spi.*
 import com.embabel.agent.spi.logging.ColorPalette
 import com.embabel.agent.spi.logging.DefaultColorPalette

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
@@ -19,10 +19,10 @@ import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.Action
 import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.InvalidLlmReturnTypeException
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.spi.AutoLlmSelectionCriteriaResolver
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.ToolDecorator
 import com.embabel.agent.spi.validation.DefaultValidationPromptGenerator

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmRanker.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmRanker.kt
@@ -19,8 +19,8 @@ import com.embabel.agent.api.common.InteractionId
 import com.embabel.agent.api.common.ranking.Ranker
 import com.embabel.agent.api.common.ranking.Ranking
 import com.embabel.agent.api.common.ranking.Rankings
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.ModelSelectionCriteria

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/SpringContextPlatformServices.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/SpringContextPlatformServices.kt
@@ -23,7 +23,7 @@ import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.core.expression.LogicalExpressionParser
-import com.embabel.agent.spi.LlmOperations
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.spi.OperationScheduler
 import com.embabel.agent.spi.expression.spel.SpelLogicalExpressionParser
 import com.embabel.chat.ConversationFactoryProvider

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/DummyObjectCreatingLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/DummyObjectCreatingLlmOperations.kt
@@ -18,8 +18,8 @@ package com.embabel.agent.test.integration
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.core.Action
 import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.chat.Message
 import com.embabel.common.util.DummyInstanceCreator
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/IntegrationTestUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/IntegrationTestUtils.kt
@@ -20,10 +20,10 @@ import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.*
 import com.embabel.agent.core.expression.LogicalExpressionParser
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.DefaultAgentPlatform
 import com.embabel.agent.core.support.InMemoryBlackboard
 import com.embabel.agent.core.support.SimpleAgentProcess
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.OperationScheduler
 import com.embabel.agent.spi.ToolGroupResolver
 import com.embabel.agent.spi.config.spring.AgentPlatformProperties.ProcessType

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/ScriptedLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/ScriptedLlmOperations.kt
@@ -19,8 +19,8 @@ import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.Action
 import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.chat.Message
 import org.slf4j.LoggerFactory
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
@@ -15,11 +15,7 @@
  */
 package com.embabel.agent.test.unit
 
-import com.embabel.agent.api.common.AgentImage
-import com.embabel.agent.api.common.ContextualPromptElement
-import com.embabel.agent.api.common.InteractionId
-import com.embabel.agent.api.common.OperationContext
-import com.embabel.agent.api.common.PromptRunner
+import com.embabel.agent.api.common.*
 import com.embabel.agent.api.common.support.DelegatingCreating
 import com.embabel.agent.api.common.support.DelegatingRendering
 import com.embabel.agent.api.common.support.PromptExecutionDelegate
@@ -28,9 +24,9 @@ import com.embabel.agent.api.tool.ToolObject
 import com.embabel.agent.api.validation.guardrails.GuardRail
 import com.embabel.agent.core.ToolGroup
 import com.embabel.agent.core.ToolGroupRequirement
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.core.support.safelyGetTools
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.chat.AssistantMessage
 import com.embabel.chat.Message
 import com.embabel.chat.UserMessage

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderActionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderActionTest.kt
@@ -20,13 +20,14 @@ import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.dsl.Frog
 import com.embabel.agent.api.dsl.SnakeMeal
 import com.embabel.agent.api.event.AgenticEventListener.Companion.DevNull
+import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.*
 import com.embabel.agent.core.hitl.ConfirmationRequest
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.InMemoryBlackboard
+import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.core.support.SimpleAgentProcess
 import com.embabel.agent.domain.io.UserInput
-import com.embabel.agent.core.support.LlmInteraction
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.support.DefaultPlannerFactory
 import com.embabel.agent.support.Dog
 import com.embabel.agent.test.integration.IntegrationTestUtils
@@ -42,7 +43,6 @@ import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.Agent as CoreAgent
 
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextPromptRunnerStreamingTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextPromptRunnerStreamingTest.kt
@@ -19,8 +19,8 @@ import com.embabel.agent.api.common.support.OperationContextPromptRunner
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.Operation
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.streaming.StreamingLlmOperations
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.agent.spi.support.springai.SpringAiLlmService

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextPromptRunnerThinkingTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextPromptRunnerThinkingTest.kt
@@ -21,8 +21,8 @@ import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.Operation
 import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.chat.Message
 import com.embabel.common.ai.model.LlmOptions

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/AgentPlatformIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/AgentPlatformIntegrationTest.kt
@@ -28,9 +28,9 @@ import com.embabel.agent.core.Agent
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcessStatusCode
 import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.domain.library.HasContent
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.expression.spel.Elephant
 import com.embabel.agent.spi.expression.spel.Spel2ActionsNoGoal
 import com.embabel.agent.spi.expression.spel.Zoo

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/LLMStreamingIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/LLMStreamingIntegrationTest.kt
@@ -23,7 +23,7 @@ import com.embabel.agent.api.common.streaming.StreamingPromptRunner
 import com.embabel.agent.api.common.streaming.asStreaming
 import com.embabel.agent.api.common.support.streaming.StreamingCapabilityDetector
 import com.embabel.agent.core.AgentPlatform
-import com.embabel.agent.spi.LlmOperations
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.ToolDecorator
 import com.embabel.agent.spi.support.FakeChatModel

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsGuardRailTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsGuardRailTest.kt
@@ -23,14 +23,10 @@ import com.embabel.agent.api.tool.ToolObject
 import com.embabel.agent.api.validation.guardrails.AssistantMessageGuardRail
 import com.embabel.agent.api.validation.guardrails.GuardRailViolationException
 import com.embabel.agent.api.validation.guardrails.UserInputGuardRail
-import com.embabel.agent.core.AgentProcess
-import com.embabel.agent.core.Blackboard
-import com.embabel.agent.core.LlmInvocation
-import com.embabel.agent.core.LlmInvocationHistory
-import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.*
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.core.support.safelyGetToolsFrom
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.agent.spi.support.springai.MaybeReturn
 import com.embabel.agent.spi.support.springai.SpringAiLlmService

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -21,11 +21,11 @@ import com.embabel.agent.api.tool.ToolObject
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.Blackboard
 import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.InvalidLlmReturnFormatException
 import com.embabel.agent.core.support.InvalidLlmReturnTypeException
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.core.support.safelyGetToolsFrom
-import com.embabel.agent.spi.LlmOperations
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.agent.spi.support.springai.MaybeReturn
 import com.embabel.agent.spi.support.springai.SpringAiLlmService

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/LlmRankerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/LlmRankerTest.kt
@@ -16,7 +16,7 @@
 package com.embabel.agent.spi.support
 
 import com.embabel.agent.core.Goal
-import com.embabel.agent.spi.LlmOperations
+import com.embabel.agent.core.internal.LlmOperations
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/SpringContextPlatformServicesTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/SpringContextPlatformServicesTest.kt
@@ -21,7 +21,7 @@ import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.core.expression.LogicalExpressionParser
-import com.embabel.agent.spi.LlmOperations
+import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.spi.OperationScheduler
 import com.embabel.agent.spi.expression.spel.SpelLogicalExpressionParser
 import com.embabel.common.textio.template.TemplateRenderer

--- a/embabel-agent-test-support/embabel-agent-test/src/main/java/com/embabel/agent/test/integration/EmbabelMockitoIntegrationTest.java
+++ b/embabel-agent-test-support/embabel-agent-test/src/main/java/com/embabel/agent/test/integration/EmbabelMockitoIntegrationTest.java
@@ -16,8 +16,8 @@
 package com.embabel.agent.test.integration;
 
 import com.embabel.agent.core.AgentPlatform;
+import com.embabel.agent.core.internal.LlmOperations;
 import com.embabel.agent.core.support.LlmInteraction;
-import com.embabel.agent.spi.LlmOperations;
 import com.embabel.chat.Message;
 import com.embabel.common.ai.model.ModelProvider;
 import org.mockito.ArgumentCaptor;


### PR DESCRIPTION
This PR moves `LlmOperations` to the new `core.internal` package, and annotates it with `ApiStatus.Internal`.
Kotlin does not support package annotations directly, so I opted to annotate the type itself rather than create a `package-info.java` in the `src/main/java` tree.

See gh-1024
Closes gh-1400