### PR TITLE
Copy Identities in Subagent.createProcessOptions

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/Subagent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/Subagent.kt
@@ -247,6 +247,7 @@ class Subagent private constructor(
             verbosity = Verbosity(showPrompts = true),
             blackboard = blackboard,
             outputChannel = parentOutputChannel,
+            identities = parentAgentProcess.processOptions.identities,
         )
     }
 


### PR DESCRIPTION
This PR ensures that the subagent's Identities are copied in Subagent.createProcessOptions.

Closes gh-1442