### PR TITLE
Add Secured McpServer Starter

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -314,6 +314,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-secured-mcpserver</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-mcpserver</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/embabel-agent-starters/embabel-agent-starter-secured-mcpserver/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-secured-mcpserver/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>0.3.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-starter-secured-mcpserver</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Secured McpServer Starter</name>
+    <description>Embabel Agent Starter Secured MCP Server</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-starter-mcpserver</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-mcp-security</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -24,6 +24,7 @@
         <module>embabel-agent-starter-platform</module>
         <module>embabel-agent-starter-shell</module>
         <module>embabel-agent-starter-observability</module>
+        <module>embabel-agent-starter-secured-mcpserver</module>
         <module>embabel-agent-starter-mcpserver</module>
         <module>embabel-agent-starter-bedrock</module>
         <module>embabel-agent-starter-openai</module>


### PR DESCRIPTION
This pull request introduces a new secured MCP Server starter module to the project. The main focus is on adding the new `embabel-agent-starter-secured-mcpserver` module, updating the build configuration to include it, and ensuring it is available as a dependency for other modules.

**New module addition:**

* Created the `embabel-agent-starter-secured-mcpserver` module, which depends on both `embabel-agent-starter-mcpserver` and `embabel-agent-mcp-security`. This module is defined with its own `pom.xml` and metadata.

**Build configuration updates:**

* Added `embabel-agent-starter-secured-mcpserver` as a module in the parent `embabel-agent-starters/pom.xml` to ensure it is built as part of the project.
* Added `embabel-agent-starter-secured-mcpserver` as a dependency in `embabel-agent-dependencies/pom.xml` so it can be used by other modules as needed.