### PR TITLE
Update version to 0.1.12-SNAPSHOT in pom.xml

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.11</version>
+        <version>0.1.12-SNAPSHOT</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>


### PR DESCRIPTION
This pull request makes a minor update to the Maven project configuration by bumping the parent dependency version to `0.1.12-SNAPSHOT` in the `pom.xml` file. This ensures the project uses the latest snapshot version of the parent dependencies.