### PR TITLE
Support custom HTTP headers and completions path in OpenAI Custom autoconfigure

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-custom-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/custom/OpenAiCustomModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-custom-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/custom/OpenAiCustomModelsConfig.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.common.ai.autoconfig.ProviderInitialization
 import com.embabel.common.ai.autoconfig.RegisteredModel
+import com.embabel.common.ai.model.LlmOptionsProperties
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import io.micrometer.observation.ObservationRegistry
 import org.springframework.beans.factory.ObjectProvider
@@ -95,7 +96,7 @@ class OpenAiCustomProperties : RetryProperties {
  * to specify which model should be the default.
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(OpenAiCustomProperties::class)
+@EnableConfigurationProperties(OpenAiCustomProperties::class, LlmOptionsProperties::class)
 @ExcludeFromJacocoGeneratedReport(reason = "OpenAi Custom configuration can't be unit tested")
 class OpenAiCustomModelsConfig(
     @param:Value("\${OPENAI_CUSTOM_BASE_URL:#{null}}")
@@ -104,16 +105,19 @@ class OpenAiCustomModelsConfig(
     private val envApiKey: String?,
     @param:Value("\${OPENAI_CUSTOM_MODELS:#{null}}")
     private val envCustomModels: String?,
+    @param:Value("\${OPENAI_CUSTOM_COMPLETIONS_PATH:#{null}}")
+    private val envCompletionsPath: String?,
     observationRegistry: ObjectProvider<ObservationRegistry>,
     private val properties: OpenAiCustomProperties,
+    private val llmOptionsProperties: LlmOptionsProperties,
     private val configurableBeanFactory: ConfigurableBeanFactory,
     requestFactory: ObjectProvider<ClientHttpRequestFactory>,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = envBaseUrl ?: properties.baseUrl,
-    apiKey = envApiKey ?: properties.apiKey
-    ?: error("OpenAI Custom API key required: set OPENAI_CUSTOM_API_KEY env var or embabel.agent.platform.models.openai.custom.api-key"),
-    completionsPath = null,
+    apiKey = envApiKey ?: properties.apiKey,
+    completionsPath = envCompletionsPath,
     embeddingsPath = null,
+    httpHeaders = llmOptionsProperties.httpHeaders,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
     requestFactory = requestFactory,
 ) {


### PR DESCRIPTION
# Support custom HTTP headers and completions path in OpenAI Custom autoconfigure

## Problem
The OpenAI Custom autoconfigure module lacked two capabilities present in the standard OpenAI module:
1. No support for custom HTTP headers, making it impossible to use providers that require non-standard auth (e.g. Azure OpenAI-compatible proxies which require an `Api-Key` header instead of `Authorization: Bearer`)
2. No support for custom completions path, making Azure-style deployment URL routing impossible
3. API key was mandatory, preventing auth-via-header-only setups

## Solution
- Wire `LlmOptionsProperties.httpHeaders` into `OpenAiCustomModelsConfig`, mirroring the standard module
- Add `OPENAI_CUSTOM_COMPLETIONS_PATH` env var support, mirroring `OPENAI_COMPLETIONS_PATH` in the standard module
- Make `api-key` optional — when absent, `NoopApiKey` is used and auth can be handled entirely via custom HTTP headers

## Example: Azure OpenAI-compatible proxy

```properties
embabel.agent.platform.models.openai.custom.base-url=https://your-proxy.example.com
embabel.agent.platform.models.openai.custom.models=gpt-4o-mini-2024-07-18
embabel.models.default-llm=gpt-4o-mini-2024-07-18
embabel.agent.platform.models.options.http-headers.Api-Key=<your-key>
OPENAI_CUSTOM_COMPLETIONS_PATH=/openai/deployments/<your-deployment>/chat/completions?api-version=<your-version>
```

## Test plan
- [x] Existing `CustomModelParsingTest` (8 tests) passes
- [ ] Verify standard OpenAI-compatible providers (Groq, Together AI) still work without these settings
- [x] Verified Azure OpenAI-compatible proxy works with `Api-Key` header and Azure-style completions path

---
🤖 Assisted by [Claude Code](https://claude.com/claude-code)
