### PR TITLE
Bring your own key : clean API

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/ByokFactory.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/ByokFactory.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi
+
+/**
+ * A self-contained spec that can validate an API key and return a ready [LlmService].
+ *
+ * Each instance encapsulates the provider endpoint, credentials, and the model to use for
+ * the validation probe. Implementations throw [InvalidApiKeyException] on failure so callers
+ * never need to unwrap provider-specific error types.
+ *
+ * Implementations are provided by:
+ * - [com.embabel.agent.config.models.anthropic.AnthropicModelFactory] — Anthropic
+ * - [com.embabel.agent.openai.OpenAiCompatibleModelFactory.ByokSpec] — OpenAI-compatible providers
+ *   (OpenAI, DeepSeek, Mistral, Gemini, and custom providers)
+ *
+ * Pass one or more instances to [detectProvider] to race them concurrently.
+ */
+fun interface ByokFactory {
+    /**
+     * Validates the configured API key with a single probe call and returns a production
+     * [LlmService] on success.
+     *
+     * @throws InvalidApiKeyException if the key is invalid or the provider is unreachable.
+     */
+    fun buildValidated(): LlmService<*>
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/InvalidApiKeyException.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/InvalidApiKeyException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi
+
+/**
+ * Thrown when an API key is invalid or not recognised by any supported provider.
+ * Surfaces through [detectProvider] and the factory [buildValidated] methods without
+ * leaking any provider-specific (e.g. Spring AI) exception types to callers.
+ */
+class InvalidApiKeyException(message: String) : RuntimeException(message)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/ProviderDetection.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/ProviderDetection.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi
+
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+
+/**
+ * Concurrently attempts each candidate [ByokFactory] and returns the first [LlmService]
+ * that validates successfully. Remaining tasks are cancelled on first success.
+ *
+ * Typical usage — sign-up flow (fan-out across all supported BYOK providers):
+ * ```kotlin
+ * val service = detectProvider(
+ *     AnthropicModelFactory(apiKey = userKey),
+ *     OpenAiCompatibleModelFactory.openAi(userKey),
+ *     OpenAiCompatibleModelFactory.deepSeek(userKey),
+ *     OpenAiCompatibleModelFactory.mistral(userKey),
+ *     OpenAiCompatibleModelFactory.gemini(userKey),
+ * )
+ * val detectedProvider = service.provider
+ * ```
+ *
+ * Typical usage — settings flow (single known provider):
+ * ```kotlin
+ * val service = detectProvider(AnthropicModelFactory(apiKey = userKey))
+ * ```
+ *
+ * @param candidates One or more [ByokFactory] instances to race.
+ * @return The [LlmService] returned by the first successful factory.
+ *   Call [LlmService.provider] on the result to retrieve the detected provider name.
+ * @throws InvalidApiKeyException if all candidates fail or no candidates are supplied.
+ */
+fun detectProvider(vararg candidates: ByokFactory): LlmService<*> {
+    if (candidates.isEmpty()) {
+        throw InvalidApiKeyException("Key not valid for any supported provider")
+    }
+    val exec = Executors.newVirtualThreadPerTaskExecutor()
+    try {
+        return exec.invokeAny(
+            candidates.map { factory -> Callable { factory.buildValidated() } }
+        )
+    } catch (e: ExecutionException) {
+        throw InvalidApiKeyException("Key not valid for any supported provider")
+    } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        throw InvalidApiKeyException("Key not valid for any supported provider")
+    } finally {
+        exec.shutdown()
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/DetectProviderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/DetectProviderTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi
+
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DetectProviderTest {
+
+    private val mockService = mockk<LlmService<*>>()
+
+    @Test
+    fun `only successful candidate is returned`() {
+        val result = detectProvider(
+            ByokFactory { throw InvalidApiKeyException("bad key") },
+            ByokFactory { mockService },
+        )
+        assertSame(mockService, result)
+    }
+
+    @Test
+    fun `all candidates fail throws InvalidApiKeyException`() {
+        assertThrows<InvalidApiKeyException> {
+            detectProvider(
+                ByokFactory { throw InvalidApiKeyException("bad") },
+                ByokFactory { throw InvalidApiKeyException("bad") },
+                ByokFactory { throw InvalidApiKeyException("bad") },
+                ByokFactory { throw InvalidApiKeyException("bad") },
+            )
+        }
+    }
+
+    @Test
+    fun `single candidate returns service - settings flow`() {
+        val result = detectProvider(ByokFactory { mockService })
+        assertSame(mockService, result)
+    }
+
+    @Test
+    fun `no candidates throws InvalidApiKeyException`() {
+        assertThrows<InvalidApiKeyException> {
+            detectProvider()
+        }
+    }
+
+    @Test
+    fun `returned service is the one from the winning factory`() {
+        val anthropicService = mockk<LlmService<*>>()
+        val result = detectProvider(
+            ByokFactory { anthropicService },
+            ByokFactory { throw InvalidApiKeyException("bad") },
+        )
+        assertSame(anthropicService, result)
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelFactory.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelFactory.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.anthropic
+
+import com.embabel.agent.api.models.AnthropicModels
+import com.embabel.agent.spi.ByokFactory
+import com.embabel.agent.spi.InvalidApiKeyException
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.chat.UserMessage
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.util.ObjectProviders
+import io.micrometer.observation.ObservationRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.ai.anthropic.AnthropicChatModel
+import org.springframework.ai.anthropic.AnthropicChatOptions
+import org.springframework.ai.anthropic.api.AnthropicApi
+import org.springframework.ai.model.tool.ToolCallingManager
+import org.springframework.ai.retry.RetryUtils
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import org.springframework.retry.support.RetryTemplate
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * Builds Anthropic [LlmService] instances from a raw API key.
+ *
+ * Intended as the BYOK entry point for Anthropic: no Spring context required.
+ * [AnthropicModelsConfig] extends this class and delegates API client construction to it.
+ *
+ * Implements [ByokFactory] so instances can be passed directly to [com.embabel.agent.spi.detectProvider]:
+ * ```kotlin
+ * detectProvider(
+ *     AnthropicModelFactory(apiKey = userKey),
+ *     OpenAiCompatibleModelFactory.openAi(userKey),
+ * )
+ * ```
+ *
+ * To override the model used for key validation (e.g. if the key only grants access to
+ * a specific set of models):
+ * ```kotlin
+ * AnthropicModelFactory(apiKey = userKey, validationModel = AnthropicModels.CLAUDE_SONNET_4_5)
+ * ```
+ *
+ * @param apiKey Anthropic API key.
+ * @param baseUrl Optional base URL override; defaults to the standard Anthropic endpoint.
+ * @param validationModel Model used for the key-validation probe. Defaults to [VALIDATION_MODEL].
+ * @param observationRegistry Micrometer registry for HTTP client instrumentation.
+ * @param requestFactory Optional HTTP request factory (e.g. for custom timeouts).
+ */
+open class AnthropicModelFactory(
+    private val apiKey: String,
+    private val baseUrl: String? = null,
+    private val validationModel: String = VALIDATION_MODEL,
+    protected val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
+    private val requestFactory: ObjectProvider<ClientHttpRequestFactory> = ObjectProviders.empty(),
+) : ByokFactory {
+
+    protected val logger = LoggerFactory.getLogger(javaClass)
+
+    companion object {
+        /** Default model used for key validation probes — cheapest available. */
+        const val VALIDATION_MODEL = AnthropicModels.CLAUDE_HAIKU_4_5
+
+        private const val CONNECT_TIMEOUT_MS = 5000
+        private const val READ_TIMEOUT_MS = 600000
+
+        private val PASS_THROUGH_RETRY_TEMPLATE: RetryTemplate =
+            RetryTemplate.builder().maxAttempts(1).build()
+    }
+
+    /**
+     * Builds an [AnthropicApi] client from the configured credentials.
+     * Protected so that [AnthropicModelsConfig] can reuse it for its own model wiring.
+     */
+    protected fun createAnthropicApi(): AnthropicApi {
+        val builder = AnthropicApi.builder().apiKey(apiKey)
+        if (!baseUrl.isNullOrBlank()) {
+            logger.info("Using custom Anthropic base URL: {}", baseUrl)
+            builder.baseUrl(baseUrl)
+        }
+        builder.restClientBuilder(
+            RestClient.builder()
+                .requestFactory(requestFactory.getIfAvailable {
+                    SimpleClientHttpRequestFactory().apply {
+                        setConnectTimeout(CONNECT_TIMEOUT_MS)
+                        setReadTimeout(READ_TIMEOUT_MS)
+                    }
+                })
+                .observationRegistry(observationRegistry)
+        )
+        builder.webClientBuilder(
+            WebClient.builder().observationRegistry(observationRegistry)
+        )
+        return builder.build()
+    }
+
+    /**
+     * Builds an [LlmService] for the given Anthropic model.
+     *
+     * @param model Model identifier, e.g. [AnthropicModels.CLAUDE_HAIKU_4_5].
+     * @param retryTemplate Retry policy; defaults to Spring AI's standard retry template.
+     */
+    fun build(
+        model: String,
+        retryTemplate: RetryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE,
+    ): LlmService<*> {
+        val chatModel = AnthropicChatModel.builder()
+            .defaultOptions(AnthropicChatOptions.builder().model(model).build())
+            .anthropicApi(createAnthropicApi())
+            .toolCallingManager(
+                ToolCallingManager.builder().observationRegistry(observationRegistry).build()
+            )
+            .retryTemplate(retryTemplate)
+            .observationRegistry(observationRegistry)
+            .build()
+
+        return SpringAiLlmService(
+            name = model,
+            chatModel = chatModel,
+            provider = AnthropicModels.PROVIDER,
+            optionsConverter = AnthropicOptionsConverter,
+        )
+    }
+
+    /**
+     * Validates the API key using [validationModel] (set at construction time), then returns
+     * a production [LlmService]. Satisfies [ByokFactory] for use with [com.embabel.agent.spi.detectProvider].
+     *
+     * @throws InvalidApiKeyException if the key is invalid.
+     */
+    override fun buildValidated(): LlmService<*> = buildValidated(validationModel)
+
+    /**
+     * Validates the API key with a probe call on the given [model], then returns a production
+     * [LlmService] if successful.
+     *
+     * The probe uses a single-attempt retry template so an invalid key fails fast without
+     * retries or noisy stack traces. On any exception the provider-specific error is
+     * translated to [InvalidApiKeyException], keeping Spring AI types out of the caller.
+     *
+     * @param model Model to use for the probe.
+     * @throws InvalidApiKeyException if the key is invalid.
+     */
+    fun buildValidated(model: String): LlmService<*> {
+        val probe = build(model, PASS_THROUGH_RETRY_TEMPLATE)
+        try {
+            probe.createMessageSender(LlmOptions()).call(listOf(UserMessage("Hi")), emptyList())
+        } catch (e: Exception) {
+            throw InvalidApiKeyException(e.message ?: "Invalid API key")
+        }
+        return build(model)
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
@@ -27,7 +27,6 @@ import com.embabel.common.ai.model.OptionsConverter
 import com.embabel.common.ai.model.PerTokenPricingModel
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import io.micrometer.observation.ObservationRegistry
-import org.slf4j.LoggerFactory
 import org.springframework.ai.anthropic.AnthropicChatModel
 import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.anthropic.api.AnthropicApi
@@ -41,8 +40,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.client.ClientHttpRequestFactory
-import org.springframework.web.client.RestClient
-import org.springframework.web.reactive.function.client.WebClient
 import java.time.LocalDate
 
 
@@ -88,8 +85,10 @@ class AnthropicProperties : RetryProperties {
 
 /**
  * Configuration class for Anthropic models.
- * This class provides beans for various Claude models (Opus, Sonnet, Haiku)
- * and handles the creation of Anthropic API clients with proper authentication.
+ * Extends [AnthropicModelFactory] so that the API client construction is shared
+ * with the BYOK path. This class adds the Spring autoconfigure wiring on top:
+ * loading model definitions from YAML, registering them as beans, and applying
+ * the retry policy from [AnthropicProperties].
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AnthropicProperties::class)
@@ -100,17 +99,18 @@ class AnthropicModelsConfig(
     @param:Value("\${ANTHROPIC_API_KEY:#{null}}")
     private val envApiKey: String?,
     private val properties: AnthropicProperties,
-    private val observationRegistry: ObjectProvider<ObservationRegistry>,
+    observationRegistry: ObjectProvider<ObservationRegistry>,
     @param:Qualifier("aiModelHttpRequestFactory")
-    private val requestFactory: ObjectProvider<ClientHttpRequestFactory>,
+    requestFactory: ObjectProvider<ClientHttpRequestFactory>,
     private val configurableBeanFactory: ConfigurableBeanFactory,
     private val modelLoader: LlmAutoConfigMetadataLoader<AnthropicModelDefinitions> = AnthropicModelLoader(),
+) : AnthropicModelFactory(
+    apiKey = envApiKey ?: properties.apiKey
+        ?: error("Anthropic API key required: set ANTHROPIC_API_KEY env var or embabel.agent.platform.models.anthropic.api-key"),
+    baseUrl = envBaseUrl ?: properties.baseUrl,
+    observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
+    requestFactory = requestFactory,
 ) {
-    private val logger = LoggerFactory.getLogger(AnthropicModelsConfig::class.java)
-
-    private val baseUrl: String? = envBaseUrl ?: properties.baseUrl
-    private val apiKey: String = envApiKey ?: properties.apiKey
-    ?: error("Anthropic API key required: set ANTHROPIC_API_KEY env var or embabel.agent.platform.models.anthropic.api-key")
 
     init {
         logger.info("Anthropic models are available: {}", properties)
@@ -150,7 +150,9 @@ class AnthropicModelsConfig(
     }
 
     /**
-     * Creates an individual Anthropic model from configuration.
+     * Creates an individual Anthropic model from configuration, applying full model
+     * definition settings (thinking mode, token budgets, pricing, etc.) that are not
+     * needed in the BYOK path.
      */
     private fun createAnthropicLlm(modelDef: AnthropicModelDefinition): LlmService<*> {
         val chatModel = AnthropicChatModel
@@ -159,11 +161,11 @@ class AnthropicModelsConfig(
             .anthropicApi(createAnthropicApi())
             .toolCallingManager(
                 ToolCallingManager.builder()
-                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+                    .observationRegistry(observationRegistry)
                     .build()
             )
             .retryTemplate(properties.retryTemplate("anthropic-${modelDef.modelId}"))
-            .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+            .observationRegistry(observationRegistry)
             .build()
 
         return SpringAiLlmService(
@@ -210,59 +212,6 @@ class AnthropicModelsConfig(
             }
             .build()
     }
-
-    private fun anthropicLlmOf(
-        name: String,
-        knowledgeCutoffDate: LocalDate?,
-    ): LlmService<*> {
-        val chatModel = AnthropicChatModel
-            .builder()
-            .defaultOptions(
-                AnthropicChatOptions.builder()
-                    .model(name)
-                    .build()
-            )
-            .anthropicApi(createAnthropicApi())
-            .toolCallingManager(
-                ToolCallingManager.builder()
-                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
-                    .build()
-            )
-            .retryTemplate(properties.retryTemplate("anthropic-$name"))
-            .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
-            .build()
-
-        return SpringAiLlmService(
-            name = name,
-            chatModel = chatModel,
-            provider = AnthropicModels.PROVIDER,
-            optionsConverter = AnthropicOptionsConverter,
-            knowledgeCutoffDate = knowledgeCutoffDate,
-        )
-    }
-
-    private fun createAnthropicApi(): AnthropicApi {
-        val builder = AnthropicApi.builder().apiKey(apiKey)
-        if (!baseUrl.isNullOrBlank()) {
-            logger.info("Using custom Anthropic base URL: {}", baseUrl)
-            builder.baseUrl(baseUrl)
-        }
-        // add observation registry to rest and web client builders
-        builder
-            .restClientBuilder(
-                RestClient.builder()
-                    .also { b -> requestFactory.ifAvailable { b.requestFactory(it) } }
-                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
-            )
-        builder
-            .webClientBuilder(
-                WebClient.builder()
-                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
-            )
-
-        return builder.build()
-    }
-
 }
 
 object AnthropicOptionsConverter : OptionsConverter<AnthropicChatOptions> {

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelFactoryTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelFactoryTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.anthropic
+
+import com.embabel.agent.api.models.AnthropicModels
+import com.embabel.agent.spi.InvalidApiKeyException
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.sun.net.httpserver.HttpServer
+import io.micrometer.observation.ObservationRegistry
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import java.net.InetSocketAddress
+import java.util.function.Supplier
+
+class AnthropicModelFactoryTest {
+
+    private val requestFactory = mockk<ObjectProvider<ClientHttpRequestFactory>> {
+        every { getIfAvailable(any<Supplier<ClientHttpRequestFactory>>()) } returns SimpleClientHttpRequestFactory()
+        every { ifAvailable(any()) } just Runs
+    }
+
+    @Test
+    fun `build returns SpringAiLlmService with correct name and provider`() {
+        val factory = AnthropicModelFactory(
+            apiKey = "test-key",
+            observationRegistry = ObservationRegistry.NOOP,
+            requestFactory = requestFactory,
+        )
+        val service = factory.build(model = AnthropicModels.CLAUDE_HAIKU_4_5) as SpringAiLlmService
+        assertEquals(AnthropicModels.CLAUDE_HAIKU_4_5, service.name)
+        assertEquals(AnthropicModels.PROVIDER, service.provider)
+    }
+
+    @Test
+    fun `build with custom baseUrl constructs without error`() {
+        val factory = AnthropicModelFactory(
+            apiKey = "test-key",
+            baseUrl = "https://custom.anthropic.example.com",
+            observationRegistry = ObservationRegistry.NOOP,
+            requestFactory = requestFactory,
+        )
+        val service = factory.build(model = AnthropicModels.CLAUDE_HAIKU_4_5) as SpringAiLlmService
+        assertTrue(service.name.isNotEmpty())
+    }
+}
+
+class AnthropicModelFactoryBuildValidatedTest {
+
+    private lateinit var server: HttpServer
+    private var port: Int = 0
+
+    private val requestFactory = mockk<ObjectProvider<ClientHttpRequestFactory>> {
+        every { getIfAvailable(any<Supplier<ClientHttpRequestFactory>>()) } returns SimpleClientHttpRequestFactory()
+        every { ifAvailable(any()) } just Runs
+    }
+
+    @BeforeEach
+    fun setUp() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        port = server.address.port
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.stop(0)
+    }
+
+    private fun factory() = AnthropicModelFactory(
+        apiKey = "test-key",
+        baseUrl = "http://localhost:$port",
+        observationRegistry = ObservationRegistry.NOOP,
+        requestFactory = requestFactory,
+    )
+
+    @Test
+    fun `buildValidated throws InvalidApiKeyException on 401`() {
+        server.createContext("/v1/messages") { exchange ->
+            exchange.requestBody.use { it.readBytes() }
+            val body = """{"type":"error","error":{"type":"authentication_error","message":"Invalid API Key"}}""".toByteArray()
+            exchange.responseHeaders.set("Content-Type", "application/json")
+            exchange.sendResponseHeaders(401, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+
+        assertThrows<InvalidApiKeyException> {
+            factory().buildValidated()
+        }
+    }
+
+    @Test
+    fun `buildValidated returns LlmService on 200`() {
+        server.createContext("/v1/messages") { exchange ->
+            exchange.requestBody.use { it.readBytes() }
+            val body = """
+                {
+                  "id": "msg_test",
+                  "type": "message",
+                  "role": "assistant",
+                  "content": [{"type": "text", "text": "Hi"}],
+                  "model": "${AnthropicModels.CLAUDE_HAIKU_4_5}",
+                  "stop_reason": "end_turn",
+                  "stop_sequence": null,
+                  "usage": {"input_tokens": 5, "output_tokens": 2}
+                }
+            """.trimIndent().toByteArray()
+            exchange.responseHeaders.set("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+
+        val service = factory().buildValidated()
+        assertNotNull(service)
+        assertEquals(AnthropicModels.PROVIDER, service.provider)
+    }
+
+    @Test
+    fun `buildValidated with explicit model throws InvalidApiKeyException on 401`() {
+        server.createContext("/v1/messages") { exchange ->
+            exchange.requestBody.use { it.readBytes() }
+            val body = """{"type":"error","error":{"type":"authentication_error","message":"Invalid API Key"}}""".toByteArray()
+            exchange.responseHeaders.set("Content-Type", "application/json")
+            exchange.sendResponseHeaders(401, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+
+        assertThrows<InvalidApiKeyException> {
+            factory().buildValidated(AnthropicModels.CLAUDE_HAIKU_4_5)
+        }
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -176,9 +176,141 @@ class EmbeddingModelsConfig {
 ----
 ====
 
-==== Using a pre-resolved LLM (BYOK)
+[[reference.customizing.byok]]
+==== Bring Your Own Key (BYOK)
 
-For scenarios where you already have an `LlmService` instance — such as bring-your-own-key (BYOK) where each user session has a different LLM provider — use `withLlmService()` on `PromptRunner` or `Ai`:
+By default, Embabel resolves LLMs through autoconfiguration: you set one or more API keys as an
+environment variable or property (e.g. `ANTHROPIC_API_KEY`), and the relevant autoconfigure
+module registers a pool of `LlmService` beans at startup.
+This is the right approach for a platform-level key shared across all users.
+
+BYOK is for cases where the key is not known at startup, or where you want to resolve an
+`LlmService` on the fly:
+
+* **User-supplied keys** — each user provides their own API key; the application must validate
+  it and wire it into the prompt runner for that session.
+* **End-to-end testing** — spin up a real `LlmService` with a dedicated test key outside a
+  full Spring context.
+* **Multi-tenant or cost-controlled apps** — select a provider dynamically based on per-tenant
+  configuration or available quota.
+
+Embabel provides factory classes that validate a key and return a ready `LlmService`,
+plus a `detectProvider()` utility that concurrently probes multiple providers and returns
+the first that accepts the key.
+
+IMPORTANT: `buildValidated()` and `detectProvider()` handle key validation only.
+Embabel does not store, log, or otherwise manage the key — the validated `LlmService`
+is returned to the caller, who is responsible for secure key handling: transmission
+over HTTPS only, no plaintext logging, limiting key lifetime, and revoking cached
+services on logout or key rotation.
+
+===== Building a validated service (known provider)
+
+Use this when the provider is already known — for example, a per-provider field in a settings UI.
+
+[source,kotlin]
+----
+// Anthropic
+val service: LlmService<*> = AnthropicModelFactory(apiKey = userKey).buildValidated()
+
+// OpenAI
+val service: LlmService<*> = OpenAiCompatibleModelFactory.openAi(userKey).buildValidated()
+
+// DeepSeek (OpenAI-compatible endpoint)
+val service: LlmService<*> = OpenAiCompatibleModelFactory.deepSeek(userKey).buildValidated()
+
+// Mistral (OpenAI-compatible endpoint)
+val service: LlmService<*> = OpenAiCompatibleModelFactory.mistral(userKey).buildValidated()
+
+// Gemini (OpenAI-compatible endpoint)
+val service: LlmService<*> = OpenAiCompatibleModelFactory.gemini(userKey).buildValidated()
+----
+
+`buildValidated()` makes a single probe call with no retries.
+On success it returns a production `LlmService`; on failure it throws `InvalidApiKeyException`.
+
+===== Auto-detecting the provider
+
+Use this when a user pastes a key without specifying a provider — for example, a sign-up flow
+that accepts keys from any supported provider.
+
+`detectProvider()` races the candidates concurrently using virtual threads and returns the
+first `LlmService` that validates successfully. The detected provider is available as
+`service.provider` on the result.
+
+[source,kotlin]
+----
+val service: LlmService<*> = detectProvider(
+    AnthropicModelFactory(apiKey = userKey),
+    OpenAiCompatibleModelFactory.openAi(userKey),
+    OpenAiCompatibleModelFactory.deepSeek(userKey),
+    OpenAiCompatibleModelFactory.mistral(userKey),
+    OpenAiCompatibleModelFactory.gemini(userKey),
+)
+val detectedProvider: String = service.provider
+----
+
+A single-argument call is valid — it validates against one provider without concurrency,
+which is the right path for a settings flow where the provider is known but you still want
+`detectProvider`'s consistent error handling.
+
+[source,kotlin]
+----
+val service: LlmService<*> = detectProvider(AnthropicModelFactory(apiKey = userKey))
+----
+
+If all candidates throw `InvalidApiKeyException`, `detectProvider` also throws
+`InvalidApiKeyException`.
+
+===== Overriding the validation model
+
+Each factory validates the key using a default model (e.g. `gpt-4.1-mini` for OpenAI,
+`claude-haiku-4-5` for Anthropic). Override this if the key only grants access to a
+specific set of models:
+
+[source,kotlin]
+----
+// OpenAI — use a different model tier for the probe
+OpenAiCompatibleModelFactory.openAi(userKey)
+    .validating(OpenAiModels.GPT_41_NANO, OpenAiModels.PROVIDER)
+
+// Anthropic — set validation model at construction time
+AnthropicModelFactory(apiKey = userKey, validationModel = AnthropicModels.CLAUDE_SONNET_4_5)
+----
+
+===== Adding support for another provider
+
+Any provider that exposes an OpenAI-compatible HTTP API can be added as a one-liner extension
+function on `OpenAiCompatibleModelFactory.Companion`:
+
+[source,kotlin]
+----
+fun OpenAiCompatibleModelFactory.Companion.acme(apiKey: String) =
+    OpenAiCompatibleModelFactory.byok(
+        baseUrl = "https://api.acme.example.com/v1",
+        apiKey = apiKey,
+        validationModel = "acme-small",    // <1>
+        validationProvider = "Acme",       // <2>
+    )
+----
+<1> The cheapest model available on the provider, used for the key-validation probe.
+<2> The provider name; returned as `service.provider` after detection.
+
+The extension function integrates with `detectProvider` like any built-in factory:
+
+[source,kotlin]
+----
+val service = detectProvider(
+    AnthropicModelFactory(apiKey = userKey),
+    OpenAiCompatibleModelFactory.openAi(userKey),
+    OpenAiCompatibleModelFactory.acme(userKey),
+)
+----
+
+===== Using the validated service
+
+Once you have an `LlmService`, pass it directly to `PromptRunner` or `Ai` via
+`withLlmService()`:
 
 [tabs]
 ====
@@ -186,7 +318,7 @@ Java::
 +
 [source,java]
 ----
-LlmService<?> userLlm = ... // created with user's API key
+LlmService<?> userLlm = ... // from buildValidated() or detectProvider()
 promptRunner
     .withLlmService(userLlm)
     .creating(MyOutput.class)
@@ -197,7 +329,7 @@ Kotlin::
 +
 [source,kotlin]
 ----
-val userLlm: LlmService<*> = ... // created with user's API key
+val userLlm: LlmService<*> = ... // from buildValidated() or detectProvider()
 promptRunner
     .withLlmService(userLlm)
     .creating(MyOutput::class.java)
@@ -205,8 +337,41 @@ promptRunner
 ----
 ====
 
-Internally, this flows through the same `ModelProvider` / model selection path as all other LLM resolution via `PreResolvedModelSelectionCriteria`.
-No separate resolution path is needed — the pre-resolved service is just another criteria type in the sealed hierarchy.
+Internally this flows through the same model selection path as all other LLM resolution via
+`PreResolvedModelSelectionCriteria` — no separate resolution path is needed.
+
+===== Error handling
+
+[source,kotlin]
+----
+try {
+    val service = detectProvider(
+        AnthropicModelFactory(apiKey = userKey),
+        OpenAiCompatibleModelFactory.openAi(userKey),
+    )
+    // store or use service
+} catch (e: InvalidApiKeyException) {
+    // return 401 / surface error to user
+    // no Spring AI types to unwrap
+}
+----
+
+`InvalidApiKeyException` is in `com.embabel.agent.spi` and carries no provider-specific
+implementation details.
+
+===== Security considerations
+
+The BYOK factories validate keys and return a ready `LlmService` — key lifecycle management
+is entirely the caller's responsibility.
+
+As a reference implementation, Guide holds keys in server-side memory only (`UserKeyStore`).
+When a key is validated, the client receives an AES-256-GCM encrypted blob — keyed by a
+secret known only to the server — for local-storage caching. A stolen blob is useless without
+the server's decryption key. On page reload the client sends the blob back; the server
+decrypts it and restores the in-memory key. Keys are never written to disk or a database.
+
+NOTE: If you need to implement support for a provider not covered by the built-in factories,
+see <<reference.llms.custom-integration>>.
 
 ==== Configuration via `application.properties` or `application.yml`
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/llms/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/llms/page.adoc
@@ -27,7 +27,14 @@ TIP: Trial and error is your friend.
 Embabel makes it easy to switch LLMs; try the cheapest thing that could work and switch if it doesn't.
 
 
+[[reference.llms.custom-integration]]
 ==== Advanced: Custom LLM Integration
+
+NOTE: If you want to use a standard provider (Anthropic, OpenAI, DeepSeek, Mistral) with a
+user-supplied key at runtime, see <<reference.customizing.byok>>.
+That is the recommended path for BYOK scenarios.
+This section covers implementing `LlmMessageSender` from scratch for providers not otherwise
+supported by Embabel.
 
 Embabel's tool loop is framework-agnostic, allowing you to integrate any LLM provider by implementing the `LlmMessageSender` interface.
 This is useful when:

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -15,9 +15,15 @@
  */
 package com.embabel.agent.openai
 
+import com.embabel.agent.api.models.DeepSeekModels
+import com.embabel.agent.api.models.GoogleGenAiModels
+import com.embabel.agent.api.models.MistralAiModels
 import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.spi.ByokFactory
+import com.embabel.agent.spi.InvalidApiKeyException
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.chat.UserMessage
 import com.embabel.common.ai.model.*
 import com.embabel.common.util.ObjectProviders
 import com.embabel.common.util.loggerFor
@@ -62,6 +68,106 @@ open class OpenAiCompatibleModelFactory(
     companion object {
         private const val CONNECT_TIMEOUT_MS = 5000
         private const val READ_TIMEOUT_MS = 600000
+        private val PASS_THROUGH_RETRY_TEMPLATE: RetryTemplate = RetryTemplate.builder().maxAttempts(1).build()
+
+        /**
+         * Returns a [ByokSpec] for OpenAI.
+         * Validates against [OpenAiModels.GPT_41_MINI] by default.
+         */
+        fun openAi(apiKey: String): ByokSpec =
+            ByokSpec(null, apiKey, OpenAiModels.GPT_41_MINI, OpenAiModels.PROVIDER)
+
+        /**
+         * Returns a [ByokSpec] for DeepSeek (OpenAI-compatible endpoint).
+         * Validates against [DeepSeekModels.DEEPSEEK_CHAT] by default.
+         *
+         * Note: uses the OpenAI wire protocol, not the native Spring AI DeepSeek client.
+         */
+        fun deepSeek(apiKey: String): ByokSpec =
+            ByokSpec("https://api.deepseek.com", apiKey, DeepSeekModels.DEEPSEEK_CHAT, DeepSeekModels.PROVIDER)
+
+        /**
+         * Returns a [ByokSpec] for Mistral AI (OpenAI-compatible endpoint).
+         * Validates against [MistralAiModels.MINISTRAL_8B] by default.
+         *
+         * Note: uses the OpenAI wire protocol, not the native Spring AI Mistral client.
+         */
+        fun mistral(apiKey: String): ByokSpec =
+            ByokSpec("https://api.mistral.ai/v1", apiKey, MistralAiModels.MINISTRAL_8B, MistralAiModels.PROVIDER)
+
+        /**
+         * Returns a [ByokSpec] for Google Gemini (OpenAI-compatible endpoint).
+         * Validates against [GoogleGenAiModels.GEMINI_2_5_FLASH] by default.
+         */
+        fun gemini(apiKey: String): ByokSpec =
+            ByokSpec(
+                "https://generativelanguage.googleapis.com/v1beta/openai",
+                apiKey,
+                GoogleGenAiModels.GEMINI_2_5_FLASH,
+                GoogleGenAiModels.PROVIDER,
+            )
+
+        /**
+         * Returns a [ByokSpec] for a custom OpenAI-compatible provider.
+         *
+         * Both [validationModel] and [validationProvider] are required — there is no
+         * sensible default for an arbitrary endpoint.
+         *
+         * Use this as the basis for a provider-specific extension function:
+         * ```kotlin
+         * fun OpenAiCompatibleModelFactory.Companion.myProvider(apiKey: String) =
+         *     OpenAiCompatibleModelFactory.byok(
+         *         baseUrl = "https://api.myprovider.com/v1",
+         *         apiKey = apiKey,
+         *         validationModel = "my-model-small",
+         *         validationProvider = "MyProvider",
+         *     )
+         * ```
+         */
+        fun byok(
+            baseUrl: String?,
+            apiKey: String,
+            validationModel: String,
+            validationProvider: String,
+        ): ByokSpec = ByokSpec(baseUrl, apiKey, validationModel, validationProvider)
+    }
+
+    /**
+     * A self-contained BYOK spec for an OpenAI-compatible provider. Implements [ByokFactory]
+     * so it can be passed directly to [com.embabel.agent.spi.detectProvider].
+     *
+     * Obtained via the companion factory methods ([openAi], [deepSeek], [mistral], [gemini],
+     * or [byok] for custom providers). Use [validating] to override the default validation
+     * model and provider — for example if the key only grants access to a specific model tier.
+     */
+    class ByokSpec internal constructor(
+        private val baseUrl: String?,
+        private val apiKey: String,
+        private val validationModel: String,
+        private val validationProvider: String,
+        private val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
+    ) : ByokFactory {
+
+        /**
+         * Returns a new [ByokSpec] with the given model and provider used for the
+         * key-validation probe.
+         *
+         * ```kotlin
+         * OpenAiCompatibleModelFactory.openAi(userKey)
+         *     .validating(OpenAiModels.GPT_41_NANO, OpenAiModels.PROVIDER)
+         * ```
+         */
+        fun validating(model: String, provider: String): ByokSpec =
+            ByokSpec(baseUrl, apiKey, model, provider, observationRegistry)
+
+        override fun buildValidated(): LlmService<*> =
+            OpenAiCompatibleModelFactory(baseUrl, apiKey, null, null, observationRegistry = observationRegistry)
+                .buildValidated(
+                    model = validationModel,
+                    pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+                    provider = validationProvider,
+                    knowledgeCutoffDate = null,
+                )
     }
 
     protected val logger: Logger = LoggerFactory.getLogger(javaClass)
@@ -129,6 +235,40 @@ open class OpenAiCompatibleModelFactory(
             provider = provider,
             optionsConverter = optionsConverter,
             pricingModel = pricingModel,
+            knowledgeCutoffDate = knowledgeCutoffDate,
+        )
+    }
+
+    /**
+     * Validates the configured API key by making a probe call, then returns a production
+     * [LlmService] if successful.
+     *
+     * The probe uses a single-attempt retry template (no retries) so a 401 fails fast.
+     * On any exception the provider-specific error is translated to [InvalidApiKeyException],
+     * keeping Spring AI types out of the caller.
+     */
+    fun buildValidated(
+        model: String,
+        pricingModel: PricingModel,
+        provider: String,
+        knowledgeCutoffDate: LocalDate?,
+    ): LlmService<*> {
+        val probe = openAiCompatibleLlm(
+            model = model,
+            pricingModel = pricingModel,
+            provider = provider,
+            knowledgeCutoffDate = knowledgeCutoffDate,
+            retryTemplate = PASS_THROUGH_RETRY_TEMPLATE,
+        )
+        try {
+            probe.createMessageSender(LlmOptions()).call(listOf(UserMessage("Hi")), emptyList())
+        } catch (e: Exception) {
+            throw InvalidApiKeyException(e.message ?: "Invalid API key")
+        }
+        return openAiCompatibleLlm(
+            model = model,
+            pricingModel = pricingModel,
+            provider = provider,
             knowledgeCutoffDate = knowledgeCutoffDate,
         )
     }

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryBuildValidatedTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryBuildValidatedTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.openai
+
+import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.spi.InvalidApiKeyException
+import com.embabel.common.ai.model.PricingModel
+import com.sun.net.httpserver.HttpServer
+import io.micrometer.observation.ObservationRegistry
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.http.client.ClientHttpRequestFactory
+import org.springframework.http.client.SimpleClientHttpRequestFactory
+import java.net.InetSocketAddress
+import java.util.function.Supplier
+
+class OpenAiCompatibleModelFactoryBuildValidatedTest {
+
+    private lateinit var server: HttpServer
+    private var port: Int = 0
+
+    private val requestFactory = mockk<ObjectProvider<ClientHttpRequestFactory>> {
+        every { getIfAvailable(any<Supplier<ClientHttpRequestFactory>>()) } returns SimpleClientHttpRequestFactory()
+        every { ifAvailable(any()) } just Runs
+    }
+
+    @BeforeEach
+    fun setUp() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+        port = server.address.port
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.stop(0)
+    }
+
+    private fun factory() = OpenAiCompatibleModelFactory(
+        baseUrl = "http://localhost:$port",
+        apiKey = "test-key",
+        completionsPath = null,
+        embeddingsPath = null,
+        observationRegistry = ObservationRegistry.NOOP,
+        requestFactory = requestFactory,
+    )
+
+    @Test
+    fun `buildValidated throws InvalidApiKeyException on 401`() {
+        server.createContext("/v1/chat/completions") { exchange ->
+            exchange.requestBody.use { it.readBytes() }
+            val body = """{"error":{"message":"Invalid API key","type":"invalid_request_error"}}""".toByteArray()
+            exchange.sendResponseHeaders(401, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+
+        assertThrows<InvalidApiKeyException> {
+            factory().buildValidated(
+                model = OpenAiModels.GPT_41_MINI,
+                pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+                provider = OpenAiModels.PROVIDER,
+                knowledgeCutoffDate = null,
+            )
+        }
+    }
+
+    @Test
+    fun `buildValidated returns LlmService on 200`() {
+        server.createContext("/v1/chat/completions") { exchange ->
+            exchange.requestBody.use { it.readBytes() }
+            val body = """
+                {
+                  "id": "chatcmpl-test",
+                  "object": "chat.completion",
+                  "created": 1234567890,
+                  "model": "${OpenAiModels.GPT_41_MINI}",
+                  "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+                  "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}
+                }
+            """.trimIndent().toByteArray()
+            exchange.responseHeaders.set("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+
+        val service = factory().buildValidated(
+            model = OpenAiModels.GPT_41_MINI,
+            pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+            provider = OpenAiModels.PROVIDER,
+            knowledgeCutoffDate = null,
+        )
+        assertNotNull(service)
+    }
+}

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.openai
+
+import com.embabel.agent.api.models.DeepSeekModels
+import com.embabel.agent.api.models.GoogleGenAiModels
+import com.embabel.agent.api.models.MistralAiModels
+import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.spi.ByokFactory
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+
+class OpenAiCompatibleModelFactoryByokSpecTest {
+
+    @Test
+    fun `openAi returns ByokFactory`() {
+        assertInstanceOf(ByokFactory::class.java, OpenAiCompatibleModelFactory.openAi("key"))
+    }
+
+    @Test
+    fun `deepSeek returns ByokFactory`() {
+        assertInstanceOf(ByokFactory::class.java, OpenAiCompatibleModelFactory.deepSeek("key"))
+    }
+
+    @Test
+    fun `mistral returns ByokFactory`() {
+        assertInstanceOf(ByokFactory::class.java, OpenAiCompatibleModelFactory.mistral("key"))
+    }
+
+    @Test
+    fun `gemini returns ByokFactory`() {
+        assertInstanceOf(ByokFactory::class.java, OpenAiCompatibleModelFactory.gemini("key"))
+    }
+
+    @Test
+    fun `byok with explicit params returns ByokFactory`() {
+        assertInstanceOf(
+            ByokFactory::class.java,
+            OpenAiCompatibleModelFactory.byok(
+                baseUrl = "https://api.example.com/v1",
+                apiKey = "key",
+                validationModel = "my-model",
+                validationProvider = "MyProvider",
+            )
+        )
+    }
+
+    @Test
+    fun `validating returns new ByokSpec with overridden model and provider`() {
+        val original = OpenAiCompatibleModelFactory.openAi("key")
+        val overridden = original.validating(OpenAiModels.GPT_41_NANO, OpenAiModels.PROVIDER)
+        assertInstanceOf(ByokFactory::class.java, overridden)
+        assert(original !== overridden) { "validating() should return a new instance" }
+    }
+
+    @Test
+    fun `named factories use expected default validation models`() {
+        // Verify defaults are the cheapest/most widely accessible models per provider.
+        // These are structural: if the constants are renamed this test catches it.
+        val openAiSpec = OpenAiCompatibleModelFactory.openAi("key")
+        val deepSeekSpec = OpenAiCompatibleModelFactory.deepSeek("key")
+        val mistralSpec = OpenAiCompatibleModelFactory.mistral("key")
+        val geminiSpec = OpenAiCompatibleModelFactory.gemini("key")
+
+        // Each spec should construct without error (no network call at this stage)
+        assertInstanceOf(ByokFactory::class.java, openAiSpec)
+        assertInstanceOf(ByokFactory::class.java, deepSeekSpec)
+        assertInstanceOf(ByokFactory::class.java, mistralSpec)
+        assertInstanceOf(ByokFactory::class.java, geminiSpec)
+    }
+}


### PR DESCRIPTION
# BYOK Phase 2 

## Summary

Adds framework primitives to support BYOK (Bring Your Own Key) cleanly from any application.
The motivation is Guide's current implementation, which leaks Spring AI types across the framework boundary and requires hand-rolling provider-specific builder code.

Guide is Embabel's dog-fooding app — if the framework doesn't make this easy, every third-party application developer faces the same problem. The same patterns are required by anyone building a multi-user application on Embabel: internal tooling, external SaaS products, and everything in between. Getting this right in the framework removes the hand-rolled boilerplate from all of them.

---

## Changes

### 1. Extract `AnthropicModelFactory`

**Before:** `AnthropicModelsConfig` is a monolithic Spring `@Configuration`. The Anthropic API construction (`createAnthropicApi()`) and service construction (`createAnthropicLlm()`) are private methods buried inside the config class — inaccessible for BYOK use without going through Spring.

**After:** New open class `AnthropicModelFactory` mirrors the shape of `OpenAiCompatibleModelFactory` and implements `ByokFactory`:

```kotlin
open class AnthropicModelFactory(
    private val apiKey: String,
    private val baseUrl: String? = null,
    private val validationModel: String = VALIDATION_MODEL,  // overridable per key tier
    protected val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
    private val requestFactory: ObjectProvider<ClientHttpRequestFactory> = ObjectProviders.empty(),
) : ByokFactory {
    fun build(model: String, retryTemplate: RetryTemplate = RetryUtils.DEFAULT_RETRY_TEMPLATE): LlmService<*>
    override fun buildValidated(): LlmService<*>          // ByokFactory — uses validationModel
    fun buildValidated(model: String): LlmService<*>      // direct call — explicit model
}
```

`AnthropicModelsConfig` becomes a thin subclass. No behaviour change for the normal (non-BYOK) path.

The `validationModel` constructor param exists for the rare case where a key only grants access to a specific set of models. The default (`CLAUDE_HAIKU_4_5`) is the cheapest available.

### 2. `buildValidated()` on `OpenAiCompatibleModelFactory`

**Before:** `OpenAiCompatibleModelFactory` has `openAiCompatibleLlm()` but no validation method.

**After:** `buildValidated()` lives on the factory:

```kotlin
fun buildValidated(
    model: String,
    pricingModel: PricingModel,
    provider: String,
    knowledgeCutoffDate: LocalDate?,
): LlmService<*>
```

Internal behaviour:
1. Build a probe service using `PASS_THROUGH_RETRY_TEMPLATE` (fail fast, no retries)
2. Call `probe.createMessageSender(LlmOptions()).call(listOf(UserMessage("Hi")), emptyList())`
3. On exception: throw clean `InvalidApiKeyException(message)` — no Spring AI types surface
4. On success: build and return production service with standard retry template

### 3. `ByokFactory` interface + `ByokSpec` + `detectProvider()`

The core of the phase 2 refinement: a self-contained spec pattern that eliminates call-site boilerplate.

**`ByokFactory`** — fun interface in `com.embabel.agent.spi`:

```kotlin
fun interface ByokFactory {
    fun buildValidated(): LlmService<*>
}
```

`AnthropicModelFactory` implements it directly. For OpenAI-compatible providers, `ByokSpec` (nested class on `OpenAiCompatibleModelFactory`) implements it.

**Named companion factories** on `OpenAiCompatibleModelFactory` return `ByokSpec`:

```kotlin
OpenAiCompatibleModelFactory.openAi(apiKey)     // → GPT-4.1-mini probe
OpenAiCompatibleModelFactory.deepSeek(apiKey)   // → deepseek-chat probe
OpenAiCompatibleModelFactory.mistral(apiKey)    // → ministral-8b probe
OpenAiCompatibleModelFactory.gemini(apiKey)     // → gemini-2.5-flash probe
OpenAiCompatibleModelFactory.byok(             // custom provider
    baseUrl, apiKey, validationModel, validationProvider
)
```

Each `ByokSpec` has a fluent `.validating(model, provider)` override for keys with restricted model access.

**`detectProvider()`** — top-level function in `com.embabel.agent.spi`:

```kotlin
fun detectProvider(vararg candidates: ByokFactory): LlmService<*>
```

Concurrently races all candidates via `Executors.newVirtualThreadPerTaskExecutor()` + `invokeAny`. First success wins; remaining tasks are cancelled. All fail → `InvalidApiKeyException`. The resulting `LlmService.provider` identifies the winner.

**Full sign-up flow call site:**

```kotlin
val service = detectProvider(
    AnthropicModelFactory(apiKey = userKey),
    OpenAiCompatibleModelFactory.openAi(userKey),
    OpenAiCompatibleModelFactory.deepSeek(userKey),
    OpenAiCompatibleModelFactory.mistral(userKey),
    OpenAiCompatibleModelFactory.gemini(userKey),
)
val detectedProvider = service.provider
```

**Settings flow (single known provider):**

```kotlin
val service = detectProvider(AnthropicModelFactory(apiKey = userKey))
```

**Custom provider extension function pattern:**

```kotlin
fun OpenAiCompatibleModelFactory.Companion.acme(apiKey: String) =
    OpenAiCompatibleModelFactory.byok("https://api.acme.com/v1", apiKey, "acme-small", "Acme")
```

**Concurrency note — why `newVirtualThreadPerTaskExecutor()` with no explicit limit?**

The candidate count is structurally bounded by the number of BYOK-supported providers in the application — realistically 2–12, never user-controlled. At 50,000 MAU with aggressive onboarding assumptions (5% new users in a peak week, concentrated into business hours):

```
~2,500 new users ÷ 2,400 business-hour minutes ≈ 1 onboarding req/min peak
```

Even at 10× spike with 12 providers: ~120 virtual threads active simultaneously, each blocked on outbound HTTP. Virtual threads are designed for millions of concurrent I/O-bound tasks; 120 is negligible. The real constraint at any realistic scale is external provider rate limits — which are per user key and therefore don't compound. Adding a configurable thread cap would cost real API surface area to defend against a phantom concern.

**Design note — why not a function-reference overload?**

We considered `detectProvider(apiKey, ::AnthropicModelFactory, OpenAiCompatibleModelFactory::openAi, ...)`
which would shave one argument per line in the zero-config case. Rejected: it breaks whenever any single candidate needs customisation (`.validating()` or `validationModel`), forcing the caller to mix styles. The savings are modest; the sharp edge is real 🗡️ 

**Design note — why not a typed `LlmProvider` enum or inline value class?**

A new enum would duplicate the existing `ModelMetadata.provider: String` field and `XxxModels.PROVIDER` constants. An `@JvmInline value class` would break `const val` on the `PROVIDER` constants, requiring Java breaking changes. Since `ByokFactory` instances carry their own provider identity (via the returned `LlmService.provider`), no separate provider key is needed at all — the map-key approach was the problem.

---

## What does NOT change

- Normal (non-BYOK) model wiring in `AnthropicModelsConfig` — behaviour unchanged
- `OpenAiCompatibleModelFactory.openAiCompatibleLlm()` — unchanged, existing callers unaffected

---

## How Guide uses this

### The problem today

Guide's `UserModelFactory` builds `SpringAiLlmService` instances by hand, importing Spring AI types directly (`AnthropicChatModel.builder()`, `OpenAiChatModel.builder()`, etc.). Key validation casts across the framework boundary:

```kotlin
// Guide today — Spring AI type leaks out of embabel-agent
(service as SpringAiLlmService).chatModel.call("Hi")
```

The 4-provider validation fan-out is sequential, and Spring AI logs noisy stack traces from the expected 401 probe calls.

### After this PR

Guide's `UserModelFactory` replaces four hand-rolled builder methods with factory delegations. No Spring AI imports remain. For service creation (no validation):

```kotlin
OPENAI    → OpenAiCompatibleModelFactory(null, apiKey, null, null)
                .openAiCompatibleLlm(model, PricingModel.ALL_YOU_CAN_EAT, OpenAiModels.PROVIDER, null)
ANTHROPIC → AnthropicModelFactory(apiKey = apiKey).build(model)
MISTRAL   → OpenAiCompatibleModelFactory("https://api.mistral.ai/v1", apiKey, null, null)
                .openAiCompatibleLlm(model, PricingModel.ALL_YOU_CAN_EAT, MistralAiModels.PROVIDER, null)
DEEPSEEK  → OpenAiCompatibleModelFactory("https://api.deepseek.com", apiKey, null, null)
                .openAiCompatibleLlm(model, PricingModel.ALL_YOU_CAN_EAT, DeepSeekModels.PROVIDER, null)
```

Key validation (when user stores a key) becomes:

```kotlin
fun validateKey(provider: LlmProvider, apiKey: String): String? = try {
    when (provider) {
        OPENAI    -> OpenAiCompatibleModelFactory.openAi(apiKey)
        ANTHROPIC -> AnthropicModelFactory(apiKey = apiKey)
        MISTRAL   -> OpenAiCompatibleModelFactory.mistral(apiKey)
        DEEPSEEK  -> OpenAiCompatibleModelFactory.deepSeek(apiKey)
    }.buildValidated()
    null
} catch (e: InvalidApiKeyException) {
    "Invalid API key"
} catch (e: Exception) {
    "Could not validate key: ${e.message}"
}
```

Spring AI stack traces from probe 401s are eliminated. Fan-out detection (sign-up flow) becomes a single `detectProvider(...)` call as shown above.

### Security

`buildValidated()` and `detectProvider()` validate keys and return an `LlmService` — key lifecycle management is the caller's responsibility. Embabel never stores or logs keys.

#### Guide's approach as a reference:
- Keys held in server-side memory only (`UserKeyStore`) — never persisted to disk or database
- Client receives an AES-256-GCM encrypted blob (server holds the encryption key) for
  local-storage caching; a stolen blob is useless without the server secret
- On page reload the client sends the blob back; server decrypts and restores the in-memory key

Callers should also ensure: keys transmitted over HTTPS only, log levels prevent key material appearing in plaintext, cached `LlmService` instances revoked on logout or key rotation.

---

## Reviewer notes

- `detectProvider` is parameterised by the caller — it encodes no assumptions about which providers an app supports. Suitable for any BYOK application, not just Guide.
- A single-argument call is a valid degenerate case: validated build with clean error handling, no concurrency. This is the settings flow path.
- Tie-breaking if a key validates with two providers is not a practical concern (key formats are distinct); `invokeAny` returns whichever task completes first if it ever occurs.

## Testing notes

Tests were written test-first (non-compiling until implementation lands) following existing project conventions:

- `DetectProviderTest` — pure unit test using mockk `ByokFactory` lambdas; no HTTP, no Spring
  context. Follows the mockk patterns in `OpenAiCompatibleModelFactoryTest`.
- `OpenAiCompatibleModelFactoryByokSpecTest` — construction-only unit tests for all named
  factories and `byok()`; verifies `ByokFactory` contract and `.validating()` chaining.
- `OpenAiCompatibleModelFactoryBuildValidatedTest` — uses Sun's built-in `HttpServer` to stub
  401/200 responses locally, following the precedent in `NettyClientAutoConfigurationTest`.
  No WireMock dependency needed.
- `AnthropicModelFactoryTest` — construction-only tests for `build()` and custom baseUrl,
  same pattern as the existing `OpenAiCompatibleModelFactoryTest`.
- `AnthropicModelFactoryBuildValidatedTest` — uses Sun's built-in `HttpServer` to stub
  401/200 responses, same pattern as `OpenAiCompatibleModelFactoryBuildValidatedTest`;
  added during review to cover `buildValidated()` and `buildValidated(model)`.