### PR TITLE
Allow ARN-based model IDs in Bedrock model validation

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModelLoader.kt
@@ -101,8 +101,10 @@ class BedrockModelLoader(
             require(model.region in VALID_REGIONS) {
                 "Region must be one of ${VALID_REGIONS.joinToString(", ")} for model ${model.name}, got: ${model.region}"
             }
-            require(model.modelId.startsWith("${model.region}.")) {
-                "Model ID must start with region prefix '${model.region}.' for model ${model.name}"
+            val isArn = model.modelId.startsWith("arn:")
+            val hasCorrectPrefix = model.modelId.startsWith("${model.region}.")
+            require(isArn || hasCorrectPrefix) {
+                "Model ID must either be an ARN or start with region prefix '${model.region}.' for model ${model.name}"
             }
         }
 


### PR DESCRIPTION
This pull request updates the validation logic for model IDs in the Bedrock model loader, allowing both region-prefixed and ARN-based model IDs. The changes also enhance the test suite to cover these new validation rules, ensuring correct behavior for both accepted and rejected model ID formats.

Validation logic updates:

* Modified `BedrockModelLoader` to accept model IDs that are either ARN-based or region-prefixed, instead of only region-prefixed.

Test suite enhancements:

* Updated existing tests in `BedrockModelLoaderTest` to check for acceptance of both region-prefixed and ARN-based model IDs. [[1]](diffhunk://#diff-7cfcc3699fc8282f10a4aad9c591ada1d86416857dc62470e5041d622a6441ddL59-R59) [[2]](diffhunk://#diff-7cfcc3699fc8282f10a4aad9c591ada1d86416857dc62470e5041d622a6441ddL74-R79) [[3]](diffhunk://#diff-7cfcc3699fc8282f10a4aad9c591ada1d86416857dc62470e5041d622a6441ddL503-R602)
* Added new tests to verify acceptance of ARN-based inference profile and imported model IDs, as well as mixed lists of region-prefixed and ARN-based IDs.
* Added a test to ensure rejection of model IDs that are neither ARN-based nor region-prefixed.