### PR TITLE
Use Asyncer for async LLM operations instead of raw CompletableFuture…

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.spi.support
 
+import com.embabel.agent.api.common.Asyncer
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.Action
@@ -38,7 +39,6 @@ import jakarta.validation.Validator
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.time.Duration
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -61,6 +61,7 @@ abstract class AbstractLlmOperations(
     private val autoLlmSelectionCriteriaResolver: AutoLlmSelectionCriteriaResolver,
     protected val dataBindingProperties: LlmDataBindingProperties,
     protected val promptsProperties: LlmOperationsPromptsProperties = LlmOperationsPromptsProperties(),
+    protected val asyncer: Asyncer,
 ) : LlmOperations {
 
     protected val logger: Logger = LoggerFactory.getLogger(javaClass)
@@ -90,7 +91,7 @@ abstract class AbstractLlmOperations(
     ): T {
         val timeoutMillis = getTimeoutMillis(llmOptions)
 
-        val future = CompletableFuture.supplyAsync { operation() }
+        val future = asyncer.async(operation)
 
         return try {
             future.get(timeoutMillis, TimeUnit.MILLISECONDS)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.spi.support
 
+import com.embabel.agent.api.common.Asyncer
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.event.ToolLoopStartEvent
 import com.embabel.agent.api.tool.Tool
@@ -97,6 +98,7 @@ open class ToolLoopLlmOperations(
     internal open val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
     protected val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
     protected val toolLoopFactory: ToolLoopFactory = ToolLoopFactory.default(),
+    asyncer: Asyncer = ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
 ) : AbstractLlmOperations(
     toolDecorator = toolDecorator,
     modelProvider = modelProvider,
@@ -105,6 +107,7 @@ open class ToolLoopLlmOperations(
     dataBindingProperties = dataBindingProperties,
     autoLlmSelectionCriteriaResolver = autoLlmSelectionCriteriaResolver,
     promptsProperties = promptsProperties,
+    asyncer = asyncer,
 ) {
 
     override fun <O> doTransform(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/LLMStreamingIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/LLMStreamingIntegrationTest.kt
@@ -132,6 +132,7 @@ class StreamingTestConfig {
             validator = validator,
             templateRenderer = templateRenderer,
             objectMapper = objectMapper,
+            asyncer = com.embabel.agent.spi.support.ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
         )
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsGuardRailTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsGuardRailTest.kt
@@ -153,6 +153,7 @@ class ChatClientLlmOperationsGuardRailTest {
             templateRenderer = JinjavaTemplateRenderer(),
             objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
             dataBindingProperties = dataBindingProperties,
+            asyncer = ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
         )
         return Setup(cco, mockAgentProcess, mutableLlmInvocationHistory)
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -152,6 +152,7 @@ class ChatClientLlmOperationsTest {
             templateRenderer = JinjavaTemplateRenderer(),
             objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
             dataBindingProperties = dataBindingProperties,
+            asyncer = ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
         )
         return Setup(cco, mockAgentProcess, mutableLlmInvocationHistory)
     }
@@ -726,6 +727,7 @@ class ChatClientLlmOperationsTest {
                 objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
                 dataBindingProperties = LlmDataBindingProperties(maxAttempts = 1),  // No retries for timeout tests
                 llmOperationsPromptsProperties = promptsProperties,
+                asyncer = ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
             )
             return Setup(cco, mockAgentProcess, mutableLlmInvocationHistory)
         }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsThinkingTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsThinkingTest.kt
@@ -111,6 +111,7 @@ class ChatClientLlmOperationsThinkingTest {
             templateRenderer = JinjavaTemplateRenderer(),
             objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
             dataBindingProperties = dataBindingProperties,
+            asyncer = ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
         )
         return Setup(cco, mockAgentProcess, mutableLlmInvocationHistory)
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
@@ -184,6 +184,7 @@ class ChatClientLlmTransformerTest {
                 toolDecorator = DefaultToolDecorator(),
                 validator = Validation.buildDefaultValidatorFactory().validator,
                 templateRenderer = JinjavaTemplateRenderer(),
+                asyncer = ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
             )
             return transformer.createObject(
                 messages = listOf(UserMessage("Say hello")),
@@ -369,6 +370,7 @@ class ChatClientLlmTransformerTest {
                     toolDecorator = DefaultToolDecorator(),
                     templateRenderer = JinjavaTemplateRenderer(),
                     validator = Validation.buildDefaultValidatorFactory().validator,
+                    asyncer = ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
                 )
             val result = transformer.createObjectIfPossible(
                 messages = listOf(UserMessage("Say hello")),

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsGuardRailTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsGuardRailTest.kt
@@ -170,6 +170,7 @@ class StreamingChatClientOperationsGuardRailTest {
             templateRenderer = JinjavaTemplateRenderer(),
             objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
             dataBindingProperties = dataBindingProperties,
+            asyncer = com.embabel.agent.spi.support.ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
         )
         val streamingOperations = StreamingChatClientOperations(cco)
         return Setup(streamingOperations, mockAgentProcess, mutableLlmInvocationHistory)


### PR DESCRIPTION
This pull request refactors the asynchronous execution mechanism in the LLM operations classes by introducing a new `Asyncer` abstraction. The main goal is to replace direct usage of `CompletableFuture.supplyAsync` with a more flexible and injectable async strategy, improving testability and configurability. The change is applied across core implementation classes and their tests.

Key changes include:

**Asynchronous Execution Refactor:**

* Replaced direct calls to `CompletableFuture.supplyAsync` with usage of an injected `Asyncer` in `AbstractLlmOperations` and its subclasses, including `ToolLoopLlmOperations` and `ChatClientLlmOperations`. This allows for pluggable async execution strategies. [[1]](diffhunk://#diff-f15c44ec6cf34f8188d9f4582e56cf9f405d76d36ec3f712d151d8cf003f7e9fL93-R94) [[2]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200L240-R243) [[3]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200L474-R477) [[4]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200L618-R621)

**Constructor and Dependency Injection Updates:**

* Updated constructors of `AbstractLlmOperations`, `ToolLoopLlmOperations`, and `ChatClientLlmOperations` to accept an `Asyncer` parameter, passing it through the class hierarchy. Default asyncer is provided where appropriate. [[1]](diffhunk://#diff-f15c44ec6cf34f8188d9f4582e56cf9f405d76d36ec3f712d151d8cf003f7e9fR64) [[2]](diffhunk://#diff-bb18beec019821cad86b7d9d33af7bf42699564e8e5c398804f93660fbb30090R101) [[3]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200R104) [[4]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200R116) [[5]](diffhunk://#diff-bb18beec019821cad86b7d9d33af7bf42699564e8e5c398804f93660fbb30090R110)

**Test Adaptations:**

* Modified all relevant test setups to inject an `ExecutorAsyncer` instance, ensuring tests use the new async abstraction. This affects several test classes, such as `LLMStreamingIntegrationTest`, `ChatClientLlmOperationsTest`, `ChatClientLlmOperationsGuardRailTest`, `ChatClientLlmOperationsThinkingTest`, `ChatClientLlmTransformerTest`, and `StreamingChatClientOperationsGuardRailTest`. [[1]](diffhunk://#diff-bdfba91edf9bc25740dc04d8193f9ad40e2b048bc73db8b8587d094c809e3b76R135) [[2]](diffhunk://#diff-d11f42ab0c604ac3bd3758da14bbe8715f9af0fc6f21a6e147cc275aea944c2bR156) [[3]](diffhunk://#diff-bf29d55ce0e64fc95e602952f20dcc99f6b82aedb04dcc3baf0c82b96cbb7300R155) [[4]](diffhunk://#diff-bf29d55ce0e64fc95e602952f20dcc99f6b82aedb04dcc3baf0c82b96cbb7300R730) [[5]](diffhunk://#diff-44345c4991b0c8b70fd2f73eff5a99d7d202fca85ebbde5f196960f79147c40bR114) [[6]](diffhunk://#diff-a585e56220c813344f0d93db084f12980f76ce91b39bfa969d5c880193fc4281R187) [[7]](diffhunk://#diff-a585e56220c813344f0d93db084f12980f76ce91b39bfa969d5c880193fc4281R373) [[8]](diffhunk://#diff-eff1d0ad2cfea5c1b118b16aea2dff37cc3a85e5fb646d595001bae5313876eeR173)

**Imports and Cleanup:**

* Updated import statements to remove unused `CompletableFuture` imports and add necessary `Asyncer` imports in affected files. [[1]](diffhunk://#diff-f15c44ec6cf34f8188d9f4582e56cf9f405d76d36ec3f712d151d8cf003f7e9fR18) [[2]](diffhunk://#diff-f15c44ec6cf34f8188d9f4582e56cf9f405d76d36ec3f712d151d8cf003f7e9fL41) [[3]](diffhunk://#diff-bb18beec019821cad86b7d9d33af7bf42699564e8e5c398804f93660fbb30090R18) [[4]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200R18)

This refactor increases modularity and flexibility in how asynchronous operations are performed throughout the LLM agent codebase.