### PR TITLE
Update list of downstream repos requiring build trigger

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -40,7 +40,6 @@ jobs:
     strategy:
       matrix:
         repo:
-          - embabel/embabel-agent
           - embabel/guide
           - embabel/embabel-agent-examples
           - embabel/vaadin-components
@@ -64,8 +63,6 @@ jobs:
           - embabel/modernizer
           - embabel/ragbot
           - embabel/urbot
-          - embabel/stashbot
-          - embabel/embabel-agent-rag-neo-ogm
     steps:
       - name: Trigger downstream workflow
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow by removing several repositories from the deploy matrix in `.github/workflows/deploy-snapshots.yml`. This means snapshot deployments will no longer be triggered for these repositories. 

Most important changes:

**Deployment matrix updates:**

* Removed `embabel/embabel-agent` from the deployment matrix.
* Removed `embabel/stashbot` and `embabel/embabel-agent-rag-neo-ogm` from the deployment matrix.