### PR TITLE
Update KDOC for clarity

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolGroupsConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolGroupsConfiguration.kt
@@ -159,9 +159,7 @@ class ToolGroupsProperties {
      * Set this to `true` in combination with
      * `spring.ai.mcp.client.initialized=false` when user OAuth tokens must be
      * present in the security context during the MCP client handshake.
-     * All [McpToolGroup] instances defer tool loading to first use regardless
-     * of this flag — this flag only controls whether server metadata is logged
-     * at startup (which itself requires an initialized client).
+     * All [McpToolGroup] instances defer tool loading to first use
      *
      * Defaults to `false` to preserve backwards-compatible behaviour.
      */


### PR DESCRIPTION
This pull request makes a minor clarification in the documentation for the `ToolGroupsProperties` class, specifically updating the comment to clarify the behavior of the `McpToolGroup` tool loading flag.

- Documentation update:
  * Clarified that all `McpToolGroup` instances defer tool loading to first use, and removed the statement about the flag only controlling server metadata logging at startup. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolGroupsConfiguration.kt`)