### PR TITLE
Add configurable API paths for OpenAI custom models and fix documentation

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-custom-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/custom/OpenAiCustomModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-custom-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/custom/OpenAiCustomModelsConfig.kt
@@ -56,6 +56,18 @@ class OpenAiCustomProperties : RetryProperties {
     var models: String? = null
 
     /**
+     * Custom path for chat completions endpoint (e.g., "/chat/completions" or "/api/chat").
+     * If not set, Spring AI's default "/v1/chat/completions" will be used.
+     */
+    var completionsPath: String? = null
+
+    /**
+     * Custom path for embeddings endpoint.
+     * If not set, Spring AI's default "/v1/embeddings" will be used.
+     */
+    var embeddingsPath: String? = null
+
+    /**
      *  Maximum number of attempts.
      */
     override var maxAttempts: Int = 10
@@ -85,7 +97,7 @@ class OpenAiCustomProperties : RetryProperties {
  *
  * Example:
  * ```
- * OPENAI_CUSTOM_BASE_URL=https://api.groq.com/openai/v1
+ * OPENAI_CUSTOM_BASE_URL=https://api.groq.com/openai
  * OPENAI_CUSTOM_API_KEY=your-api-key
  * OPENAI_CUSTOM_MODELS=llama-3.3-70b-versatile,mixtral-8x7b-32768,gemma2-9b-it
  * EMBABEL_MODELS_DEFAULT_LLM=llama-3.3-70b-versatile
@@ -104,6 +116,10 @@ class OpenAiCustomModelsConfig(
     private val envApiKey: String?,
     @param:Value("\${OPENAI_CUSTOM_MODELS:#{null}}")
     private val envCustomModels: String?,
+    @param:Value("\${OPENAI_CUSTOM_COMPLETIONS_PATH:#{null}}")
+    private val envCompletionsPath: String?,
+    @param:Value("\${OPENAI_CUSTOM_EMBEDDINGS_PATH:#{null}}")
+    private val envEmbeddingsPath: String?,
     observationRegistry: ObjectProvider<ObservationRegistry>,
     private val properties: OpenAiCustomProperties,
     private val configurableBeanFactory: ConfigurableBeanFactory,
@@ -112,8 +128,8 @@ class OpenAiCustomModelsConfig(
     baseUrl = envBaseUrl ?: properties.baseUrl,
     apiKey = envApiKey ?: properties.apiKey
     ?: error("OpenAI Custom API key required: set OPENAI_CUSTOM_API_KEY env var or embabel.agent.platform.models.openai.custom.api-key"),
-    completionsPath = null,
-    embeddingsPath = null,
+    completionsPath = envCompletionsPath ?: properties.completionsPath,
+    embeddingsPath = envEmbeddingsPath ?: properties.embeddingsPath,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
     requestFactory = requestFactory,
 ) {

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -324,6 +324,8 @@ dependencies {
 * Optional:
 - `OPENAI_CUSTOM_BASE_URL`: base URL for the OpenAI-compatible API
 - `OPENAI_CUSTOM_MODELS`: comma-separated list of custom model names to register (useful for OpenAI-compatible providers like Groq, Together AI, etc.)
+- `OPENAI_CUSTOM_COMPLETIONS_PATH`: custom path for chat completions endpoint 
+- `OPENAI_CUSTOM_EMBEDDINGS_PATH`: custom path for embeddings endpoint
 
 When using `OPENAI_CUSTOM_MODELS`, set `EMBABEL_MODELS_DEFAULT_LLM` to specify which model to use as the default.
 
@@ -331,7 +333,7 @@ Example for using Groq:
 
 [source,bash]
 ----
-export OPENAI_CUSTOM_BASE_URL="https://api.groq.com/openai/v1"
+export OPENAI_CUSTOM_BASE_URL="https://api.groq.com/openai"
 export OPENAI_CUSTOM_API_KEY="your-groq-api-key"
 export OPENAI_CUSTOM_MODELS="llama-3.3-70b-versatile,mixtral-8x7b-32768"
 export EMBABEL_MODELS_DEFAULT_LLM="llama-3.3-70b-versatile"
@@ -348,8 +350,18 @@ embabel:
         openai:
           custom:
             api-key: ${OPENAI_CUSTOM_API_KEY:your-dev-key}
-            base-url: https://api.groq.com/openai/v1
+            base-url: https://api.groq.com/openai
             models: llama-3.3-70b-versatile,mixtral-8x7b-32768
+----
+
+For APIs with non-standard paths (e.g., Z.AI), use the completions path override:
+
+[source,bash]
+----
+export OPENAI_CUSTOM_BASE_URL="https://api.z.ai/api/coding/paas"
+export OPENAI_CUSTOM_API_KEY="your-api-key"
+export OPENAI_CUSTOM_COMPLETIONS_PATH="/v4/chat/completions"
+export OPENAI_CUSTOM_MODELS="your-model-name"
 ----
 
 You also need to add the `embabel-agent-starter-openai-custom` starter.


### PR DESCRIPTION
Hey, 

I was playing with embabel in my side project and noticed that integration for https://z.ai/ requires overwriting configuration as the `completionsPath` is set by default to `/v1/chat/completions` for custom models and can't be changed. This requires implementing own configuration like:

```java
@Configuration
public class ZaiModelsConfig extends OpenAiCompatibleModelFactory {
    
    public ZaiModelsConfig(ObjectProvider<ObservationRegistry> observationRegistry, ObjectProvider<ClientHttpRequestFactory> requestFactory) {
        super(
            "https://api.z.ai/api/coding/paas",
            System.getenv("ZAI_API_KEY"),
            "/v4/chat/completions",
            null,
            java.util.Map.of(),
            observationRegistry.getIfUnique(() -> ObservationRegistry.NOOP),
            requestFactory
        );
    }

    @Bean
    public LlmService<?> zaiModel() {
        return openAiCompatibleLlm(
            "glm-4-flash",
            PricingModel.usdPer1MTokens(1.0, 3.0),
            "Z.AI",
            null
        );
    }
}
```

This PR adds `completionsPath` and `embeddingsPath` configuration options for OpenAI custom models to support APIs with non-standard endpoints (e.g., Z.AI) and fixes incorrect Groq configuration examples that would result in `/v1/v1/chat/completions' URLs.