### PR TITLE
Consistent Package Names in McpServer Security Module

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/mcpserver/security/AgentMcpServerAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/mcpserver/security/AgentMcpServerAutoConfiguration.java
@@ -16,7 +16,7 @@
 package com.embabel.agent.autoconfigure.mcpserver.security;
 
 import com.embabel.agent.config.mcpserver.security.SecureAgentToolConfiguration;
-import com.embabel.agent.config.mcpserver.security.SecuredAgentSecurityConfiguration;
+import com.embabel.agent.config.mcpserver.security.SecureAgentSecurityConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
@@ -32,6 +32,6 @@ import org.springframework.context.annotation.Import;
  */
 @AutoConfiguration
 @ComponentScan(basePackages = "com.embabel.agent.mcpserver")
-@Import({SecureAgentToolConfiguration.class, SecuredAgentSecurityConfiguration.class})
+@Import({SecureAgentToolConfiguration.class, SecureAgentSecurityConfiguration.class})
 public class AgentMcpServerAutoConfiguration {
 }

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/kotlin/com/embabel/agent/config/mcpserver/security/SecureAgentSecurityConfiguration.kt
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/main/kotlin/com/embabel/agent/config/mcpserver/security/SecureAgentSecurityConfiguration.kt
@@ -38,7 +38,7 @@ import org.springframework.security.web.SecurityFilterChain
  */
 @Configuration
 @EnableWebSecurity
-class SecuredAgentSecurityConfiguration {
+class SecureAgentSecurityConfiguration {
 
     /**
      * Registers a [SecurityFilterChain] that protects all MCP-related endpoints.


### PR DESCRIPTION
This pull request primarily corrects naming inconsistencies in the security configuration for the MCP server agent. The main focus is on standardizing the use of "Secure" instead of "Secured" in class and package names, and updating all relevant imports and references accordingly.

**Package and class renaming:**

* Changed the package name from `com.embabel.agent.autoconfigure.mcpserver.secured` to `com.embabel.agent.autoconfigure.mcpserver.security` in `AgentMcpServerAutoConfiguration.java` to align with the correct naming convention.
* Renamed the configuration class from `SecuredAgentSecurityConfiguration` to `SecureAgentSecurityConfiguration` and updated all imports and references to use the new name. [[1]](diffhunk://#diff-2dd8b9e95432b337d0b91e9c63df9aaa0e034a8ba8f82e84a03a348c28e9351fL16-R19) [[2]](diffhunk://#diff-2dd8b9e95432b337d0b91e9c63df9aaa0e034a8ba8f82e84a03a348c28e9351fL35-R35) [[3]](diffhunk://#diff-304d72d06cc52e57c3e345246bc225512b128214d3324191dfbb67026657b741L41-R41)

These changes help maintain consistency in naming across the codebase and prevent potential confusion or import errors.