### PR TITLE
Update onyx usage docs.

### DIFF
--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/autoconfig/ProviderInitialization.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/autoconfig/ProviderInitialization.kt
@@ -18,7 +18,26 @@ package com.embabel.common.ai.autoconfig
 import java.time.Instant
 
 /**
- * Result of LLM initialization process.
+ * Result of model provider initialization.
+ *
+ * Each provider auto-configuration returns a [ProviderInitialization] bean from its
+ * `@Bean` factory method. Inside that factory method, individual [LlmService] and
+ * [EmbeddingService][com.embabel.common.ai.model.EmbeddingService] instances are
+ * registered via [ConfigurableBeanFactory.registerSingleton][org.springframework.beans.factory.config.ConfigurableBeanFactory.registerSingleton],
+ * using the model name as the bean name. This allows dynamic registration of
+ * multiple models per provider, with names driven by configuration rather than
+ * compile-time `@Bean` definitions.
+ *
+ * **Note on direct consumption:** Beans registered via `registerSingleton` are not
+ * visible to Spring's dependency resolver at bean-definition time. This is transparent
+ * in most cases, since framework beans like [ModelProvider] already depend on the
+ * initializer beans and handle resolution internally. However, if application code
+ * outside the framework injects an [EmbeddingService] or [LlmService] directly
+ * (e.g. to wire a custom store), Spring may attempt to resolve the dependency before
+ * the initializer's factory method has run — resulting in a `NoSuchBeanDefinitionException`
+ * even though the bean would have been registered moments later. In this case, add
+ * `@DependsOn` on the corresponding initializer bean
+ * (e.g. `@DependsOn("onnxEmbeddingInitializer")`) to force ordering.
  */
 data class ProviderInitialization(
     val provider: String,

--- a/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
@@ -1264,17 +1264,18 @@ Java::
 +
 [source,java]
 ----
+@DependsOn("onnxEmbeddingInitializer")  // <1>
 @Bean
 DrivineStore drivineStore(
         PersistenceManager persistenceManager,
         EmbeddingService embeddingService,
-        ChunkTransformer chunkTransformer,  // <1>
+        ChunkTransformer chunkTransformer,  // <2>
         MyProperties properties) {
     return new DrivineStore(
         persistenceManager,
         properties.neoRag(),
         properties.chunkerConfig(),
-        chunkTransformer,  // <2>
+        chunkTransformer,  // <3>
         embeddingService,
         platformTransactionManager,
         new DrivineCypherSearch(persistenceManager)
@@ -1286,18 +1287,19 @@ Kotlin::
 +
 [source,kotlin]
 ----
+@DependsOn("onnxEmbeddingInitializer")  // <1>
 @Bean
 fun drivineStore(
     persistenceManager: PersistenceManager,
     embeddingService: EmbeddingService,
-    chunkTransformer: ChunkTransformer,  // <1>
+    chunkTransformer: ChunkTransformer,  // <2>
     properties: MyProperties
 ): DrivineStore {
     return DrivineStore(
         persistenceManager,
         properties.neoRag(),
         properties.chunkerConfig(),
-        chunkTransformer,  // <2>
+        chunkTransformer,  // <3>
         embeddingService,
         platformTransactionManager,
         DrivineCypherSearch(persistenceManager)
@@ -1306,8 +1308,14 @@ fun drivineStore(
 ----
 ====
 
-<1> Inject the `ChunkTransformer` bean
-<2> Pass it to the store constructor
+<1> Ensure the `EmbeddingService` bean is registered before this configuration is wired (see note below)
+<2> Inject the `ChunkTransformer` bean
+<3> Pass it to the store constructor
+
+NOTE: `EmbeddingService` beans are registered dynamically by model provider auto-configurations via `registerSingleton`.
+If your `@Configuration` class injects `EmbeddingService` directly (as above), you should add `@DependsOn` on the provider's initializer bean — e.g. `@DependsOn("onnxEmbeddingInitializer")` for the ONNX provider.
+Without it, Spring may resolve the dependency before the initializer has run, resulting in a `NoSuchBeanDefinitionException`.
+This is only necessary when consuming model beans directly; framework beans like `ModelProvider` handle this internally.
 
 TIP: For most use cases, `AddTitlesChunkTransformer` is all you need.
 It adds essential context that significantly improves retrieval quality without adding complexity.


### PR DESCRIPTION
 ## Summary

  - Document `@DependsOn` requirement when directly injecting model beans (`EmbeddingService`, `LlmService`) registered via `registerSingleton`
  - Update `ProviderInitialization` KDoc to explain the dynamic registration pattern and its implications for consumers
  - Update RAG reference docs with `@DependsOn` in the `DrivineStore` code examples (Java and Kotlin)

  ## Context

  Model provider auto-configurations register beans dynamically via `ConfigurableBeanFactory.registerSingleton()` to support multiple models per provider with configuration-driven names. This is invisible to most consumers since framework beans like `ModelProvider` handle ordering internally.
  However, application code that injects `EmbeddingService` or `LlmService` directly (e.g. wiring a custom `DrivineStore`) will get a `NoSuchBeanDefinitionException` without `@DependsOn`, because Spring resolves the dependency before the initializer's factory method has run.

  Discovered while integrating the ONNX embedding module in [embabel/guide](https://github.com/embabel/guide).

  ## Changes

  | File | Change |
  |------|--------|
  | `embabel-agent-common/embabel-agent-ai/.../ProviderInitialization.kt` | Expanded KDoc: explains `registerSingleton` pattern, when `@DependsOn` is needed, and why |
  | `embabel-agent-docs/.../reference/rag/page.adoc` | Added `@DependsOn("onnxEmbeddingInitializer")` to Java and Kotlin examples; added NOTE explaining the requirement |
