### PR TITLE
 Deep Refactoring of  API createObjecIfPossible WithThinking

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
@@ -369,15 +369,13 @@ internal data class OperationContextDelegate(
     override fun supportsThinking(): Boolean = true
 
     // Patterned after createObject() - uses ProcessContext flow
-    // Uses thinkingInteraction() with additions from createObject(): toolGroups, validation
     override fun <T> createObjectWithThinking(
         messages: List<Message>,
         outputClass: Class<T>
     ): ThinkingResponse<T> {
         val combinedMessages = combineImagesWithMessages(this.messages + messages)
-        val interaction = thinkingInteraction().copy(
+        val interaction = thinkingInteraction(
             toolGroups = this.toolGroups + toolGroups,
-            validation = validation,
         )
         return context.processContext.createObjectWithThinking(
             messages = combinedMessages,
@@ -388,18 +386,20 @@ internal data class OperationContextDelegate(
         )
     }
 
+    // Patterned after createObjectWithThinking() - uses ProcessContext flow
     override fun <T> createObjectIfPossibleWithThinking(
         messages: List<Message>,
         outputClass: Class<T>
     ): ThinkingResponse<T?> {
-        val llmOperations = context.agentPlatform().platformServices.llmOperations as ChatClientLlmOperations
-        val combinedMessages = this.messages + messages
-        val result = llmOperations.doTransformWithThinkingIfPossible(
+        val combinedMessages = combineImagesWithMessages(this.messages + messages)
+        val interaction = thinkingInteraction(
+            toolGroups = this.toolGroups + toolGroups,
+        )
+        val result = context.processContext.createObjectIfPossibleWithThinking(
             messages = combinedMessages,
-            interaction = thinkingInteraction(),
+            interaction = interaction,
             outputClass = outputClass,
-            llmRequestEvent = null,
-            agentProcess = context.agentProcess,
+            agentProcess = context.processContext.agentProcess,
             action = action,
         )
 
@@ -466,7 +466,9 @@ internal data class OperationContextDelegate(
         )
     }
 
-    private fun thinkingInteraction(): LlmInteraction {
+    private fun thinkingInteraction(
+        toolGroups: Set<ToolGroupRequirement> = this.toolGroups,
+    ): LlmInteraction {
         val thinkingEnabledLlm = llm.withThinking(Thinking.withExtraction())
         val toolConfig = resolveToolConfig()
         return LlmInteraction(
@@ -479,6 +481,7 @@ internal data class OperationContextDelegate(
             id = interactionId ?: InteractionId("${context.operation.name}-thinking"),
             generateExamples = generateExamples,
             fieldFilter = fieldFilter,
+            validation = this.validation,
             guardRails = guardRails,
             additionalInjectionStrategies = toolConfig.injectionStrategies,
             inspectors = inspectors,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/AgentProcessEvent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/AgentProcessEvent.kt
@@ -26,6 +26,7 @@ import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.chat.Message
 import com.embabel.common.ai.model.LlmMetadata
 import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.core.thinking.ThinkingResponse
 import com.embabel.common.core.types.Timed
 import com.embabel.common.util.VisualizableTask
 import com.embabel.plan.Goal
@@ -268,6 +269,30 @@ class LlmRequestEvent<O>(
         response: Result<O>,
         runningTime: Duration,
     ): LlmResponseEvent<Result<O>> {
+        return LlmResponseEvent(
+            request = this,
+            outputClass = outputClass,
+            response = response,
+            runningTime = runningTime
+        )
+    }
+
+    fun thinkingResponseEvent(
+        response: ThinkingResponse<O>,
+        runningTime: Duration,
+    ): LlmResponseEvent<ThinkingResponse<O>> {
+        return LlmResponseEvent(
+            request = this,
+            outputClass = outputClass,
+            response = response,
+            runningTime = runningTime
+        )
+    }
+
+    fun maybeThinkingResponseEvent(
+        response: Result<ThinkingResponse<O>>,
+        runningTime: Duration,
+    ): LlmResponseEvent<Result<ThinkingResponse<O>>> {
         return LlmResponseEvent(
             request = this,
             outputClass = outputClass,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/internal/LlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/internal/LlmOperations.kt
@@ -189,4 +189,20 @@ interface LlmOperations {
         llmRequestEvent: LlmRequestEvent<O>?,
     ): ThinkingResponse<O>
 
+    /**
+     * Low level transform with thinking block extraction and MaybeReturn semantics,
+     * not necessarily aware of platform.
+     * Returns a failure result if the LLM indicates it cannot create the object.
+     * @param messages messages
+     * @param interaction The LLM call options
+     * @param outputClass Class of the output object
+     * @param llmRequestEvent Event already published for this request if one has been
+     */
+    fun <O> doTransformWithThinkingIfPossible(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>?,
+    ): Result<ThinkingResponse<O>>
+
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
@@ -323,8 +323,8 @@ abstract class AbstractLlmOperations(
         }
         logger.debug("LLM thinking response={}", thinkingResponse)
         agentProcess.processContext.onProcessEvent(
-            llmRequestEvent.responseEvent(
-                response = thinkingResponse.result!!,
+            llmRequestEvent.thinkingResponseEvent(
+                response = thinkingResponse,
                 runningTime = Duration.ofMillis(ms),
             ),
         )
@@ -338,10 +338,49 @@ abstract class AbstractLlmOperations(
         agentProcess: AgentProcess,
         action: Action?,
     ): Result<ThinkingResponse<O>> {
-        // Critical implementation requirements:
-        // 1. LLM can't create object → return thinking blocks (if any)
-        // 2. Thinking block extraction fails → wrap exception with captured thinking (could be empty)
-        TODO("Use OperationContextDelegate path for now")
+        val (allTools, llmRequestEvent) = getToolsAndEvent(
+            agentProcess = agentProcess,
+            interaction = interaction,
+            action = action,
+            messages = messages,
+            outputClass = outputClass,
+        )
+
+        val interactionWithToolDecoration = interaction.copy(
+            tools = allTools.map {
+                toolDecorator.decorate(
+                    tool = it,
+                    agentProcess = agentProcess,
+                    action = action,
+                    llmOptions = interaction.llm,
+                )
+            }
+        )
+
+        val (response, ms) = time {
+            dataBindingProperties.retryTemplate(interaction.id.value)
+                .execute<Result<ThinkingResponse<O>>, Exception> {
+                    executeWithTimeout(
+                        interactionId = interaction.id.value,
+                        llmOptions = interaction.llm,
+                    ) {
+                        doTransformWithThinkingIfPossible(
+                            messages = messages,
+                            interaction = interactionWithToolDecoration,
+                            outputClass = outputClass,
+                            llmRequestEvent = llmRequestEvent,
+                        )
+                    }
+                }
+        }
+        logger.debug("LLM createObjectIfPossibleWithThinking response={}", response)
+        agentProcess.processContext.onProcessEvent(
+            llmRequestEvent.maybeThinkingResponseEvent(
+                response = response,
+                runningTime = Duration.ofMillis(ms),
+            ),
+        )
+        return response
     }
 
     protected fun chooseLlm(
@@ -362,13 +401,6 @@ abstract class AbstractLlmOperations(
         outputClass: Class<O>,
         llmRequestEvent: LlmRequestEvent<O>,
     ): Result<O>
-
-    protected abstract fun <O> doTransformWithThinkingIfPossible(
-        messages: List<Message>,
-        interaction: LlmInteraction,
-        outputClass: Class<O>,
-        llmRequestEvent: LlmRequestEvent<O>?,
-    ): Result<ThinkingResponse<O>>
 
     private fun <O> getToolsAndEvent(
         agentProcess: AgentProcess,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
@@ -392,16 +392,140 @@ open class ToolLoopLlmOperations(
         return thinkingResponse
     }
 
+    @OptIn(InternalThinkingApi::class)
     override fun <O> doTransformWithThinkingIfPossible(
         messages: List<Message>,
         interaction: LlmInteraction,
         outputClass: Class<O>,
         llmRequestEvent: LlmRequestEvent<O>?,
     ): Result<ThinkingResponse<O>> {
-        // Critical implementation requirements:
-        // 1. LLM can't create object → return thinking blocks (if any)
-        // 2. Thinking block extraction fails → wrap exception with captured thinking (could be empty)
-        TODO("Use OperationContextDelegate path for now")
+        return try {
+            val llm = chooseLlm(interaction.llm)
+            val promptContributions = buildPromptContributions(interaction, llm)
+
+            val messageSender = createMessageSender(llm, interaction.llm, llmRequestEvent)
+
+            val converter = createMaybeReturnOutputConverter(outputClass, interaction)!!
+
+            val schemaFormat = converter.getFormat()
+
+            // Output parser: extract thinking blocks FIRST, then parse MaybeReturn
+            val outputParser: (String) -> Result<ThinkingResponse<O>> = { text ->
+                val thinkingBlocks = extractAllThinkingBlocks(text)
+                try {
+                    val maybeResult = if (text.isNotBlank()) {
+                        converter.convert(text)!!
+                    } else {
+                        MaybeReturn.noOutput<O>()
+                    }
+
+                    // Convert MaybeReturn<O> to Result<ThinkingResponse<O>>
+                    @Suppress("UNCHECKED_CAST")
+                    val innerResult = maybeResult.toResult()
+                    when {
+                        innerResult.isSuccess -> {
+                            val thinkingResponse = ThinkingResponse(
+                                result = innerResult.getOrThrow(),
+                                thinkingBlocks = thinkingBlocks
+                            )
+                            Result.success(thinkingResponse)
+                        }
+
+                        else -> {
+                            // LLM indicated it can't create the object - wrap with thinking blocks
+                            Result.failure(
+                                ThinkingException(
+                                    message = "Object creation not possible: ${innerResult.exceptionOrNull()?.message ?: "Unknown error"}",
+                                    thinkingBlocks = thinkingBlocks
+                                )
+                            )
+                        }
+                    }
+                } catch (e: Exception) {
+                    // Conversion failed - wrap exception with captured thinking blocks
+                    Result.failure(
+                        ThinkingException(
+                            message = "Conversion failed: ${e.message}",
+                            thinkingBlocks = thinkingBlocks
+                        )
+                    )
+                }
+            }
+
+            val injectedToolDecorator = createInjectedToolDecorator(llmRequestEvent, interaction)
+            val injectionStrategy = createInjectionStrategy(interaction)
+
+            val toolLoop = toolLoopFactory.create(
+                llmMessageSender = messageSender,
+                objectMapper = objectMapper,
+                injectionStrategy = injectionStrategy,
+                maxIterations = interaction.maxToolIterations,
+                toolDecorator = injectedToolDecorator,
+                inspectors = interaction.inspectors,
+                transformers = interaction.transformers,
+            )
+
+            // Build MaybeReturn prompt contribution
+            val maybeReturnPromptContribution = templateRenderer.renderLoadedTemplate(
+                promptsProperties.maybePromptTemplate,
+                emptyMap(),
+            )
+
+            val initialMessages = buildInitialMessagesWithMaybeReturn(
+                promptContributions,
+                messages,
+                maybeReturnPromptContribution,
+                schemaFormat,
+            )
+
+            emitCallEvent(llmRequestEvent, promptContributions, messages, schemaFormat)
+
+            // Guardrails: Pre-validation of user input
+            val userMessages = messages.filterIsInstance<com.embabel.chat.UserMessage>()
+            validateUserInput(userMessages, interaction, llmRequestEvent?.agentProcess?.blackboard)
+
+            val tools = interaction.tools
+            val toolLoopStartEvent = publishToolLoopStartEvent(llmRequestEvent, tools, interaction, outputClass)
+
+            val result = toolLoop.execute(
+                initialMessages = initialMessages,
+                initialTools = tools,
+                outputParser = outputParser,
+            )
+
+            handleToolLoopCompletion(toolLoopStartEvent, result, llmRequestEvent, llm)
+
+            val thinkingResult = result.result
+
+            // Guardrails: Post-validation of assistant response
+            // Validate ThinkingResponse on success, or thinking blocks on failure (if non-empty)
+            if (thinkingResult.isSuccess) {
+                validateAssistantResponse(
+                    thinkingResult.getOrNull()!!,
+                    interaction,
+                    llmRequestEvent?.agentProcess?.blackboard
+                )
+            } else {
+                val exception = thinkingResult.exceptionOrNull()
+                if (exception is ThinkingException && exception.thinkingBlocks.isNotEmpty()) {
+                    val thinkingResponse = ThinkingResponse(
+                        result = null,
+                        thinkingBlocks = exception.thinkingBlocks
+                    )
+                    validateAssistantResponse(
+                        thinkingResponse,
+                        interaction,
+                        llmRequestEvent?.agentProcess?.blackboard
+                    )
+                }
+            }
+
+            thinkingResult
+        } catch (e: Exception) {
+            // Technical errors (including GuardRailViolationException) return Result.failure
+            // without ThinkingException wrapper - thinking blocks weren't extracted yet
+            Result.failure(e)
+        }
     }
 
     /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -659,9 +659,27 @@ internal class ChatClientLlmOperations(
 
     /**
      * Transform messages with thinking extraction using IfPossible pattern.
+     * Delegates to either tool loop or Spring AI implementation based on configuration.
      */
     @OptIn(InternalThinkingApi::class)
-    internal fun <O> doTransformWithThinkingIfPossible(
+    override fun <O> doTransformWithThinkingIfPossible(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>?,
+    ): Result<ThinkingResponse<O>> {
+        return if (interaction.useEmbabelToolLoop) {
+            super.doTransformWithThinkingIfPossible(messages, interaction, outputClass, llmRequestEvent)
+        } else {
+            doTransformWithThinkingIfPossibleSpringAi(messages, interaction, outputClass, llmRequestEvent, null, null)
+        }
+    }
+
+    /**
+     * Spring AI implementation of transform with thinking extraction using IfPossible pattern.
+     */
+    @OptIn(InternalThinkingApi::class)
+    internal fun <O> doTransformWithThinkingIfPossibleSpringAi(
         messages: List<Message>,
         interaction: LlmInteraction,
         outputClass: Class<O>,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/DummyObjectCreatingLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/DummyObjectCreatingLlmOperations.kt
@@ -105,6 +105,18 @@ open class DummyObjectCreatingLlmOperations(
         thinkingBlocks = emptyList(),
     )
 
+    override fun <O> doTransformWithThinkingIfPossible(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>?,
+    ): Result<ThinkingResponse<O>> = Result.success(
+        ThinkingResponse(
+            result = doTransform(messages, interaction, outputClass, llmRequestEvent),
+            thinkingBlocks = emptyList(),
+        )
+    )
+
     companion object {
 
         /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/ScriptedLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/test/integration/ScriptedLlmOperations.kt
@@ -332,4 +332,16 @@ class ScriptedLlmOperations : LlmOperations {
         result = doTransform(messages, interaction, outputClass, llmRequestEvent),
         thinkingBlocks = emptyList(),
     )
+
+    override fun <O> doTransformWithThinkingIfPossible(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>?,
+    ): Result<ThinkingResponse<O>> = Result.success(
+        ThinkingResponse(
+            result = doTransform(messages, interaction, outputClass, llmRequestEvent),
+            thinkingBlocks = emptyList(),
+        )
+    )
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextPromptRunnerThinkingTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextPromptRunnerThinkingTest.kt
@@ -157,6 +157,13 @@ class OperationContextPromptRunnerThinkingTest {
                 outputClass: Class<O>,
                 llmRequestEvent: LlmRequestEvent<O>?
             ): ThinkingResponse<O> = throw UnsupportedOperationException("Test implementation")
+
+            override fun <O> doTransformWithThinkingIfPossible(
+                messages: List<Message>,
+                interaction: LlmInteraction,
+                outputClass: Class<O>,
+                llmRequestEvent: LlmRequestEvent<O>?
+            ): Result<ThinkingResponse<O>> = Result.failure(UnsupportedOperationException("Test implementation"))
         }
 
         val context = createMockOperationContextWithLlmOperations(unsupportedLlmOps)

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/OperationContextDelegateTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/OperationContextDelegateTest.kt
@@ -284,12 +284,14 @@ class OperationContextDelegateTest {
         }
 
         @Test
-        fun `createObjectIfPossibleWithThinking should call underlying method`() {
-            val (mockContext, mockChatClientOps, _) = createMockedContext()
+        fun `createObjectIfPossibleWithThinking should call ProcessContext createObjectIfPossibleWithThinking`() {
+            val (mockContext, _, _) = createMockedContext()
+            val mockProcessContext = mockk<ProcessContext>(relaxed = true)
 
+            every { mockContext.processContext } returns mockProcessContext
             every {
-                mockChatClientOps.doTransformWithThinkingIfPossible<TestResult>(
-                    any(), any(), any(), any(), any(), any()
+                mockProcessContext.createObjectIfPossibleWithThinking<TestResult>(
+                    any(), any(), any(), any(), any()
                 )
             } returns Result.success(ThinkingResponse(result = TestResult("test"), thinkingBlocks = emptyList()))
 
@@ -305,8 +307,8 @@ class OperationContextDelegateTest {
                 delegate.createObjectIfPossibleWithThinking(listOf(UserMessage("test")), TestResult::class.java)
 
             verify {
-                mockChatClientOps.doTransformWithThinkingIfPossible<TestResult>(
-                    any(), any(), any(), any(), any(), any()
+                mockProcessContext.createObjectIfPossibleWithThinking<TestResult>(
+                    any(), any(), any(), any(), any()
                 )
             }
             assertEquals("test", result.result?.value)

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/thinking/ThinkingPromptRunnerOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/thinking/ThinkingPromptRunnerOperationsTest.kt
@@ -353,7 +353,7 @@ class ThinkingPromptRunnerOperationsTest {
         } returns Result.success(testResult)
 
         every {
-            mockChatClientOps.doTransformWithThinkingIfPossible<SimpleTestData>(
+            mockChatClientOps.doTransformWithThinkingIfPossibleSpringAi<SimpleTestData>(
                 any(), any(), any(), any(), any(), any()
             )
         } returns Result.success(
@@ -396,7 +396,7 @@ class ThinkingPromptRunnerOperationsTest {
         )
 
         every {
-            mockChatClientOps.doTransformWithThinkingIfPossible<SimpleTestData>(
+            mockChatClientOps.doTransformWithThinkingIfPossibleSpringAi<SimpleTestData>(
                 any(), any(), any(), any(), any(), any()
             )
         } returns Result.failure(exception)
@@ -441,7 +441,7 @@ class ThinkingPromptRunnerOperationsTest {
         } returns ThinkingResponse(result = SimpleTestData("created", 123), thinkingBlocks = emptyList())
 
         every {
-            mockChatClientOps.doTransformWithThinkingIfPossible<SimpleTestData>(
+            mockChatClientOps.doTransformWithThinkingIfPossibleSpringAi<SimpleTestData>(
                 any(), any(), eq(SimpleTestData::class.java), any(), any(), any()
             )
         } returns Result.success(
@@ -497,7 +497,7 @@ class ThinkingPromptRunnerOperationsTest {
         )
 
         every {
-            mockChatClientOps.doTransformWithThinkingIfPossible<SimpleTestData>(
+            mockChatClientOps.doTransformWithThinkingIfPossibleSpringAi<SimpleTestData>(
                 any(), any(), eq(SimpleTestData::class.java), any(), any(), any()
             )
         } returns Result.success(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/thinking/support/ThinkingPromptRunnerOperationsImpl.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/thinking/support/ThinkingPromptRunnerOperationsImpl.kt
@@ -59,7 +59,7 @@ internal class ThinkingPromptRunnerOperationsImpl(
         outputClass: Class<T>,
     ): ThinkingResponse<T?> {
         val combinedMessages = this.messages + messages
-        val result = chatClientOperations.doTransformWithThinkingIfPossible(
+        val result = chatClientOperations.doTransformWithThinkingIfPossibleSpringAi(
             messages = combinedMessages,
             interaction = interaction,
             outputClass = outputClass,

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsThinkingTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsThinkingTest.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.spi.support
 
 import com.embabel.agent.api.common.InteractionId
 import com.embabel.agent.api.event.LlmRequestEvent
+import com.embabel.agent.api.event.LlmResponseEvent
 import com.embabel.agent.api.validation.guardrails.AssistantMessageGuardRail
 import com.embabel.agent.api.validation.guardrails.UserInputGuardRail
 import com.embabel.agent.core.AgentProcess
@@ -36,6 +37,8 @@ import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.ModelProvider
 import com.embabel.common.ai.model.ModelSelectionCriteria
 import com.embabel.common.core.thinking.ThinkingException
+import com.embabel.common.core.thinking.ThinkingResponse
+import org.junit.jupiter.api.Nested
 import com.embabel.common.core.validation.ValidationResult
 import com.embabel.common.textio.template.JinjavaTemplateRenderer
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
@@ -58,7 +61,7 @@ import kotlin.test.assertTrue
  *
  * Focuses on the new thinking-aware methods:
  * - doTransformWithThinking() for comprehensive thinking extraction
- * - doTransformWithThinkingIfPossible() for safe thinking extraction with MaybeReturn
+ * - doTransformWithThinkingIfPossibleSpringAi() for safe thinking extraction with MaybeReturn
  * - Integration with SuppressThinkingConverter and existing LlmOperations infrastructure
  *
  * NOTE: For comprehensive business scenario testing,
@@ -70,6 +73,7 @@ class ChatClientLlmOperationsThinkingTest {
         val llmOperations: ChatClientLlmOperations,
         val mockAgentProcess: AgentProcess,
         val mutableLlmInvocationHistory: MutableLlmInvocationHistory,
+        val eventListener: EventSavingAgenticEventListener,
     )
 
     private fun createChatClientLlmOperations(
@@ -114,7 +118,7 @@ class ChatClientLlmOperationsThinkingTest {
             dataBindingProperties = dataBindingProperties,
             asyncer = ExecutorAsyncer(java.util.concurrent.Executors.newCachedThreadPool()),
         )
-        return Setup(cco, mockAgentProcess, mutableLlmInvocationHistory)
+        return Setup(cco, mockAgentProcess, mutableLlmInvocationHistory, ese)
     }
 
     // Test data class
@@ -502,7 +506,7 @@ class ChatClientLlmOperationsThinkingTest {
     }
 
     @Test
-    fun `doTransformWithThinkingIfPossible should handle success path`() {
+    fun `doTransformWithThinkingIfPossibleSpringAi should handle success path`() {
         // Given: LlmOperations with valid MaybeReturn success response
         val successResponse = """
             {
@@ -515,8 +519,8 @@ class ChatClientLlmOperationsThinkingTest {
         val fakeChatModel = FakeChatModel(successResponse)
         val setup = createChatClientLlmOperations(fakeChatModel)
 
-        // When: Call doTransformWithThinkingIfPossible
-        val result = setup.llmOperations.doTransformWithThinkingIfPossible<SimpleResult>(
+        // When: Call doTransformWithThinkingIfPossibleSpringAi
+        val result = setup.llmOperations.doTransformWithThinkingIfPossibleSpringAi<SimpleResult>(
             messages = listOf(UserMessage("Test thinking success")),
             interaction = LlmInteraction(InteractionId("thinking-success")),
             outputClass = SimpleResult::class.java,
@@ -995,7 +999,7 @@ class ChatClientLlmOperationsThinkingTest {
     }
 
     @Test
-    fun `doTransformWithThinkingIfPossible should validate guardrails for user input and assistant response`() {
+    fun `doTransformWithThinkingIfPossibleSpringAi should validate guardrails for user input and assistant response`() {
         val inputValidationCalled = mutableListOf<String>()
         val responseValidationCalled = mutableListOf<com.embabel.common.core.thinking.ThinkingResponse<*>>()
 
@@ -1052,7 +1056,7 @@ class ChatClientLlmOperationsThinkingTest {
         val llmRequestEvent = mockk<LlmRequestEvent<SimpleResult>>(relaxed = true)
         every { llmRequestEvent.agentProcess } returns setup.mockAgentProcess
 
-        val result = setup.llmOperations.doTransformWithThinkingIfPossible<SimpleResult>(
+        val result = setup.llmOperations.doTransformWithThinkingIfPossibleSpringAi<SimpleResult>(
             messages = listOf(UserMessage("Test thinking if possible input with guardrails")),
             interaction = interaction,
             outputClass = SimpleResult::class.java,
@@ -1111,7 +1115,7 @@ class ChatClientLlmOperationsThinkingTest {
     }
 
     @Test
-    fun `doTransformWithThinkingIfPossible should handle failure scenarios with preserved thinking blocks`() {
+    fun `doTransformWithThinkingIfPossibleSpringAi should handle failure scenarios with preserved thinking blocks`() {
         // Test both MaybeReturn failure and conversion exception scenarios
 
         // Scenario 1: MaybeReturn failure response
@@ -1129,7 +1133,7 @@ class ChatClientLlmOperationsThinkingTest {
         val fakeChatModel1 = FakeChatModel(failureResponse)
         val setup1 = createChatClientLlmOperations(fakeChatModel1)
 
-        val result1 = setup1.llmOperations.doTransformWithThinkingIfPossible<SimpleResult>(
+        val result1 = setup1.llmOperations.doTransformWithThinkingIfPossibleSpringAi<SimpleResult>(
             messages = listOf(UserMessage("Process insufficient data")),
             interaction = LlmInteraction(InteractionId("thinking-ifpossible-failure")),
             outputClass = SimpleResult::class.java,
@@ -1157,7 +1161,7 @@ class ChatClientLlmOperationsThinkingTest {
         val fakeChatModel2 = FakeChatModel(malformedResponse)
         val setup2 = createChatClientLlmOperations(fakeChatModel2)
 
-        val result2 = setup2.llmOperations.doTransformWithThinkingIfPossible<SimpleResult>(
+        val result2 = setup2.llmOperations.doTransformWithThinkingIfPossibleSpringAi<SimpleResult>(
             messages = listOf(UserMessage("Generate malformed JSON")),
             interaction = LlmInteraction(InteractionId("thinking-ifpossible-exception")),
             outputClass = SimpleResult::class.java,
@@ -1202,6 +1206,35 @@ class ChatClientLlmOperationsThinkingTest {
     }
 
     @Test
+    fun `doTransformWithThinkingIfPossible should delegate to ToolLoop when useEmbabelToolLoop is true`() {
+        val responseWithThinking = """
+            <think>Testing Embabel tool loop delegation for IfPossible</think>
+            {"success": {"status": "success", "value": 456}}
+        """.trimIndent()
+
+        val fakeChatModel = FakeChatModel(responseWithThinking)
+        val setup = createChatClientLlmOperations(fakeChatModel)
+
+        val interaction = LlmInteraction(
+            id = InteractionId("embabel-toolloop-switch-ifpossible"),
+            useEmbabelToolLoop = true,
+        )
+
+        val result = setup.llmOperations.doTransformWithThinkingIfPossible(
+            messages = listOf(UserMessage("Test switch to Embabel tool loop for IfPossible")),
+            interaction = interaction,
+            outputClass = SimpleResult::class.java,
+            llmRequestEvent = null,
+        )
+
+        assertTrue(result.isSuccess)
+        val thinkingResponse = result.getOrThrow()
+        assertNotNull(thinkingResponse.result)
+        assertTrue(thinkingResponse.thinkingBlocks.isNotEmpty())
+        assertTrue(thinkingResponse.thinkingBlocks[0].content.contains("Embabel tool loop"))
+    }
+
+    @Test
     fun `createObjectWithThinking should extract thinking and return result`() {
         val responseWithThinking = """
             <think>Analyzing the request for a simple result</think>
@@ -1228,5 +1261,85 @@ class ChatClientLlmOperationsThinkingTest {
         assertEquals(123, result.result.value)
         assertTrue(result.thinkingBlocks.isNotEmpty())
         assertTrue(result.thinkingBlocks[0].content.contains("Analyzing the request"))
+    }
+
+    @Nested
+    inner class ThinkingEventEmissionTests {
+
+        @Test
+        fun `createObjectWithThinking emits event with ThinkingResponse containing thinking blocks`() {
+            val responseWithThinking = """
+                <think>Event emission test thinking</think>
+                {"status": "success", "value": 999}
+            """.trimIndent()
+
+            val fakeChatModel = FakeChatModel(responseWithThinking)
+            val setup = createChatClientLlmOperations(fakeChatModel)
+
+            val interaction = LlmInteraction(
+                id = InteractionId("event-test-with-thinking"),
+            )
+
+            setup.llmOperations.createObjectWithThinking(
+                messages = listOf(UserMessage("Test event emission")),
+                interaction = interaction,
+                outputClass = SimpleResult::class.java,
+                agentProcess = setup.mockAgentProcess,
+                action = null,
+            )
+
+            // Verify event was emitted with ThinkingResponse containing thinking blocks
+            val responseEvents = setup.eventListener.processEvents
+                .filterIsInstance<LlmResponseEvent<*>>()
+            assertEquals(1, responseEvents.size, "Should emit exactly one LlmResponseEvent")
+
+            val responseEvent = responseEvents[0]
+            val response = responseEvent.response
+            assertTrue(response is ThinkingResponse<*>, "Response should be ThinkingResponse")
+
+            val thinkingResponse = response as ThinkingResponse<*>
+            assertTrue(thinkingResponse.thinkingBlocks.isNotEmpty(), "Event should contain thinking blocks")
+            assertTrue(thinkingResponse.thinkingBlocks[0].content.contains("Event emission test"))
+        }
+
+        @Test
+        fun `createObjectIfPossibleWithThinking emits event with Result containing ThinkingResponse`() {
+            val responseWithThinking = """
+                <think>IfPossible event emission test</think>
+                {"success": {"status": "success", "value": 888}}
+            """.trimIndent()
+
+            val fakeChatModel = FakeChatModel(responseWithThinking)
+            val setup = createChatClientLlmOperations(fakeChatModel)
+
+            val interaction = LlmInteraction(
+                id = InteractionId("event-test-if-possible-with-thinking"),
+            )
+
+            setup.llmOperations.createObjectIfPossibleWithThinking(
+                messages = listOf(UserMessage("Test event emission for IfPossible")),
+                interaction = interaction,
+                outputClass = SimpleResult::class.java,
+                agentProcess = setup.mockAgentProcess,
+                action = null,
+            )
+
+            // Verify event was emitted with Result<ThinkingResponse> containing thinking blocks
+            val responseEvents = setup.eventListener.processEvents
+                .filterIsInstance<LlmResponseEvent<*>>()
+            assertEquals(1, responseEvents.size, "Should emit exactly one LlmResponseEvent")
+
+            val responseEvent = responseEvents[0]
+            val response = responseEvent.response
+            assertTrue(response is Result<*>, "Response should be Result")
+
+            @Suppress("UNCHECKED_CAST")
+            val resultResponse = response as Result<ThinkingResponse<*>>
+            assertTrue(resultResponse.isSuccess, "Result should be success")
+
+            val thinkingResponse = resultResponse.getOrThrow()
+            assertTrue(thinkingResponse.thinkingBlocks.isNotEmpty(), "Event should contain thinking blocks")
+            assertTrue(thinkingResponse.thinkingBlocks[0].content.contains("IfPossible event emission"))
+        }
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperationsTest.kt
@@ -120,12 +120,15 @@ class ToolLoopLlmOperationsTest {
     /**
      * Creates a MaybeReturn converter for testing doTransformIfPossible.
      * Parses JSON like {"success": <value>} or {"failure": "reason"}.
+     * Strips thinking blocks before parsing (simulates SuppressThinkingConverter behavior).
      */
     @Suppress("UNCHECKED_CAST")
     private fun <T> createMaybeReturnConverter(innerClass: Class<T>): OutputConverter<MaybeReturn<*>> {
         return object : OutputConverter<MaybeReturn<T>> {
             override fun convert(source: String): MaybeReturn<T>? {
-                val tree = objectMapper.readTree(source)
+                // Strip thinking blocks before parsing (simulates SuppressThinkingConverter)
+                val cleaned = source.replace(Regex("<think>.*?</think>"), "").trim()
+                val tree = objectMapper.readTree(cleaned)
                 return when {
                     tree.has("success") -> {
                         val successValue = objectMapper.treeToValue(tree.get("success"), innerClass)
@@ -770,6 +773,116 @@ class ToolLoopLlmOperationsTest {
     }
 
     @Nested
+    inner class DoTransformWithThinkingIfPossibleTests {
+
+        @Test
+        fun `doTransformWithThinkingIfPossible returns success with thinking blocks extracted`() {
+            val responseWithThinking = """<think>I should check if this can succeed</think>{"success": "Success!"}"""
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(textResponse(responseWithThinking))
+            )
+            val operations = createTestableOperations(
+                messageSender = messageSender,
+                maybeReturnConverter = createMaybeReturnConverter(String::class.java),
+            )
+
+            val result = operations.testDoTransformWithThinkingIfPossible(
+                messages = listOf(UserMessage("Try something")),
+                interaction = createInteraction(),
+                outputClass = String::class.java,
+            )
+
+            assertTrue(result.isSuccess)
+            val thinkingResponse = result.getOrThrow()
+            assertEquals("Success!", thinkingResponse.result)
+            assertEquals(1, thinkingResponse.thinkingBlocks.size)
+            assertTrue(thinkingResponse.thinkingBlocks[0].content.contains("check if this can succeed"))
+        }
+
+        @Test
+        fun `doTransformWithThinkingIfPossible returns failure with thinking blocks preserved in ThinkingException`() {
+            val responseWithThinking = """<think>I cannot fulfill this request</think>{"failure": "Cannot create this object"}"""
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(textResponse(responseWithThinking))
+            )
+            val operations = createTestableOperations(
+                messageSender = messageSender,
+                maybeReturnConverter = createMaybeReturnConverter(String::class.java),
+            )
+
+            val result = operations.testDoTransformWithThinkingIfPossible(
+                messages = listOf(UserMessage("Try something impossible")),
+                interaction = createInteraction(),
+                outputClass = String::class.java,
+            )
+
+            assertTrue(result.isFailure)
+            val exception = result.exceptionOrNull() as com.embabel.common.core.thinking.ThinkingException
+            assertTrue(exception.message?.contains("Object creation not possible") == true)
+            assertEquals(1, exception.thinkingBlocks.size)
+            assertTrue(exception.thinkingBlocks[0].content.contains("cannot fulfill this request"))
+        }
+
+        @Test
+        fun `doTransformWithThinkingIfPossible wraps conversion exception in ThinkingException`() {
+            // Response with thinking blocks but malformed MaybeReturn JSON
+            val malformedResponse = """<think>Attempting to parse</think>{ completely malformed JSON"""
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(textResponse(malformedResponse))
+            )
+            val maybeConverter = object : OutputConverter<MaybeReturn<String>> {
+                override fun convert(source: String): MaybeReturn<String>? {
+                    throw IllegalArgumentException("Cannot parse malformed JSON")
+                }
+                override fun getFormat(): String = "MaybeReturn format"
+            }
+            @Suppress("UNCHECKED_CAST")
+            val operations = createTestableOperations(
+                messageSender = messageSender,
+                maybeReturnConverter = maybeConverter as OutputConverter<MaybeReturn<*>>,
+            )
+
+            val result = operations.testDoTransformWithThinkingIfPossible(
+                messages = listOf(UserMessage("Parse malformed")),
+                interaction = createInteraction(),
+                outputClass = String::class.java,
+            )
+
+            assertTrue(result.isFailure)
+            val exception = result.exceptionOrNull() as com.embabel.common.core.thinking.ThinkingException
+            assertTrue(exception.message?.contains("Conversion failed") == true)
+            assertEquals(1, exception.thinkingBlocks.size)
+            assertTrue(exception.thinkingBlocks[0].content.contains("Attempting to parse"))
+        }
+
+        @Test
+        fun `doTransformWithThinkingIfPossible handles structured output with thinking blocks`() {
+            data class TestOutput(val message: String)
+
+            val responseWithThinking = """<think>Processing request</think>{"success": {"message": "Processed"}}"""
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(textResponse(responseWithThinking))
+            )
+            val operations = createTestableOperations(
+                messageSender = messageSender,
+                maybeReturnConverter = createMaybeReturnConverter(TestOutput::class.java),
+            )
+
+            val result = operations.testDoTransformWithThinkingIfPossible(
+                messages = listOf(UserMessage("Process this")),
+                interaction = createInteraction(),
+                outputClass = TestOutput::class.java,
+            )
+
+            assertTrue(result.isSuccess)
+            val thinkingResponse = result.getOrThrow()
+            assertEquals("Processed", thinkingResponse.result?.message)
+            assertEquals(1, thinkingResponse.thinkingBlocks.size)
+            assertTrue(thinkingResponse.thinkingBlocks[0].content.contains("Processing request"))
+        }
+    }
+
+    @Nested
     inner class ExtensionPointTests {
 
         private fun setupMockModelProvider(): ModelProvider {
@@ -1063,6 +1176,20 @@ internal open class TestableToolLoopLlmOperations(
         outputClass: Class<O>,
     ): ThinkingResponse<O> {
         return doTransformWithThinking(
+            messages = messages,
+            interaction = interaction,
+            outputClass = outputClass,
+            llmRequestEvent = null,
+        )
+    }
+
+    // Expose doTransformWithThinkingIfPossible for direct testing
+    fun <O> testDoTransformWithThinkingIfPossible(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+    ): Result<ThinkingResponse<O>> {
+        return doTransformWithThinkingIfPossible(
             messages = messages,
             interaction = interaction,
             outputClass = outputClass,


### PR DESCRIPTION
 ## Overview

 * Align with createObject WithThinking pattern for consistency
  * Enhance LLMOperations interface and add impl to Abstract LLM Ops
  * implemented switch to toggle between modern and legacy code
  * updated unit tests

Continuation of PR:

https://github.com/embabel/embabel-agent/pull/1458
                                                                             
  ### Summary      
                                                             
  - Adds `doTransformWithThinkingIfPossible` to `LlmOperations` interface for   
  design consistency with `doTransformWithThinking`                             
  - Ensures all thinking-aware methods follow the same architectural pattern    
  across all implementations                                                    
                                                                                
  ### Changes                                                                   
                                                                                
  **Interface & Abstract Layer:**                                               
  - `LlmOperations.kt` - Added `doTransformWithThinkingIfPossible` declaration  
  - `AbstractLlmOperations.kt` -   _createObjectIfPossibleWithThinking_- implementation  of interface                                                  
  - `AgentProcessEvent.kt` - Added `maybeThinkingResponseEvent` for             
  `createObjectIfPossibleWithThinking` event emission                           
                                                                                
  **Implementations:**                                                          
  - `ToolLoopLlmOperations.kt` - Added `override fun                            
  doTransformWithThinkingIfPossible` implementation with tool loop support      
  - `ChatClientLlmOperations.kt` - Added toggle switch: delegates to            
  `super.doTransformWithThinkingIfPossible` (ToolLoop) when                     
  `useEmbabelToolLoop=true`, otherwise calls                                    
  `doTransformWithThinkingIfPossibleSpringAi`                                   
  - `OperationContextDelegate.kt` - Uses                                        
  `processContext.createObjectIfPossibleWithThinking` which calls through to the
   interface method                                                             
                                                                                
                                                                                 
  **Tests:**                                                                    
  - `ToolLoopLlmOperationsTest.kt` - Added                                      
  `DoTransformWithThinkingIfPossibleTests` nested class with unit tests         
  - `ChatClientLlmOperationsThinkingTest.kt` - Added toggle test for            
  `doTransformWithThinkingIfPossible`                                           
                                                                                
  ### Design Consistency                                                        
  All `*WithThinking` and `*WithThinkingIfPossible` methods now follow identical
   patterns across:                                                             
  - `LlmOperations` interface                                                   
  - `AbstractLlmOperations`                                                     
  - `ToolLoopLlmOperations`                                                     
  - `ChatClientLlmOperations` (toggle pattern)                                  
  - `OperationContextDelegate`                                                  
  - Test implementations    