### PR TITLE
Consistently allow for aiModelRestClientBuilder

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/gemini/GeminiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/gemini/GeminiModelsConfig.kt
@@ -28,12 +28,14 @@ import com.embabel.common.ai.model.PricingModel
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import io.micrometer.observation.ObservationRegistry
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
 
 /**
  * Configuration properties for Gemini models.
@@ -94,13 +96,16 @@ class GeminiModelsConfig(
     private val properties: GeminiProperties,
     private val configurableBeanFactory: ConfigurableBeanFactory,
     private val modelLoader: LlmAutoConfigMetadataLoader<GeminiModelDefinitions> = GeminiModelLoader(),
+    @Qualifier("aiModelRestClientBuilder")
+    restClientBuilder: ObjectProvider<RestClient.Builder>,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = envBaseUrl ?: properties.baseUrl ?: DEFAULT_BASE_URL,
     apiKey = envApiKey ?: properties.apiKey
     ?: error("Gemini API key required: set GEMINI_API_KEY env var or embabel.agent.platform.models.gemini.api-key"),
     completionsPath = null,
     embeddingsPath = null,
-    observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP }
+    observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
+    restClientBuilder = restClientBuilder,
 ) {
 
     init {

--- a/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfig.kt
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.micrometer.observation.ObservationRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -81,6 +82,8 @@ class LmStudioModelsConfig(
     private val lmStudioProperties: LmStudioProperties,
     private val configurableBeanFactory: ConfigurableBeanFactory,
     observationRegistry: ObjectProvider<ObservationRegistry>,
+    @Qualifier("aiModelRestClientBuilder")
+    restClientBuilder: ObjectProvider<RestClient.Builder>,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = lmStudioProperties.baseUrl,
     apiKey = lmStudioProperties.apiKey,

--- a/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfigTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfigTest.kt
@@ -33,6 +33,8 @@ class LmStudioModelsConfigTest {
     private val mockLmStudioProperties = mockk<LmStudioProperties>()
     private val mockBeanFactory = mockk<ConfigurableBeanFactory>(relaxed = true)
     private val mockObservationRegistry = mockk<ObjectProvider<ObservationRegistry>>()
+    private val mockRestClientBuilderProvider = mockk<ObjectProvider<RestClient.Builder>>()
+    private val mockRestClientBuilder = mockk<RestClient.Builder>()
     private val mockRestClient = mockk<RestClient>()
     private val mockRequestHeadersUriSpec = mockk<RestClient.RequestHeadersUriSpec<*>>()
     private val mockRequestHeadersSpec = mockk<RestClient.RequestHeadersSpec<*>>()
@@ -49,17 +51,20 @@ class LmStudioModelsConfigTest {
         every { mockBeanFactory.registerSingleton(any(), any()) } just Runs
         every { mockObservationRegistry.getIfUnique(any()) } returns ObservationRegistry.NOOP
 
-        // Mock RestClient.builder() static/chain
+        // Mock the ObjectProvider wrapping the builder (used by the constructor / parent class)
+        every { mockRestClientBuilderProvider.getIfAvailable(any()) } returns mockRestClientBuilder
+
+        // Mock RestClient.builder() static call (used by loadModelsFromUrl internally)
         mockkStatic("org.springframework.web.client.RestClient")
-        val builder = mockk<RestClient.Builder>()
-        every { RestClient.builder() } returns builder
-        every { builder.requestFactory(any()) } returns builder
-        every { builder.build() } returns mockRestClient
-        every { builder.observationRegistry(any()) } returns builder
-        every { builder.clone() } returns builder
-        every { builder.baseUrl(any<String>()) } returns builder
-        every { builder.defaultHeaders(any()) } returns builder
-        every { builder.defaultStatusHandler(any()) } returns builder
+        every { RestClient.builder() } returns mockRestClientBuilder
+
+        every { mockRestClientBuilder.requestFactory(any()) } returns mockRestClientBuilder
+        every { mockRestClientBuilder.build() } returns mockRestClient
+        every { mockRestClientBuilder.observationRegistry(any()) } returns mockRestClientBuilder
+        every { mockRestClientBuilder.clone() } returns mockRestClientBuilder
+        every { mockRestClientBuilder.baseUrl(any<String>()) } returns mockRestClientBuilder
+        every { mockRestClientBuilder.defaultHeaders(any()) } returns mockRestClientBuilder
+        every { mockRestClientBuilder.defaultStatusHandler(any()) } returns mockRestClientBuilder
 
         // Setup standard RestClient call chain
         every { mockRestClient.get() } returns mockRequestHeadersUriSpec
@@ -90,7 +95,8 @@ class LmStudioModelsConfigTest {
         val config = LmStudioModelsConfig(
             lmStudioProperties = mockLmStudioProperties,
             configurableBeanFactory = mockBeanFactory,
-            observationRegistry = mockObservationRegistry
+            observationRegistry = mockObservationRegistry,
+            restClientBuilder = mockRestClientBuilderProvider
         )
 
         // When
@@ -112,7 +118,8 @@ class LmStudioModelsConfigTest {
         val config = LmStudioModelsConfig(
             lmStudioProperties = mockLmStudioProperties,
             configurableBeanFactory = mockBeanFactory,
-            observationRegistry = mockObservationRegistry
+            observationRegistry = mockObservationRegistry,
+            restClientBuilder = mockRestClientBuilderProvider
         )
 
         // When
@@ -130,7 +137,8 @@ class LmStudioModelsConfigTest {
         val config = LmStudioModelsConfig(
             lmStudioProperties = mockLmStudioProperties,
             configurableBeanFactory = mockBeanFactory,
-            observationRegistry = mockObservationRegistry
+            observationRegistry = mockObservationRegistry,
+            restClientBuilder = mockRestClientBuilderProvider
         )
 
         // When
@@ -156,7 +164,8 @@ class LmStudioModelsConfigTest {
         val config = LmStudioModelsConfig(
             lmStudioProperties = mockLmStudioProperties,
             configurableBeanFactory = mockBeanFactory,
-            observationRegistry = mockObservationRegistry
+            observationRegistry = mockObservationRegistry,
+            restClientBuilder = mockRestClientBuilderProvider
         )
 
         // When


### PR DESCRIPTION
This PR ensures that all subclasses of OpenAiCompatibleModelFactory have a `restClientBuilder: ObjectProvider<RestClient.Builder>` constructor parameter.