### PR TITLE
Introduce vendor-neutral  message streamer  for streaming LLM operations

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/streaming/LlmMessageStreamer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/streaming/LlmMessageStreamer.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.loop.streaming
+
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.spi.loop.LlmMessageSender
+import com.embabel.agent.spi.loop.ToolLoop
+import com.embabel.chat.Message
+import reactor.core.publisher.Flux
+
+/**
+ * Framework-agnostic interface for streaming LLM inference.
+ *
+ * Streaming counterpart of [LlmMessageSender]. Implementations handle the actual
+ * LLM communication (Spring AI, LangChain4j, etc.) and return a reactive stream
+ * of raw content chunks.
+ *
+ * **Key Differences from Non-Streaming:**
+ * - Returns `Flux<String>` instead of `LlmMessageResponse`
+ * - Tool execution is managed by the underlying framework (e.g., Spring AI)
+ *   since the streaming API is opaque - we cannot inject a custom [ToolLoop]
+ * - Only observation of tool execution is possible (via callbacks in Phase 2)
+ *
+ * @see LlmMessageSender for non-streaming equivalent
+ */
+fun interface LlmMessageStreamer {
+
+    /**
+     * Stream raw content chunks from the LLM.
+     *
+     * The returned Flux emits content as it arrives from the LLM.
+     * Tool calls are handled internally by the underlying framework.
+     *
+     * @param messages The conversation history
+     * @param tools Available tools for the LLM to invoke during streaming
+     * @return Flux of raw content chunks
+     */
+    fun stream(
+        messages: List<Message>,
+        tools: List<Tool>,
+    ): Flux<String>
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/SpringAiLlmMessageStreamer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/SpringAiLlmMessageStreamer.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.springai.streaming
+
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.spi.loop.streaming.LlmMessageStreamer
+import com.embabel.agent.spi.support.springai.SpringAiLlmMessageSender
+import com.embabel.agent.spi.support.springai.toSpringAiMessage
+import com.embabel.agent.spi.support.springai.toSpringToolCallbacks
+import com.embabel.chat.Message
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.chat.prompt.Prompt
+import reactor.core.publisher.Flux
+
+/**
+ * Spring AI implementation of [LlmMessageStreamer].
+ *
+ * Streams raw content chunks from the LLM using Spring AI's ChatClient.
+ * Tool execution is handled internally by Spring AI during streaming.
+ *
+ * @param chatClient The Spring AI ChatClient for streaming
+ * @param chatOptions Options for the LLM call (temperature, model, etc.)
+ * @see SpringAiLlmMessageSender for non-streaming equivalent
+ */
+internal class SpringAiLlmMessageStreamer(
+    private val chatClient: ChatClient,
+    private val chatOptions: ChatOptions,
+) : LlmMessageStreamer {
+
+    override fun stream(
+        messages: List<Message>,
+        tools: List<Tool>,
+    ): Flux<String> {
+        val springAiMessages = messages.map { it.toSpringAiMessage() }
+        val toolCallbacks = tools.toSpringToolCallbacks()
+        val prompt = Prompt(springAiMessages)
+
+        return chatClient
+            .prompt(prompt)
+            .toolCallbacks(toolCallbacks)
+            .options(chatOptions)
+            .stream()
+            .content()
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperations.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.core.Action
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.loop.streaming.LlmMessageStreamer
 import com.embabel.agent.spi.streaming.StreamingLlmOperations
 import com.embabel.agent.spi.support.PROMPT_ELEMENT_SEPARATOR
 import com.embabel.agent.spi.support.guardrails.validateUserInput
@@ -56,6 +57,12 @@ import reactor.core.publisher.Mono
  */
 internal class StreamingChatClientOperations(
     private val chatClientLlmOperations: ChatClientLlmOperations,
+    /**
+     * When true, delegates raw streaming to [LlmMessageStreamer] instead of
+     * calling Spring AI ChatClient directly. This decouples streaming from
+     * Spring AI, enabling vendor-neutral implementations.
+     */
+    private val useMessageStreamer: Boolean = false,
 ) : StreamingLlmOperations {
 
     // once streaming feature gets stable set log level to TRACE
@@ -160,12 +167,14 @@ internal class StreamingChatClientOperations(
         // Resolve tool groups and decorate tools
         val tools = chatClientLlmOperations.resolveAndDecorateTools(interaction, agentProcess, action)
 
-        return chatClient
-            .prompt(springAiPrompt)
-            .toolCallbacks(tools.toSpringToolCallbacks())
-            .options(chatOptions)
-            .stream()
-            .content()
+        return createStreamInternal(
+            chatClient = chatClient,
+            messages = messages,
+            promptContributions = promptContributions,
+            tools = tools,
+            chatOptions = chatOptions,
+            springAiPrompt = springAiPrompt,
+        )
     }
 
     /**
@@ -351,13 +360,14 @@ internal class StreamingChatClientOperations(
         val tools = chatClientLlmOperations.resolveAndDecorateTools(interaction, agentProcess, action)
 
         // Step 1: Original raw chunk stream from LLM
-        val rawChunkFlux: Flux<String> = chatClient
-            .prompt(springAiPrompt)
-            .toolCallbacks(tools.toSpringToolCallbacks())
-            .options(chatOptions)
-            .stream()
-            .content()
-            .filter { it.isNotEmpty() }
+        val rawChunkFlux: Flux<String> = createStreamInternal(
+            chatClient = chatClient,
+            messages = messages,
+            promptContributions = fullPromptContributions,
+            tools = tools,
+            chatOptions = chatOptions,
+            springAiPrompt = springAiPrompt,
+        ).filter { it.isNotEmpty() }
             .doOnNext { chunk -> logger.trace("RAW CHUNK: '${chunk.replace("\n", "\\n")}'") }
 
         // Step 2: Transform raw chunks to complete newline-delimited lines
@@ -409,5 +419,69 @@ internal class StreamingChatClientOperations(
         )
     }
 
+    /* -------------------------------------------------------------------------
+     * Streaming Abstraction Layer
+     *
+     * Supports decoupling streaming from Spring AI via LlmMessageStreamer interface.
+     * Controlled by useMessageStreamer flag:
+     *   - false (default): uses Spring AI ChatClient directly
+     *   - true: delegates to vendor-neutral LlmMessageStreamer
+     *
+     * Enables future support for non-Spring AI providers (e.g., LangChain4j).
+     * ------------------------------------------------------------------------ */
 
+    /**
+     * Build message list with prompt contributions prepended as system message.
+     *
+     * Mirrors [buildSpringAiPrompt] but returns Embabel messages instead of Spring AI Prompt.
+     * Used by the decoupled streaming path (when useMessageStreamer=true).
+     *
+     * @param messages Conversation messages
+     * @param promptContributions Prompt contributions to prepend
+     * @return Message list with contributions as first system message (if non-empty)
+     */
+    private fun buildMessagesWithContributions(
+        messages: List<Message>,
+        promptContributions: String,
+    ): List<Message> = buildList {
+        if (promptContributions.isNotEmpty()) {
+            add(com.embabel.chat.SystemMessage(promptContributions))
+        }
+        addAll(messages)
+    }
+
+    /**
+     * Create raw content stream from LLM.
+     *
+     * Switches between decoupled path (LlmMessageStreamer) and current path (Spring AI direct)
+     * based on [useMessageStreamer] flag.
+     *
+     * @param chatClient Spring AI ChatClient instance
+     * @param messages Embabel conversation messages
+     * @param promptContributions Prompt contributions string
+     * @param tools Embabel tools available for LLM
+     * @param chatOptions Spring AI chat options
+     * @param springAiPrompt Pre-built Spring AI prompt (used when useMessageStreamer=false)
+     * @return Flux of raw content chunks
+     */
+    private fun createStreamInternal(
+        chatClient: org.springframework.ai.chat.client.ChatClient,
+        messages: List<Message>,
+        promptContributions: String,
+        tools: List<com.embabel.agent.api.tool.Tool>,
+        chatOptions: org.springframework.ai.chat.prompt.ChatOptions,
+        springAiPrompt: Prompt,
+    ): Flux<String> {
+        return if (useMessageStreamer) {
+            val streamerMessages = buildMessagesWithContributions(messages, promptContributions)
+            SpringAiLlmMessageStreamer(chatClient, chatOptions).stream(streamerMessages, tools)
+        } else {
+            chatClient
+                .prompt(springAiPrompt)
+                .toolCallbacks(tools.toSpringToolCallbacks())
+                .options(chatOptions)
+                .stream()
+                .content()
+        }
+    }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/SpringAiLlmMessageStreamerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/SpringAiLlmMessageStreamerTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.springai.streaming
+
+import com.embabel.agent.api.tool.Tool
+import com.embabel.chat.AssistantMessage
+import com.embabel.chat.SystemMessage
+import com.embabel.chat.UserMessage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.client.ChatClient
+import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.tool.ToolCallback
+import reactor.core.publisher.Flux
+import reactor.test.StepVerifier
+import java.time.Duration
+
+/**
+ * Unit tests for [SpringAiLlmMessageStreamer].
+ *
+ * Verifies that the streamer correctly:
+ * - Converts Embabel messages to Spring AI messages
+ * - Converts Embabel tools to Spring AI tool callbacks
+ * - Calls the ChatClient streaming chain correctly
+ */
+class SpringAiLlmMessageStreamerTest {
+
+    private lateinit var mockChatClient: ChatClient
+    private lateinit var mockChatOptions: ChatOptions
+    private lateinit var mockRequestSpec: ChatClient.ChatClientRequestSpec
+    private lateinit var mockStreamSpec: ChatClient.StreamResponseSpec
+
+    @BeforeEach
+    fun setUp() {
+        mockChatClient = mockk(relaxed = true)
+        mockChatOptions = mockk(relaxed = true)
+        mockRequestSpec = mockk(relaxed = true)
+        mockStreamSpec = mockk(relaxed = true)
+
+        // Setup the fluent chain
+        every { mockChatClient.prompt(any<Prompt>()) } returns mockRequestSpec
+        every { mockRequestSpec.toolCallbacks(any<List<ToolCallback>>()) } returns mockRequestSpec
+        every { mockRequestSpec.options(any<ChatOptions>()) } returns mockRequestSpec
+        every { mockRequestSpec.stream() } returns mockStreamSpec
+    }
+
+    @Test
+    fun `stream calls ChatClient with correct chain`() {
+        // Given
+        val streamer = SpringAiLlmMessageStreamer(mockChatClient, mockChatOptions)
+        val messages = listOf(UserMessage("Hello"))
+        val tools = emptyList<Tool>()
+        every { mockStreamSpec.content() } returns Flux.just("response")
+
+        // When
+        streamer.stream(messages, tools)
+
+        // Then
+        verify { mockChatClient.prompt(any<Prompt>()) }
+        verify { mockRequestSpec.toolCallbacks(any<List<ToolCallback>>()) }
+        verify { mockRequestSpec.options(mockChatOptions) }
+        verify { mockRequestSpec.stream() }
+    }
+
+    @Test
+    fun `stream returns content from ChatClient`() {
+        // Given
+        val streamer = SpringAiLlmMessageStreamer(mockChatClient, mockChatOptions)
+        val messages = listOf(UserMessage("Hello"))
+        val expectedContent = Flux.just("chunk1", "chunk2", "chunk3")
+        every { mockStreamSpec.content() } returns expectedContent
+
+        // When
+        val result = streamer.stream(messages, emptyList())
+
+        // Then
+        StepVerifier.create(result)
+            .expectNext("chunk1")
+            .expectNext("chunk2")
+            .expectNext("chunk3")
+            .verifyComplete()
+    }
+
+    @Test
+    fun `stream handles empty message list`() {
+        // Given
+        val streamer = SpringAiLlmMessageStreamer(mockChatClient, mockChatOptions)
+        every { mockStreamSpec.content() } returns Flux.just("response")
+
+        // When
+        val result = streamer.stream(emptyList(), emptyList())
+
+        // Then
+        StepVerifier.create(result)
+            .expectNext("response")
+            .verifyComplete()
+    }
+
+    @Test
+    fun `stream handles multiple message types`() {
+        // Given
+        val streamer = SpringAiLlmMessageStreamer(mockChatClient, mockChatOptions)
+        val messages = listOf(
+            SystemMessage("You are helpful"),
+            UserMessage("Hello"),
+            AssistantMessage("Hi there"),
+            UserMessage("How are you?")
+        )
+        every { mockStreamSpec.content() } returns Flux.just("response")
+
+        // When
+        val result = streamer.stream(messages, emptyList())
+
+        // Then - should complete without error
+        StepVerifier.create(result)
+            .expectNext("response")
+            .verifyComplete()
+
+        // Verify prompt was built with all messages
+        verify { mockChatClient.prompt(any<Prompt>()) }
+    }
+
+    @Test
+    fun `stream handles empty flux response`() {
+        // Given
+        val streamer = SpringAiLlmMessageStreamer(mockChatClient, mockChatOptions)
+        every { mockStreamSpec.content() } returns Flux.empty()
+
+        // When
+        val result = streamer.stream(listOf(UserMessage("test")), emptyList())
+
+        // Then
+        StepVerifier.create(result)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `stream propagates errors from ChatClient`() {
+        // Given
+        val streamer = SpringAiLlmMessageStreamer(mockChatClient, mockChatOptions)
+        val expectedError = RuntimeException("LLM error")
+        every { mockStreamSpec.content() } returns Flux.error(expectedError)
+
+        // When
+        val result = streamer.stream(listOf(UserMessage("test")), emptyList())
+
+        // Then
+        StepVerifier.create(result)
+            .expectError(RuntimeException::class.java)
+            .verify(Duration.ofSeconds(1))
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsTest.kt
@@ -28,6 +28,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.client.ChatClient
@@ -477,5 +478,91 @@ class StreamingChatClientOperationsTest {
         every { mockRequestSpec.stream() } returns mockContentStreamSpec
         every { mockContentStreamSpec.content() } returns chunkFlux
 
+    }
+
+    /**
+     * Tests for useMessageStreamer=true (decoupled streaming path via LlmMessageStreamer).
+     */
+    @Nested
+    inner class MessageStreamerTests {
+
+        private lateinit var streamingOpsWithStreamer: StreamingChatClientOperations
+
+        @BeforeEach
+        fun setUpStreamer() {
+            streamingOpsWithStreamer = StreamingChatClientOperations(
+                mockChatClientLlmOperations,
+                useMessageStreamer = true
+            )
+        }
+
+        @Test
+        fun `should use LlmMessageStreamer when useMessageStreamer is true`() {
+            // Given
+            val chunkFlux = Flux.just("streamed ", "content")
+            mockChatClientForStreaming(chunkFlux)
+
+            // When
+            val result = streamingOpsWithStreamer.generateStream(
+                listOf(UserMessage("test")),
+                mockInteraction,
+                mockAgentProcess,
+                mockAction
+            )
+
+            // Then
+            StepVerifier.create(result)
+                .expectNext("streamed ")
+                .expectNext("content")
+                .verifyComplete()
+        }
+
+        @Test
+        fun `should prepend prompt contributions as system message`() {
+            // Given
+            val mockContributor = mockk<com.embabel.common.ai.prompt.PromptContributor>()
+            every { mockContributor.contribution() } returns "System contribution"
+            every { mockInteraction.promptContributors } returns listOf(mockContributor)
+
+            val chunkFlux = Flux.just("response")
+            mockChatClientForStreaming(chunkFlux)
+
+            // When
+            val result = streamingOpsWithStreamer.generateStream(
+                listOf(UserMessage("user message")),
+                mockInteraction,
+                mockAgentProcess,
+                mockAction
+            )
+
+            // Then
+            StepVerifier.create(result)
+                .expectNext("response")
+                .verifyComplete()
+        }
+
+        @Test
+        fun `should handle object streaming`() {
+            // Given
+            val chunkFlux = Flux.just("{\"name\":\"Test\",\"value\":42}\n")
+            mockChatClientForStreaming(chunkFlux)
+
+            // When
+            val result = streamingOpsWithStreamer.createObjectStreamWithThinking(
+                messages = listOf(UserMessage("test")),
+                interaction = mockInteraction,
+                outputClass = TestItem::class.java,
+                agentProcess = mockAgentProcess,
+                action = mockAction
+            )
+
+            // Then
+            StepVerifier.create(result)
+                .expectNextMatches {
+                    it.isObject() && it.getObject()?.name == "Test" && it.getObject()?.value == 42
+                }
+                .expectComplete()
+                .verify(Duration.ofSeconds(1))
+        }
     }
 }


### PR DESCRIPTION
## OVERVIEW

Please refer to:
https://github.com/embabel/embabel-agent/issues/1474

- Introduce vendor-neutral LlmMessageStreamer interface for streaming LLM operations
 - Add SpringAiLlmMessageStreamer as Spring AI implementation
 - Wire into StreamingChatClientOperations with useMessageStreamer flag (disabled by default)

This PR sets foundation fot subsequent PRs.

### Testing                                                                                                                                                                                
                                                                                                                                                                                              
  - Unit tests for SpringAiLlmMessageStreamer                                                                                                                                                 
  - Nested tests for useMessageStreamer=true path in StreamingChatClientOperationsTest                                                                                                        
  - Existing tests, including IT, pass (current path unchanged)                                                                                                                                              
                                                                                                                                                                                              
 ## Future PRs                                                                                                                                                                                  
                                                                                                                                                                                              
###  PR 2: Full Pluggability                                                                                                                                                                     
                                                                                                                                                                                              
  Inject LlmMessageStreamer via constructor instead of inline creation, enabling:                                                                                                             
                                                                                                                                                                                              
  1. Implement LlmMessageStreamer for your provider:        
  ```                                                                                                                                 
  class LangChain4jLlmMessageStreamer(                                                                                                                                                        
      private val chatModel: ChatModel,                                                                                                                                                       
      private val options: ChatOptions,                                                                                                                                                       
  ) : LlmMessageStreamer {                                                                                                                                                                    
      override fun stream(messages, tools) = ...                                                                                                                                              
  }      
```                                                                                                                                                                                     
  2. Create factory/auto-configuration that provides the streamer                                                                                                                             
  3. Framework injects appropriate implementation based on available dependencies                                                                                                             
                                                                                                                                                                                              
 ### PR 3: Streaming Callbacks                                                                                                                                                                   
                                                                                                                                                                                              
 Add callback hooks for observing tool execution during streaming (tool start, tool result, etc.) since the streaming API is opaque and tool execution is managed by the underlying   framework.

