### PR TITLE
Consistently allow for aiModelWebClientBuilder

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-netty-client-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-netty-client-autoconfigure/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>spring-web</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+        </dependency>
+
         <!--Netty Client-->
         <dependency>
             <groupId>io.projectreactor.netty</groupId>

--- a/embabel-agent-autoconfigure/embabel-agent-netty-client-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/netty/NettyClientAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-netty-client-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/netty/NettyClientAutoConfiguration.java
@@ -23,7 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.client.ReactorClientHttpRequestFactory;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
 import java.time.Duration;
@@ -48,14 +50,24 @@ public class NettyClientAutoConfiguration {
     @Bean("aiModelRestClientBuilder")
     @ConditionalOnProperty(value = "embabel.agent.platform.http-client.use-reactor-netty", havingValue = "true", matchIfMissing = true)
     RestClient.Builder reactorRestClientBuilder(NettyClientFactoryProperties httpClientProperties) {
-        var httpClient = HttpClient.create()
+        var httpClient = httpClient(httpClientProperties);
+        return RestClient.builder().requestFactory(new ReactorClientHttpRequestFactory(httpClient));
+    }
+
+    @Bean("aiModelWebClientBuilder")
+    @ConditionalOnProperty(value = "embabel.agent.platform.http-client.use-reactor-netty", havingValue = "true", matchIfMissing = true)
+    WebClient.Builder reactorWebClientBuilder(NettyClientFactoryProperties httpClientProperties) {
+        var httpClient = httpClient(httpClientProperties);
+        return WebClient.builder().clientConnector(new ReactorClientHttpConnector(httpClient));
+    }
+
+    private static HttpClient httpClient(NettyClientFactoryProperties httpClientProperties) {
+        return HttpClient.create()
                 .followRedirect(true)
                 .responseTimeout(httpClientProperties.readTimeout())
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) httpClientProperties
                         .connectTimeout()
                         .toMillis());
-
-        return RestClient.builder().requestFactory(new ReactorClientHttpRequestFactory(httpClient));
     }
 
 }

--- a/embabel-agent-autoconfigure/embabel-agent-netty-client-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/netty/NettyClientAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-netty-client-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/netty/NettyClientAutoConfigurationTest.java
@@ -19,7 +19,9 @@ import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
@@ -88,5 +90,22 @@ class NettyClientAutoConfigurationTest {
                 org.springframework.http.client.ReactorClientHttpRequestFactory.class,
                 factory
         );
+    }
+
+    @Test
+    void webClientBuilderIsNettyBacked() throws NoSuchFieldException, IllegalAccessException {
+        var config = new NettyClientAutoConfiguration();
+        var props = new NettyClientFactoryProperties(null, null);
+        var builder = config.reactorWebClientBuilder(props);
+
+        assertInstanceOf(WebClient.Builder.class, builder);
+        WebClient webClient = builder.build();
+        Field exchangeFunctionField = webClient.getClass().getDeclaredField("exchangeFunction");
+        exchangeFunctionField.setAccessible(true);
+        Object exchangeFunction = exchangeFunctionField.get(webClient);
+        Field connectorField = exchangeFunction.getClass().getDeclaredField("connector");
+        connectorField.setAccessible(true);
+        Object connector = connectorField.get(exchangeFunction);
+        assertInstanceOf(ReactorClientHttpConnector.class, connector);
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/gemini/GeminiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/gemini/GeminiModelsConfig.kt
@@ -36,6 +36,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
 
 /**
  * Configuration properties for Gemini models.
@@ -98,6 +99,8 @@ class GeminiModelsConfig(
     private val modelLoader: LlmAutoConfigMetadataLoader<GeminiModelDefinitions> = GeminiModelLoader(),
     @Qualifier("aiModelRestClientBuilder")
     restClientBuilder: ObjectProvider<RestClient.Builder>,
+    @Qualifier("aiModelWebClientBuilder")
+    webClientBuilder: ObjectProvider<WebClient.Builder>,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = envBaseUrl ?: properties.baseUrl ?: DEFAULT_BASE_URL,
     apiKey = envApiKey ?: properties.apiKey
@@ -106,6 +109,7 @@ class GeminiModelsConfig(
     embeddingsPath = null,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
     restClientBuilder = restClientBuilder,
+    webClientBuilder = webClientBuilder,
 ) {
 
     init {

--- a/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfig.kt
@@ -36,6 +36,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
 import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
 
 @ConfigurationProperties(prefix = "embabel.agent.platform.models.lmstudio")
 class LmStudioProperties : RetryProperties {
@@ -84,12 +85,16 @@ class LmStudioModelsConfig(
     observationRegistry: ObjectProvider<ObservationRegistry>,
     @Qualifier("aiModelRestClientBuilder")
     restClientBuilder: ObjectProvider<RestClient.Builder>,
+    @Qualifier("aiModelWebClientBuilder")
+    webClientBuilder: ObjectProvider<WebClient.Builder>,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = lmStudioProperties.baseUrl,
     apiKey = lmStudioProperties.apiKey,
     completionsPath = null,
     embeddingsPath = null,
-    observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP }
+    observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
+    restClientBuilder = restClientBuilder,
+    webClientBuilder = webClientBuilder,
 ) {
 
     private val log = LoggerFactory.getLogger(LmStudioModelsConfig::class.java)

--- a/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfigTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfigTest.kt
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.http.MediaType
 import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
 
 /**
  * Unit tests for LM Studio configuration and bean registration.
@@ -35,6 +36,8 @@ class LmStudioModelsConfigTest {
     private val mockObservationRegistry = mockk<ObjectProvider<ObservationRegistry>>()
     private val mockRestClientBuilderProvider = mockk<ObjectProvider<RestClient.Builder>>()
     private val mockRestClientBuilder = mockk<RestClient.Builder>()
+    private val mockWebClientBuilderProvider = mockk<ObjectProvider<WebClient.Builder>>()
+    private val mockWebClientBuilder = mockk<WebClient.Builder>(relaxed = true)
     private val mockRestClient = mockk<RestClient>()
     private val mockRequestHeadersUriSpec = mockk<RestClient.RequestHeadersUriSpec<*>>()
     private val mockRequestHeadersSpec = mockk<RestClient.RequestHeadersSpec<*>>()
@@ -51,12 +54,18 @@ class LmStudioModelsConfigTest {
         every { mockBeanFactory.registerSingleton(any(), any()) } just Runs
         every { mockObservationRegistry.getIfUnique(any()) } returns ObservationRegistry.NOOP
 
-        // Mock the ObjectProvider wrapping the builder (used by the constructor / parent class)
+        // Mock the ObjectProviders wrapping the builders (used by the constructor / parent class)
         every { mockRestClientBuilderProvider.getIfAvailable(any()) } returns mockRestClientBuilder
+        every { mockWebClientBuilderProvider.getIfAvailable(any()) } returns mockWebClientBuilder
 
         // Mock RestClient.builder() static call (used by loadModelsFromUrl internally)
         mockkStatic("org.springframework.web.client.RestClient")
         every { RestClient.builder() } returns mockRestClientBuilder
+
+        // Mock WebClient.Builder chain (used by parent class)
+        every { mockWebClientBuilder.observationRegistry(any()) } returns mockWebClientBuilder
+        every { mockWebClientBuilder.clone() } returns mockWebClientBuilder
+        every { mockWebClientBuilder.build() } returns mockk(relaxed = true)
 
         every { mockRestClientBuilder.requestFactory(any()) } returns mockRestClientBuilder
         every { mockRestClientBuilder.build() } returns mockRestClient
@@ -96,7 +105,8 @@ class LmStudioModelsConfigTest {
             lmStudioProperties = mockLmStudioProperties,
             configurableBeanFactory = mockBeanFactory,
             observationRegistry = mockObservationRegistry,
-            restClientBuilder = mockRestClientBuilderProvider
+            restClientBuilder = mockRestClientBuilderProvider,
+            webClientBuilder = mockWebClientBuilderProvider
         )
 
         // When
@@ -119,7 +129,8 @@ class LmStudioModelsConfigTest {
             lmStudioProperties = mockLmStudioProperties,
             configurableBeanFactory = mockBeanFactory,
             observationRegistry = mockObservationRegistry,
-            restClientBuilder = mockRestClientBuilderProvider
+            restClientBuilder = mockRestClientBuilderProvider,
+            webClientBuilder = mockWebClientBuilderProvider
         )
 
         // When
@@ -138,7 +149,8 @@ class LmStudioModelsConfigTest {
             lmStudioProperties = mockLmStudioProperties,
             configurableBeanFactory = mockBeanFactory,
             observationRegistry = mockObservationRegistry,
-            restClientBuilder = mockRestClientBuilderProvider
+            restClientBuilder = mockRestClientBuilderProvider,
+            webClientBuilder = mockWebClientBuilderProvider
         )
 
         // When
@@ -165,7 +177,8 @@ class LmStudioModelsConfigTest {
             lmStudioProperties = mockLmStudioProperties,
             configurableBeanFactory = mockBeanFactory,
             observationRegistry = mockObservationRegistry,
-            restClientBuilder = mockRestClientBuilderProvider
+            restClientBuilder = mockRestClientBuilderProvider,
+            webClientBuilder = mockWebClientBuilderProvider
         )
 
         // When

--- a/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/minimax/MiniMaxModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/minimax/MiniMaxModelsConfig.kt
@@ -19,7 +19,6 @@ import com.embabel.agent.api.models.MiniMaxModels
 import com.embabel.agent.openai.OpenAiCompatibleModelFactory
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.common.RetryProperties
-import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.OptionsConverter
 import com.embabel.common.ai.model.PerTokenPricingModel
@@ -34,8 +33,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.ClientHttpRequestFactory
 import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
 import java.time.LocalDate
 
 /**
@@ -104,6 +103,8 @@ class MiniMaxModelsConfig(
     private val properties: MiniMaxProperties,
     @Qualifier("aiModelRestClientBuilder")
     restClientBuilder: ObjectProvider<RestClient.Builder>,
+    @Qualifier("aiModelWebClientBuilder")
+    webClientBuilder: ObjectProvider<WebClient.Builder>,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = envBaseUrl ?: properties.baseUrl,
     apiKey = envApiKey?.trim()?.takeIf { it.isNotEmpty() }
@@ -113,6 +114,7 @@ class MiniMaxModelsConfig(
     embeddingsPath = null,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
     restClientBuilder = restClientBuilder,
+    webClientBuilder = webClientBuilder,
 ) {
 
     init {

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -32,13 +32,14 @@ import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import io.micrometer.observation.ObservationRegistry
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.web.client.RestClient
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
 
 /**
  * Configuration properties for OpenAI model settings.
@@ -109,9 +110,11 @@ class OpenAiModelsConfig(
     @Qualifier("aiModelRestClientBuilder")
     restClientBuilder: ObjectProvider<RestClient.Builder>,
     private val properties: OpenAiProperties,
-    private val llmOptionsProperties: LlmOptionsProperties,
+    llmOptionsProperties: LlmOptionsProperties,
     private val configurableBeanFactory: ConfigurableBeanFactory,
     private val modelLoader: LlmAutoConfigMetadataLoader<OpenAiModelDefinitions> = OpenAiModelLoader(),
+    @Qualifier("aiModelWebClientBuilder")
+    webClientBuilder: ObjectProvider<WebClient.Builder>,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = envBaseUrl ?: properties.baseUrl,
     apiKey = envApiKey ?: properties.apiKey
@@ -121,6 +124,7 @@ class OpenAiModelsConfig(
     httpHeaders = llmOptionsProperties.httpHeaders,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
     restClientBuilder = restClientBuilder,
+    webClientBuilder = webClientBuilder,
 ) {
 
     init {

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-custom-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/custom/OpenAiCustomModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-custom-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/custom/OpenAiCustomModelsConfig.kt
@@ -26,14 +26,15 @@ import com.embabel.common.ai.model.LlmOptionsProperties
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import io.micrometer.observation.ObservationRegistry
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
 
 /**
  * Configuration properties for OpenAI Custom model settings.
@@ -128,6 +129,8 @@ class OpenAiCustomModelsConfig(
     private val configurableBeanFactory: ConfigurableBeanFactory,
     @Qualifier("aiModelRestClientBuilder")
     restClientBuilder: ObjectProvider<RestClient.Builder>,
+    @Qualifier("aiModelWebClientBuilder")
+    webClientBuilder: ObjectProvider<WebClient.Builder>,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = envBaseUrl ?: properties.baseUrl,
     apiKey = envApiKey?.trim()?.takeIf { it.isNotEmpty() }
@@ -140,6 +143,7 @@ class OpenAiCustomModelsConfig(
     httpHeaders = llmOptionsProperties.httpHeaders,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
     restClientBuilder = restClientBuilder,
+    webClientBuilder = webClientBuilder,
 ) {
 
     private val customModelList: List<String> = (envCustomModels ?: properties.models)

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -61,7 +61,8 @@ open class OpenAiCompatibleModelFactory(
     private val embeddingsPath: String?,
     private val httpHeaders: Map<String,String> = emptyMap(),
     private val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
-    private val restClientBuilder: ObjectProvider<RestClient.Builder> = ObjectProviders.empty()
+    private val restClientBuilder: ObjectProvider<RestClient.Builder> = ObjectProviders.empty(),
+    private val webClientBuilder: ObjectProvider<WebClient.Builder> = ObjectProviders.empty(),
 ) {
 
     companion object {
@@ -213,7 +214,9 @@ open class OpenAiCompatibleModelFactory(
             )
         builder
             .webClientBuilder(
-                WebClient.builder()
+                webClientBuilder.getIfAvailable {
+                    WebClient.builder()
+                }
                     .observationRegistry(observationRegistry)
             )
 


### PR DESCRIPTION
This PR ensures that all subclasses of OpenAiCompatibleModelFactory have a `webClientBuilder: ObjectProvider<WebClient.Builder>` constructor parameter, so that users can configure WebClient (e.g. for OAuth2 or custom authentication) without having to bypass autoconfiguration.

Closes gh-1584