### PR TITLE
Update version numbers in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.11</version>
+        <version>0.1.12-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -15,7 +15,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <embabel-common.version>0.1.10</embabel-common.version>
+        <embabel-common.version>0.1.11-SNAPSHOT</embabel-common.version>
         <netty.version>4.1.125.Final</netty.version>
     </properties>
 


### PR DESCRIPTION
This pull request updates the project dependencies to use the latest snapshot versions. These are minor version bumps to keep the project in sync with the latest development versions of its parent and common modules.

Dependency version updates:

* Updated the parent project version in `pom.xml` from `0.1.11` to `0.1.12-SNAPSHOT` to use the latest snapshot of the build parent.
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.10` to `0.1.11-SNAPSHOT` to use the latest snapshot of the common module.