### PR TITLE
RunSubagent methods always throw and code after the call is unreachable (#1390)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/RunSubagent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/RunSubagent.kt
@@ -48,6 +48,21 @@ object RunSubagent {
      * Run the agent instance as a subagent and return the result.
      * @param agent The agent instance to run as a subagent.
      * @param type The expected return type.
+     *
+     * **IMPORTANT:** This method always throws [SubagentExecutionRequest] internally.
+     * The framework catches this exception and uses it to execute the subagent.
+     * Any code written after this call in your action method will **never execute**.
+     * Use this call as the final statement in your action method, treating it like a `return`.
+     *
+     * ```java
+     * // WRONG — log.info will never run
+     * Result r = RunSubagent.instance(myAgent, Result.class);
+     * log.info("result: {}", r);
+     * return r;
+     *
+     * // CORRECT — this is the last statement
+     * return RunSubagent.instance(myAgent, Result.class);
+     * ```
      */
     @JvmStatic
     @Throws(SubagentExecutionRequest::class)
@@ -64,6 +79,21 @@ object RunSubagent {
      * Run the @Agent annotated instance as a subagent and return the result.
      * @param instance The @Agent annotated instance to run as a subagent.
      * @param type The expected return type.
+     *
+     * **IMPORTANT:** This method always throws [SubagentExecutionRequest] internally.
+     * The framework catches this exception and uses it to execute the subagent.
+     * Any code written after this call in your action method will **never execute**.
+     * Use this call as the final statement in your action method, treating it like a `return`.
+     *
+     * ```java
+     * // WRONG — log.info will never run
+     * Result r = RunSubagent.fromAnnotatedInstance(myAgent, Result.class);
+     * log.info("result: {}", r);
+     * return r;
+     *
+     * // CORRECT — this is the last statement
+     * return RunSubagent.fromAnnotatedInstance(myAgent, Result.class);
+     * ```
      */
     @JvmStatic
     @Throws(SubagentExecutionRequest::class)


### PR DESCRIPTION
This pull request improves the documentation for the `RunSubagent` utility by clarifying its control flow behavior. Specifically, it highlights that the `instance` and `fromAnnotatedInstance` methods always throw a `SubagentExecutionRequest` exception, meaning any code after these calls will not execute. The documentation now includes clear warnings and code examples to guide correct usage.

Documentation improvements:

* Added explicit warnings to the KDoc for both `RunSubagent.instance` and `RunSubagent.fromAnnotatedInstance` methods, explaining that these methods always throw `SubagentExecutionRequest` and should be used as the final statement in an action method. [[1]](diffhunk://#diff-f2cf80382dd498240d48ccb9eb2f12bc52eb7e6ad7133d0adf49a4b5e990fc42R51-R65) [[2]](diffhunk://#diff-f2cf80382dd498240d48ccb9eb2f12bc52eb7e6ad7133d0adf49a4b5e990fc42R82-R96)
* Included illustrative code snippets showing both incorrect and correct usage patterns for these methods to prevent common mistakes. [[1]](diffhunk://#diff-f2cf80382dd498240d48ccb9eb2f12bc52eb7e6ad7133d0adf49a4b5e990fc42R51-R65) [[2]](diffhunk://#diff-f2cf80382dd498240d48ccb9eb2f12bc52eb7e6ad7133d0adf49a4b5e990fc42R82-R96)