### PR TITLE
Reference gh-1413

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
@@ -562,6 +562,17 @@ interface PromptRunner : LlmUse, PromptRunnerOperations {
         fun withPropertyFilter(filter: Predicate<String>): Creating<T>
 
         /**
+         * Add a filter that determines which properties are to be included when creating an object.
+         *
+         * Note that each predicate is applied *in addition to* previously registered predicates, including
+         * [withProperties] and [withoutProperties].
+         *
+         * @param skipAnnotationFilter the property annotation to be skipped
+         * @return this instance for method chaining
+         */
+        fun withAnnotationFilter(skipAnnotationFilter: Class<out Annotation>): Creating<T>
+
+        /**
          * Include the given properties when creating an object.
          *
          * Note that each predicate is applied *in addition to* previously registered predicates, including

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/DelegatingCreating.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/DelegatingCreating.kt
@@ -61,6 +61,10 @@ internal data class DelegatingCreating<T>(
         delegate = delegate.withPropertyFilter(filter)
     )
 
+    override fun withAnnotationFilter(skipAnnotationFilter: Class<out Annotation>): PromptRunner.Creating<T> = copy(
+        delegate = delegate.withAnnotationFilter(skipAnnotationFilter)
+    )
+
     override fun withValidation(
         validation: Boolean
     ): PromptRunner.Creating<T> = copy(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingPromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingPromptRunner.kt
@@ -29,6 +29,7 @@ import com.embabel.agent.experimental.primitive.Determination
 import com.embabel.chat.AssistantMessage
 import com.embabel.chat.Message
 import com.embabel.chat.UserMessage
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.core.types.ZeroToOne
@@ -57,7 +58,7 @@ internal data class DelegatingStreamingPromptRunner(
     override val generateExamples: Boolean?
         get() = delegate.generateExamples
 
-    override val propertyFilter: java.util.function.Predicate<String>
+    override val propertyFilter: JacksonPropertyFilter
         get() = delegate.propertyFilter
 
     override val validation: Boolean

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
@@ -32,6 +32,7 @@ import com.embabel.chat.AssistantMessage
 import com.embabel.chat.ImagePart
 import com.embabel.chat.Message
 import com.embabel.chat.UserMessage
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.Thinking
 import com.embabel.common.ai.prompt.PromptContributor
@@ -60,7 +61,7 @@ internal data class OperationContextDelegate(
     override val promptContributors: List<PromptContributor>,
     private val contextualPromptContributors: List<ContextualPromptElement> = emptyList(),
     override val generateExamples: Boolean? = null,
-    override val propertyFilter: Predicate<String> = Predicate { true },
+    override val propertyFilter: JacksonPropertyFilter = JacksonPropertyFilter.allowAll(),
     override val validation: Boolean = true,
     private val otherTools: List<Tool> = emptyList(),
     private val guardRails: List<GuardRail> = emptyList(),
@@ -113,6 +114,9 @@ internal data class OperationContextDelegate(
 
     override fun withPropertyFilter(filter: Predicate<String>): PromptExecutionDelegate =
         copy(propertyFilter = this.propertyFilter.and(filter))
+
+    override fun withAnnotationFilter(skipAnnotationFilter: Class<out Annotation>): PromptExecutionDelegate =
+        copy(propertyFilter = this.propertyFilter.and(JacksonPropertyFilter.SkipAnnotation(skipAnnotationFilter)))
 
     override fun withValidation(validation: Boolean): PromptExecutionDelegate = copy(validation = validation)
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/PromptExecutionDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/PromptExecutionDelegate.kt
@@ -86,6 +86,8 @@ internal interface PromptExecutionDelegate : LlmUse {
 
     fun withPropertyFilter(filter: Predicate<String>): PromptExecutionDelegate
 
+    fun withAnnotationFilter(skipAnnotationFilter: Class<out Annotation>): PromptExecutionDelegate
+
     fun withValidation(validation: Boolean): PromptExecutionDelegate
 
     fun withGuardRails(vararg guards: GuardRail): PromptExecutionDelegate

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/LlmInteraction.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/LlmInteraction.kt
@@ -21,6 +21,7 @@ import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.ToolConsumer
 import com.embabel.agent.core.ToolGroupConsumer
 import com.embabel.agent.core.ToolGroupRequirement
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.ai.prompt.PromptContributorConsumer
@@ -29,7 +30,6 @@ import com.embabel.common.core.MobyNameGenerator
 import com.embabel.common.core.types.HasInfoString
 import com.embabel.common.util.indent
 import jakarta.validation.ConstraintViolation
-import java.util.function.Predicate
 
 /**
  * Spec for calling an LLM. Optional LlmOptions,
@@ -47,7 +47,7 @@ interface LlmUse : PromptContributorConsumer, ToolGroupConsumer {
     /**
      * Filter that determines which properties to include when creating objects.
      */
-    val propertyFilter: Predicate<String>
+    val propertyFilter: JacksonPropertyFilter
 
     /**
      * Whether to validate generated objects.
@@ -88,7 +88,7 @@ private data class LlmCallImpl(
     override val promptContributors: List<PromptContributor> = emptyList(),
     override val contextualPromptContributors: List<ContextualPromptElement> = emptyList(),
     override val generateExamples: Boolean = false,
-    override val propertyFilter: Predicate<String> = Predicate { true },
+    override val propertyFilter: JacksonPropertyFilter = JacksonPropertyFilter.allowAll(),
     override val validation: Boolean = true,
 ) : LlmCall
 
@@ -119,7 +119,7 @@ data class LlmInteraction(
     override val promptContributors: List<PromptContributor> = emptyList(),
     override val contextualPromptContributors: List<ContextualPromptElement> = emptyList(),
     override val generateExamples: Boolean? = null,
-    override val propertyFilter: Predicate<String> = Predicate { true },
+    override val propertyFilter: JacksonPropertyFilter = JacksonPropertyFilter.allowAll(),
     override val validation: Boolean = true,
     val useEmbabelToolLoop: Boolean = true,
     val maxToolIterations: Int = 20,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -56,6 +56,7 @@ import org.springframework.ai.chat.messages.SystemMessage
 import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.converter.StructuredOutputConverter
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.context.ApplicationContext
 import org.springframework.core.ParameterizedTypeReference
@@ -1056,7 +1057,7 @@ internal class ChatClientLlmOperations(
  * Adapter to wrap Spring AI's StructuredOutputConverter as our OutputConverter.
  */
 private class SpringAiOutputConverterAdapter<T>(
-    private val delegate: org.springframework.ai.converter.StructuredOutputConverter<T>,
+    private val delegate: StructuredOutputConverter<T>,
 ) : OutputConverter<T> {
     override fun convert(source: String): T? = delegate.convert(source)
     override fun getFormat(): String? = delegate.format

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/unit/FakePromptRunner.kt
@@ -30,6 +30,7 @@ import com.embabel.agent.core.support.safelyGetTools
 import com.embabel.chat.AssistantMessage
 import com.embabel.chat.Message
 import com.embabel.chat.UserMessage
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.core.MobyNameGenerator
@@ -75,7 +76,7 @@ data class FakePromptRunner(
     override val promptContributors: List<PromptContributor>,
     private val contextualPromptContributors: List<ContextualPromptElement>,
     override val generateExamples: Boolean?,
-    override val propertyFilter: Predicate<String> = Predicate { true },
+    override val propertyFilter: JacksonPropertyFilter = JacksonPropertyFilter.allowAll(),
     override val validation: Boolean = true,
     private val context: OperationContext,
     private val _llmInvocations: MutableList<LlmInvocation> = mutableListOf(),
@@ -129,7 +130,7 @@ data class FakePromptRunner(
         override val generateExamples: Boolean?
             get() = this@FakePromptRunner.generateExamples
 
-        override val propertyFilter: Predicate<String>
+        override val propertyFilter: JacksonPropertyFilter
             get() = this@FakePromptRunner.propertyFilter
 
         override val validation: Boolean
@@ -190,6 +191,12 @@ data class FakePromptRunner(
 
         override fun withPropertyFilter(filter: Predicate<String>): PromptExecutionDelegate {
             return this@FakePromptRunner.copy(propertyFilter = this@FakePromptRunner.propertyFilter.and(filter))
+                .DelegateAdapter()
+        }
+
+        override fun withAnnotationFilter(skipAnnotationFilter: Class<out Annotation>): PromptExecutionDelegate {
+            return this@FakePromptRunner.copy(propertyFilter = this@FakePromptRunner.propertyFilter.and(
+                JacksonPropertyFilter.SkipAnnotation(skipAnnotationFilter)))
                 .DelegateAdapter()
         }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/nested/support/PromptRunnerCreating.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/nested/support/PromptRunnerCreating.kt
@@ -54,6 +54,10 @@ internal data class PromptRunnerCreating<T>(
         )
     }
 
+    override fun withAnnotationFilter(filter: Class<out Annotation>): PromptRunnerCreating<T> {
+        return this;
+    }
+
     override fun withValidation(
         validation: Boolean
     ): PromptRunner.Creating<T> {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingPromptRunnerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingPromptRunnerTest.kt
@@ -23,6 +23,7 @@ import com.embabel.agent.core.ToolGroup
 import com.embabel.agent.core.ToolGroupRequirement
 import com.embabel.agent.experimental.primitive.Determination
 import com.embabel.chat.UserMessage
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.textio.template.TemplateRenderer
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
-import java.util.function.Predicate
 
 class DelegatingStreamingPromptRunnerTest {
 
@@ -106,7 +106,7 @@ class DelegatingStreamingPromptRunnerTest {
 
         @Test
         fun `should delegate propertyFilter property`() {
-            val filter = Predicate<String> { true }
+            val filter = JacksonPropertyFilter.allowAll()
             every { mockDelegate.propertyFilter } returns filter
 
             val runner = createPromptRunner()

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/OperationContextPromptRunner.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/OperationContextPromptRunner.kt
@@ -40,6 +40,7 @@ import com.embabel.agent.spi.support.springai.streaming.StreamingChatClientOpera
 import com.embabel.chat.ImagePart
 import com.embabel.chat.Message
 import com.embabel.chat.UserMessage
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.Thinking
 import com.embabel.common.ai.prompt.PromptContributor
@@ -62,7 +63,7 @@ internal data class OperationContextPromptRunner(
     override val promptContributors: List<PromptContributor>,
     private val contextualPromptContributors: List<ContextualPromptElement>,
     override val generateExamples: Boolean?,
-    override val propertyFilter: Predicate<String> = Predicate { true },
+    override val propertyFilter: JacksonPropertyFilter = JacksonPropertyFilter.allowAll(),
     override val validation: Boolean = true,
     private val otherTools: List<Tool> = emptyList(),
     private val guardRails: List<GuardRail> = emptyList(),

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/thinking/ThinkingPromptRunnerOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/thinking/ThinkingPromptRunnerOperationsTest.kt
@@ -25,6 +25,7 @@ import com.embabel.agent.core.ToolGroupRequirement
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.chat.AssistantMessage
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.embabel.common.core.thinking.ThinkingBlock
 import com.embabel.common.core.thinking.ThinkingException
 import com.embabel.common.core.thinking.ThinkingResponse
@@ -176,7 +177,8 @@ class ThinkingPromptRunnerOperationsTest {
             override val toolObjects: List<ToolObject> = emptyList()
             override val promptContributors: List<com.embabel.common.ai.prompt.PromptContributor> = emptyList()
             override val generateExamples: Boolean? = null
-            override val propertyFilter: java.util.function.Predicate<String> = java.util.function.Predicate { true }
+            override val propertyFilter: JacksonPropertyFilter =
+                JacksonPropertyFilter.allowAll()
             override val validation: Boolean = true
 
             override fun <T> createObject(messages: List<com.embabel.chat.Message>, outputClass: Class<T>): T {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsTest.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.spi.streaming.StreamingLlmOperations
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.chat.UserMessage
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
@@ -84,7 +85,7 @@ class StreamingChatClientOperationsTest {
         every { mockInteraction.llm } returns mockk(relaxed = true)
         every { mockInteraction.tools } returns emptyList()
         every { mockChatClientLlmOperations.objectMapper } returns jacksonObjectMapper()
-        every { mockInteraction.propertyFilter } returns { true }
+        every { mockInteraction.propertyFilter } returns JacksonPropertyFilter.allowAll()
 
         streamingOperations = StreamingChatClientOperations(mockChatClientLlmOperations)
     }

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
@@ -36,7 +36,7 @@ import java.lang.reflect.Type
  * of the used schema via [postProcessSchema]
  */
 open class JacksonOutputConverter<T> protected constructor(
-    private val type: Type,
+    protected val type: Type,
     val objectMapper: ObjectMapper,
 ) : StructuredOutputConverter<T> {
 

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonPropertyFilter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonPropertyFilter.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.ai.converters
+
+import com.fasterxml.jackson.databind.introspect.AnnotatedField
+import java.util.function.Predicate
+
+sealed interface JacksonPropertyFilter {
+
+    fun test(field: AnnotatedField): Boolean
+
+    fun test(property: String): Boolean
+
+    data class MatchesPropertyValue(
+        val predicate: Predicate<String>
+    ) : JacksonPropertyFilter {
+        override fun test(field: AnnotatedField): Boolean {
+            return true
+        }
+
+        override fun test(property: String): Boolean {
+            return predicate.test(property)
+        }
+    }
+
+    data class SkipAnnotation(
+        val annotation: Class<out Annotation>
+    ) : JacksonPropertyFilter {
+        override fun test(field: AnnotatedField): Boolean {
+            return !field.hasAnnotation(annotation)
+        }
+
+        override fun test(property: String): Boolean {
+            return true
+        }
+    }
+
+    data class Composite(
+        val filters: List<JacksonPropertyFilter>
+    ) : JacksonPropertyFilter {
+        override fun test(field: AnnotatedField): Boolean {
+            return filters.all { it.test(field) }
+        }
+
+        override fun test(property: String): Boolean {
+            return filters.all { it.test(property) }
+        }
+    }
+
+    infix fun and(other: Predicate<String>): JacksonPropertyFilter {
+        return and(property(other))
+    }
+
+    infix fun and(other: JacksonPropertyFilter): JacksonPropertyFilter {
+        return when {
+            this is Composite && other is Composite ->
+                Composite(this.filters + other.filters)
+
+            this is Composite ->
+                Composite(this.filters + other)
+
+            other is Composite ->
+                Composite(listOf(this) + other.filters)
+
+            else ->
+                Composite(listOf(this, other))
+        }
+    }
+
+    companion object {
+
+        fun allowAll(): JacksonPropertyFilter =
+            MatchesPropertyValue { true }
+
+        fun property(predicate: Predicate<String>) =
+            MatchesPropertyValue(predicate)
+
+        fun skip(annotation: Class<out Annotation>) =
+            SkipAnnotation(annotation)
+    }
+}

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/SchemaPruner.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/SchemaPruner.kt
@@ -1,0 +1,473 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.ai.converters
+
+import com.fasterxml.jackson.databind.JavaType
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import java.lang.reflect.Modifier
+import org.slf4j.LoggerFactory
+import java.util.IdentityHashMap
+
+class SchemaPruner(
+    private val objectMapper: ObjectMapper,
+    private val shouldKeepProperty: (propName: String, prop: BeanPropertyDefinition) -> Boolean,
+    private val shouldKeepTopLevelPropertyName: (propName: String) -> Boolean = { true }
+) {
+
+    fun pruneAndSweep(rootJavaType: JavaType, schemaRoot: ObjectNode) {
+        if (!validateSchemaOrFallback(schemaRoot)) return
+
+        // 1) Prune properties (type-aware), resolving $ref as needed
+        val pruneVisited = IdentityHashMap<JsonNode, Boolean>()
+        pruneNodeForType(rootJavaType, schemaRoot, schemaRoot, pruneVisited, true)
+
+        // 2) Mark & sweep $defs/definitions based on reachability
+        sweepUnusedDefs(schemaRoot)
+    }
+
+    private fun validateSchemaOrFallback(schemaRoot: ObjectNode): Boolean {
+        return try {
+            validateSchema(schemaRoot)
+            true
+        } catch (e: RuntimeException) {
+            logger.error(
+                "Schema validation failed; falling back to top-level-only pruning: {}",
+                e.message
+            )
+            pruneTopLevelPropertiesOnly(schemaRoot)
+            false
+        }
+    }
+
+    /**
+     * Walk schema + JavaType in lockstep.
+     *
+     * @param rootSchema the actual schema root (used to resolve #/... pointers)
+     * @param node current schema node
+     */
+    private fun pruneNodeForType(
+        currentType: JavaType,
+        rootSchema: ObjectNode,
+        node: JsonNode,
+        visited: MutableMap<JsonNode, Boolean>,
+        isTopLevel: Boolean
+    ) {
+        // Prefer under-pruning over over-pruning for polymorphic base declarations.
+        if (isPolymorphicBaseType(currentType)) return
+
+        val resolved = resolveRefIfPresent(rootSchema, node)
+        if (visited.put(resolved, true) != null) return
+
+        // Handle schema composition wrappers
+        handleCombinators(currentType, rootSchema, resolved, visited, isTopLevel)
+
+        when {
+            isObjectSchema(resolved) -> pruneObjectSchema(
+                currentType = currentType,
+                rootSchema = rootSchema,
+                objSchema = resolved as ObjectNode,
+                visited = visited,
+                applyTopLevelPropertyNameFilter = isTopLevel
+            )
+            isArraySchema(resolved)  -> pruneArraySchema(currentType, rootSchema, resolved as ObjectNode, visited)
+            isMapSchema(resolved)    -> pruneMapSchema(currentType, rootSchema, resolved as ObjectNode, visited)
+            else -> {
+                // primitives or unknown shapes: nothing to prune recursively
+            }
+        }
+    }
+
+    private fun pruneObjectSchema(
+        currentType: JavaType,
+        rootSchema: ObjectNode,
+        objSchema: ObjectNode,
+        visited: MutableMap<JsonNode, Boolean>,
+        applyTopLevelPropertyNameFilter: Boolean
+    ) {
+        val propsNode = objSchema.get("properties") as? ObjectNode ?: return
+
+        val propsByName = jacksonPropertiesByName(currentType)
+
+        val it = propsNode.fieldNames() as MutableIterator<String>
+        while (it.hasNext()) {
+            val propName = it.next()
+            if (applyTopLevelPropertyNameFilter && !shouldKeepTopLevelPropertyName(propName)) {
+                it.remove()
+                removeRequiredProperty(objSchema, propName)
+                continue
+            }
+            val propDef = propsByName[propName]
+            if (propDef == null) {
+                if (isLikelyDiscriminatorMetadata(propsNode.get(propName))) {
+                    continue
+                }
+                // Schema has a property Jackson doesn't see; safest is remove it.
+                it.remove()
+                removeRequiredProperty(objSchema, propName)
+                continue
+            }
+
+            if (!shouldKeepProperty(propName, propDef)) {
+                it.remove()
+                removeRequiredProperty(objSchema, propName)
+                continue
+            }
+
+            // Recurse into the property's schema node using property's JavaType
+            val propSchemaNode = propsNode.get(propName)
+            val propType = propDef.primaryTypeOrNull() ?: continue
+            pruneNodeForType(propType, rootSchema, propSchemaNode, visited, false)
+        }
+    }
+
+    private fun pruneArraySchema(
+        currentType: JavaType,
+        rootSchema: ObjectNode,
+        arrSchema: ObjectNode,
+        visited: MutableMap<JsonNode, Boolean>
+    ) {
+        val items = arrSchema.get("items") ?: return
+        val contentType = currentType.contentType ?: return
+        pruneNodeForType(contentType, rootSchema, items, visited, false)
+    }
+
+    private fun pruneMapSchema(
+        currentType: JavaType,
+        rootSchema: ObjectNode,
+        mapSchema: ObjectNode,
+        visited: MutableMap<JsonNode, Boolean>
+    ) {
+        val ap = mapSchema.get("additionalProperties") ?: return
+        if (ap.isBoolean) return // additionalProperties: true/false
+        val valueType = currentType.contentType ?: return
+        pruneNodeForType(valueType, rootSchema, ap, visited, false)
+    }
+
+    private fun handleCombinators(
+        currentType: JavaType,
+        rootSchema: ObjectNode,
+        node: JsonNode,
+        visited: MutableMap<JsonNode, Boolean>,
+        isTopLevel: Boolean
+    ) {
+        // oneOf/anyOf/allOf
+        listOf("oneOf", "anyOf", "allOf").forEach { key ->
+            (node.get(key) as? ArrayNode)?.forEach { child ->
+                pruneNodeForType(currentType, rootSchema, child, visited, isTopLevel)
+            }
+        }
+
+        // not
+        node.get("not")?.let { child ->
+            pruneNodeForType(currentType, rootSchema, child, visited, false)
+        }
+
+        // if/then/else
+        node.get("if")?.let { pruneNodeForType(currentType, rootSchema, it, visited, false) }
+        node.get("then")?.let { pruneNodeForType(currentType, rootSchema, it, visited, false) }
+        node.get("else")?.let { pruneNodeForType(currentType, rootSchema, it, visited, false) }
+    }
+
+    private fun jacksonPropertiesByName(rootType: JavaType): Map<String, BeanPropertyDefinition> {
+        val cfg = objectMapper.serializationConfig
+        val beanDesc = cfg.introspect(rootType)
+        return beanDesc.findProperties().associateBy { it.name }
+    }
+
+    private fun BeanPropertyDefinition.primaryTypeOrNull(): JavaType? {
+        this.primaryMember?.let { return it.type }
+        this.getter?.let { return it.type }
+        this.field?.let { return it.type }
+        this.constructorParameter?.let { return it.type }
+        return null
+    }
+
+    /**
+     * Resolve a local $ref (e.g. "#/$defs/Foo") to its target node.
+     * If the node is not a $ref or not resolvable, returns the node as-is.
+     */
+    private fun resolveRefIfPresent(rootSchema: ObjectNode, node: JsonNode): JsonNode {
+        val obj = node as? ObjectNode ?: return node
+        val refNode = obj.get("\$ref")
+        if (refNode != null && refNode.isTextual) {
+            val ref = refNode.asText()
+            if (ref.startsWith("#/")) {
+                val pointer = ref.removePrefix("#")
+                val target = rootSchema.at(pointer)
+                if (!target.isMissingNode && !target.isNull) return target
+            }
+        }
+        return node
+    }
+
+    private fun isObjectSchema(node: JsonNode): Boolean {
+        if (node !is ObjectNode) return false
+        val t = node.get("type")
+        return (t?.isTextual == true && t.asText() == "object") || node.has("properties")
+    }
+
+    private fun isArraySchema(node: JsonNode): Boolean {
+        if (node !is ObjectNode) return false
+        val t = node.get("type")
+        return (t?.isTextual == true && t.asText() == "array") || node.has("items")
+    }
+
+    private fun isMapSchema(node: JsonNode): Boolean {
+        if (node !is ObjectNode) return false
+        return node.has("additionalProperties")
+    }
+
+    /**
+     * Mark & sweep all unused defs. Works with Draft 2020-12 ($defs) and older (definitions).
+     */
+    private fun sweepUnusedDefs(rootSchema: ObjectNode) {
+        val defs = (rootSchema.get("\$defs") as? ObjectNode)
+            ?: (rootSchema.get("definitions") as? ObjectNode)
+            ?: return
+
+        // Mark reachable definition keys
+        val reachable = linkedSetOf<String>()
+        val visited = IdentityHashMap<JsonNode, Boolean>()
+
+        fun mark(node: JsonNode) {
+            if (visited.put(node, true) != null) return
+
+            val obj = node as? ObjectNode
+            if (obj != null) {
+                val refNode = obj.get("\$ref")
+                if (refNode != null && refNode.isTextual) {
+                    val ref = refNode.asText()
+                    // expect "#/$defs/Name" or "#/definitions/Name"
+                    val name = extractDefName(ref)
+                    if (name != null && reachable.add(name)) {
+                        val target = defs.get(name)
+                        if (target != null) mark(target)
+                    }
+                }
+
+                // traverse all children (covers properties/items/additionalProperties/combinators/etc.)
+                val fields = obj.fields()
+                while (fields.hasNext()) {
+                    val (k, v) = fields.next()
+                    // Optional micro-optimization: skip defs container itself
+                    if (k == "\$defs" || k == "definitions") continue
+                    mark(v)
+                }
+            } else if (node is ArrayNode) {
+                node.forEach { mark(it) }
+            }
+        }
+
+        // Mark from the root schema (excluding the defs container)
+        mark(rootSchema)
+
+        // Sweep: remove defs not reachable
+        val defNames = defs.fieldNames() as MutableIterator<String>
+        while (defNames.hasNext()) {
+            val name = defNames.next()
+            if (!reachable.contains(name)) defNames.remove()
+        }
+
+        // If empty, you can remove the container
+        if (defs.size() == 0) {
+            rootSchema.remove("\$defs")
+            rootSchema.remove("definitions")
+        }
+    }
+
+    private fun extractDefName(ref: String): String? {
+        // "#/$defs/Foo" or "#/definitions/Foo"
+        val p1 = "#/\$defs/"
+        val p2 = "#/definitions/"
+        return when {
+            ref.startsWith(p1) -> ref.removePrefix(p1).takeIf { it.isNotBlank() }
+            ref.startsWith(p2) -> ref.removePrefix(p2).takeIf { it.isNotBlank() }
+            else -> null
+        }
+    }
+
+    private fun removeRequiredProperty(objSchema: ObjectNode, propertyName: String) {
+        val required = objSchema.get("required") as? ArrayNode ?: return
+        for (i in required.size() - 1 downTo 0) {
+            val requiredName = required.get(i)
+            if (requiredName.isTextual && requiredName.asText() == propertyName) {
+                required.remove(i)
+            }
+        }
+        if (required.size() == 0) {
+            objSchema.remove("required")
+        }
+    }
+
+    private fun pruneTopLevelPropertiesOnly(schemaRoot: ObjectNode) {
+        val propsNode = schemaRoot.get("properties") as? ObjectNode ?: return
+        val it = propsNode.fieldNames() as MutableIterator<String>
+        while (it.hasNext()) {
+            val name = it.next()
+            if (shouldKeepTopLevelPropertyName(name)) continue
+            it.remove()
+            removeRequiredProperty(schemaRoot, name)
+        }
+    }
+
+    private fun isLikelyDiscriminatorMetadata(node: JsonNode?): Boolean {
+        val objNode = node as? ObjectNode ?: return false
+        val constNode = objNode.get("const")
+        if (constNode?.isTextual == true) return true
+        val enumNode = objNode.get("enum") as? ArrayNode ?: return false
+        return enumNode.size() == 1 && enumNode.get(0).isTextual
+    }
+
+    private fun isPolymorphicBaseType(currentType: JavaType): Boolean {
+        val rawClass = currentType.rawClass
+        if (rawClass.`package`?.name?.startsWith("java.") == true) return false
+        if (Collection::class.java.isAssignableFrom(rawClass)) return false
+        if (Map::class.java.isAssignableFrom(rawClass)) return false
+        return rawClass.isInterface || Modifier.isAbstract(rawClass.modifiers)
+    }
+
+    private fun validateSchema(rootSchema: ObjectNode) {
+        validateSchemaObject(rootSchema, "#")
+    }
+
+    private fun validateSchemaObject(schemaNode: ObjectNode, path: String) {
+        val fields = schemaNode.fields()
+        while (fields.hasNext()) {
+            val (key, value) = fields.next()
+            if (!KNOWN_SCHEMA_KEYWORDS.contains(key)) {
+                throw IllegalStateException("Unexpected schema keyword '$key' at '$path'")
+            }
+            when (key) {
+                "\$schema", "\$id", "\$ref", "\$anchor", "\$dynamicRef", "\$dynamicAnchor", "\$comment" ->
+                    validateTextKeywordValue(value, "$path/$key")
+                "\$vocabulary" ->
+                    validateVocabulary(value, "$path/$key")
+                "properties", "patternProperties", "\$defs", "definitions", "dependentSchemas" ->
+                    validateSchemaObjectContainer(value, "$path/$key")
+                "items" ->
+                    validateSchemaNodeOrArray(value, "$path/$key")
+                "additionalProperties", "unevaluatedProperties", "unevaluatedItems", "not", "if", "then", "else",
+                "contains", "propertyNames", "contentSchema" ->
+                    validateSchemaNodeOrBoolean(value, "$path/$key")
+                "oneOf", "anyOf", "allOf", "prefixItems" ->
+                    validateSchemaArray(value, "$path/$key")
+                "dependentRequired" ->
+                    validateDependentRequired(value, "$path/$key")
+            }
+        }
+    }
+
+    private fun validateSchemaObjectContainer(node: JsonNode, path: String) {
+        val container = node as? ObjectNode
+            ?: throw IllegalStateException("Expected object node at '$path', got ${node.nodeType}")
+        val fields = container.fields()
+        while (fields.hasNext()) {
+            val (name, schemaValue) = fields.next()
+            validateSchemaNodeOrBoolean(schemaValue, "$path/$name")
+        }
+    }
+
+    private fun validateSchemaArray(node: JsonNode, path: String) {
+        val arr = node as? ArrayNode
+            ?: throw IllegalStateException("Expected array node at '$path', got ${node.nodeType}")
+        for (i in 0 until arr.size()) {
+            validateSchemaNodeOrBoolean(arr.get(i), "$path/$i")
+        }
+    }
+
+    private fun validateSchemaNodeOrArray(node: JsonNode, path: String) {
+        when (node) {
+            is ArrayNode -> {
+                for (i in 0 until node.size()) {
+                    validateSchemaNodeOrBoolean(node.get(i), "$path/$i")
+                }
+            }
+            else -> validateSchemaNodeOrBoolean(node, path)
+        }
+    }
+
+    private fun validateSchemaNodeOrBoolean(node: JsonNode, path: String) {
+        when {
+            node is ObjectNode -> validateSchemaObject(node, path)
+            node.isBoolean -> Unit // boolean-schema form: true/false
+            else -> throw IllegalStateException("Expected schema object/boolean at '$path', got ${node.nodeType}")
+        }
+    }
+
+    private fun validateDependentRequired(node: JsonNode, path: String) {
+        val container = node as? ObjectNode
+            ?: throw IllegalStateException("Expected object node at '$path', got ${node.nodeType}")
+        val fields = container.fields()
+        while (fields.hasNext()) {
+            val (name, depsValue) = fields.next()
+            val deps = depsValue as? ArrayNode
+                ?: throw IllegalStateException("Expected array node at '$path/$name', got ${depsValue.nodeType}")
+            for (i in 0 until deps.size()) {
+                val dep = deps.get(i)
+                if (!dep.isTextual) {
+                    throw IllegalStateException("Expected string dependency at '$path/$name/$i', got ${dep.nodeType}")
+                }
+            }
+        }
+    }
+
+    private fun validateTextKeywordValue(node: JsonNode, path: String) {
+        if (!node.isTextual) {
+            throw IllegalStateException("Expected string value at '$path', got ${node.nodeType}")
+        }
+    }
+
+    private fun validateVocabulary(node: JsonNode, path: String) {
+        val container = node as? ObjectNode
+            ?: throw IllegalStateException("Expected object node at '$path', got ${node.nodeType}")
+        val fields = container.fields()
+        while (fields.hasNext()) {
+            val (name, vocabEnabled) = fields.next()
+            if (name.isBlank()) {
+                throw IllegalStateException("Expected non-blank vocabulary URI key at '$path'")
+            }
+            if (!vocabEnabled.isBoolean) {
+                throw IllegalStateException("Expected boolean vocabulary flag at '$path/$name', got ${vocabEnabled.nodeType}")
+            }
+        }
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(SchemaPruner::class.java)
+
+        private val KNOWN_SCHEMA_KEYWORDS = setOf(
+            "\$schema", "\$id", "\$ref", "\$anchor", "\$dynamicRef", "\$dynamicAnchor", "\$vocabulary", "\$comment",
+            "\$defs", "definitions",
+            "type", "properties", "items", "additionalProperties",
+            "oneOf", "anyOf", "allOf", "not", "if", "then", "else",
+            "required", "enum", "const",
+            "title", "description", "format", "default", "examples",
+            "deprecated", "readOnly", "writeOnly",
+            "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
+            "minLength", "maxLength", "pattern",
+            "minItems", "maxItems", "uniqueItems", "contains", "minContains", "maxContains",
+            "minProperties", "maxProperties",
+            "prefixItems", "unevaluatedItems", "unevaluatedProperties",
+            "patternProperties", "propertyNames",
+            "dependentRequired", "dependentSchemas",
+            "contentEncoding", "contentMediaType", "contentSchema"
+        )
+    }
+}

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/annotations.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/annotations.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.ai.converters
+
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.PROPERTY_GETTER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class SkipPropertyFilter

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/streaming/StreamingJacksonOutputConverter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/streaming/StreamingJacksonOutputConverter.kt
@@ -16,6 +16,7 @@
 package com.embabel.common.ai.converters.streaming
 
 import com.embabel.common.ai.converters.FilteringJacksonOutputConverter
+import com.embabel.common.ai.converters.JacksonPropertyFilter
 import com.embabel.common.ai.converters.streaming.support.ThinkingDetector
 import com.embabel.common.core.streaming.StreamingEvent
 import com.embabel.common.core.streaming.ThinkingState
@@ -45,14 +46,20 @@ class StreamingJacksonOutputConverter<T> : FilteringJacksonOutputConverter<T> {
 
     constructor(
         clazz: Class<T>,
+        propertyFilter: JacksonPropertyFilter = JacksonPropertyFilter.allowAll(),
+        objectMapper: ObjectMapper,
+    ) : super(clazz, objectMapper, propertyFilter)
+
+    constructor(
+        clazz: Class<T>,
         objectMapper: ObjectMapper,
         propertyFilter: Predicate<String> = Predicate { true },
-    ) : super(clazz, objectMapper, propertyFilter)
+    ) : super(clazz, objectMapper, JacksonPropertyFilter.MatchesPropertyValue(propertyFilter))
 
     constructor(
         typeReference: ParameterizedTypeReference<T>,
         objectMapper: ObjectMapper,
-        propertyFilter: Predicate<String> = Predicate { true },
+        propertyFilter: JacksonPropertyFilter = JacksonPropertyFilter.allowAll(),
     ) : super(typeReference, objectMapper, propertyFilter)
 
     /**

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/FilteringJacksonOutputConverterTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/FilteringJacksonOutputConverterTest.kt
@@ -15,7 +15,15 @@
  */
 package com.embabel.common.ai.converters
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -24,6 +32,18 @@ class FilteringJacksonOutputConverterTest {
 
     private val objectMapper = jacksonObjectMapper()
 
+    @kotlin.annotation.Target(AnnotationTarget.FIELD)
+    @kotlin.annotation.Retention(AnnotationRetention.RUNTIME)
+    annotation class SkipA
+
+    @kotlin.annotation.Target(AnnotationTarget.FIELD)
+    @kotlin.annotation.Retention(AnnotationRetention.RUNTIME)
+    annotation class SkipB
+
+    @kotlin.annotation.Target(AnnotationTarget.FIELD)
+    @kotlin.annotation.Retention(AnnotationRetention.RUNTIME)
+    annotation class SkipC
+
     data class Person(
         val name: String,
         val age: Int,
@@ -31,36 +51,868 @@ class FilteringJacksonOutputConverterTest {
         val address: String
     )
 
+    data class Password(
+        @field:SkipPropertyFilter
+        val passwordString: String,
+        val hash: String
+    )
+
+    data class SomePerson(
+        val name: String,
+        val age: Int,
+        @field:SkipPropertyFilter
+        val email: String,
+        @field:SkipPropertyFilter
+        val address: String,
+        val password: Password
+    )
+
+    @Test
+    fun `test schema should skip deeply nested and preserve expected metadata`() {
+        val skipFilter = JacksonPropertyFilter.SkipAnnotation(SkipPropertyFilter::class.java)
+
+        val graphSchema = parseSchema(
+            FilteringJacksonOutputConverter<Graph>(
+                clazz = Graph::class.java,
+                objectMapper = objectMapper,
+                propertyFilter = skipFilter
+            ).jsonSchema
+        )
+        val graphProperties = allPropertyNames(graphSchema)
+
+        assertTrue(graphProperties.containsAll(setOf("root", "edges", "to", "attrs")))
+        assertFalse(graphProperties.contains("id"))
+        assertFalse(graphProperties.contains("label"))
+
+        val ruleSchema = parseSchema(
+            FilteringJacksonOutputConverter<Rule>(
+                clazz = Rule::class.java,
+                objectMapper = objectMapper,
+                propertyFilter = skipFilter
+            ).jsonSchema
+        )
+        val ruleProperties = allPropertyNames(ruleSchema)
+
+        assertTrue(ruleProperties.containsAll(setOf("enabled", "condition", "operands", "actions", "id", "effect")))
+        assertFalse(ruleProperties.contains("expr"))
+    }
+
+    @Test
+    fun `test schema should skip annotations recursively`() {
+        val schema = parseSchema(
+            FilteringJacksonOutputConverter<SomePerson>(
+                clazz = SomePerson::class.java,
+                objectMapper = objectMapper,
+                propertyFilter = JacksonPropertyFilter.SkipAnnotation(SkipPropertyFilter::class.java)
+            ).jsonSchema
+        )
+        val propertyNames = allPropertyNames(schema)
+
+        assertTrue(propertyNames.containsAll(setOf("name", "age", "password", "hash")))
+        assertFalse(propertyNames.contains("email"))
+        assertFalse(propertyNames.contains("address"))
+        assertFalse(propertyNames.contains("passwordString"))
+    }
+
     @Test
     fun `test schema should include only specified properties`() {
-        val converter = FilteringJacksonOutputConverter<Person>(
-            clazz = Person::class.java,
-            objectMapper = objectMapper,
-            propertyFilter = { it == "name" || it == "age" }
+        val schema = parseSchema(
+            FilteringJacksonOutputConverter<Person>(
+                clazz = Person::class.java,
+                objectMapper = objectMapper,
+                propertyFilter = JacksonPropertyFilter.MatchesPropertyValue({ it == "name" || it == "age" })
+            ).jsonSchema
         )
 
-        val schema = converter.jsonSchema
-
-        assertTrue(schema.contains("name"))
-        assertTrue(schema.contains("age"))
-        assertFalse(schema.contains("email"))
-        assertFalse(schema.contains("address"))
+        assertEquals(setOf("name", "age"), rootPropertyNames(schema))
     }
 
     @Test
     fun `test schema should exclude specified properties`() {
-        val converter = FilteringJacksonOutputConverter<Person>(
-            clazz = Person::class.java,
-            objectMapper = objectMapper,
-            propertyFilter = { it != "email" && it != "address" }
+        val schema = parseSchema(
+            FilteringJacksonOutputConverter<Person>(
+                clazz = Person::class.java,
+                objectMapper = objectMapper,
+                propertyFilter = JacksonPropertyFilter.MatchesPropertyValue({ it != "email" && it != "address" })
+            ).jsonSchema
         )
 
-        val schema = converter.jsonSchema
-
-        assertTrue(schema.contains("name"))
-        assertTrue(schema.contains("age"))
-        assertFalse(schema.contains("email"))
-        assertFalse(schema.contains("address"))
+        assertEquals(setOf("name", "age"), rootPropertyNames(schema))
     }
+
+    @Test
+    fun `schema validation failure should fallback to top-level pruning`() {
+        val filter = JacksonPropertyFilter
+            .SkipAnnotation(SkipPropertyFilter::class.java)
+            .and(JacksonPropertyFilter.property { it == "name" })
+        val converter = SchemaMutatingConverter(
+            clazz = Person::class.java,
+            objectMapper = objectMapper,
+            propertyFilter = filter
+        )
+
+        val schema = assertDoesNotThrow<String> {
+            converter.jsonSchema
+        }
+        val root = parseSchema(schema)
+        assertEquals(setOf("name"), rootPropertyNames(root))
+    }
+
+    @Test
+    fun `top-level-only pruning should skip schema validation`() {
+        val converter = SchemaMutatingConverter(
+            clazz = Person::class.java,
+            objectMapper = objectMapper,
+            propertyFilter = JacksonPropertyFilter.MatchesPropertyValue { it == "name" }
+        )
+
+        val schema = assertDoesNotThrow<String> {
+            converter.jsonSchema
+        }
+        val root = parseSchema(schema)
+        assertEquals(setOf("name"), rootPropertyNames(root))
+    }
+
+    @Test
+    fun `schema validation should allow draft 2020 core keywords`() {
+        val converter = CoreKeywordsMutatingConverter(
+            clazz = Person::class.java,
+            objectMapper = objectMapper,
+            propertyFilter = JacksonPropertyFilter.SkipAnnotation(SkipPropertyFilter::class.java)
+        )
+
+        val schema = assertDoesNotThrow<String> {
+            converter.jsonSchema
+        }
+        val root = parseSchema(schema)
+        assertTrue(root.has("\$anchor"))
+        assertTrue(root.has("\$dynamicRef"))
+        assertTrue(root.has("\$dynamicAnchor"))
+        assertTrue(root.has("\$vocabulary"))
+        assertTrue(root.has("\$comment"))
+    }
+
+    @Test
+    fun `invalid vocabulary should fallback to top-level pruning`() {
+        val filter = JacksonPropertyFilter
+            .SkipAnnotation(SkipPropertyFilter::class.java)
+            .and(JacksonPropertyFilter.property { it == "name" })
+        val converter = InvalidVocabularyMutatingConverter(
+            clazz = Person::class.java,
+            objectMapper = objectMapper,
+            propertyFilter = filter
+        )
+
+        val schema = assertDoesNotThrow<String> {
+            converter.jsonSchema
+        }
+        val root = parseSchema(schema)
+        assertEquals(setOf("name"), rootPropertyNames(root))
+    }
+
+    @Test
+    fun `skip annotations should be conditional per annotation type`() {
+        val skipA = JacksonPropertyFilter.SkipAnnotation(SkipA::class.java)
+        val skipB = JacksonPropertyFilter.SkipAnnotation(SkipB::class.java)
+        val skipC = JacksonPropertyFilter.SkipAnnotation(SkipC::class.java)
+
+        val contactA = rootPropertyNames(parseSchema(schemaForClass(Contact::class.java, skipA)))
+        val contactB = rootPropertyNames(parseSchema(schemaForClass(Contact::class.java, skipB)))
+        assertFalse(contactA.contains("address"))
+        assertTrue(contactB.contains("address"))
+
+        val notificationA = rootPropertyNames(parseSchema(schemaForClass(NotificationPolicy::class.java, skipA)))
+        val notificationB = rootPropertyNames(parseSchema(schemaForClass(NotificationPolicy::class.java, skipB)))
+        assertTrue(notificationA.contains("rules"))
+        assertFalse(notificationB.contains("rules"))
+
+        val targetB = rootPropertyNames(parseSchema(schemaForClass(Target::class.java, skipB)))
+        val targetC = rootPropertyNames(parseSchema(schemaForClass(Target::class.java, skipC)))
+        assertTrue(targetB.contains("destination"))
+        assertFalse(targetC.contains("destination"))
+
+        val metaA = rootPropertyNames(parseSchema(schemaForClass(MetaString::class.java, skipA)))
+        val metaC = rootPropertyNames(parseSchema(schemaForClass(MetaString::class.java, skipC)))
+        assertFalse(metaA.contains("v"))
+        assertTrue(metaC.contains("v"))
+
+        val attrA = rootPropertyNames(parseSchema(schemaForClass(AttrString::class.java, skipA)))
+        val attrC = rootPropertyNames(parseSchema(schemaForClass(AttrString::class.java, skipC)))
+        assertTrue(attrA.contains("v"))
+        assertFalse(attrC.contains("v"))
+    }
+
+    @Test
+    fun `combined annotation filters should apply union of skips`() {
+        val filter = JacksonPropertyFilter
+            .SkipAnnotation(SkipA::class.java)
+            .and(JacksonPropertyFilter.SkipAnnotation(SkipB::class.java))
+
+        val notificationPolicyProps = rootPropertyNames(parseSchema(schemaForClass(NotificationPolicy::class.java, filter)))
+        assertFalse(notificationPolicyProps.contains("rules"))
+
+        val contactProps = rootPropertyNames(parseSchema(schemaForClass(Contact::class.java, filter)))
+        assertFalse(contactProps.contains("address"))
+
+        val actionProps = rootPropertyNames(parseSchema(schemaForClass(Action::class.java, filter)))
+        assertFalse(actionProps.contains("id"))
+    }
+
+    @Test
+    fun `top level predicate should only prune root properties`() {
+        val schema = parseSchema(
+            FilteringJacksonOutputConverter<Root>(
+                clazz = Root::class.java,
+                objectMapper = objectMapper,
+                propertyFilter = JacksonPropertyFilter.MatchesPropertyValue {
+                    it == "profile"
+                }
+            ).jsonSchema
+        )
+
+        assertEquals(setOf("profile"), rootPropertyNames(schema))
+
+        // Nested names are still present because name-predicate pruning is top-level only.
+        val nestedPropertyNames = allPropertyNames(schema)
+        assertTrue(nestedPropertyNames.contains("name"))
+        assertTrue(nestedPropertyNames.contains("contacts"))
+        assertTrue(nestedPropertyNames.contains("notifications"))
+    }
+
+    @Test
+    fun `recursive pruning should remove dangling refs and unreachable defs`() {
+        val filter = JacksonPropertyFilter
+            .SkipAnnotation(SkipPropertyFilter::class.java)
+            .and(JacksonPropertyFilter.property { it == "profile" })
+        val schema = parseSchema(
+            FilteringJacksonOutputConverter<Root>(
+                clazz = Root::class.java,
+                objectMapper = objectMapper,
+                propertyFilter = filter
+            ).jsonSchema
+        )
+
+        assertEquals(setOf("profile"), rootPropertyNames(schema))
+        val defs = defNames(schema)
+        assertFalse(defs.contains("Session"))
+        assertFalse(defs.contains("OrgSettings"))
+
+        val refTargets = refTargets(schema)
+        assertTrue(refTargets.all { defs.contains(it) })
+    }
+
+    @Test
+    fun `top-level-only pruning should not sweep defs`() {
+        val schema = parseSchema(
+            FilteringJacksonOutputConverter<Root>(
+                clazz = Root::class.java,
+                objectMapper = objectMapper,
+                propertyFilter = JacksonPropertyFilter.MatchesPropertyValue { false }
+            ).jsonSchema
+        )
+
+        assertTrue(rootPropertyNames(schema).isEmpty())
+        assertTrue(schema.has("\$defs") || schema.has("definitions"))
+        val defs = defNames(schema)
+        val refs = refTargets(schema)
+        assertTrue(refs.all { defs.contains(it) })
+    }
+
+    @Test
+    fun `polymorphic collections should under prune subtype fields`() {
+        val allowAll = JacksonPropertyFilter.allowAll()
+        val filter = JacksonPropertyFilter
+            .SkipAnnotation(SkipA::class.java)
+            .and(JacksonPropertyFilter.SkipAnnotation(SkipC::class.java))
+
+        val baselineSchema = parseSchema(schemaForClass(PolymorphicCollections::class.java, allowAll))
+        val schema = parseSchema(schemaForClass(PolymorphicCollections::class.java, filter))
+
+        assertTrue(rootPropertyNames(schema).containsAll(setOf("transports", "effectsById", "transportBatches")))
+        assertEquals(allPropertyNames(baselineSchema), allPropertyNames(schema))
+        assertEquals(defNames(baselineSchema), defNames(schema))
+
+        val defs = defNames(schema)
+        val refs = refTargets(schema)
+        assertTrue(refs.all { defs.contains(it) })
+    }
+
+    @Test
+    fun `skipping one polymorphic reference should not prune shared polymorphic refs`() {
+        val allowAll = JacksonPropertyFilter.allowAll()
+        val filter = JacksonPropertyFilter
+            .SkipAnnotation(SkipA::class.java)
+            .and(JacksonPropertyFilter.SkipAnnotation(SkipC::class.java))
+
+        val baselineSchema = parseSchema(schemaForClass(PolymorphicSharedRefs::class.java, allowAll))
+        val schema = parseSchema(schemaForClass(PolymorphicSharedRefs::class.java, filter))
+        val rootProps = rootPropertyNames(schema)
+        val baselineRootProps = rootPropertyNames(baselineSchema)
+
+        assertFalse(rootProps.contains("skippedTransport"))
+        assertTrue(rootProps.contains("keptTransport"))
+        assertTrue(rootProps.contains("effects"))
+        assertTrue(baselineRootProps.contains("skippedTransport"))
+
+        // Pruning one polymorphic reference should not change nested polymorphic shape.
+        val expectedNames = allPropertyNames(baselineSchema) - "skippedTransport"
+        assertEquals(expectedNames, allPropertyNames(schema))
+        assertEquals(defNames(baselineSchema), defNames(schema))
+
+        val defs = defNames(schema)
+        val refs = refTargets(schema)
+        assertTrue(refs.isNotEmpty())
+        assertTrue(refs.all { defs.contains(it) })
+    }
+
+    @Test
+    fun `abstract polymorphic bases should under prune subtype fields`() {
+        val allowAll = JacksonPropertyFilter.allowAll()
+        val filter = JacksonPropertyFilter
+            .SkipAnnotation(SkipA::class.java)
+            .and(JacksonPropertyFilter.SkipAnnotation(SkipC::class.java))
+
+        val baselineSchema = parseSchema(schemaForClass(AbstractPolymorphicRefs::class.java, allowAll))
+        val schema = parseSchema(schemaForClass(AbstractPolymorphicRefs::class.java, filter))
+        val rootProps = rootPropertyNames(schema)
+
+        assertFalse(rootProps.contains("skippedShape"))
+        assertTrue(rootProps.containsAll(setOf("keptShape", "shapes", "shapeMap")))
+
+        // Skip-annotated fields inside abstract polymorphic branches are kept by design (under-prune).
+        val expectedNames = allPropertyNames(baselineSchema) - "skippedShape"
+        assertEquals(expectedNames, allPropertyNames(schema))
+        assertEquals(defNames(baselineSchema), defNames(schema))
+
+        val defs = defNames(schema)
+        val refs = refTargets(schema)
+        assertTrue(refs.isNotEmpty())
+        assertTrue(refs.all { defs.contains(it) })
+    }
+
+    @Test
+    fun `polymorphic list should keep tag effect fields under skip annotation`() {
+        val allowAll = JacksonPropertyFilter.allowAll()
+        val skipC = JacksonPropertyFilter.SkipAnnotation(SkipC::class.java)
+
+        val baselineSchema = parseSchema(schemaForClass(EffectListContainer::class.java, allowAll))
+        val schema = parseSchema(schemaForClass(EffectListContainer::class.java, skipC))
+
+        val baselineNames = allPropertyNames(baselineSchema)
+        val filteredNames = allPropertyNames(schema)
+        assertTrue(baselineNames.contains("tags"))
+        assertTrue(filteredNames.contains("tags"))
+        assertEquals(baselineNames, filteredNames)
+        assertEquals(defNames(baselineSchema), defNames(schema))
+    }
+
+    @Test
+    fun `polymorphic map should keep tag effect fields under skip annotation`() {
+        val allowAll = JacksonPropertyFilter.allowAll()
+        val skipC = JacksonPropertyFilter.SkipAnnotation(SkipC::class.java)
+
+        val baselineSchema = parseSchema(schemaForClass(EffectMapContainer::class.java, allowAll))
+        val schema = parseSchema(schemaForClass(EffectMapContainer::class.java, skipC))
+
+        assertTrue(rootPropertyNames(schema).contains("effectsById"))
+        val baselineNames = allPropertyNames(baselineSchema)
+        val filteredNames = allPropertyNames(schema)
+        // For map value schemas, generator currently omits concrete subtype fields like "tags".
+        assertFalse(baselineNames.contains("tags"))
+        assertFalse(filteredNames.contains("tags"))
+        assertEquals(baselineNames, filteredNames)
+        assertEquals(defNames(baselineSchema), defNames(schema))
+    }
+
+    @Test
+    fun `polymorphic map of list should keep tag effect fields under skip annotation`() {
+        val allowAll = JacksonPropertyFilter.allowAll()
+        val skipC = JacksonPropertyFilter.SkipAnnotation(SkipC::class.java)
+
+        val baselineSchema = parseSchema(schemaForClass(EffectMapOfListContainer::class.java, allowAll))
+        val schema = parseSchema(schemaForClass(EffectMapOfListContainer::class.java, skipC))
+
+        assertTrue(rootPropertyNames(schema).contains("effectsByGroup"))
+        val baselineNames = allPropertyNames(baselineSchema)
+        val filteredNames = allPropertyNames(schema)
+        // For map/list-map value schemas, generator currently omits concrete subtype fields like "tags".
+        assertFalse(baselineNames.contains("tags"))
+        assertFalse(filteredNames.contains("tags"))
+        assertEquals(baselineNames, filteredNames)
+        assertEquals(defNames(baselineSchema), defNames(schema))
+    }
+
+    @Test
+    fun `concrete effect implementation should still be pruned by skip annotation`() {
+        val skipC = JacksonPropertyFilter.SkipAnnotation(SkipC::class.java)
+
+        val tagEffectSchema = parseSchema(schemaForClass(TagEffect::class.java, skipC))
+        val tagEffectNames = rootPropertyNames(tagEffectSchema)
+        assertFalse(tagEffectNames.contains("tags"))
+    }
+
+    @Test
+    fun `should generate schema for every listed type`() {
+        val filter = JacksonPropertyFilter.SkipAnnotation(SkipPropertyFilter::class.java)
+        val allTypes = listOf(
+            Root::class.java,
+            Profile::class.java,
+            Name::class.java,
+            Contact::class.java,
+            Address::class.java,
+            Geo::class.java,
+            Preferences::class.java,
+            NotificationPolicy::class.java,
+            Channel::class.java,
+            Transport::class.java,
+            EmailTransport::class.java,
+            SmsTransport::class.java,
+            WebhookTransport::class.java,
+            Rule::class.java,
+            Condition::class.java,
+            Operand::class.java,
+            Action::class.java,
+            Effect::class.java,
+            TagEffect::class.java,
+            ForwardEffect::class.java,
+            Target::class.java,
+            Session::class.java,
+            Timeline::class.java,
+            Node::class.java,
+            MetaValue::class.java,
+            MetaString::class.java,
+            MetaNumber::class.java,
+            MetaObject::class.java,
+            OrgSettings::class.java,
+            OrgPolicy::class.java,
+            RetentionPolicy::class.java,
+            ArchiveTarget::class.java,
+            Graph::class.java,
+            GNode::class.java,
+            Edge::class.java,
+            AttrValue::class.java,
+            AttrString::class.java,
+            AttrInt::class.java,
+            AttrObj::class.java,
+            PolymorphicCollections::class.java,
+            PolymorphicSharedRefs::class.java,
+            Shape::class.java,
+            Circle::class.java,
+            Rectangle::class.java,
+            AbstractPolymorphicRefs::class.java,
+            EffectListContainer::class.java,
+            EffectMapContainer::class.java,
+            EffectMapOfListContainer::class.java
+        )
+
+        allTypes.forEach { clazz ->
+            assertDoesNotThrow {
+                schemaForClass(clazz, filter)
+            }
+        }
+    }
+
+    private fun rootPropertyNames(schema: JsonNode): Set<String> {
+        val propertiesNode = schema.get("properties") as? ObjectNode ?: return emptySet()
+        val names = linkedSetOf<String>()
+        val iterator = propertiesNode.fieldNames()
+        while (iterator.hasNext()) {
+            names.add(iterator.next())
+        }
+        return names
+    }
+
+    private fun allPropertyNames(schema: JsonNode): Set<String> {
+        val names = linkedSetOf<String>()
+        fun collect(node: JsonNode) {
+            when (node) {
+                is ObjectNode -> {
+                    val propertiesNode = node.get("properties") as? ObjectNode
+                    if (propertiesNode != null) {
+                        val iterator = propertiesNode.fieldNames()
+                        while (iterator.hasNext()) {
+                            names.add(iterator.next())
+                        }
+                    }
+                    val fields = node.fields()
+                    while (fields.hasNext()) {
+                        collect(fields.next().value)
+                    }
+                }
+                is ArrayNode -> node.forEach(::collect)
+            }
+        }
+        collect(schema)
+        return names
+    }
+
+    private fun parseSchema(schema: String): ObjectNode {
+        return objectMapper.readTree(schema) as ObjectNode
+    }
+
+    private fun schemaForClass(
+        clazz: Class<*>,
+        propertyFilter: JacksonPropertyFilter
+    ): String {
+        @Suppress("UNCHECKED_CAST")
+        val converter = FilteringJacksonOutputConverter(
+            clazz = clazz as Class<Any>,
+            objectMapper = objectMapper,
+            propertyFilter = propertyFilter
+        )
+        return converter.jsonSchema
+    }
+
+    private fun defNames(schema: ObjectNode): Set<String> {
+        val defs = (schema.get("\$defs") as? ObjectNode)
+            ?: (schema.get("definitions") as? ObjectNode)
+            ?: return emptySet()
+        val names = linkedSetOf<String>()
+        val iterator = defs.fieldNames()
+        while (iterator.hasNext()) {
+            names.add(iterator.next())
+        }
+        return names
+    }
+
+    private fun refTargets(schema: JsonNode): Set<String> {
+        val targets = linkedSetOf<String>()
+        fun collect(node: JsonNode) {
+            when (node) {
+                is ObjectNode -> {
+                    val refNode = node.get("\$ref")
+                    if (refNode?.isTextual == true) {
+                        extractDefName(refNode.asText())?.let { targets.add(it) }
+                    }
+                    val fields = node.fields()
+                    while (fields.hasNext()) {
+                        collect(fields.next().value)
+                    }
+                }
+                is ArrayNode -> node.forEach(::collect)
+            }
+        }
+        collect(schema)
+        return targets
+    }
+
+    private fun extractDefName(ref: String): String? {
+        val defsPrefix = "#/\$defs/"
+        val definitionsPrefix = "#/definitions/"
+        return when {
+            ref.startsWith(defsPrefix) -> ref.removePrefix(defsPrefix)
+            ref.startsWith(definitionsPrefix) -> ref.removePrefix(definitionsPrefix)
+            else -> null
+        }.takeIf { !it.isNullOrBlank() }
+    }
+
+    private class SchemaMutatingConverter<T>(
+        clazz: Class<T>,
+        objectMapper: ObjectMapper,
+        propertyFilter: JacksonPropertyFilter
+    ) : FilteringJacksonOutputConverter<T>(clazz, objectMapper, propertyFilter) {
+        override fun postProcessSchema(jsonNode: JsonNode) {
+            val root = jsonNode as? ObjectNode ?: return
+            val propertiesNode = root.get("properties") as? ObjectNode ?: root.putObject("properties")
+            val emailNode = propertiesNode.get("email") as? ObjectNode ?: propertiesNode.putObject("email")
+            emailNode.put("unexpectedSchemaKeyword", "boom")
+            super.postProcessSchema(root)
+        }
+    }
+
+    private class CoreKeywordsMutatingConverter<T>(
+        clazz: Class<T>,
+        objectMapper: ObjectMapper,
+        propertyFilter: JacksonPropertyFilter
+    ) : FilteringJacksonOutputConverter<T>(clazz, objectMapper, propertyFilter) {
+        override fun postProcessSchema(jsonNode: JsonNode) {
+            val root = jsonNode as? ObjectNode ?: return
+            root.put("\$anchor", "rootAnchor")
+            root.put("\$dynamicRef", "#/\$defs/Any")
+            root.put("\$dynamicAnchor", "dynamicAnchor")
+            root.put("\$comment", "schema comment")
+            val vocabulary = root.putObject("\$vocabulary")
+            vocabulary.put("https://json-schema.org/draft/2020-12/vocab/core", true)
+            super.postProcessSchema(root)
+        }
+    }
+
+    private class InvalidVocabularyMutatingConverter<T>(
+        clazz: Class<T>,
+        objectMapper: ObjectMapper,
+        propertyFilter: JacksonPropertyFilter
+    ) : FilteringJacksonOutputConverter<T>(clazz, objectMapper, propertyFilter) {
+        override fun postProcessSchema(jsonNode: JsonNode) {
+            val root = jsonNode as? ObjectNode ?: return
+            val vocabulary = root.putObject("\$vocabulary")
+            vocabulary.put("https://json-schema.org/draft/2020-12/vocab/core", "true")
+            super.postProcessSchema(root)
+        }
+    }
+
+    data class Root(
+        val id: String,
+        val profile: Profile,
+        val sessions: List<Session>,
+        val settingsByOrg: Map<String, OrgSettings>,
+    )
+
+    data class Profile(
+        val name: Name,
+        val contacts: List<Contact>,
+        val preferences: Preferences,
+    )
+
+    data class Name(
+        val first: String,
+        val last: String,
+    )
+
+    data class Contact(
+        val kind: ContactKind,
+        @field:SkipA
+        val address: Address?,
+    )
+
+    enum class ContactKind { EMAIL, PHONE, POSTAL }
+
+    data class Address(
+        val lines: List<String>,
+        val geo: Geo?,
+    )
+
+    data class Geo(
+        val lat: Double,
+        val lon: Double,
+    )
+
+    data class Preferences(
+        val locale: String,
+        val notifications: NotificationPolicy,
+    )
+
+    data class NotificationPolicy(
+        val channels: List<Channel>,
+        @field:SkipB
+        val rules: Map<String, Rule>,
+    )
+
+    data class Channel(
+        val id: String,
+        val transport: Transport,
+    )
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    @JsonSubTypes(
+        JsonSubTypes.Type(value = EmailTransport::class, name = "email"),
+        JsonSubTypes.Type(value = SmsTransport::class, name = "sms"),
+        JsonSubTypes.Type(value = WebhookTransport::class, name = "webhook"),
+    )
+    sealed interface Transport
+
+    data class EmailTransport(
+        val from: String,
+        @field:SkipA
+        val replyTo: String?
+    ) : Transport
+
+    data class SmsTransport(
+        val provider: String,
+        @field:SkipA
+        val senderId: String?
+    ) : Transport
+
+    data class WebhookTransport(
+        val url: String,
+        @field:SkipA
+        val headers: Map<String, String>
+    ) : Transport
+
+    data class Rule(
+        val enabled: Boolean,
+        val condition: Condition,
+        val actions: List<Action>,
+    )
+
+    data class Condition(
+        @field:SkipPropertyFilter
+        val expr: String,
+        val operands: List<Operand>,
+    )
+
+    data class Operand(
+        val key: String,
+        @field:SkipB
+        val value: String,
+    )
+
+    data class Action(
+        @field:SkipB
+        val id: String,
+        val effect: Effect,
+    )
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+    @JsonSubTypes(
+        JsonSubTypes.Type(value = TagEffect::class, name = "tag"),
+        JsonSubTypes.Type(value = ForwardEffect::class, name = "forward"),
+    )
+    sealed interface Effect
+
+    data class TagEffect(
+        @field:SkipC
+        val tags: Set<String>
+    ) : Effect
+
+    data class ForwardEffect(
+        @field:SkipC
+        val target: Target
+    ) : Effect
+
+    data class Target(
+        val type: TargetType,
+        @field:SkipC
+        val destination: String,
+    )
+
+    enum class TargetType { EMAIL, WEBHOOK }
+
+    data class Session(
+        @field:SkipPropertyFilter
+        val sessionId: String,
+        val timeline: Timeline,
+    )
+
+    data class Timeline(
+        val head: Node
+    )
+
+    /**
+     * Recursive type -> strongly encourages $defs/$ref usage.
+     */
+    data class Node(
+        @field:SkipPropertyFilter
+        val name: String,
+        val children: List<Node> = emptyList(),
+        val metadata: Map<String, MetaValue> = emptyMap(),
+    )
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "t")
+    @JsonSubTypes(
+        JsonSubTypes.Type(value = MetaString::class, name = "s"),
+        JsonSubTypes.Type(value = MetaNumber::class, name = "n"),
+        JsonSubTypes.Type(value = MetaObject::class, name = "o"),
+    )
+    sealed interface MetaValue
+
+    data class MetaString(@field:SkipA val v: String) : MetaValue
+    data class MetaNumber(@field:SkipA val v: Double) : MetaValue
+    data class MetaObject(@field:SkipA val v: Map<String, MetaValue>) : MetaValue
+
+    data class OrgSettings(
+        @field:SkipB
+        val orgId: String,
+        val policy: OrgPolicy
+    )
+
+    data class OrgPolicy(
+        @field:SkipB
+        val maxSessions: Int,
+        val retention: RetentionPolicy
+    )
+
+    data class RetentionPolicy(
+        @field:SkipB
+        val days: Int,
+        val archive: ArchiveTarget
+    )
+
+    data class ArchiveTarget(
+        @field:SkipPropertyFilter
+        val bucket: String,
+        val pathPrefix: String
+    )
+
+    data class PolymorphicCollections(
+        val transports: List<Transport>,
+        val effectsById: Map<String, Effect>,
+        val transportBatches: Map<String, List<Transport>>
+    )
+
+    data class PolymorphicSharedRefs(
+        @field:SkipA
+        val skippedTransport: Transport,
+        val keptTransport: Transport,
+        val effects: List<Effect>
+    )
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "shapeType")
+    @JsonSubTypes(
+        JsonSubTypes.Type(value = Circle::class, name = "circle"),
+        JsonSubTypes.Type(value = Rectangle::class, name = "rectangle"),
+    )
+    sealed class Shape
+
+    data class Circle(
+        @field:SkipA
+        val radius: Double,
+        val unit: String
+    ) : Shape()
+
+    data class Rectangle(
+        @field:SkipC
+        val width: Double,
+        val height: Double
+    ) : Shape()
+
+    data class AbstractPolymorphicRefs(
+        @field:SkipA
+        val skippedShape: Shape,
+        val keptShape: Shape,
+        val shapes: List<Shape>,
+        val shapeMap: Map<String, Shape>
+    )
+
+    data class EffectListContainer(
+        val effects: List<Effect>
+    )
+
+    data class EffectMapContainer(
+        val effectsById: Map<String, Effect>
+    )
+
+    data class EffectMapOfListContainer(
+        val effectsByGroup: Map<String, List<Effect>>
+    )
+
+    data class Graph(
+        val root: GNode
+    )
+
+    data class GNode(
+        @field:SkipPropertyFilter
+        val id: String,
+        val edges: List<Edge>,
+        val attrs: Map<String, AttrValue>,
+    )
+
+    data class Edge(
+        @field:SkipPropertyFilter
+        val label: String,
+        val to: GNode  // recursion through a different path than "children"
+    )
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "k")
+    @JsonSubTypes(
+        JsonSubTypes.Type(value = AttrString::class, name = "str"),
+        JsonSubTypes.Type(value = AttrInt::class, name = "int"),
+        JsonSubTypes.Type(value = AttrObj::class, name = "obj"),
+    )
+    sealed interface AttrValue
+
+    data class AttrString(@field:SkipC val v: String) : AttrValue
+    data class AttrInt(@field:SkipC val v: Int) : AttrValue
+    data class AttrObj(@field:SkipC val v: Map<String, AttrValue>) : AttrValue
+
 
 }


### PR DESCRIPTION
reference gh-1413

added property filter nested jackson-schema experiment

- Replaced Predicate<String> with JacksonPropertyFilter.kt
- Added a SchemaPruner.kt which prunes recursively for annotations - but keeps the current pruning behavior Predicate<String> only for top-level.

Note that SchemaPruner.kt skips polymorphic types entirely - it does not event try to prune a polymorphic type. Also note that schema validation was added so that if the schema doesn't match our known form, then no pruning is performed at all, except the previous pruning of top-level properties. No recursive pruning of properties was added - pruning of annotation is only recursive from this.