### PR TITLE
fix(docs): remove unclosed example block in llms/page.adoc

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/llms/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/llms/page.adoc
@@ -72,9 +72,7 @@ The implementation makes a single LLM inference call and returns the response.
 Importantly, it does **not** execute tools--it only returns any tool call requests from the LLM.
 Tool execution is handled by Embabel's `DefaultToolLoop`.
 
-======
-
-Even more advanced control over tools execution is available - tools can be executed in parallel, controlled by  `ParallelToolLoop`. In order to activate `ParallelToolLoop`, please set the following parameter:
+NOTE: Even more advanced control over tools execution is available - tools can be executed in parallel, controlled by  `ParallelToolLoop`. In order to activate `ParallelToolLoop`, please set the following parameter:
 ```
 embabel.agent.platform.toolloop.type=parallel
 ```


### PR DESCRIPTION
fix(docs): remove unclosed example block in llms/page.adoc that swallowed remaining chapters