### PR TITLE
Make consistent OPENAI base url

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiGuardRailsIntegrationIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiGuardRailsIntegrationIT.java
@@ -71,7 +71,13 @@ class OpenAiModerationClient {
     private final OpenAIClient client;
 
     public OpenAiModerationClient() {
-        this.client = OpenAIOkHttpClient.fromEnv(); // Automatically uses OPENAI_API_KEY
+        // Build explicitly rather than fromEnv() because the openai-java SDK
+        // expects baseUrl to include /v1, but OPENAI_BASE_URL is set without it
+        // (Spring AI appends /v1 internally).
+        this.client = OpenAIOkHttpClient.builder()
+                .baseUrl(System.getenv().getOrDefault("OPENAI_BASE_URL", "https://api.openai.com") + "/v1")
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .build();
     }
 
     public ModerationCreateResponse moderate(String inputText) {

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -92,7 +92,7 @@ open class OpenAiCompatibleModelFactory(
          * Note: uses the OpenAI wire protocol, not the native Spring AI Mistral client.
          */
         fun mistral(apiKey: String): ByokSpec =
-            ByokSpec("https://api.mistral.ai/v1", apiKey, MistralAiModels.MINISTRAL_8B, MistralAiModels.PROVIDER)
+            ByokSpec("https://api.mistral.ai", apiKey, MistralAiModels.MINISTRAL_8B, MistralAiModels.PROVIDER)
 
         /**
          * Returns a [ByokSpec] for Google Gemini (OpenAI-compatible endpoint).
@@ -116,7 +116,7 @@ open class OpenAiCompatibleModelFactory(
          * ```kotlin
          * fun OpenAiCompatibleModelFactory.Companion.myProvider(apiKey: String) =
          *     OpenAiCompatibleModelFactory.byok(
-         *         baseUrl = "https://api.myprovider.com/v1",
+         *         baseUrl = "https://api.myprovider.com",
          *         apiKey = apiKey,
          *         validationModel = "my-model-small",
          *         validationProvider = "MyProvider",

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokIT.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokIT.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.openai
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+
+/**
+ * IT tests that validate BYOK endpoints against real provider APIs.
+ * Each test requires the corresponding API key in the environment.
+ */
+class OpenAiCompatibleModelFactoryByokIT {
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
+    fun `openAi buildValidated succeeds with valid key`() {
+        val service = OpenAiCompatibleModelFactory.openAi(System.getenv("OPENAI_API_KEY"))
+            .buildValidated()
+        assertNotNull(service)
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "DEEPSEEK_API_KEY", matches = ".+")
+    fun `deepSeek buildValidated succeeds with valid key`() {
+        val service = OpenAiCompatibleModelFactory.deepSeek(System.getenv("DEEPSEEK_API_KEY"))
+            .buildValidated()
+        assertNotNull(service)
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "MISTRAL_API_KEY", matches = ".+")
+    fun `mistral buildValidated succeeds with valid key`() {
+        val service = OpenAiCompatibleModelFactory.mistral(System.getenv("MISTRAL_API_KEY"))
+            .buildValidated()
+        assertNotNull(service)
+    }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "GOOGLE_GENAI_API_KEY", matches = ".+")
+    fun `gemini buildValidated succeeds with valid key`() {
+        val service = OpenAiCompatibleModelFactory.gemini(System.getenv("GOOGLE_GENAI_API_KEY"))
+            .buildValidated()
+        assertNotNull(service)
+    }
+}

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
@@ -50,7 +50,7 @@ class OpenAiCompatibleModelFactoryByokSpecTest {
         assertInstanceOf(
             ByokFactory::class.java,
             OpenAiCompatibleModelFactory.byok(
-                baseUrl = "https://api.example.com/v1",
+                baseUrl = "https://api.example.com",
                 apiKey = "key",
                 validationModel = "my-model",
                 validationProvider = "MyProvider",


### PR DESCRIPTION
# Fix inconsistent /v1 in OpenAI-compatible base URLs

## Problem

Spring AI's `OpenAiApi.builder().baseUrl()` appends `/v1` internally. The `openai-java` SDK (`OpenAIOkHttpClient`) does NOT — it uses the URL as-is. Both read `OPENAI_BASE_URL`, which is set without `/v1` for Spring AI compatibility. This mismatch causes issues in several places.

## Fixes

- **`OpenAiCompatibleModelFactory.mistral()`** — base URL included `/v1`, producing double `/v1/v1/` through Spring AI
- **`OpenAiCompatibleModelFactory.byok()` KDoc** — example URL included `/v1`, misleading for Spring AI consumers
- **`OpenAiCompatibleModelFactoryByokSpecTest`** — test example URL included `/v1`
- **`LLMOpenAiGuardRailsIntegrationIT`** — `OpenAIOkHttpClient.fromEnv()` used `OPENAI_BASE_URL` without `/v1`, producing 404s on the moderation endpoint

### New file

- **`OpenAiCompatibleModelFactoryByokIT`** — IT tests that validate BYOK `buildValidated()` against real provider APIs (OpenAI, DeepSeek, Mistral, Gemini). Each test is gated by `@EnabledIfEnvironmentVariable` so it skips cleanly without the corresponding API key.

## Details

### `OpenAiCompatibleModelFactory.mistral()`

**Before:** `ByokSpec("https://api.mistral.ai/v1", ...)` — Spring AI appends `/v1` internally, producing `https://api.mistral.ai/v1/v1/chat/completions` (confirmed 404 via curl).

**After:** `ByokSpec("https://api.mistral.ai", ...)` — Spring AI appends `/v1`, producing the correct `https://api.mistral.ai/v1/chat/completions` (confirmed 200 via curl and BYOK IT test).

### `LLMOpenAiGuardRailsIntegrationIT`

**Before:** `OpenAIOkHttpClient.fromEnv()` — reads `OPENAI_BASE_URL` (spring AI compatible version of `https://api.openai.com`), SDK appends `/moderations` directly → hits `https://api.openai.com/moderations` → 404. This was masked by the previous `try/catch` pattern in `testThinkingCreateObject` — the `NotFoundException` was silently swallowed because it wasn't a `GuardRailViolationException`. Only surfaced after #1577 replaced the catch with `assertThrows`.

**After:** Explicit builder reads `OPENAI_BASE_URL` and appends `/v1` → `https://api.openai.com/v1`, SDK appends `/moderations` → hits `https://api.openai.com/v1/moderations` → 200. Moderation correctly flags the content (`violence` category) and `GuardRailViolationException` is thrown.

## Verified

- All 15 unit tests in `embabel-agent-openai` pass.
- `OpenAiCompatibleModelFactoryByokIT` — 3 passed (OpenAI, DeepSeek, Mistral), 1 skipped (Gemini, no key). Mistral confirmed working against the real API after the `/v1` fix.
- `LLMOpenAiGuardRailsIntegrationIT.testThinkingCreateObject` now passes.

## Fun fact

The guardrails test prompt mentions blowing up crocodiles in Florida. Southern Florida is actually the only place in the world where alligators and crocodiles coexist — the American crocodile (*Crocodylus acutus*) lives alongside the American alligator in the Everglades. The more you know.
