### PR TITLE
Consolidate and restructure shell documentation

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/getting-started/running/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/running/page.adoc
@@ -36,27 +36,16 @@ NOTE: For Google GenAI, you can use either `GOOGLE_API_KEY` (Google AI Studio) o
 
 Spring Shell is an easy way to interact with the Embabel agent framework, especially during development.
 
-Type `help` to see available commands.
-Use `execute` or `x` to run an agent:
+Type `help` to see available commands, or use `execute` / `x` to run an agent:
 
 ----
 execute "Lynda is a Scorpio, find news for her" -p -r
 ----
 
-This will look for an agent, choose the star finder agent and run the flow. `-p` will log prompts `-r` will log LLM responses.
-Omit these for less verbose logging.
+The `-p` and `-r` flags log prompts and LLM responses respectively; omit them for quiet output.
+Use `chat` for an interactive conversation, and `choose-goal` to inspect how Embabel ranks goals without running anything.
 
-Options:
-
-- `-p` logs prompts
-- `-r` logs LLM responses
-
-Use the `chat` command to enter an interactive chat with the agent.
-It will attempt to run the most appropriate agent for each command.
-
-TIP: Spring Shell supports history.
-Type `!!` to repeat the last command.
-This will survive restarts, so is handy when iterating on an agent.
+For a full description of every command, flags, tab completion, and history shortcuts, see <<shell.guide>>.
 
 ==== Example Commands
 
@@ -75,63 +64,6 @@ x "fact check the following: holden cars are still made in australia"
 
 ==== Implementing Your Own Shell Commands
 
-Particularly during development, you may want to implement your own shell commands to try agents or flows.
-Simply write a Spring Shell component and Spring will inject it and register it automatically.
-
-For example, you can inject the `AgentPlatform` and use it to invoke agents directly, as in this code from the examples repository:
-
-[tabs]
-====
-Java::
-+
-[source,java]
-----
-@ShellComponent
-public record SupportAgentShellCommands(
-        AgentPlatform agentPlatform
-) {
-
-    @ShellMethod("Get bank support for a customer query")
-    public String bankSupport(
-            @ShellOption(value = "id", help = "customer id", defaultValue = "123") Long id,
-            @ShellOption(value = "query", help = "customer query", defaultValue = "What's my balance, including pending amounts?") String query
-    ) {
-        var supportInput = new SupportInput(id, query);
-        System.out.println("Support input: " + supportInput);
-        var invocation = AgentInvocation
-                .builder(agentPlatform)
-                .options(ProcessOptions.builder().verbosity(v -> v.showPrompts(true)).build())
-                .build(SupportOutput.class);
-        var result = invocation.invoke(supportInput);
-        return result.toString();
-    }
-}
-----
-
-Kotlin::
-+
-[source,kotlin]
-----
-@ShellComponent
-class SupportAgentShellCommands(
-    private val agentPlatform: AgentPlatform
-) {
-
-    @ShellMethod("Get bank support for a customer query")
-    fun bankSupport(
-        @ShellOption(value = ["id"], help = "customer id", defaultValue = "123") id: Long,
-        @ShellOption(value = ["query"], help = "customer query", defaultValue = "What's my balance, including pending amounts?") query: String
-    ): String {
-        val supportInput = SupportInput(id, query)
-        println("Support input: $supportInput")
-        val invocation = AgentInvocation
-            .builder(agentPlatform)
-            .options(ProcessOptions.builder().verbosity { it.showPrompts(true) }.build())
-            .build(SupportOutput::class.java)
-        val result = invocation.invoke(supportInput)
-        return result.toString()
-    }
-}
-----
-====
+You can add custom shell commands to invoke specific agents directly during development.
+See <<shell.commands.custom>> for a full example and explanation.
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/invoking/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/invoking/page.adoc
@@ -1143,9 +1143,8 @@ val options = GoalSelectionOptions(
 
 ===== Shell Usage
 
-The Embabel Shell uses `Autonomy` for the `execute` (or `x`) command:
+The Embabel Shell uses `Autonomy` for the `execute` (`x`) and `choose-goal` commands:
 
-[source,bash]
 ----
 # Closed mode (default) - select best agent
 x "Find a horoscope for Alice who is a Scorpio"
@@ -1156,6 +1155,8 @@ x "Find a horoscope for Alice who is a Scorpio" -o
 # Show goal rankings without executing
 choose-goal "Find a horoscope for Alice"
 ----
+
+See <<shell.commands.execute>> and <<shell.commands>> for full command and flag documentation.
 
 ===== Handling Selection Failures
 

--- a/embabel-agent-docs/src/main/asciidoc/shell/commands.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/shell/commands.adoc
@@ -1,6 +1,81 @@
 [[shell.commands]]
 === Shell Commands
 
+==== Agent Execution Commands
+
+[[shell.commands.execute]]
+===== execute (x)
+
+Run the most appropriate agent for the given natural-language input.
+Embabel uses <<reference.invoking__autonomy,Autonomy>> to rank all registered agents and selects the best match.
+
+----
+execute "Lynda is a Scorpio, find news for her"
+
+# Shorthand alias
+x "Lynda is a Scorpio, find news for her"
+----
+
+[cols="1,3"]
+|===
+|Option |Description
+
+|`-p`
+|Log LLM prompts during execution
+
+|`-r`
+|Log raw LLM responses during execution
+
+|`-o` / `--open`
+|Open mode: select the best _goal_ across all agents, then assemble a dynamic agent from any available actions to achieve it.
+Without this flag, closed mode is used: a single agent is selected and runs in isolation.
+
+|`-c key=val,...`
+|Per-execution tool call context entries, merged with any persistent context set via `set-context`.
+Per-execution entries win on conflict.
+|===
+
+Example combining flags:
+
+----
+# Verbose closed-mode run
+x "fact check: the Eiffel Tower is in Berlin" -p -r
+
+# Open mode with prompt logging
+x "Research the latest Go release" -o -p
+
+# Per-execution context override
+x "Find news for Alice" -c "tenantId=beta,correlationId=req-456"
+----
+
+===== chat
+
+Start an interactive back-and-forth conversation with the most appropriate agent.
+The agent responds to each message in turn, maintaining state across the session.
+
+----
+shell:> chat
+chat:> What does the document say about taxes?
+chat:> Summarise that in three bullet points.
+chat:> exit
+----
+
+Type `exit` to end the chat session and return to the main shell prompt.
+
+===== choose-goal
+
+Use the LLM to rank all available goals across all agents against the provided input, and display the rankings without executing anything.
+Useful for understanding which goal Embabel would select for a given input, and for tuning agent descriptions.
+
+----
+choose-goal "Find a horoscope for Alice who is a Scorpio"
+----
+
+The output shows each candidate goal, its score, and the agent it belongs to.
+If the top-ranked goal is not what you expected, revisit the `description` attribute on the relevant `@AchievesGoal` or `@Agent` annotation.
+
+See <<reference.invoking__autonomy>> for the confidence threshold configuration that controls when a goal is considered a strong enough match to execute.
+
 ==== Tool Call Context Commands
 
 The shell supports setting out-of-band metadata that is passed to all tools during agent execution.
@@ -44,3 +119,67 @@ x "Find news for Alice" -c "correlationId=req-456,tenantId=beta"
 
 In this example the effective context for that single execution is `{tenantId=beta, authToken=bearer-xyz123, correlationId=req-456}`.
 The persistent context remains `{tenantId=acme, authToken=bearer-xyz123}` for future invocations.
+
+[[shell.commands.custom]]
+==== Implementing Custom Shell Commands
+
+During development you may want to add your own shell commands to invoke specific agents or flows directly, bypassing the natural-language routing of `execute`.
+Because the Embabel Shell is a standard Spring Shell application, any `@ShellComponent` bean is discovered and registered automatically by Spring.
+
+Inject `AgentPlatform` and use `AgentInvocation` to call agents with strong typing:
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+@ShellComponent
+public record SupportAgentShellCommands(
+        AgentPlatform agentPlatform
+) {
+
+    @ShellMethod("Get bank support for a customer query")
+    public String bankSupport(
+            @ShellOption(value = "id", help = "customer id", defaultValue = "123") Long id,
+            @ShellOption(value = "query", help = "customer query", defaultValue = "What's my balance, including pending amounts?") String query
+    ) {
+        var supportInput = new SupportInput(id, query);
+        System.out.println("Support input: " + supportInput);
+        var invocation = AgentInvocation
+                .builder(agentPlatform)
+                .options(ProcessOptions.builder().verbosity(v -> v.showPrompts(true)).build())
+                .build(SupportOutput.class);
+        return invocation.invoke(supportInput).toString();
+    }
+}
+----
+
+Kotlin::
++
+[source,kotlin]
+----
+@ShellComponent
+class SupportAgentShellCommands(
+    private val agentPlatform: AgentPlatform
+) {
+
+    @ShellMethod("Get bank support for a customer query")
+    fun bankSupport(
+        @ShellOption(value = ["id"], help = "customer id", defaultValue = "123") id: Long,
+        @ShellOption(value = ["query"], help = "customer query", defaultValue = "What's my balance, including pending amounts?") query: String
+    ): String {
+        val supportInput = SupportInput(id, query)
+        println("Support input: $supportInput")
+        val invocation = AgentInvocation
+            .builder(agentPlatform)
+            .options(ProcessOptions.builder().verbosity { it.showPrompts(true) }.build())
+            .build(SupportOutput::class.java)
+        return invocation.invoke(supportInput).toString()
+    }
+}
+----
+====
+
+TIP: Custom shell commands are particularly useful when you want to pre-populate inputs with test data or invoke a specific agent directly rather than relying on Autonomy's natural-language selection.
+For full `AgentInvocation` API details see <<reference.invoking>>.

--- a/embabel-agent-docs/src/main/asciidoc/shell/how-to.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/shell/how-to.adoc
@@ -1,2 +1,66 @@
 [[shell.how-to]]
 === How to Use the Shell
+
+The Embabel Shell is built on https://spring.io/projects/spring-shell[Spring Shell] and provides an interactive command-line interface for running and developing agents.
+It is the fastest way to try agents, iterate on prompts, and observe agent behaviour in detail.
+
+==== Starting the Shell
+
+With the `embabel-agent-starter-shell` dependency and API keys configured, start your application normally.
+The shell prompt appears automatically:
+
+----
+shell:>
+----
+
+If you are using the Embabel example or template projects, use the provided convenience script:
+
+[source,bash]
+----
+./scripts/shell.sh
+----
+
+==== Navigating the Shell
+
+Type `help` to list all available commands with a short description of each:
+
+----
+shell:> help
+----
+
+Tab completion is supported for command names and, where applicable, for option values.
+Press `<Tab>` after typing a partial command or flag to see available completions.
+
+The shell maintains a persistent command history across restarts.
+Use the up/down arrow keys to navigate previous commands, or type `!!` to repeat the last command — especially handy when iterating on an agent prompt:
+
+----
+shell:> !!
+----
+
+==== How User Input Reaches an Agent
+
+When you run `execute "some text"`, the shell wraps the quoted string in a `UserInput` object and places it on the agent process blackboard.
+Agents declare a dependency on `UserInput` by accepting it as a parameter in their first `@Action` method.
+Embabel's planner sees that `UserInput` is available and selects the appropriate action automatically.
+
+This is the same mechanism used in web controllers and webhook handlers — only the source of `UserInput` changes (shell vs. HTTP request vs. event payload).
+See <<reference.invoking>> for programmatic invocation patterns.
+
+==== Logging Verbosity
+
+The `-p` and `-r` flags on `execute` control what gets logged during a run:
+
+[cols="1,3"]
+|===
+|Flag |Effect
+
+|`-p`
+|Log LLM prompts sent by the agent
+
+|`-r`
+|Log raw LLM responses received by the agent
+|===
+
+Omit both flags for quiet output showing only the final result.
+Use both together for maximum visibility when debugging a misbehaving agent.

--- a/embabel-agent-docs/src/main/asciidoc/user-guide.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/user-guide.adoc
@@ -7,13 +7,11 @@ include::overview/page.adoc[]
 
 include::getting-started/page.adoc[]
 
+include::shell/shell-guide.adoc[]
+
 include::modules/page.adoc[]
 
-
 include::reference/reference.adoc[]
-
-
-// include::shell/shell-guide.adoc[]
 
 // include::eval/eval-guide.adoc[]
 


### PR DESCRIPTION
Shell content was scattered across five locations with no cross-references, how-to.adoc was empty, and the shell section was buried after Reference.

- Move shell chapter immediately after Getting Started in user-guide.adoc
- Fill how-to.adoc: startup, navigation, help/tab/history/!!, UserInput flow explanation, verbosity flags table
- Add execute/chat/choose-goal command entries to commands.adoc with full flag reference tables and examples
- Relocate @ShellComponent custom commands example from getting-started into commands.adoc under a dedicated section
- Condense getting-started/running shell intro; replace duplicated content with cross-references to shell chapter
- Replace orphaned shell code block in reference/invoking with restored original examples plus cross-reference to commands.adoc