### PR TITLE
Add workflow step to trigger acceptance tests

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -152,3 +152,9 @@ jobs:
               echo 'Testing web access:' &&
               curl -I http://localhost/embabel-agent/guide/$VERSION/index.html || echo 'Versioned guide not responding'
             "
+      - name: Trigger acceptance repo workflow to validate User Guide
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: embabel/embabel-acceptance-tests
+          event-type: publish-docs


### PR DESCRIPTION
This pull request introduces a new step to the documentation deployment workflow, focusing on automating validation of the User Guide after publishing. The most important change is the integration with the acceptance tests repository to trigger validation.

User Guide validation automation:

* [`.github/workflows/deploy-docs.yml`](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6R155-R160): Added a step to trigger the `embabel-acceptance-tests` repository workflow using `repository-dispatch`, enabling automated validation of the User Guide after docs are published.