### PR TITLE
Improve RequiredToolGroupException diagnostics and correctness

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolConsumer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolConsumer.kt
@@ -103,7 +103,7 @@ interface ToolConsumer : ToolSpecConsumer,
                     if (requirement.requiredToolNames.isNotEmpty()) {
                         throw RequiredToolGroupException(
                             role = requirement.role,
-                            message = "Required tool group with role='${requirement.role}' has no tools",
+                            message = "Required tool group with role='${requirement.role}' has no tools; required: ${requirement.requiredToolNames}",
                         )
                     }
                     loggerFor<ToolConsumer>().warn(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/RequiredToolGroupException.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/RequiredToolGroupException.kt
@@ -22,5 +22,5 @@ package com.embabel.agent.spi.loop
  */
 class RequiredToolGroupException(
     val role: String,
-    override val message: String,
+    message: String,
 ) : RuntimeException(message)

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ToolConsumerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ToolConsumerTest.kt
@@ -243,9 +243,11 @@ class ToolConsumerTest {
                 toolGroups = setOf(ToolGroupRequirement("missing-role", setOf("some-tool"))),
             )
 
-            assertThrows<RequiredToolGroupException> {
+            val ex = assertThrows<RequiredToolGroupException> {
                 consumer.resolveTools(resolver)
             }
+            assertEquals("missing-role", ex.role)
+            assertTrue(ex.message!!.contains("missing-role"))
         }
 
         @Test
@@ -258,9 +260,12 @@ class ToolConsumerTest {
                 toolGroups = setOf(ToolGroupRequirement("empty-role", setOf("some-tool"))),
             )
 
-            assertThrows<RequiredToolGroupException> {
+            val ex = assertThrows<RequiredToolGroupException> {
                 consumer.resolveTools(resolver)
             }
+            assertEquals("empty-role", ex.role)
+            assertTrue(ex.message!!.contains("empty-role"))
+            assertTrue(ex.message!!.contains("some-tool"))
         }
 
         @Test
@@ -274,9 +279,12 @@ class ToolConsumerTest {
                 toolGroups = setOf(ToolGroupRequirement("partial-role", setOf("present-tool", "absent-tool"))),
             )
 
-            assertThrows<RequiredToolGroupException> {
+            val ex = assertThrows<RequiredToolGroupException> {
                 consumer.resolveTools(resolver)
             }
+            assertEquals("partial-role", ex.role)
+            assertTrue(ex.message!!.contains("absent-tool"))
+            assertTrue(ex.message!!.contains("present-tool"))
         }
 
         @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/RequiredToolGroupExceptionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/RequiredToolGroupExceptionTest.kt
@@ -42,10 +42,5 @@ class RequiredToolGroupExceptionTest {
             assertEquals("search", ex.role)
         }
 
-        @Test
-        fun `is a RuntimeException`() {
-            val ex = RequiredToolGroupException(role = "r", message = "m")
-            assertTrue(ex is RuntimeException)
-        }
     }
 }


### PR DESCRIPTION
- Remove `override val message` in RequiredToolGroupException; delegate to RuntimeException(message) to avoid nullable-override fragility on Throwable.message

- Include required tool names in the empty-group error message so the cause is immediately actionable without inspecting source

- Strengthen RequiredToolGroupTest assertions to verify ex.role and ex.message content, not just exception type

- Remove vacuous `is a RuntimeException` test in RequiredToolGroupExceptionTest (compile-time fact, not runtime behaviour)

Follow-up to #1493