### PR TITLE
Publish agent-snapshot-deployed cross all repos

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -1,9 +1,7 @@
-# This workflow will build a Java / Kotlin project with Maven
-
 name: Deploy Snapshots
 
 on:
-  workflow_dispatch:  # Enables manual triggering
+  workflow_dispatch:
   workflow_run:
     workflows: ["Build"]
     types:
@@ -13,7 +11,6 @@ on:
 
 jobs:
   build-and-deploy:
-
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
@@ -30,13 +27,34 @@ jobs:
           servers: ${{secrets.EMBABEL_ARTIFACTORY}}
       - name: Build and analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn -U -DskipTests=true clean deploy
 
-      - name: Trigger examples repo workflow
+  get-repos:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    outputs:
+      repos: ${{ steps.list.outputs.repos }}
+    steps:
+      - name: List all repos
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          repos=$(gh api orgs/embabel/repos --paginate \
+            --jq '[.[].full_name]')
+          echo "repos=$repos" >> $GITHUB_OUTPUT
+
+  dispatch:
+    needs: get-repos
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ${{ fromJson(needs.get-repos.outputs.repos) }}
+    steps:
+      - name: Trigger downstream workflow
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          repository: embabel/embabel-agent-examples
+          repository: ${{ matrix.repo }}
           event-type: agent-snapshots-deployed


### PR DESCRIPTION
This pull request updates the `deploy-snapshots.yml` GitHub Actions workflow to generalize and automate the process of triggering downstream workflows across all repositories in the organization, rather than just a single target repository. The workflow now dynamically fetches all organization repositories and dispatches the `agent-snapshots-deployed` event to each one after a successful build and deploy.

Key workflow automation improvements:

* Added a new `get-repos` job that uses the GitHub CLI to fetch all repositories in the `embabel` organization and outputs their names for use in downstream jobs.
* Introduced a `dispatch` job that uses a matrix strategy to iterate over all fetched repositories and trigger the `agent-snapshots-deployed` event in each via the `repository-dispatch` action.

Other workflow changes:

* Removed the hardcoded reference to `embabel/embabel-agent-examples` in favor of dynamically targeting all repositories.
* Minor cleanup of comments and whitespace for clarity in the workflow file. [[1]](diffhunk://#diff-441fb097201dd492df86898768fa710e824a03b73403c88c6e4b84404bc76528L1-R4) [[2]](diffhunk://#diff-441fb097201dd492df86898768fa710e824a03b73403c88c6e4b84404bc76528L16)