### PR TITLE
feature: migration from gemini 3 preview to gemini 3.1 preview

### DIFF
--- a/embabel-agent-api/src/main/java/com/embabel/agent/api/models/GeminiModels.java
+++ b/embabel-agent-api/src/main/java/com/embabel/agent/api/models/GeminiModels.java
@@ -17,7 +17,7 @@ package com.embabel.agent.api.models;
 
 /**
  * Well-known models from Google Gemini.
- * Updated with latest Gemini 2.5 and 3.0 models as of 2025.
+ * Updated with latest Gemini 2.5 and 3.1 models as of 2025.
  */
 public final class GeminiModels {
 
@@ -25,8 +25,8 @@ public final class GeminiModels {
         // Utility class - prevent instantiation
     }
 
-    // Gemini 3.0 Family (Latest)
-    public static final String GEMINI_3_PRO_PREVIEW = "gemini-3-pro-preview";
+    // Gemini 3.1 Family (Latest)
+    public static final String GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview";
 
     // Gemini 2.5 Family (Current Generation)
     public static final String GEMINI_2_5_PRO = "gemini-2.5-pro";

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
@@ -25,8 +25,8 @@ class GoogleGenAiModels {
 
     companion object {
 
-        // Gemini 3 Family (Preview - Latest Generation)
-        const val GEMINI_3_PRO_PREVIEW = "gemini-3-pro-preview"
+        // Gemini 3.1 Family (Preview - Latest Generation)
+        const val GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview"
         const val GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
 
         // Gemini 2.5 Family (Stable - Current Generation)

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/resources/models/gemini-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/resources/models/gemini-models.yml
@@ -7,10 +7,10 @@ models:
   # GEMINI 3 FAMILY (Preview - Latest Generation)
   # ========================================
 
-  # Gemini 3 Pro Preview - Most advanced reasoning model
-  - name: "gemini_3_pro_preview"
-    model_id: "gemini-3-pro-preview"
-    display_name: "Gemini 3 Pro Preview"
+  # Gemini 3.1 Pro Preview - Most advanced reasoning model
+  - name: "gemini_3_1_pro_preview"
+    model_id: "gemini-3.1-pro-preview"
+    display_name: "Gemini 3.1 Pro Preview"
     knowledge_cutoff_date: "2025-01-01"
     max_tokens: 65536
     temperature: 0.7

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiModelLoaderTest.kt
@@ -93,7 +93,7 @@ class GeminiModelLoaderTest {
         assertEquals(6, result.models.size, "Should load exactly 6 Gemini models")
 
         val expectedModels = listOf(
-            "gemini_3_pro_preview", "gemini_25_pro", "gemini_25_flash",
+            "gemini_3_1_pro_preview", "gemini_25_pro", "gemini_25_flash",
             "gemini_25_flash_lite", "gemini_20_flash", "gemini_20_flash_lite"
         )
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
@@ -10,10 +10,10 @@ models:
   # GEMINI 3 FAMILY (Preview - Latest Generation)
   # ========================================
 
-  # Gemini 3 Pro Preview - Most advanced reasoning model
-  - name: "gemini_3_pro_preview"
-    model_id: "gemini-3-pro-preview"
-    display_name: "Gemini 3 Pro Preview"
+  # Gemini 3.1 Pro Preview - Most advanced reasoning model
+  - name: "gemini_3_1_pro_preview"
+    model_id: "gemini-3.1-pro-preview"
+    display_name: "Gemini 3.1 Pro Preview"
     knowledge_cutoff_date: "2025-01-01"
     max_output_tokens: 65536
     temperature: 0.7

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
@@ -376,18 +376,18 @@ class GoogleGenAiModelLoaderTest {
     }
 
     @Test
-    fun `should load Gemini 3 Pro preview model`() {
+    fun `should load Gemini 3_1 Pro preview model`() {
         // Arrange
         val loader = GoogleGenAiModelLoader()
 
         // Act
         val result = loader.loadAutoConfigMetadata()
 
-        // Assert - verify Gemini 3 Pro preview is present
-        val gemini3ProPreview = result.models.find { it.modelId == "gemini-3-pro-preview" }
-        assertNotNull(gemini3ProPreview, "Gemini 3 Pro preview should be loaded")
-        assertEquals("gemini_3_pro_preview", gemini3ProPreview?.name)
-        assertEquals("gemini-3-pro-preview", gemini3ProPreview?.modelId)
+        // Assert - verify Gemini 3.1 Pro preview is present
+        val gemini31ProPreview = result.models.find { it.modelId == "gemini-3.1-pro-preview" }
+        assertNotNull(gemini31ProPreview, "Gemini 3.1 Pro preview should be loaded")
+        assertEquals("gemini_3_1_pro_preview", gemini31ProPreview?.name)
+        assertEquals("gemini-3.1-pro-preview", gemini31ProPreview?.modelId)
     }
 
     /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperationsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperationsIT.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.embabel.agent.spi.support.springai
 
 import com.embabel.agent.api.dsl.agent

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -603,7 +603,7 @@ dependencies {
 
 Available LLM models include:
 
-* `gemini-3-pro-preview` - Latest Gemini 3 Pro preview with advanced reasoning
+* `gemini-3.1-pro-preview` - Latest Gemini 3.1 Pro preview with advanced reasoning
 * `gemini-2.5-pro` - High-performance model with thinking support
 * `gemini-2.5-flash` - Best price-performance model
 * `gemini-2.5-flash-lite` - Cost-effective high-throughput model
@@ -625,7 +625,7 @@ embabel:
     llms:
       fast: gemini-2.5-flash
       best: gemini-2.5-pro
-      reasoning: gemini-3-pro-preview
+      reasoning: gemini-3.1-pro-preview
     embedding-services:
       default: gemini-embedding-001
 


### PR DESCRIPTION
 ## Summary
 - Migrate `gemini-3-pro-preview` to `gemini-3.1-pro-preview` before Google deprecation deadline (March 9, 2026)
 - Update model constants (`GeminiModels.java`, `GoogleGenAiModels.kt`)
 - Update YAML model configs (`google-genai-models.yml`, `gemini-models.yml`)
 - Update tests and documentation

 ## References
 - https://discuss.ai.google.dev/t/migrate-from-gemini-3-pro-preview-to-gemini-3-1-pro-preview-before-march-9-2026/127062

 ## Test plan
 - [x] `GoogleGenAiModelLoaderTest` — 30/30 passing
 - [x] `GeminiModelLoaderTest` — 15/15 passing
 - [x] Compilation verified across all affected modules