### PR TITLE
Add notify job for build failures in GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,7 +9,6 @@ on:
   push:
   pull_request:
     types: [ opened, synchronize, reopened ]
-
 jobs:
   # Detect if docs changed - runs first, in parallel with nothing
   detect-changes:
@@ -24,7 +23,6 @@ jobs:
           filters: |
             docs:
               - 'embabel-agent-docs/**/*.adoc'
-
   build:
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
@@ -81,7 +79,6 @@ jobs:
           echo "testcontainers.reuse.enable=true" > /home/runner/.testcontainers.properties
           # Build without Sonar Cloud
           mvn -U -B test verify
-
   # Trigger docs workflow if .adoc files changed (only on main branch push)
   trigger-docs:
     needs: [detect-changes, build]
@@ -97,3 +94,9 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repository: ${{ github.repository }}
           event-type: publish-docs
+
+  notify:
+    needs: [build]
+    if: failure() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/discord-notify.yml@main
+    secrets: inherit


### PR DESCRIPTION
Added a notification job for build failures on m
This pull request updates the `.github/workflows/maven.yml` file to improve CI workflow management, particularly around notification and job configuration. The most important changes are grouped below:

**Workflow notification improvements:**

* Added a new `notify` job that triggers a Discord notification if the `build` job fails on the `main` branch, using a reusable workflow and inheriting secrets.

**Workflow configuration and cleanup:**

* Removed an unnecessary blank line after the `pull_request` event configuration in the `on:` section for better formatting.
* Removed a blank line after the `docs` filter configuration in the `detect-changes` job for cleaner YAML structure.
* Removed a blank line after the Maven build command in the `build` job for improved formatting.ain branch.