### PR TITLE
Add recovery notification for successful builds

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -104,3 +104,12 @@ jobs:
     if: failure() && github.ref == 'refs/heads/main'
     uses: embabel/embabel-build/.github/workflows/discord-notify.yml@main
     secrets: inherit
+
+  # Build Recovery (if prior build failed) Notification
+  notify-recovery:
+    needs: [build]
+    if: success() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/notify-recovery.yml@main
+    with:
+      branch: main
+    secrets: inherit


### PR DESCRIPTION
This pull request adds a new workflow job to notify when a previously failing build on the `main` branch has recovered and now passes. This helps the team stay informed about build status improvements.

**Build notification enhancements:**

* Added a `notify-recovery` job to `.github/workflows/maven.yml` that triggers a recovery notification when a previously failing build on the `main` branch succeeds. This uses the `notify-recovery.yml` workflow from the shared repository.