### PR TITLE
Trigger build in downstream projects

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -30,13 +30,24 @@ jobs:
           servers: ${{secrets.EMBABEL_ARTIFACTORY}}
       - name: Build and analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
         run: mvn -U -DskipTests=true clean deploy
 
-      - name: Trigger examples repo workflow
+  dispatch:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo:
+          - embabel/embabel-agent-examples
+          - embabel/embabel-agent-experimental
+          - embabel/guide
+          - embabel/tripper
+    steps:
+      - name: Trigger downstream workflow
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          repository: embabel/embabel-agent-examples
+          repository: ${{ matrix.repo }}
           event-type: agent-snapshots-deployed


### PR DESCRIPTION
This pull request updates the deployment workflow to trigger downstream workflows in multiple repositories after a successful build and deploy. The main improvement is the use of a matrix strategy to automate notifications to several related repositories, streamlining the deployment process.

**Workflow automation improvements:**

* Added a new `dispatch` job that depends on the `build-and-deploy` job and uses a matrix strategy to trigger the `agent-snapshots-deployed` event in four downstream repositories (`embabel/embabel-agent-examples`, `embabel/embabel-agent-experimental`, `embabel/guide`, and `embabel/tripper`) via the `repository-dispatch` action. (.github/workflows/deploy-snapshots.yml)