### PR TITLE
Make LlmOptions.criteria read-only for Jackson

### DIFF
--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/LlmOptions.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/LlmOptions.kt
@@ -20,6 +20,7 @@ import com.embabel.common.ai.model.ModelSelectionCriteria.Companion.byName
 import com.embabel.common.ai.model.ModelSelectionCriteria.Companion.byRole
 import com.embabel.common.core.types.HasInfoString
 import com.embabel.common.util.indent
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Duration
 
@@ -122,6 +123,9 @@ data class LlmOptions @JvmOverloads constructor(
     @get:Schema(
         description = "If provided, custom selection criteria for the LLM to use. If not provided, a default LLM will be used.",
         required = false,
+    )
+    @get:JsonProperty(
+        access = JsonProperty.Access.READ_ONLY
     )
     val criteria: ModelSelectionCriteria
         get() =

--- a/embabel-agent-docs/src/main/asciidoc/reference/types/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/types/page.adoc
@@ -50,8 +50,7 @@ val analyticalOptions = LlmOptions
 - `withTopK(Integer)`: Set top-K sampling parameter
 - `withPersona(String)`: Add a system message persona
 
-`LlmOptions` is serializable to JSON, so you can set properties of type
-`LlmOptions` in `application.yml` and other application configuration files.
+`LlmOptions` is deserializable, so you can set properties of type `LlmOptions` in `application.yml` and other application configuration files.
 This is a powerful way of externalizing not only models, but hyperparameters.
 
 ==== PromptRunner


### PR DESCRIPTION
This PR makes LlmOptions.criteria read-only when read using Jackson. It also clarifies the reference documentation that LlmOptions is meant to be deserialized; not serialized.

Closes gh-1377