### PR TITLE
Feature/google genai 3.1 flash lite and customtools

### DIFF
--- a/embabel-agent-api/src/main/java/com/embabel/agent/api/models/GeminiModels.java
+++ b/embabel-agent-api/src/main/java/com/embabel/agent/api/models/GeminiModels.java
@@ -27,6 +27,8 @@ public final class GeminiModels {
 
     // Gemini 3.1 Family (Latest)
     public static final String GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview";
+    public static final String GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = "gemini-3.1-pro-preview-customtools";
+    public static final String GEMINI_3_1_FLASH_LITE_PREVIEW = "gemini-3.1-flash-lite-preview";
 
     // Gemini 2.5 Family (Current Generation)
     public static final String GEMINI_2_5_PRO = "gemini-2.5-pro";

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
@@ -28,6 +28,8 @@ class GoogleGenAiModels {
         // Gemini 3.1 Family (Preview - Latest Generation)
         const val GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview"
         const val GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
+        const val GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = "gemini-3.1-pro-preview-customtools"
+        const val GEMINI_3_1_FLASH_LITE_PREVIEW = "gemini-3.1-flash-lite-preview"
 
         // Gemini 2.5 Family (Stable - Current Generation)
         const val GEMINI_2_5_PRO = "gemini-2.5-pro"

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/resources/models/gemini-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/resources/models/gemini-models.yml
@@ -18,6 +18,28 @@ models:
       usd_per1m_input_tokens: 2.00
       usd_per1m_output_tokens: 12.00
 
+  # Gemini 3.1 Pro Preview Customtools - Optimized for custom tool usage
+  - name: "gemini_3_1_pro_preview_customtools"
+    model_id: "gemini-3.1-pro-preview-customtools"
+    display_name: "Gemini 3.1 Pro Preview Customtools"
+    knowledge_cutoff_date: "2025-01-01"
+    max_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 2.00
+      usd_per1m_output_tokens: 12.00
+
+  # Gemini 3.1 Flash Lite Preview - Lightweight and cost-effective latest generation model
+  - name: "gemini_3_1_flash_lite_preview"
+    model_id: "gemini-3.1-flash-lite-preview"
+    display_name: "Gemini 3.1 Flash Lite Preview"
+    knowledge_cutoff_date: "2025-01-01"
+    max_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 1.50
+
   # ========================================
   # GEMINI 2.5 FAMILY (Stable - Current Generation)
   # ========================================

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiModelLoaderTest.kt
@@ -82,7 +82,7 @@ class GeminiModelLoaderTest {
     }
 
     @Test
-    fun `should load all 6 expected Gemini models`() {
+    fun `should load all 8 expected Gemini models`() {
         // Arrange
         val loader = GeminiModelLoader()
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiModelLoaderTest.kt
@@ -90,10 +90,12 @@ class GeminiModelLoaderTest {
         val result = loader.loadAutoConfigMetadata()
 
         // Assert
-        assertEquals(6, result.models.size, "Should load exactly 6 Gemini models")
+        assertEquals(8, result.models.size, "Should load exactly 8 Gemini models")
 
         val expectedModels = listOf(
-            "gemini_3_1_pro_preview", "gemini_25_pro", "gemini_25_flash",
+            "gemini_3_1_pro_preview", "gemini_3_1_pro_preview_customtools",
+            "gemini_3_1_flash_lite_preview",
+            "gemini_25_pro", "gemini_25_flash",
             "gemini_25_flash_lite", "gemini_20_flash", "gemini_20_flash_lite"
         )
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
@@ -21,6 +21,17 @@ models:
       usd_per1m_input_tokens: 2.00
       usd_per1m_output_tokens: 12.00
 
+  # Gemini 3.1 Pro Preview Customtools - Optimized for custom tool usage
+  - name: "gemini_3_1_pro_preview_customtools"
+    model_id: "gemini-3.1-pro-preview-customtools"
+    display_name: "Gemini 3.1 Pro Preview Customtools"
+    knowledge_cutoff_date: "2025-01-01"
+    max_output_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 2.00
+      usd_per1m_output_tokens: 12.00
+
   # Gemini 3 Flash Preview - Fast model with thinking capabilities
   - name: "gemini_3_flash_preview"
     model_id: "gemini-3-flash-preview"
@@ -31,6 +42,17 @@ models:
     pricing_model:
       usd_per1m_input_tokens: 0.50
       usd_per1m_output_tokens: 3.00
+
+  # Gemini 3.1 Flash Lite Preview - Lightweight and cost-effective latest generation model
+  - name: "gemini_3_1_flash_lite_preview"
+    model_id: "gemini-3.1-flash-lite-preview"
+    display_name: "Gemini 3.1 Flash Lite Preview"
+    knowledge_cutoff_date: "2025-01-01"
+    max_output_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 1.50
 
   # ========================================
   # GEMINI 2.5 FAMILY (Stable - Current Generation)

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
@@ -390,6 +390,21 @@ class GoogleGenAiModelLoaderTest {
         assertEquals("gemini-3.1-pro-preview", gemini31ProPreview?.modelId)
     }
 
+    @Test
+    fun `should load Gemini 3_1 Pro preview customtools model`() {
+        // Arrange
+        val loader = GoogleGenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify Gemini 3.1 Pro preview customtools is present
+        val model = result.models.find { it.modelId == "gemini-3.1-pro-preview-customtools" }
+        assertNotNull(model, "Gemini 3.1 Pro preview customtools should be loaded")
+        assertEquals("gemini_3_1_pro_preview_customtools", model?.name)
+        assertEquals("gemini-3.1-pro-preview-customtools", model?.modelId)
+    }
+
     /**
      * Gemini 3 Flash Preview - Fast model with thinking capabilities
      * Added as part of the Gemini 3 family support
@@ -407,6 +422,21 @@ class GoogleGenAiModelLoaderTest {
         assertNotNull(gemini3FlashPreview, "Gemini 3 Flash preview should be loaded")
         assertEquals("gemini_3_flash_preview", gemini3FlashPreview?.name)
         assertEquals("gemini-3-flash-preview", gemini3FlashPreview?.modelId)
+    }
+
+    @Test
+    fun `should load Gemini 3_1 Flash Lite preview model`() {
+        // Arrange
+        val loader = GoogleGenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify Gemini 3.1 Flash Lite preview is present
+        val gemini31FlashLitePreview = result.models.find { it.modelId == "gemini-3.1-flash-lite-preview" }
+        assertNotNull(gemini31FlashLitePreview, "Gemini 3.1 Flash Lite preview should be loaded")
+        assertEquals("gemini_3_1_flash_lite_preview", gemini31FlashLitePreview?.name)
+        assertEquals("gemini-3.1-flash-lite-preview", gemini31FlashLitePreview?.modelId)
     }
 
     @Test

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -604,6 +604,8 @@ dependencies {
 Available LLM models include:
 
 * `gemini-3.1-pro-preview` - Latest Gemini 3.1 Pro preview with advanced reasoning
+* `gemini-3.1-pro-preview-customtools` - Gemini 3.1 Pro optimized for custom tool usage
+* `gemini-3.1-flash-lite-preview` - Lightweight and cost-effective latest generation model
 * `gemini-2.5-pro` - High-performance model with thinking support
 * `gemini-2.5-flash` - Best price-performance model
 * `gemini-2.5-flash-lite` - Cost-effective high-throughput model


### PR DESCRIPTION
### Add Gemini 3.1 Flash Lite Preview and Gemini 3.1 Pro Preview Customtools models 
                                                                                                                                                                                                                                                                                      
  **Summary**

  Add support for two new Google Gemini 3.1 models:

  - gemini-3.1-flash-lite-preview - Lightweight and cost-effective latest generation model ($0.25/$1.50 per 1M tokens input/output)
  - gemini-3.1-pro-preview-customtools - Behavioral variant of Gemini 3.1 Pro optimized for prioritizing custom tools  ($2.00/$12.00 per 1M tokens input/output)

  **Changes**

  - Added model constants in GoogleGenAiModels.kt (Kotlin) and GeminiModels.java (Java)
  - Added model definitions in both google-genai-models.yml (Google GenAI / AI Studio) and gemini-models.yml (Vertex AI)
  - Added unit tests for both models in GoogleGenAiModelLoaderTest and GeminiModelLoaderTest
  - Updated getting-started documentation with new model entries

  **Test plan**

  - GoogleGenAiModelLoaderTest — 32 tests passing
  - GeminiModelLoaderTest — 15 tests passing