### PR TITLE
Prepare 0.3.5 Release

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.12-SNAPSHOT</version>
+        <version>0.1.12</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/embabel-agent-onnx/src/test/kotlin/com/embabel/agent/onnx/embeddings/OnnxEmbeddingServiceTest.kt
+++ b/embabel-agent-onnx/src/test/kotlin/com/embabel/agent/onnx/embeddings/OnnxEmbeddingServiceTest.kt
@@ -27,6 +27,8 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 
 class OnnxEmbeddingServiceTest {
 
@@ -100,6 +102,7 @@ class OnnxEmbeddingServiceTest {
     }
 
     @Nested
+    @DisabledOnOs(OS.WINDOWS, disabledReason = "ONNX Runtime native DLL requires Visual C++ Redistributable; OrtEnvironment.<clinit> fires even in mock tests")
     inner class EmbedWithMocksTest {
 
         private val environment = OrtEnvironment.getEnvironment()

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.12-SNAPSHOT</version>
+        <version>0.1.12</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,7 +16,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <embabel-common.version>0.1.11-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.11</embabel-common.version>
         <netty.version>4.1.132.Final</netty.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>


### PR DESCRIPTION
This pull request updates project dependencies to use stable (non-SNAPSHOT) versions and improves test reliability on Windows platforms. The most important changes are:

Dependency version updates:

* Updated the parent project version in `pom.xml` and `embabel-agent-dependencies/pom.xml` from `0.1.12-SNAPSHOT` to the stable `0.1.12` release. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L8-R8) [[2]](diffhunk://#diff-afe07651950d7d2835eb6cc02163f9241976a101f42ab11fe2d932fc246750f9L7-R7)
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.11-SNAPSHOT` to `0.1.11`.

Test reliability improvements:

* Added `@DisabledOnOs(OS.WINDOWS)` to the `EmbedWithMocksTest` nested test class in `OnnxEmbeddingServiceTest.kt` to prevent failures on Windows due to missing ONNX Runtime native DLL dependencies.
* Imported `org.junit.jupiter.api.condition.DisabledOnOs` and `org.junit.jupiter.api.condition.OS` to support the new test annotation.