### PR TITLE
Fix Guide Issue 31 - don't call out for vector dimensions if already …

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelsConfig.kt
@@ -315,6 +315,7 @@ class GoogleGenAiModelsConfig(
             name = embeddingDef.modelId,
             model = embeddingModel,
             provider = GoogleGenAiModels.PROVIDER,
+            configuredDimensions = embeddingDef.dimensions,
         )
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -217,6 +217,7 @@ class OpenAiModelsConfig(
         return openAiCompatibleEmbeddingService(
             model = embeddingDef.modelId,
             provider = OpenAiModels.PROVIDER,
+            configuredDimensions = embeddingDef.dimensions,
         )
     }
 }

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/SpringAiEmbeddingService.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/SpringAiEmbeddingService.kt
@@ -20,15 +20,20 @@ import org.springframework.ai.embedding.EmbeddingModel
 
 /**
  * Wraps a Spring AI EmbeddingModel exposing an embedding service.
+ * @param configuredDimensions If provided, uses this value for [dimensions] instead of
+ * making a live API call via [EmbeddingModel.dimensions]. This avoids startup failures
+ * when the embedding endpoint is not available (e.g., Azure OpenAI deployments that
+ * only expose chat completions).
  */
 @JsonSerialize(`as` = EmbeddingServiceMetadata::class)
 data class SpringAiEmbeddingService(
     override val name: String,
     override val provider: String,
     override val model: EmbeddingModel,
+    val configuredDimensions: Int? = null,
 ) : EmbeddingService {
 
-    override val dimensions get() = model.dimensions()
+    override val dimensions get() = configuredDimensions ?: model.dimensions()
 
     override fun embed(text: String): FloatArray = model.embed(text)
 

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/model/SpringAiEmbeddingServiceTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/model/SpringAiEmbeddingServiceTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.ai.model
+
+import org.junit.jupiter.api.Test
+import org.springframework.ai.document.Document
+import org.springframework.ai.embedding.EmbeddingModel
+import org.springframework.ai.embedding.EmbeddingRequest
+import org.springframework.ai.embedding.EmbeddingResponse
+import kotlin.test.assertEquals
+
+class SpringAiEmbeddingServiceTest {
+
+    /**
+     * EmbeddingModel that tracks whether dimensions() was called
+     * and throws if it is, simulating an unreachable endpoint.
+     */
+    private class UnreachableEmbeddingModel : EmbeddingModel {
+        var dimensionsCalled = false
+
+        override fun dimensions(): Int {
+            dimensionsCalled = true
+            throw RuntimeException("Embedding endpoint not available (simulated 404)")
+        }
+
+        override fun embed(document: Document): FloatArray =
+            throw UnsupportedOperationException("Not implemented")
+
+        override fun embed(texts: List<String>): MutableList<FloatArray> =
+            throw UnsupportedOperationException("Not implemented")
+
+        override fun call(request: EmbeddingRequest): EmbeddingResponse =
+            throw UnsupportedOperationException("Not implemented")
+    }
+
+    /**
+     * Simple EmbeddingModel that returns a known dimension.
+     */
+    private class FixedDimensionEmbeddingModel(private val dims: Int) : EmbeddingModel {
+        override fun dimensions(): Int = dims
+
+        override fun embed(document: Document): FloatArray =
+            throw UnsupportedOperationException("Not implemented")
+
+        override fun embed(texts: List<String>): MutableList<FloatArray> =
+            throw UnsupportedOperationException("Not implemented")
+
+        override fun call(request: EmbeddingRequest): EmbeddingResponse =
+            throw UnsupportedOperationException("Not implemented")
+    }
+
+    @Test
+    fun `dimensions uses configured value when provided`() {
+        val model = UnreachableEmbeddingModel()
+        val service = SpringAiEmbeddingService(
+            name = "test-model",
+            model = model,
+            provider = "TestProvider",
+            configuredDimensions = 1536,
+        )
+
+        assertEquals(1536, service.dimensions)
+        assertEquals(false, model.dimensionsCalled)
+    }
+
+    @Test
+    fun `dimensions falls back to model when not configured`() {
+        val service = SpringAiEmbeddingService(
+            name = "test-model",
+            model = FixedDimensionEmbeddingModel(3072),
+            provider = "TestProvider",
+        )
+
+        assertEquals(3072, service.dimensions)
+    }
+}

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -136,6 +136,7 @@ open class OpenAiCompatibleModelFactory(
     fun openAiCompatibleEmbeddingService(
         model: String,
         provider: String,
+        configuredDimensions: Int? = null,
     ): EmbeddingService {
         val embeddingModel = OpenAiEmbeddingModel(
             openAiApi,
@@ -148,6 +149,7 @@ open class OpenAiCompatibleModelFactory(
             name = model,
             model = embeddingModel,
             provider = provider,
+            configuredDimensions = configuredDimensions,
         )
     }
 


### PR DESCRIPTION
 # Fix startup crash when embedding endpoint is unavailable (guide#31)                                                                                 
                                                                                                                                                      
##  Problem                                                                                                                                             
                                                                                                                                                      
When running the Embabel Hub with Azure OpenAI, the application crashes at startup with:                                                            
                                                                                                                                                      
NonTransientAiException: 404 - {"error":{"code":"404","message": "Resource not found"}}

The failure occurs because DrivineStore.createVectorIndex calls Spring AI's AbstractEmbeddingModel.dimensions(), which makes a live API call to determine embedding vector dimensions. Azure OpenAI deployments that only expose chat completions (e.g., gpt-4.1_corporate) do not serve the embeddings endpoint, resulting in a 404 that crashes the entire application during bean initialization.

##  Root Cause

SpringAiEmbeddingService.dimensions unconditionally delegates to model.dimensions(), triggering a network call — even though the dimensions are already known from YAML configuration (openai-models.yml / google-genai-models.yml).

##  Fix

  - Add optional configuredDimensions parameter to SpringAiEmbeddingService. When set, the configured value is returned directly, bypassing the live
  API call.
  - Wire the dimensions from YAML model definitions through the OpenAI and Google GenAI autoconfiguration paths.

##  Changes

  ```
┌─────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────┐
  │              File               │                                   Change                                    │
  ├─────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────┤
  │ SpringAiEmbeddingService.kt     │ Add configuredDimensions: Int? parameter; prefer it over model.dimensions() │
  ├─────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────┤
  │ OpenAiCompatibleModelFactory.kt │ Accept and pass through configuredDimensions                                │
  ├─────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────┤
  │ OpenAiModelsConfig.kt           │ Pass embeddingDef.dimensions from YAML config                               │
  ├─────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────┤
  │ GoogleGenAiModelsConfig.kt      │ Pass embeddingDef.dimensions from YAML config                               │
  ├─────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────┤
  │ SpringAiEmbeddingServiceTest.kt │ New test: verifies configured dimensions skip API call; verifies fallback   │
  └─────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────┘
```

##  Notes

  - Backwards compatible: configuredDimensions defaults to null, so providers that don't specify dimensions (Bedrock, Ollama, Docker, LMStudio) are
  unaffected.
  - Also improves startup performance for all users by eliminating an unnecessary network round-trip when dimensions are known from config.

  Fixes https://github.com/embabel/guide/issues/31
