### PR TITLE
Add McpServer Security Autoconfiguration

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-autoconfigure</artifactId>
+        <version>0.3.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-mcpserver-security-autoconfigure</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent MCP Server Security AutoConfiguration</name>
+    <description>Spring Boot AutoConfiguration for Embabel MCP Server Security</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <!-- Main Dependencies -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-mcp-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-config</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/mcpserver/security/AgentMcpServerAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/mcpserver/security/AgentMcpServerAutoConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.mcpserver.secured;
+
+import com.embabel.agent.config.mcpserver.security.SecureAgentToolConfiguration;
+import com.embabel.agent.config.mcpserver.security.SecuredAgentSecurityConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Auto-configuration class for Embabel Agent Secured MCP Server.
+ *
+ * <p>This class imports the configurations for both synchronous and asynchronous
+ * MCP server setups, enabling the necessary components and services for handling
+ * multi-channel processing in the agent.
+ *
+ * @since 3.5
+ */
+@AutoConfiguration
+@ComponentScan(basePackages = "com.embabel.agent.mcpserver")
+@Import({SecureAgentToolConfiguration.class, SecuredAgentSecurityConfiguration.class})
+public class AgentMcpServerAutoConfiguration {
+}

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/kotlin/com/embabel/agent/config/mcpserver/security/SecureAgentToolConfiguration.kt
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/kotlin/com/embabel/agent/config/mcpserver/security/SecureAgentToolConfiguration.kt
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.mcpserver.security
+package com.embabel.agent.config.mcpserver.security
 
+import com.embabel.agent.mcpserver.security.SecureAgentToolAspect
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler
@@ -22,15 +23,15 @@ import org.springframework.security.access.expression.method.MethodSecurityExpre
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 
 /**
- * Spring configuration that wires [SecureAgentToolAspect] into the application context.
+ * Spring configuration that wires [com.embabel.agent.mcpserver.security.SecureAgentToolAspect] into the application context.
  *
  * Enables Spring method security via
  * [@EnableMethodSecurity][org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity],
  * making a [MethodSecurityExpressionHandler][org.springframework.security.access.expression.method.MethodSecurityExpressionHandler]
- * available for [SecureAgentToolAspect] to evaluate SpEL expressions using the same engine
+ * available for [com.embabel.agent.mcpserver.security.SecureAgentToolAspect] to evaluate SpEL expressions using the same engine
  * that powers [@PreAuthorize][org.springframework.security.access.prepost.PreAuthorize].
  *
- * Declares [SecureAgentToolAspect] as an explicit Spring bean rather than relying on
+ * Declares [com.embabel.agent.mcpserver.security.SecureAgentToolAspect] as an explicit Spring bean rather than relying on
  * `@Component` scanning, keeping lifecycle predictable when used as a library dependency.
  *
  * ### Usage
@@ -47,8 +48,8 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
  * > endpoint at the HTTP transport layer, add an `HttpSecurity` configuration that secures
  * > the `/sse` and `/mcp` paths with an OAuth2 resource server or equivalent.
  *
- * @see SecureAgentToolAspect
- * @see SecureAgentTool
+ * @see com.embabel.agent.mcpserver.security.SecureAgentToolAspect
+ * @see com.embabel.agent.mcpserver.security.SecureAgentTool
  */
 @Configuration
 @EnableMethodSecurity
@@ -56,7 +57,7 @@ class SecureAgentToolConfiguration {
 
     /**
      * Provides the [MethodSecurityExpressionHandler][org.springframework.security.access.expression.method.MethodSecurityExpressionHandler]
-     * used by [SecureAgentToolAspect] to evaluate [SecureAgentTool] SpEL expressions.
+     * used by [com.embabel.agent.mcpserver.security.SecureAgentToolAspect] to evaluate [com.embabel.agent.mcpserver.security.SecureAgentTool] SpEL expressions.
      *
      * [DefaultMethodSecurityExpressionHandler][org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler]
      * supports the full Spring Security SpEL vocabulary: `hasAuthority`, `hasRole`,
@@ -70,13 +71,13 @@ class SecureAgentToolConfiguration {
         DefaultMethodSecurityExpressionHandler()
 
     /**
-     * Registers [SecureAgentToolAspect] as a Spring-managed bean.
+     * Registers [com.embabel.agent.mcpserver.security.SecureAgentToolAspect] as a Spring-managed bean.
      *
      * Declared explicitly here rather than via `@Component` on the aspect class to avoid
      * auto-scan surprises when the module is used as a library without full classpath scanning.
      *
-     * @param expressionHandler the [MethodSecurityExpressionHandler][org.springframework.security.access.expression.method.MethodSecurityExpressionHandler]
-     * used to evaluate SpEL expressions declared in [SecureAgentTool.value]
+     * @param expressionHandler the [MethodSecurityExpressionHandler][MethodSecurityExpressionHandler]
+     * used to evaluate SpEL expressions declared in [com.embabel.agent.mcpserver.security.SecureAgentTool.value]
      */
     @Bean
     fun secureAgentToolAspect(

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/kotlin/com/embabel/agent/config/mcpserver/security/SecuredAgentSecurityConfiguration.kt
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/kotlin/com/embabel/agent/config/mcpserver/security/SecuredAgentSecurityConfiguration.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.mcpserver.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+import org.springframework.security.web.SecurityFilterChain
+
+/**
+ * Security configuration for MCP endpoints, active only when the `secured` Spring profile is set.
+ *
+ * Requires a valid JWT bearer token on all requests to `/sse/`, `/mcp/`, and `/message/`.
+ * Sessions are stateless — no HTTP session is created or consulted between calls.
+ *
+ * Per-tool authority checks are enforced via `@SecureAgentTool` on `@AchievesGoal` actions.
+ *
+ * JWT authorities are read from the `authorities` claim with no prefix applied, so a claim
+ * value such as `"TOOL_search"` maps directly to the Spring Security granted authority
+ * `"TOOL_search"`.
+ */
+@Configuration
+@EnableWebSecurity
+class SecuredAgentSecurityConfiguration {
+
+    /**
+     * Registers a [SecurityFilterChain] that protects all MCP-related endpoints.
+     *
+     * - All requests to `/sse/`, `/mcp/`, and `/message/` must be authenticated.
+     * - Session creation policy is [SessionCreationPolicy.STATELESS].
+     * - OAuth2 resource server JWT validation delegates to [jwtAuthenticationConverter].
+     * - CSRF protection is disabled (appropriate for stateless, token-based APIs).
+     *
+     * @param http the [HttpSecurity] builder to configure
+     * @return the built [SecurityFilterChain]
+     */
+    @Bean
+    fun securedFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .securityMatcher("/sse/**", "/mcp/**", "/message/**")
+            .authorizeHttpRequests { auth ->
+                auth.anyRequest().authenticated()
+            }
+            .sessionManagement { session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+            .oauth2ResourceServer { oauth2 ->
+                oauth2.jwt { jwt ->
+                    jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())
+                }
+            }
+            .csrf { it.disable() }
+        return http.build()
+    }
+
+    /**
+     * Produces a [JwtAuthenticationConverter] that extracts granted authorities from the
+     * `authorities` claim in the JWT payload.
+     *
+     * No authority prefix is applied, so claim values map directly to Spring Security
+     * granted authorities without modification.
+     *
+     * @return the configured [JwtAuthenticationConverter]
+     */
+    @Bean
+    fun jwtAuthenticationConverter(): JwtAuthenticationConverter {
+        val authoritiesConverter = JwtGrantedAuthoritiesConverter().apply {
+            setAuthoritiesClaimName("authorities")
+            setAuthorityPrefix("")
+        }
+        return JwtAuthenticationConverter().apply {
+            setJwtGrantedAuthoritiesConverter(authoritiesConverter)
+        }
+    }
+}

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2025-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.embabel.agent.autoconfigure.mcpserver.security.AgentMcpServerAutoConfiguration

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/test/kotlin/com/embabel/agent/mcpserver/security/SecureAgentToolAspectIntegrationTest.kt
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/test/kotlin/com/embabel/agent/mcpserver/security/SecureAgentToolAspectIntegrationTest.kt
@@ -15,13 +15,9 @@
  */
 package com.embabel.agent.mcpserver.security
 
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
+import com.embabel.agent.config.mcpserver.security.SecureAgentToolConfiguration
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.*
 import org.springframework.aop.framework.AopProxyUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Bean
@@ -96,7 +92,7 @@ class SecureAgentToolAspectIntegrationTest {
     fun `agent bean is a Spring AOP proxy, not a plain instance`() {
         // Confirms CGLIB proxying is active - if this fails, no advice will fire
         val targetClass = AopProxyUtils.ultimateTargetClass(agent)
-        assertThat(agent.javaClass).isNotEqualTo(targetClass)
+        Assertions.assertThat(agent.javaClass).isNotEqualTo(targetClass)
     }
 
     @Nested
@@ -106,13 +102,13 @@ class SecureAgentToolAspectIntegrationTest {
         @Test
         fun `grants access when principal has required authority`() {
             authenticateWith("payments:write")
-            assertThat(agent.processPayment()).isEqualTo("payment-processed")
+            Assertions.assertThat(agent.processPayment()).isEqualTo("payment-processed")
         }
 
         @Test
         fun `denies access when principal has wrong authority`() {
             authenticateWith("payments:read")
-            assertThatThrownBy { agent.processPayment() }
+            Assertions.assertThatThrownBy { agent.processPayment() }
                 .isInstanceOf(AccessDeniedException::class.java)
                 .hasMessageContaining("processPayment")
                 .hasMessageContaining("integration-user")
@@ -121,7 +117,7 @@ class SecureAgentToolAspectIntegrationTest {
         @Test
         fun `denies access when SecurityContext is empty`() {
             // No authentication set at all
-            assertThatThrownBy { agent.processPayment() }
+            Assertions.assertThatThrownBy { agent.processPayment() }
                 .isInstanceOf(AccessDeniedException::class.java)
                 .hasMessageContaining("No Authentication present")
         }
@@ -134,19 +130,19 @@ class SecureAgentToolAspectIntegrationTest {
         @Test
         fun `grants access with first matching authority`() {
             authenticateWith("finance:read")
-            assertThat(agent.getBalance()).isEqualTo("balance-result")
+            Assertions.assertThat(agent.getBalance()).isEqualTo("balance-result")
         }
 
         @Test
         fun `grants access with second matching authority`() {
             authenticateWith("finance:admin")
-            assertThat(agent.getBalance()).isEqualTo("balance-result")
+            Assertions.assertThat(agent.getBalance()).isEqualTo("balance-result")
         }
 
         @Test
         fun `denies access with unrelated authority`() {
             authenticateWith("payments:write")
-            assertThatThrownBy { agent.getBalance() }
+            Assertions.assertThatThrownBy { agent.getBalance() }
                 .isInstanceOf(AccessDeniedException::class.java)
         }
     }
@@ -158,13 +154,13 @@ class SecureAgentToolAspectIntegrationTest {
         @Test
         fun `grants access when principal carries ROLE_ prefixed authority`() {
             authenticateWith("ROLE_ADMIN")
-            assertThat(agent.adminOperation()).isEqualTo("admin-result")
+            Assertions.assertThat(agent.adminOperation()).isEqualTo("admin-result")
         }
 
         @Test
         fun `denies access when ROLE_ prefix is missing`() {
             authenticateWith("ADMIN")
-            assertThatThrownBy { agent.adminOperation() }
+            Assertions.assertThatThrownBy { agent.adminOperation() }
                 .isInstanceOf(AccessDeniedException::class.java)
         }
     }
@@ -176,14 +172,14 @@ class SecureAgentToolAspectIntegrationTest {
         @Test
         fun `passes through with authentication present`() {
             authenticateWith("any:authority")
-            assertThat(agent.unprotectedOperation()).isEqualTo("unprotected-result")
+            Assertions.assertThat(agent.unprotectedOperation()).isEqualTo("unprotected-result")
         }
 
         @Test
         fun `passes through with no authentication - aspect must not fire`() {
             // Critical: if the aspect incorrectly intercepts unannotated methods
             // this call would throw AccessDeniedException
-            assertThat(agent.unprotectedOperation()).isEqualTo("unprotected-result")
+            Assertions.assertThat(agent.unprotectedOperation()).isEqualTo("unprotected-result")
         }
     }
 
@@ -194,13 +190,13 @@ class SecureAgentToolAspectIntegrationTest {
         @Test
         fun `grants access when one of multiple carried authorities matches`() {
             authenticateWith("payments:read", "payments:write", "finance:read")
-            assertThat(agent.processPayment()).isEqualTo("payment-processed")
+            Assertions.assertThat(agent.processPayment()).isEqualTo("payment-processed")
         }
 
         @Test
         fun `denies access when none of multiple carried authorities match`() {
             authenticateWith("reporting:read", "audit:read")
-            assertThatThrownBy { agent.processPayment() }
+            Assertions.assertThatThrownBy { agent.processPayment() }
                 .isInstanceOf(AccessDeniedException::class.java)
         }
     }

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -25,6 +25,7 @@
         <module>embabel-agent-shell-autoconfigure</module>
         <module>embabel-agent-observability-autoconfigure</module>
         <module>embabel-agent-mcpserver-autoconfigure</module>
+        <module>embabel-agent-mcpserver-security-autoconfigure</module>
         <module>embabel-agent-netty-client-autoconfigure</module>
         <module>models/embabel-agent-bedrock-autoconfigure</module>
         <module>models/embabel-agent-openai-autoconfigure</module>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -98,6 +98,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-mcpserver-security-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-netty-client-autoconfigure</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -314,7 +320,7 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
-                <artifactId>embabel-agent-starter-secured-mcpserver</artifactId>
+                <artifactId>embabel-agent-starter-mcpserver-security</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/embabel-agent-mcp/embabel-agent-mcp-security/pom.xml
+++ b/embabel-agent-mcp/embabel-agent-mcp-security/pom.xml
@@ -23,20 +23,13 @@
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
-            <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-config</artifactId>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
 

--- a/embabel-agent-starters/embabel-agent-starter-mcpserver-security/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-mcpserver-security/pom.xml
@@ -6,10 +6,10 @@
         <artifactId>embabel-agent-starters</artifactId>
         <version>0.3.5-SNAPSHOT</version>
     </parent>
-    <artifactId>embabel-agent-starter-secured-mcpserver</artifactId>
+    <artifactId>embabel-agent-starter-mcpserver-security</artifactId>
     <packaging>jar</packaging>
-    <name>Embabel Agent Secured McpServer Starter</name>
-    <description>Embabel Agent Starter Secured MCP Server</description>
+    <name>Embabel Agent Secured McpServer Security Starter</name>
+    <description>Embabel Agent Starter MCP Server Security</description>
     <url>https://github.com/embabel/embabel-agent</url>
 
     <scm>
@@ -22,12 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-starter-mcpserver</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-mcp-security</artifactId>
+            <artifactId>embabel-agent-mcpserver-security-autoconfigure</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -24,8 +24,8 @@
         <module>embabel-agent-starter-platform</module>
         <module>embabel-agent-starter-shell</module>
         <module>embabel-agent-starter-observability</module>
-        <module>embabel-agent-starter-secured-mcpserver</module>
         <module>embabel-agent-starter-mcpserver</module>
+        <module>embabel-agent-starter-mcpserver-security</module>
         <module>embabel-agent-starter-bedrock</module>
         <module>embabel-agent-starter-openai</module>
         <module>embabel-agent-starter-openai-custom</module>


### PR DESCRIPTION
This pull request introduces a new Spring Boot auto-configuration module for securing Embabel MCP server endpoints and refactors existing security configuration code into a reusable library module. The changes include new auto-configuration and security classes, dependency declarations, and updates to tests and package structure.

The most important changes are:

**New Auto-Configuration Module:**
- Added a new Maven module `embabel-agent-mcpserver-security-autoconfigure` with its own `pom.xml`, declaring dependencies on Spring Security and the core security logic.
- Introduced `AgentMcpServerAutoConfiguration` as the entry point for auto-configuration, importing security configuration classes and enabling component scanning for MCP server packages.
- Registered the auto-configuration in the `org.springframework.boot.autoconfigure.AutoConfiguration.imports` metadata file for Spring Boot discovery.

**Security Configuration Enhancements:**
- Added `SecuredAgentSecurityConfiguration` to enforce JWT-based stateless security on `/sse/`, `/mcp/`, and `/message/` endpoints, extracting authorities from the JWT `authorities` claim with no prefix.
- Refactored `SecureAgentToolConfiguration` and related classes to a new package (`com.embabel.agent.config.mcpserver.security`), updating documentation and import paths for clarity and modularity. [[1]](diffhunk://#diff-97bba2a5c8ffad691138422289e77ac368565c29f4fc7c0c49c719428bb884d9L16-R34) [[2]](diffhunk://#diff-97bba2a5c8ffad691138422289e77ac368565c29f4fc7c0c49c719428bb884d9L50-R60) [[3]](diffhunk://#diff-97bba2a5c8ffad691138422289e77ac368565c29f4fc7c0c49c719428bb884d9L73-R80)

**Test and Codebase Updates:**
- Updated integration tests to use the new configuration package and refactored static assertions for consistency. [[1]](diffhunk://#diff-258b725d8fc43805041bef901fe27110b9be7e36f91043f059f936cb01577bd1L18-R20) [[2]](diffhunk://#diff-258b725d8fc43805041bef901fe27110b9be7e36f91043f059f936cb01577bd1L99-R95) [[3]](diffhunk://#diff-258b725d8fc43805041bef901fe27110b9be7e36f91043f059f936cb01577bd1L109-R111) [[4]](diffhunk://#diff-258b725d8fc43805041bef901fe27110b9be7e36f91043f059f936cb01577bd1L124-R120) [[5]](diffhunk://#diff-258b725d8fc43805041bef901fe27110b9be7e36f91043f059f936cb01577bd1L137-R145) [[6]](diffhunk://#diff-258b725d8fc43805041bef901fe27110b9be7e36f91043f059f936cb01577bd1L161-R163) [[7]](diffhunk://#diff-258b725d8fc43805041bef901fe27110b9be7e36f91043f059f936cb01577bd1L179-R182) [[8]](diffhunk://#diff-258b725d8fc43805041bef901fe27110b9be7e36f91043f059f936cb01577bd1L197-R199)