### PR TITLE
Fix onxy module Netty config

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-onnx-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/onnx/embeddings/OnnxEmbeddingAutoConfiguration.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-onnx-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/onnx/embeddings/OnnxEmbeddingAutoConfiguration.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.onnx.embeddings.OnnxEmbeddingService
 import com.embabel.common.ai.autoconfig.ProviderInitialization
 import com.embabel.common.ai.autoconfig.RegisteredModel
 import jakarta.annotation.PreDestroy
+import java.net.http.HttpClient
 import java.nio.file.Path
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
@@ -31,6 +32,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.JdkClientHttpRequestFactory
 import org.springframework.web.client.RestClient
 
 /**
@@ -41,9 +43,10 @@ import org.springframework.web.client.RestClient
  * via [ConfigurableBeanFactory.registerSingleton] so the bean name
  * matches the model name used in [ProviderInitialization].
  *
- * Uses the shared `aiModelHttpRequestFactory` (if available) for model
- * downloads, consistent with other providers. Falls back to default
- * JDK-based `RestClient` when the factory bean is absent.
+ * Uses the shared `aiModelHttpRequestFactory` (Netty-backed, if available) for model
+ * downloads, consistent with other providers. Falls back to a [JdkClientHttpRequestFactory]
+ * configured with [HttpClient.Redirect.NORMAL] so that HuggingFace CDN redirects are
+ * followed even when no other starter brings Netty onto the classpath.
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(OnnxEmbeddingService::class)
@@ -68,7 +71,15 @@ class OnnxEmbeddingAutoConfiguration(
     fun onnxEmbeddingInitializer(properties: OnnxEmbeddingProperties): ProviderInitialization {
         val cacheDir = Path.of(properties.cacheDir, properties.modelName)
         val restClient = RestClient.builder()
-            .also { b -> requestFactory.ifAvailable { b.requestFactory(it) } }
+            .requestFactory(
+                requestFactory.getIfAvailable {
+                    JdkClientHttpRequestFactory(
+                        HttpClient.newBuilder()
+                            .followRedirects(HttpClient.Redirect.NORMAL)
+                            .build()
+                    )
+                }
+            )
             .build()
         val modelPath = OnnxModelLoader.resolve(properties.modelUri, cacheDir, "model.onnx", restClient)
         val tokenizerPath = OnnxModelLoader.resolve(properties.tokenizerUri, cacheDir, "tokenizer.json", restClient)

--- a/embabel-agent-starters/embabel-agent-starter-onnx/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-onnx/pom.xml
@@ -28,10 +28,6 @@
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-onnx-autoconfigure</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-netty-client-autoconfigure</artifactId>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
## Fix ONNX model download failure in CI

### Problem

The [Export Seed Database](https://github.com/embabel/guide/actions/runs/23477834784) workflow fails because OnnxModelLoader downloads truncated files from HuggingFace (1KB instead of ~30MB), causing an ORT_INVALID_PROTOBUF crash on startup. _(Currently has workaround applied: Pre-download using curl)_

### Context

`OnnxEmbeddingAutoConfiguration` previously used the default JDK `RestClient` because Reactor Netty didn't follow redirects, and HuggingFace serves model files via 302 redirects to CDN URLs. Since then, NettyClientAutoConfiguration was updated with `.followRedirect(true)` — but the ONNX config was never updated to use it.

This worked locally because other starters on the classpath (e.g. OpenAI, Anthropic) pull in the netty module transitively. In CI — or any deployment where embabel-agent-starter-onnx is the only starter making HTTP downloads — the netty factory was absent, so `RestClient` fell back to the default JDK HttpURLConnection client, which doesn't follow HuggingFace's cross-origin CDN redirects.

### Fix

Two changes to wire ONNX downloads through the shared netty-backed HTTP client:

1. Add `@Qualifier("aiModelHttpRequestFactory")` to OnnxEmbeddingAutoConfiguration's requestFactory parameter — matching Anthropic, OpenAI, and Ollama configs. Without this, Spring may not inject the netty-backed factory even when it's available.
2. Add `embabel-agent-netty-client-autoconfigure` dependency to `embabel-agent-starter-onnx` — ensures the netty module is on the classpath even when no other starter brings it in.