### PR TITLE
Add mockk Async to ShellCommandsContextTest

### DIFF
--- a/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/ShellCommandsContextTest.kt
+++ b/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/ShellCommandsContextTest.kt
@@ -83,6 +83,7 @@ class ShellCommandsContextTest {
             toolsStats = toolsStats,
             context = context,
             shellProperties = ShellProperties(),
+            asyncer =  mockk(relaxed = true)
         )
     }
 


### PR DESCRIPTION
This pull request makes a minor adjustment to the test setup in `ShellCommandsContextTest`. The change adds a mocked `asyncer` dependency to the constructor, ensuring that asynchronous behavior is properly handled during testing.