### PR TITLE
Ensure that Java tools are executed with Java reflection

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionMethodManager.kt
@@ -257,7 +257,7 @@ internal class DefaultActionMethodManager(
         actionContext: TransformationActionContext<List<Any>, O>,
     ): O {
         logger.debug("Invoking action method {} with payload {}", method.name, actionContext.input)
-        val result = if (KotlinDetector.isKotlinReflectPresent()) {
+        val result = if (KotlinDetector.isKotlinReflectPresent() && KotlinDetector.isKotlinType(instance.javaClass)) {
             val kFunction = method.kotlinFunction
             if (kFunction != null) invokeActionMethodKotlinReflect(method, kFunction, instance, actionContext)
             else invokeActionMethodJavaReflect(method, instance, actionContext)
@@ -337,6 +337,8 @@ internal class DefaultActionMethodManager(
         val result = try {
             method.trySetAccessible()
             ReflectionUtils.invokeMethod(method, instance, *args)
+        } catch (sre: SpecialReturnException) {
+            handleSpecial(sre, actionContext)
         } catch (awe: AwaitableResponseException) {
             handleAwaitableResponseException(instance.javaClass.name, method.name, awe)
         } catch (t: Throwable) {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/StateActionMethodManager.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/StateActionMethodManager.kt
@@ -139,7 +139,9 @@ internal class StateActionMethodManager(
             stateInstance.javaClass.getMethod(method.name, *method.parameterTypes)
         }
 
-        val result = if (KotlinDetector.isKotlinReflectPresent()) {
+        val result = if (KotlinDetector.isKotlinReflectPresent() &&
+            KotlinDetector.isKotlinType(stateInstance.javaClass)
+        ) {
             val kFunction = actualMethod.kotlinFunction
             if (kFunction != null) invokeStateActionMethodKotlinReflect(
                 actualMethod,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodTool.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodTool.kt
@@ -233,7 +233,7 @@ internal class JavaMethodTool(
                 val paramAnnotation = param.getAnnotation(Param::class.java)
                 ParameterInfo(
                     name = param.name,
-                    type = param.type,
+                    type = param.parameterizedType,
                     description = paramAnnotation?.description ?: "",
                     required = paramAnnotation?.required ?: true,
                 )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodToolFactory.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodToolFactory.kt
@@ -109,12 +109,12 @@ interface MethodToolFactory {
             return listOf(UnfoldingTool.fromInstance(instance, objectMapper))
         }
 
-        val tools = if (KotlinDetector.isKotlinReflectPresent()) {
+        val tools = if (KotlinDetector.isKotlinReflectPresent() && KotlinDetector.isKotlinType(instance.javaClass)) {
             instance::class.functions
                 .filter { it.hasAnnotation<LlmTool>() }
                 .map { fromMethod(instance, it, objectMapper) }
         } else {
-            instance.javaClass.methods
+            instance.javaClass.declaredMethods
                 .filter { it.isAnnotationPresent(LlmTool::class.java) }
                 .map { fromMethod(instance, it, objectMapper) }
         }

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/tool/ToolFromInstanceJavaTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/tool/ToolFromInstanceJavaTest.java
@@ -16,10 +16,12 @@
 package com.embabel.agent.api.tool;
 
 import com.embabel.agent.api.annotation.LlmTool;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -368,6 +370,59 @@ class ToolFromInstanceJavaTest {
 
             assertInstanceOf(Tool.Result.Text.class, toolResult);
             assertEquals("ID: 42, Name: Test", ((Tool.Result.Text) toolResult).getContent());
+        }
+    }
+
+    public static class GreetingWithOptionalTitleTool {
+        @LlmTool(description = "Greet a person, optionally with a title")
+        public String greet(
+                @LlmTool.Param(description = "Person's name") String name,
+                @LlmTool.Param(description = "Optional title, e.g. Dr.", required = false) String title
+        ) {
+            if (title == null || title.isBlank()) {
+                return "Hello, " + name + "!";
+            }
+            return "Hello, " + title + " " + name + "!";
+        }
+    }
+
+    @Nested
+    class JavaOptionalParameters {
+
+        @Test
+        void javaToolWithOptionalParamCanBeCalledWithoutThatParam() {
+            var instance = new GreetingWithOptionalTitleTool();
+            var tool = Tool.fromInstance(instance).getFirst();
+
+            var result = tool.call("{\"name\":\"Alice\"}");
+
+            assertInstanceOf(Tool.Result.Text.class, result);
+            assertEquals("Hello, Alice!", ((Tool.Result.Text) result).getContent());
+        }
+
+        @Test
+        void javaToolWithOptionalParamCanBeCalledWithThatParam() {
+            var instance = new GreetingWithOptionalTitleTool();
+            var tool = Tool.fromInstance(instance).getFirst();
+
+            var result = tool.call("{\"name\":\"Smith\",\"title\":\"Dr.\"}");
+
+            assertInstanceOf(Tool.Result.Text.class, result);
+            assertEquals("Hello, Dr. Smith!", ((Tool.Result.Text) result).getContent());
+        }
+
+        @Test
+        void optionalParamIsNotInRequiredArrayOfSchema() throws Exception {
+            var instance = new GreetingWithOptionalTitleTool();
+            var tool = Tool.fromInstance(instance).getFirst();
+
+            var schema = tool.getDefinition().getInputSchema().toJsonSchema();
+            var schemaMap = new ObjectMapper().readValue(schema, Map.class);
+
+            var required = (List<?>) schemaMap.get("required");
+            assertNotNull(required, "Schema should have a 'required' array");
+            assertTrue(required.contains("name"), "'name' should be required");
+            assertFalse(required.contains("title"), "'title' must NOT be in required: " + required);
         }
     }
 }


### PR DESCRIPTION
This PR makes sure that Java tools are executed using Java reflection, whereas previously this was done using Kotlin reflection.

The same issue is resolved in several other places that use the same Java/Kotlin execution logic.

Closes gh-1500