### PR TITLE
Integrate ToolCallContextMcpMetaConverter into MCP tool pipeline (#1323)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolGroupsConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolGroupsConfiguration.kt
@@ -23,6 +23,7 @@ import com.embabel.agent.core.ToolGroupPermission
 import com.embabel.agent.spi.common.Constants.EMBABEL_PROVIDER
 import com.embabel.agent.tools.math.MathTools
 import com.embabel.agent.tools.mcp.McpToolGroup
+import com.embabel.agent.tools.mcp.ToolCallContextMcpMetaConverter
 import com.embabel.common.core.types.Semver
 import io.modelcontextprotocol.client.McpSyncClient
 import org.slf4j.LoggerFactory
@@ -30,6 +31,7 @@ import org.springframework.ai.tool.ToolCallback
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Condition
 import org.springframework.context.annotation.ConditionContext
@@ -160,7 +162,11 @@ class ToolGroupsProperties {
 class ToolGroupsConfiguration(
     private val mcpSyncClients: List<McpSyncClient>,
     private val properties: ToolGroupsProperties,
+    private val metaConverterProvider: ObjectProvider<ToolCallContextMcpMetaConverter>,
 ) {
+
+    private fun converter(): ToolCallContextMcpMetaConverter =
+        metaConverterProvider.getIfAvailable { ToolCallContextMcpMetaConverter.passThrough() }
 
     private val logger = LoggerFactory.getLogger(ToolGroupsConfiguration::class.java)
 
@@ -203,7 +209,8 @@ class ToolGroupsConfiguration(
                     gid.tools.joinToString(", ") { t -> "'$t'" }
                 )
                 included
-            }
+            },
+            metaConverter = converter(),
         )
     }
 
@@ -231,6 +238,7 @@ class ToolGroupsConfiguration(
                         wikipediaTools.any { wt -> it.toolDefinition.name().contains(wt) }) &&
                         !(it.toolDefinition.name().contains("brave_local_search"))
             },
+            metaConverter = converter(),
         )
     }
 
@@ -247,7 +255,8 @@ class ToolGroupsConfiguration(
             clients = mcpSyncClients,
             filter = {
                 it.toolDefinition.name().contains("maps_")
-            }
+            },
+            metaConverter = converter(),
         )
     }
 
@@ -263,6 +272,7 @@ class ToolGroupsConfiguration(
             ),
             clients = mcpSyncClients,
             filter = { it.toolDefinition.name().contains("puppeteer") },
+            metaConverter = converter(),
         )
     }
 
@@ -292,6 +302,7 @@ class ToolGroupsConfiguration(
                     it.toolDefinition.name().contains(ght)
                 }
             },
+            metaConverter = converter(),
         )
     }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringToolCallbackAdapter.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringToolCallbackAdapter.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.spi.support.springai
 
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolCallContext
+import com.embabel.agent.tools.mcp.ToolCallContextMcpMetaConverter
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.ToolCallback
@@ -94,9 +95,15 @@ fun List<Tool>.toSpringToolCallbacks(): List<ToolCallback> = map { it.toSpringTo
  *
  * This reverse adapter allows existing Spring AI tools to be used
  * within the Embabel framework.
+ *
+ * @param callback the Spring AI [ToolCallback] to wrap
+ * @param metaConverter controls which [ToolCallContext] entries are forwarded
+ *   as MCP `_meta` when the underlying callback is an MCP tool.
+ *   Defaults to [ToolCallContextMcpMetaConverter.passThrough].
  */
 class SpringToolCallbackWrapper(
     private val callback: ToolCallback,
+    private val metaConverter: ToolCallContextMcpMetaConverter = ToolCallContextMcpMetaConverter.passThrough(),
 ) : Tool {
 
     override val definition: Tool.Definition = object : Tool.Definition {
@@ -123,7 +130,8 @@ class SpringToolCallbackWrapper(
             val result = if (context.isEmpty) {
                 callback.call(input)
             } else {
-                callback.call(input, ToolContext(context.toMap()))
+                val meta = metaConverter.convert(context)
+                callback.call(input, ToolContext(meta))
             }
             Tool.Result.text(result)
         } catch (e: Exception) {
@@ -148,9 +156,13 @@ private class SpringInputSchema(
 /**
  * Extension function to wrap a Spring AI ToolCallback as an Embabel Tool.
  */
-fun ToolCallback.toEmbabelTool(): Tool = SpringToolCallbackWrapper(this)
+fun ToolCallback.toEmbabelTool(
+    metaConverter: ToolCallContextMcpMetaConverter = ToolCallContextMcpMetaConverter.passThrough(),
+): Tool = SpringToolCallbackWrapper(this, metaConverter)
 
 /**
  * Extension function to wrap a list of Spring AI ToolCallbacks as Embabel Tools.
  */
-fun List<ToolCallback>.toEmbabelTools(): List<Tool> = map { it.toEmbabelTool() }
+fun List<ToolCallback>.toEmbabelTools(
+    metaConverter: ToolCallContextMcpMetaConverter = ToolCallContextMcpMetaConverter.passThrough(),
+): List<Tool> = map { it.toEmbabelTool(metaConverter) }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/mcp/McpToolGroup.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/mcp/McpToolGroup.kt
@@ -44,6 +44,7 @@ class McpToolGroup(
     permissions: Set<ToolGroupPermission>,
     private val clients: List<McpSyncClient>,
     filter: ((ToolCallback) -> Boolean),
+    private val metaConverter: ToolCallContextMcpMetaConverter = ToolCallContextMcpMetaConverter.passThrough(),
 ) : ToolGroup {
 
     override val metadata: ToolGroupMetadata = ToolGroupMetadata(
@@ -61,7 +62,7 @@ class McpToolGroup(
             )
             // Filter the raw callbacks, then convert to native Tool
             val filteredCallbacks = provider.toolCallbacks.filter(filter)
-            val nativeTools = filteredCallbacks.map { it.toEmbabelTool() }
+            val nativeTools = filteredCallbacks.map { it.toEmbabelTool(metaConverter) }
             loggerFor<McpToolGroup>().debug(
                 "ToolGroup role={}: {}",
                 description.role,

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringToolCallbackAdapterTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringToolCallbackAdapterTest.kt
@@ -16,7 +16,16 @@
 package com.embabel.agent.spi.support.springai
 
 import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.api.tool.ToolCallContext
+import com.embabel.agent.tools.mcp.ToolCallContextMcpMetaConverter
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.modelcontextprotocol.client.McpSyncClient
+import io.modelcontextprotocol.spec.McpSchema
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest
+import org.mockito.ArgumentCaptor
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.springframework.ai.mcp.SyncMcpToolCallbackProvider
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -265,6 +274,110 @@ class SpringToolCallbackAdapterTest {
                     return callResult
                 }
             }
+        }
+    }
+
+    /**
+     * Proves that _meta actually reaches the MCP wire layer.
+     *
+     * Uses a real [SyncMcpToolCallbackProvider] + [SyncMcpToolCallback] (Spring AI's
+     * real implementation) backed by a mock [McpSyncClient] that captures the
+     * [CallToolRequest]. Asserting on [CallToolRequest.meta] is equivalent to
+     * asserting on what a real MCP server would receive in its McpMeta parameter.
+     */
+    @Nested
+    inner class McpMetaWireVerification {
+
+        @Test
+        fun `_meta is populated on the wire when ToolCallContext has entries`() {
+            val (tool, captor) = buildMcpToolWithCaptor()
+
+            val ctx = ToolCallContext.of("tenantId" to "acme", "locale" to "en-AU")
+            tool.call("{}", ctx)
+
+            val request = captor.value
+            assertEquals("acme", request.meta["tenantId"])
+            assertEquals("en-AU", request.meta["locale"])
+        }
+
+        @Test
+        fun `_meta is null on the wire when context is empty`() {
+            val (tool, captor) = buildMcpToolWithCaptor()
+
+            tool.call("{}", ToolCallContext.EMPTY)
+
+            // SpringToolCallbackWrapper skips the two-arg call when context is empty,
+            // so SyncMcpToolCallback.call(input) is invoked — meta is not set.
+            assertNull(captor.value.meta)
+        }
+
+        @Test
+        fun `allowKeys converter limits what appears in _meta`() {
+            val converter = ToolCallContextMcpMetaConverter.allowKeys("tenantId")
+            val (tool, captor) = buildMcpToolWithCaptor(converter)
+
+            val ctx = ToolCallContext.of(
+                "tenantId" to "acme",
+                "apiKey" to "secret",
+                "locale" to "en-AU",
+            )
+            tool.call("{}", ctx)
+
+            val meta = captor.value.meta
+            assertEquals("acme", meta["tenantId"])
+            assertNull(meta["apiKey"])     // blocked by allowKeys
+            assertNull(meta["locale"])     // blocked by allowKeys
+        }
+
+        @Test
+        fun `noOp converter produces empty _meta map on the wire`() {
+            val (tool, captor) = buildMcpToolWithCaptor(ToolCallContextMcpMetaConverter.noOp())
+
+            val ctx = ToolCallContext.of("tenantId" to "acme", "apiKey" to "secret")
+            tool.call("{}", ctx)
+
+            // noOp → empty map → SyncMcpToolCallback receives ToolContext({}) → meta={}
+            val meta = captor.value.meta
+            assertNotNull(meta)
+            assertTrue(meta!!.isEmpty())
+        }
+
+        /**
+         * Builds a real [SyncMcpToolCallback] (via [SyncMcpToolCallbackProvider]) backed
+         * by a mock [McpSyncClient], wrapped in a [SpringToolCallbackWrapper] with the
+         * given [converter]. Returns the Embabel [Tool] and the [ArgumentCaptor] that
+         * captures the [CallToolRequest] sent to the mock client.
+         */
+        private fun buildMcpToolWithCaptor(
+            converter: ToolCallContextMcpMetaConverter = ToolCallContextMcpMetaConverter.passThrough(),
+        ): Pair<Tool, ArgumentCaptor<CallToolRequest>> {
+            val captor = ArgumentCaptor.forClass(CallToolRequest::class.java)
+
+            // Use mock — McpSchema.Tool has no public builder (mirrors Spring AI test patterns)
+            val mcpTool = mock(McpSchema.Tool::class.java)
+            `when`(mcpTool.name()).thenReturn("test_tool")
+            `when`(mcpTool.description()).thenReturn("Test tool")
+
+            val listResult = mock(McpSchema.ListToolsResult::class.java)
+            `when`(listResult.tools()).thenReturn(listOf(mcpTool))
+
+            val callResult = mock(McpSchema.CallToolResult::class.java)
+            `when`(callResult.isError).thenReturn(false)
+            `when`(callResult.content()).thenReturn(listOf(McpSchema.TextContent("ok")))
+
+            val clientInfo = McpSchema.Implementation("test-client", "1.0.0")
+            val mcpClient = mock(McpSyncClient::class.java)
+            `when`(mcpClient.clientInfo).thenReturn(clientInfo)
+            `when`(mcpClient.listTools()).thenReturn(listResult)
+            `when`(mcpClient.callTool(captor.capture())).thenReturn(callResult)
+
+            // Use Spring AI's real SyncMcpToolCallbackProvider — same path as production
+            val callbacks = SyncMcpToolCallbackProvider(listOf(mcpClient)).toolCallbacks
+            assertEquals(1, callbacks.size)
+
+            // Wrap with Embabel's SpringToolCallbackWrapper + our converter
+            val tool = callbacks[0].toEmbabelTool(converter)
+            return tool to captor
         }
     }
 


### PR DESCRIPTION
Wire ToolCallContextMcpMetaConverter as the Embabel-owned boundary that controls which ToolCallContext entries are forwarded as MCP _meta when calling external MCP servers.

Production changes:
- SpringToolCallbackWrapper accepts ToolCallContextMcpMetaConverter, applies it before passing context to Spring AI ToolContext
- toEmbabelTool() / toEmbabelTools() extension functions thread the converter through to SpringToolCallbackWrapper
- McpToolGroup accepts metaConverter and passes it to toEmbabelTool()
- ToolGroupsConfiguration injects optional ObjectProvider<ToolCallContextMcpMetaConverter> bean, falling back to passThrough() when none is defined

Tests:
- ToolCallContextMcpMetaConverterTest: pure unit tests for all factory methods (passThrough, noOp, allowKeys, denyKeys, custom lambda), no Spring AI imports — converter is tested as an Embabel concept
- McpMetaWireVerification in SpringToolCallbackAdapterTest: proves _meta reaches the actual CallToolRequest on the wire using a real SyncMcpToolCallbackProvider backed by a mock McpSyncClient

_meta is a first-class field in the MCP 2025-06-18 specification. ToolCallContextMcpMetaConverter keeps the filtering decision at the Embabel boundary, independent of which MCP client library is used below it.