### PR TITLE
Trigger build on changes in embabel-common

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -38,5 +38,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          repository: embabel/embabel-common
+          repository: embabel/embabel-agent-examples
           event-type: agent-snapshots-deployed

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,8 @@
 # documentation.
 name: Build
 on:
+  repository_dispatch:
+    types: [common-snapshots-deployed]
   push:
   pull_request:
     types: [ opened, synchronize, reopened ]


### PR DESCRIPTION
This pull request updates our GitHub workflow configurations to improve automation around snapshot deployments and build triggers. The main changes involve updating which repository receives deployment notifications and configuring the build workflow to respond to new snapshot deployment events.

**Workflow configuration updates:**

* Changed the deployment notification recipient in `.github/workflows/deploy-snapshots.yml` from `embabel/embabel-common` to `embabel/embabel-agent-examples` to ensure the correct repository is notified after agent snapshot deployments.

* Updated `.github/workflows/maven.yml` to trigger the build workflow on `repository_dispatch` events of type `common-snapshots-deployed`, enabling automated builds when new common snapshots are deployed.