### PR TITLE
Refactor createObjectIfPossible API

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmOperationsCommon.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmOperationsCommon.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support
+
+import com.embabel.common.textio.template.CompiledTemplate
+import com.embabel.common.textio.template.TemplateRenderer
+
+/**
+ * Common reusable artifacts for LlmOperations implementations.
+ * These are framework-agnostic utilities shared by both the base tool loop
+ * implementation and Spring AI-specific implementations.
+ */
+
+/**
+ * Structure to be returned by the LLM for "if possible" operations.
+ * Allows the LLM to return a result structure under success, or an error message.
+ * One of success or failure must be set, but not both.
+ */
+internal data class MaybeReturn<T>(
+    val success: T? = null,
+    val failure: String? = null,
+) {
+    fun toResult(): Result<T> {
+        return if (success != null) {
+            Result.success(success)
+        } else {
+            Result.failure(Exception(failure))
+        }
+    }
+}
+
+/**
+ * No-op TemplateRenderer that throws UnsupportedOperationException when used.
+ * Used as default when no real TemplateRenderer is provided.
+ * Operations requiring template rendering (e.g., doTransformIfPossible) will fail
+ * clearly if this default is used.
+ */
+internal object NoOpTemplateRenderer : TemplateRenderer {
+    private fun unsupported(): Nothing =
+        throw UnsupportedOperationException("TemplateRenderer not configured. Provide a real TemplateRenderer for operations that require template rendering.")
+
+    override fun load(templateName: String): String = unsupported()
+    override fun renderLoadedTemplate(templateName: String, model: Map<String, Any>): String = unsupported()
+    override fun renderLiteralTemplate(template: String, model: Map<String, Any>): String = unsupported()
+    override fun compileLoadedTemplate(templateName: String): CompiledTemplate = unsupported()
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/WithExampleConverter.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/WithExampleConverter.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.spi.support.springai
 
+import com.embabel.agent.spi.support.MaybeReturn
 import com.embabel.common.util.DummyInstanceCreator
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/messageConverters.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/messageConverters.kt
@@ -128,11 +128,18 @@ internal fun List<SpringAiMessage>.mergeConsecutiveToolResponses(): List<SpringA
  */
 fun SpringAiAssistantMessage.toEmbabelMessage(): Message {
     val toolCalls = this.toolCalls
+    val content = this.text ?: ""
     return if (toolCalls.isNullOrEmpty()) {
-        AssistantMessage(content = this.text ?: "")
+        // AssistantMessage requires non-empty content (TextPart validation).
+        // For empty content, use AssistantMessageWithToolCalls which handles empty content gracefully.
+        if (content.isEmpty()) {
+            AssistantMessageWithToolCalls(content = "", toolCalls = emptyList())
+        } else {
+            AssistantMessage(content = content)
+        }
     } else {
         AssistantMessageWithToolCalls(
-            content = this.text ?: "",
+            content = content,
             toolCalls = toolCalls.map { ToolCall(it.id(), it.name(), it.arguments()) }
         )
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsGuardRailTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsGuardRailTest.kt
@@ -28,7 +28,7 @@ import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.core.support.safelyGetToolsFrom
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
-import com.embabel.agent.spi.support.springai.MaybeReturn
+import com.embabel.agent.spi.support.MaybeReturn
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.agent.spi.validation.DefaultValidationPromptGenerator
 import com.embabel.agent.support.SimpleTestAgent

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -27,7 +27,7 @@ import com.embabel.agent.core.support.InvalidLlmReturnTypeException
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.core.support.safelyGetToolsFrom
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
-import com.embabel.agent.spi.support.springai.MaybeReturn
+import com.embabel.agent.spi.support.MaybeReturn
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.agent.spi.validation.DefaultValidationPromptGenerator
 import com.embabel.agent.support.SimpleTestAgent

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/MessageConversionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/MessageConversionTest.kt
@@ -225,12 +225,16 @@ class MessageConversionTest {
         }
 
         @Test
-        fun `throws exception when converting Spring AI AssistantMessage with empty text`() {
+        fun `converts Spring AI AssistantMessage with empty text to AssistantMessageWithToolCalls`() {
+            // Empty text is handled gracefully to allow exceptions to propagate
+            // to the converter level where they get wrapped in InvalidLlmReturnFormatException
             val springMessage = SpringAiAssistantMessage("")
 
-            org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
-                springMessage.toEmbabelMessage()
-            }
+            val embabelMessage = springMessage.toEmbabelMessage()
+
+            assertThat(embabelMessage).isInstanceOf(AssistantMessageWithToolCalls::class.java)
+            assertThat(embabelMessage.content).isEmpty()
+            assertThat((embabelMessage as AssistantMessageWithToolCalls).toolCalls).isEmpty()
         }
 
         @Test

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/LLMStreamingIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/LLMStreamingIT.kt
@@ -18,7 +18,7 @@ package com.embabel.agent.config.models.openai
 
 import com.embabel.agent.api.common.Ai
 import com.embabel.agent.api.common.autonomy.Autonomy
-import com.embabel.agent.api.common.createObject
+import com.embabel.agent.api.common.createObjectIfPossible
 import com.embabel.agent.api.common.streaming.asStreaming
 import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
 import com.embabel.agent.spi.LlmService
@@ -195,9 +195,9 @@ class LLMStreamingIT(
             println("DEBUG: Created runner")
 
             // Test non-streaming call first
-            val response = runner.createObject<MonthItem>(
+            val response = runner.createObjectIfPossible<MonthItem>(
                 """
-            get hottest month in florida
+            get hottest summer month in florida boca-raton
             """.trimIndent(),
             )
 


### PR DESCRIPTION
 ## Overview            

Please refer to issue:    https://github.com/embabel/embabel-agent/issues/1438
                                                 
                                                                                
  Refactor createObjectIfPossible to reduce dependency on Spring AI by          
  implementing doTransformIfPossible in ToolLoopLlmOperations with native       
  MaybeReturn semantics.     


* Move logic from ChatClientLLMOperations to ToolLoopLLMOperations
* Apply switch to toggle between legacy code in ChatClientLLMOperations and new implementation                                                   
                                                                                
  Previously, doTransformIfPossible with MaybeReturn converter logic only       
  existed in ChatClientLlmOperations (Spring AI path). This change is  incorporated within framework-agnostic ToolLoopLlmOperations (similar to createObject) 
  enabling createObjectIfPossible to work through the Embabel tool loop path.   
                                                                                
  Goal: Move toward a pluggable LLM backend architecture where Spring AI is one 
  possible implementation rather than a hard dependency.                        
                                                                                
  ## Changes                                                                       
                                                                                
  Abstract Layer in AbstractLlmOperations:                                      
  - createObjectIfPossible wraps doTransformIfPossible with retry and timeout   
  handling                                                                      
  - Delegates to subclass implementations for framework-specific behavior       
  - Consistent error handling contract (InvalidLlmReturnFormatException,        
  InvalidLlmReturnTypeException)                                                
                                                                                
  Core Implementation in ToolLoopLlmOperations:                                 
  - doTransformIfPossible with native MaybeReturn handling (not delegating to   
  doTransform)                                                                  
  - createMaybeReturnOutputConverter extension point for framework-specific     
  MaybeReturn converters                                                        
  - buildInitialMessagesWithMaybeReturn helper for MaybeReturn prompt           
  construction                                                                  
  - MaybeReturn prompt contribution via templateRenderer                        
  - MaybeReturn → Result conversion                                             
  - Guardrails validation (pre/post) for the if-possible path                   
  - ToolLoopStartEvent/ToolLoopCompletedEvent emission                          
  - Usage recording and replan handling                                         
                                                                                
  Delegation in ChatClientLlmOperations:                                        
  - doTransformIfPossible now checks useEmbabelToolLoop flag                    
  - When true: delegates to super.doTransformIfPossible() (tool loop path)      
  - When false: uses doTransformIfPossibleWithSpringAi() (legacy Spring AI path)
  - createMaybeReturnOutputConverter override provides Spring AI-specific       
  converter                                                                     
                                                                                
  New Tests in ToolLoopLlmOperationsTest.kt:                                    
  - doTransformIfPossible returns success when LLM returns MaybeReturn success  
  - doTransformIfPossible returns failure when LLM returns MaybeReturn failure  
  - doTransformIfPossible throws on empty response                              
  - doTransformIfPossible executes tools when LLM requests them                 
  - doTransformIfPossible returns result with accumulated usage                 
  - buildInitialMessagesWithMaybeReturn inserts MaybeReturn prompt after system 
  message                                                                       
  - buildInitialMessagesWithMaybeReturn works without system message            
  - createMaybeReturnOutputConverter is called for doTransformIfPossible        
                                                                               
                                                                       
  ## TODO                                                                          
                                                                                
  Replan + MaybeReturn + Tool Loop Design Gap                                   
                                                                                
  Issue: When replan is requested during doTransformIfPossible, the tool loop   
  passes an empty string to outputParser, but the MaybeReturn converter cannot  
  parse empty string.                                                           
                                                                                
  Flow:                                                                         
  1. Tool throws ReplanRequestedException                                       
  2. Tool loop catches it, sets state.replanRequested = true                    
  3. Tool loop calls buildResult("", outputParser, state)                       
  4. MaybeReturn converter fails to parse ""                                    
  5. Never reaches caller's replan check                                        
                                                                                
  Suggested fix: Create specialized MaybeReturn bean deserializer that handles  
  empty input, please refer to: lhttps://github.com/embabel/embabel-agent/pull/1386
                                                             
                                                                                
  Current mitigation: Test @Disabled with documentation. Replan coverage exists 
  via doTransform test. 
