### PR TITLE
Add build failure notification to workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -97,3 +97,10 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repository: ${{ github.repository }}
           event-type: publish-docs
+
+  # Build Failure Notification
+  notify:
+    needs: [build]
+    if: failure() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/discord-notify.yml@main
+    secrets: inherit


### PR DESCRIPTION
Added build failure notification step for main branch.
This pull request adds a new workflow step to notify on build failures in the main branch. The main change is the integration of an automated Discord notification when a build fails, improving visibility of CI issues.

**CI/CD Improvements:**

* Added a `notify` job to `.github/workflows/maven.yml` that triggers a Discord notification using the `embabel/embabel-build/.github/workflows/discord-notify.yml` workflow when a build fails on the `main` branch. This step inherits secrets and runs only if the build fails.