### PR TITLE
Update models

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/OpenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/OpenAiModels.kt
@@ -18,27 +18,97 @@ package com.embabel.agent.api.models
 
 /**
  * Well-known models from OpenAI.
+ * Model IDs verified against GET /v1/models on 2026-03-29.
+ * Undated aliases (e.g. GPT_54) always resolve to the latest pinned version.
+ * Use dated constants (e.g. GPT_54_2026_03_05) for reproducible behaviour.
  */
 class OpenAiModels {
 
     companion object {
 
-        const val GPT_41_MINI = "gpt-4.1-mini"
+        // =====================================================================
+        // GPT-5.4 FAMILY (Current Flagship - March 2026)
+        // =====================================================================
 
-        const val GPT_41 = "gpt-4.1"
+        const val GPT_54 = "gpt-5.4"
+        const val GPT_54_2026_03_05 = "gpt-5.4-2026-03-05"
 
-        const val GPT_41_NANO = "gpt-4.1-nano"
+        const val GPT_54_MINI = "gpt-5.4-mini"
+        const val GPT_54_MINI_2026_03_17 = "gpt-5.4-mini-2026-03-17"
+
+        const val GPT_54_NANO = "gpt-5.4-nano"
+        const val GPT_54_NANO_2026_03_17 = "gpt-5.4-nano-2026-03-17"
+
+        const val GPT_54_PRO = "gpt-5.4-pro"
+        const val GPT_54_PRO_2026_03_05 = "gpt-5.4-pro-2026-03-05"
+
+        // =====================================================================
+        // GPT-5.2 FAMILY (December 2025)
+        // =====================================================================
+
+        const val GPT_52 = "gpt-5.2"
+        const val GPT_52_2025_12_11 = "gpt-5.2-2025-12-11"
+
+        const val GPT_52_PRO = "gpt-5.2-pro"
+        const val GPT_52_PRO_2025_12_11 = "gpt-5.2-pro-2025-12-11"
+
+        // =====================================================================
+        // GPT-5.1 FAMILY (November 2025)
+        // =====================================================================
+
+        const val GPT_51 = "gpt-5.1"
+        const val GPT_51_2025_11_13 = "gpt-5.1-2025-11-13"
+
+        // =====================================================================
+        // GPT-5 FAMILY (August 2025)
+        // =====================================================================
 
         const val GPT_5 = "gpt-5"
+        const val GPT_5_2025_08_07 = "gpt-5-2025-08-07"
 
         const val GPT_5_MINI = "gpt-5-mini"
+        const val GPT_5_MINI_2025_08_07 = "gpt-5-mini-2025-08-07"
 
         const val GPT_5_NANO = "gpt-5-nano"
+        const val GPT_5_NANO_2025_08_07 = "gpt-5-nano-2025-08-07"
 
-        const val PROVIDER = "OpenAI"
+        const val GPT_5_PRO = "gpt-5-pro"
+        const val GPT_5_PRO_2025_10_06 = "gpt-5-pro-2025-10-06"
 
+        // =====================================================================
+        // GPT-4.1 FAMILY (April 2025 - 1M token context window)
+        // =====================================================================
+
+        const val GPT_41 = "gpt-4.1"
+        const val GPT_41_2025_04_14 = "gpt-4.1-2025-04-14"
+
+        const val GPT_41_MINI = "gpt-4.1-mini"
+        const val GPT_41_MINI_2025_04_14 = "gpt-4.1-mini-2025-04-14"
+
+        const val GPT_41_NANO = "gpt-4.1-nano"
+        const val GPT_41_NANO_2025_04_14 = "gpt-4.1-nano-2025-04-14"
+
+        // =====================================================================
+        // GPT-4o FAMILY (retained — only models with audio input/output support)
+        // =====================================================================
+
+        const val GPT_4O = "gpt-4o"
+        const val GPT_4O_MINI = "gpt-4o-mini"
+
+        // =====================================================================
+        // EMBEDDING MODELS
+        // =====================================================================
+
+        const val TEXT_EMBEDDING_3_LARGE = "text-embedding-3-large"
         const val TEXT_EMBEDDING_3_SMALL = "text-embedding-3-small"
+        const val TEXT_EMBEDDING_ADA_002 = "text-embedding-ada-002"
 
         const val DEFAULT_TEXT_EMBEDDING_MODEL = TEXT_EMBEDDING_3_SMALL
+
+        // =====================================================================
+        // PROVIDER
+        // =====================================================================
+
+        const val PROVIDER = "OpenAI"
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
@@ -2,108 +2,212 @@
 # openai-models.yml
 # ============================================
 # OpenAI and compatible models configuration
+# Model IDs verified against GET /v1/models on 2026-03-29
+# GPT-5.4 pricing verified against openai.com/api/pricing on 2026-03-29
+# All other pricing sourced from web — verify at openai.com/api/pricing
+# Note: undated aliases (e.g. "gpt-5.4") resolve to OpenAI's current recommended
+#       pinned version and may change over time. Use dated model IDs in the
+#       OpenAiModels constants if reproducibility is required.
+# Note: cached_input pricing is intentionally omitted — PerTokenPricingModel
+#       only supports usd_per1m_input_tokens and usd_per1m_output_tokens.
 
 models:
   # ========================================
-  # GPT-5 FAMILY (Latest Generation)
+  # GPT-5.4 FAMILY (Current Flagship - March 2026)
+  # Pricing verified: openai.com/api/pricing 2026-03-29
+  # Cached input (not stored): gpt54=$0.25, gpt54mini=$0.075, gpt54nano=$0.02
   # ========================================
 
-  # GPT-5 - Most capable model
+  - name: "gpt54"
+    model_id: "gpt-5.4"
+    display_name: "GPT-5.4"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 2.50
+      usd_per1m_output_tokens: 15.00
+    special_handling:
+      supports_temperature: false
+
+  - name: "gpt54mini"
+    model_id: "gpt-5.4-mini"
+    display_name: "GPT-5.4 Mini"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 0.750
+      usd_per1m_output_tokens: 4.500
+    special_handling:
+      supports_temperature: false
+
+  - name: "gpt54nano"
+    model_id: "gpt-5.4-nano"
+    display_name: "GPT-5.4 Nano"
+    max_tokens: 8192
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 0.20
+      usd_per1m_output_tokens: 1.25
+    special_handling:
+      supports_temperature: false
+
+  - name: "gpt54pro"
+    model_id: "gpt-5.4-pro"
+    display_name: "GPT-5.4 Pro"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 15.0   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 60.0  # ESTIMATED - verify at openai.com/api/pricing
+    special_handling:
+      supports_temperature: false
+
+  # ========================================
+  # GPT-5.2 FAMILY (December 2025)
+  # ========================================
+
+  - name: "gpt52"
+    model_id: "gpt-5.2"
+    display_name: "GPT-5.2"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 1.75   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 14.0  # ESTIMATED - verify at openai.com/api/pricing
+    special_handling:
+      supports_temperature: false
+
+  - name: "gpt52pro"
+    model_id: "gpt-5.2-pro"
+    display_name: "GPT-5.2 Pro"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 21.0   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 168.0 # ESTIMATED - verify at openai.com/api/pricing
+    special_handling:
+      supports_temperature: false
+
+  # ========================================
+  # GPT-5.1 FAMILY (November 2025)
+  # ========================================
+
+  - name: "gpt51"
+    model_id: "gpt-5.1"
+    display_name: "GPT-5.1"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 1.50   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 12.0  # ESTIMATED - verify at openai.com/api/pricing
+    special_handling:
+      supports_temperature: false
+
+  # ========================================
+  # GPT-5 FAMILY (August 2025)
+  # ========================================
+
   - name: "gpt5"
     model_id: "gpt-5"
     display_name: "GPT-5"
-    knowledge_cutoff_date: "2024-10-01"
     max_tokens: 16384
     temperature: 1.0
     pricing_model:
-      usd_per1m_input_tokens: 1.25
-      usd_per1m_output_tokens: 10.0
+      usd_per1m_input_tokens: 1.25   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 10.0  # ESTIMATED - verify at openai.com/api/pricing
     special_handling:
-      supports_temperature: false  # GPT-5 uses fixed temperature
+      supports_temperature: false
 
-  # GPT-5 Mini - Balanced performance and cost
   - name: "gpt5mini"
     model_id: "gpt-5-mini"
     display_name: "GPT-5 Mini"
-    knowledge_cutoff_date: "2024-05-31"
     max_tokens: 16384
     temperature: 1.0
     pricing_model:
-      usd_per1m_input_tokens: 0.25
-      usd_per1m_output_tokens: 2.0
+      usd_per1m_input_tokens: 0.25   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 2.0   # ESTIMATED - verify at openai.com/api/pricing
     special_handling:
       supports_temperature: false
 
-  # GPT-5 Nano - Ultra-fast and cost-effective
   - name: "gpt5nano"
     model_id: "gpt-5-nano"
     display_name: "GPT-5 Nano"
-    knowledge_cutoff_date: "2024-05-31"
     max_tokens: 8192
     temperature: 1.0
     pricing_model:
-      usd_per1m_input_tokens: 0.05
-      usd_per1m_output_tokens: 0.40
+      usd_per1m_input_tokens: 0.05   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 0.40  # ESTIMATED - verify at openai.com/api/pricing
+    special_handling:
+      supports_temperature: false
+
+  - name: "gpt5pro"
+    model_id: "gpt-5-pro"
+    display_name: "GPT-5 Pro"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 15.0   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 60.0  # ESTIMATED - verify at openai.com/api/pricing
     special_handling:
       supports_temperature: false
 
   # ========================================
-  # GPT-4.1 FAMILY
+  # GPT-4.1 FAMILY (April 2025 - 1M token context window)
   # ========================================
 
-  # GPT-4.1 - High capability model
   - name: "gpt41"
     model_id: "gpt-4.1"
     display_name: "GPT-4.1"
-    knowledge_cutoff_date: "2024-08-06"
     max_tokens: 16384
     temperature: 1.0
     pricing_model:
-      usd_per1m_input_tokens: 2.0
-      usd_per1m_output_tokens: 8.0
+      usd_per1m_input_tokens: 2.0    # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 8.0   # ESTIMATED - verify at openai.com/api/pricing
 
-  # GPT-4.1 Mini - Smaller, faster variant
   - name: "gpt41mini"
     model_id: "gpt-4.1-mini"
     display_name: "GPT-4.1 Mini"
-    knowledge_cutoff_date: "2024-07-18"
     max_tokens: 16384
     temperature: 1.0
     pricing_model:
-      usd_per1m_input_tokens: 0.40
-      usd_per1m_output_tokens: 1.6
+      usd_per1m_input_tokens: 0.40   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 1.60  # ESTIMATED - verify at openai.com/api/pricing
 
-  # GPT-4.1 Nano - Most efficient variant
   - name: "gpt41nano"
     model_id: "gpt-4.1-nano"
     display_name: "GPT-4.1 Nano"
-    knowledge_cutoff_date: "2024-08-06"
     max_tokens: 8192
     temperature: 1.0
     pricing_model:
-      usd_per1m_input_tokens: 0.1
-      usd_per1m_output_tokens: 0.4
+      usd_per1m_input_tokens: 0.10   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 0.40  # ESTIMATED - verify at openai.com/api/pricing
 
   # ========================================
-  # GPT-4o FAMILY
+  # GPT-4o FAMILY (retained for audio support only)
   # ========================================
 
-  # GPT-4o Mini - Fast and cost-effective
-  - name: "gpt4omini"
-    model_id: "gpt-4o-mini"
-    display_name: "GPT-4o Mini"
-    knowledge_cutoff_date: "2023-10-01"
+  - name: "gpt4o"
+    model_id: "gpt-4o"
+    display_name: "GPT-4o"
     max_tokens: 16384
     temperature: 1.0
     pricing_model:
-      usd_per1m_input_tokens: 0.15
-      usd_per1m_output_tokens: 0.60
+      usd_per1m_input_tokens: 2.50   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 10.0  # ESTIMATED - verify at openai.com/api/pricing
+
+  - name: "gpt4omini"
+    model_id: "gpt-4o-mini"
+    display_name: "GPT-4o Mini"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 0.15   # ESTIMATED - verify at openai.com/api/pricing
+      usd_per1m_output_tokens: 0.60  # ESTIMATED - verify at openai.com/api/pricing
 
 # ========================================
 # EMBEDDING MODELS
 # ========================================
 embedding_models:
-  # Default text embedding model
   - name: "text_embedding_3_large"
     model_id: "text-embedding-3-large"
     display_name: "Text Embedding 3 Large"
@@ -111,7 +215,6 @@ embedding_models:
     pricing_model:
       usd_per1m_tokens: 0.13
 
-  # Smaller embedding model
   - name: "text_embedding_3_small"
     model_id: "text-embedding-3-small"
     display_name: "Text Embedding 3 Small"
@@ -119,7 +222,6 @@ embedding_models:
     pricing_model:
       usd_per1m_tokens: 0.02
 
-  # Legacy embedding model
   - name: "text_embedding_ada_002"
     model_id: "text-embedding-ada-002"
     display_name: "Text Embedding Ada 002"


### PR DESCRIPTION
This pull request adds comprehensive support for the latest OpenAI GPT-5.4 and related model families, updates model constants and configuration, and improves documentation for reproducibility and pricing accuracy. The changes ensure that both code and configuration are aligned with OpenAI's latest offerings as of March 2026, and that future updates can be handled more systematically.

**Key changes include:**

### OpenAI Model Support and Constants

- Introduced new constants in `OpenAiModels.kt` for all GPT-5.4, GPT-5.2, GPT-5.1, and updated GPT-5, GPT-4.1, and GPT-4o model variants, including both undated aliases and pinned (dated) versions for reproducibility. Also added missing embedding model constants.

### Model Configuration and Pricing

- Significantly expanded `openai-models.yml` to include detailed entries for all new GPT-5.4, GPT-5.2, and GPT-5.1 models, with up-to-date pricing (where available), notes on pricing verification, and clear guidance on alias usage versus pinned model IDs. Also added missing entries for GPT-5 Pro, GPT-4o, and improved embedding model documentation.

### Documentation Improvements

- Enhanced comments in both `OpenAiModels.kt` and `openai-models.yml` to clarify model ID verification dates, alias behavior, and reproducibility best practices. [[1]](diffhunk://#diff-b50897a852b76b2134cda2da8f0ee06671c8b3ac1cde823de2d49b10f254325aR21-R112) [[2]](diffhunk://#diff-bb2de57ba57baddd2643e6a86359e1590cee73aa407b63989cad2fa7939efe86R5-L122)

### Minor Configuration Clarification

- Updated a comment in `ToolGroupsConfiguration.kt` to clarify that tool loading is always deferred to first use, regardless of the initialization flag, for improved accuracy and maintainability.