### PR TITLE
Collect all validation error codes

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/validation/DefaultAgentStructureValidator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/validation/DefaultAgentStructureValidator.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.api.annotation.Agent
 import com.embabel.agent.api.annotation.Condition
 import com.embabel.agent.core.AgentScope
 import com.embabel.common.core.validation.ValidationError
+import com.embabel.common.core.validation.ValidationErrorCodes
 import com.embabel.common.core.validation.ValidationLocation
 import com.embabel.common.core.validation.ValidationResult
 import com.embabel.common.core.validation.ValidationSeverity
@@ -60,7 +61,7 @@ class DefaultAgentStructureValidator(
 
             if (actionMethods.isEmpty() && conditionMethods.isEmpty() && !hasGoals) {
                 val error = ValidationError(
-                    code = "EMPTY_AGENT_STRUCTURE",
+                    code = ValidationErrorCodes.EMPTY_AGENT_STRUCTURE,
                     message = "Agent class '${clazz.name}' has no @Action or @Condition methods and no goals defined. This agent will NOT be registered!",
                     severity = ValidationSeverity.ERROR,
                     location = ValidationLocation(
@@ -82,7 +83,7 @@ class DefaultAgentStructureValidator(
         if (agentScope.actions.isEmpty() && agentScope.conditions.isEmpty() && agentScope.goals.isEmpty()) {
             errors.add(
                 ValidationError(
-                    code = "EMPTY_AGENT_STRUCTURE",
+                    code = ValidationErrorCodes.EMPTY_AGENT_STRUCTURE,
                     message = "Agent '${agentScope.name}' has no actions, conditions, or goals defined",
                     severity = ValidationSeverity.ERROR,
                     location = ValidationLocation(
@@ -99,7 +100,7 @@ class DefaultAgentStructureValidator(
         if (agentScope.goals.isEmpty()) {
             errors.add(
                 ValidationError(
-                    code = "MISSING_GOALS",
+                    code = ValidationErrorCodes.MISSING_GOALS,
                     message = "Agent '${agentScope.name}' must have at least one goal defined",
                     severity = ValidationSeverity.ERROR,
                     location = ValidationLocation(
@@ -116,7 +117,7 @@ class DefaultAgentStructureValidator(
         agentScope.actions.groupBy { it.name }.filter { it.value.size > 1 }.forEach { (name, _) ->
             errors.add(
                 ValidationError(
-                    code = "DUPLICATE_ACTION_NAME",
+                    code = ValidationErrorCodes.DUPLICATE_ACTION_NAME,
                     message = "Agent '${agentScope.name}' has more than one action named '$name'",
                     severity = ValidationSeverity.ERROR,
                     location = ValidationLocation(
@@ -141,7 +142,7 @@ class DefaultAgentStructureValidator(
             if (preconditionsWithMultipleParams) {
                 errors.add(
                     ValidationError(
-                        code = "INVALID_ACTION_SIGNATURE",
+                        code = ValidationErrorCodes.INVALID_ACTION_SIGNATURE,
                         message = "Action '${action.name}' has preconditions with multiple parameters",
                         severity = ValidationSeverity.ERROR,
                         location = ValidationLocation(
@@ -163,7 +164,7 @@ class DefaultAgentStructureValidator(
             if (method?.parameterCount ?: 0 > 1) {
                 errors.add(
                     ValidationError(
-                        code = "INVALID_CONDITION_SIGNATURE",
+                        code = ValidationErrorCodes.INVALID_CONDITION_SIGNATURE,
                         message = "Condition '${condition.name}' must have at most one parameter",
                         severity = ValidationSeverity.ERROR,
                         location = ValidationLocation(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/validation/GoapPathToCompletionValidator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/validation/GoapPathToCompletionValidator.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.spi.validation
 import com.embabel.agent.core.AgentScope
 import com.embabel.agent.core.support.Rerun.HAS_RUN_CONDITION_PREFIX
 import com.embabel.common.core.validation.ValidationError
+import com.embabel.common.core.validation.ValidationErrorCodes
 import com.embabel.common.core.validation.ValidationLocation
 import com.embabel.common.core.validation.ValidationResult
 import com.embabel.common.core.validation.ValidationSeverity
@@ -47,7 +48,13 @@ class GoapPathToCompletionValidator : PathToCompletionAgentValidator {
         }
 
         if (agentScope.actions.isEmpty()) {
-            errors.add(error("NO_ACTIONS_TO_GOALS", "Agent '${agentScope.name}' has no actions.", agentScope))
+            errors.add(
+                error(
+                    ValidationErrorCodes.NO_ACTIONS_TO_GOALS,
+                    "Agent '${agentScope.name}' has no actions.",
+                    agentScope
+                )
+            )
             return ValidationResult(false, errors)
         }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/core/validation/ValidationErrorCodes.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/core/validation/ValidationErrorCodes.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.core.validation
+
+/**
+ * Well-known error codes used in [ValidationError] instances produced by the built-in validators.
+ */
+class ValidationErrorCodes {
+    companion object {
+        /** Agent class has no @Action or @Condition methods and no goals defined. */
+        const val EMPTY_AGENT_STRUCTURE = "EMPTY_AGENT_STRUCTURE"
+
+        /** Agent has no goals, so it can never be considered complete. */
+        const val MISSING_GOALS = "MISSING_GOALS"
+
+        /** Two or more actions in the same agent share the same name, typically caused by overloaded @Action methods. */
+        const val DUPLICATE_ACTION_NAME = "DUPLICATE_ACTION_NAME"
+
+        /** An action has preconditions whose backing methods take more than one parameter. */
+        const val INVALID_ACTION_SIGNATURE = "INVALID_ACTION_SIGNATURE"
+
+        /** A condition method takes more than one parameter. */
+        const val INVALID_CONDITION_SIGNATURE = "INVALID_CONDITION_SIGNATURE"
+
+        /** Agent has goals but no actions, so no plan can ever reach them. */
+        const val NO_ACTIONS_TO_GOALS = "NO_ACTIONS_TO_GOALS"
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/DefaultAgentStructureValidatorTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/DefaultAgentStructureValidatorTest.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.api.annotation.support.AgentMetadataReader
 import com.embabel.agent.api.annotation.support.AgentWithDuplicateActionNames
 import com.embabel.agent.api.dsl.evenMoreEvilWizard
 import com.embabel.agent.spi.validation.DefaultAgentStructureValidator
+import com.embabel.common.core.validation.ValidationErrorCodes
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
@@ -59,7 +60,7 @@ class DefaultAgentStructureValidatorTest {
             val result = validator().validate(agentScope)
 
             assertTrue(
-                result.errors.any { it.code == "DUPLICATE_ACTION_NAME" },
+                result.errors.any { it.code == ValidationErrorCodes.DUPLICATE_ACTION_NAME },
                 "Expected a DUPLICATE_ACTION_NAME validation error, but got: ${result.errors}",
             )
         }


### PR DESCRIPTION
This PR collects all validation error codes into ValidationErrorCodes.kt.

I opted to use a constant class instead of an enum because validation error codes are not a closed set: any future validator would need to modify a central enum just to introduce new codes. There's also no real benefit to exhaustive `when` matching here, since callers typically filter by code to find specific errors rather than switching over all possible values.

Closes: gh-1533