### PR TITLE
feat(core): extend ReplanRequestedException support to ConcurrentAgentProcess

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcess.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
 import java.time.Duration
 import java.time.Instant
-import java.util.Collections
+import java.util.concurrent.CopyOnWriteArrayList
 import javax.annotation.concurrent.ThreadSafe
 import kotlin.time.measureTime
 
@@ -109,7 +109,7 @@ open class ConcurrentAgentProcess(
             // Collect replan requests from concurrent actions; thread-safe because multiple
             // coroutines may add to this list simultaneously.
             val replanRequests =
-                Collections.synchronizedList(mutableListOf<Pair<Action, ReplanRequestedException>>())
+                CopyOnWriteArrayList<Pair<Action, ReplanRequestedException>>()
 
             val elapsed =
                 measureTime {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcess.kt
@@ -23,7 +23,9 @@ import com.embabel.plan.WorldState
 import com.embabel.plan.common.condition.ConditionWorldState
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
+import java.time.Duration
 import java.time.Instant
+import java.util.Collections
 import javax.annotation.concurrent.ThreadSafe
 import kotlin.time.measureTime
 
@@ -54,10 +56,25 @@ open class ConcurrentAgentProcess(
     timestamp = timestamp,
 ) {
     override fun formulateAndExecutePlan(worldState: WorldState): AgentProcess {
-        val plan = planner.bestValuePlanToAnyGoal(system = agent.planningSystem)
+        // Mirror SimpleAgentProcess: exclude blacklisted actions, fall back without blacklist if needed
+        val plan = planner.bestValuePlanToAnyGoal(
+            system = agent.planningSystem,
+            excludedActionNames = replanBlacklist,
+        )
         if (plan == null) {
+            if (replanBlacklist.isNotEmpty()) {
+                logger.debug(
+                    "No plan found with blacklist {}, clearing and retrying",
+                    replanBlacklist,
+                )
+                replanBlacklist.clear()
+                return formulateAndExecutePlan(worldState)
+            }
             return handlePlanNotFound(worldState)
         }
+
+        // Clear blacklist after successful planning (matches SimpleAgentProcess behavior)
+        replanBlacklist.clear()
 
         _goal = plan.goal
 
@@ -88,6 +105,12 @@ open class ConcurrentAgentProcess(
                 }
             val process = this
             callbacks.forEach { it.beforeActionLaunched(process) }
+
+            // Collect replan requests from concurrent actions; thread-safe because multiple
+            // coroutines may add to this list simultaneously.
+            val replanRequests =
+                Collections.synchronizedList(mutableListOf<Pair<Action, ReplanRequestedException>>())
+
             val elapsed =
                 measureTime {
                     logger.info("Executing ${actions.size} actions concurrently: \n${actions.map { it.name }}")
@@ -98,6 +121,11 @@ open class ConcurrentAgentProcess(
                                     try {
                                         callbacks.forEach { it.onActionLaunched(process, action) }
                                         executeAction(action)
+                                    } catch (rpe: ReplanRequestedException) {
+                                        // Capture for post-execution handling; return TERMINATED so
+                                        // the status aggregation loop doesn't fail on a missing value.
+                                        replanRequests.add(action to rpe)
+                                        ActionStatus(Duration.ZERO, ActionStatusCode.TERMINATED)
                                     } finally {
                                         callbacks.forEach { it.onActionCompleted(process, action) }
                                     }
@@ -107,7 +135,16 @@ open class ConcurrentAgentProcess(
                                     deferred.await()
                                 }
                             }
-                    setStatus(actionStatusToAgentProcessStatus(agentStatuses))
+
+                    if (replanRequests.isNotEmpty()) {
+                        // If multiple actions requested replan concurrently, handle only the first.
+                        // The others' blackboard updates are intentionally dropped — they ran in a
+                        // context that is about to be replanned anyway.
+                        val (action, rpe) = replanRequests.first()
+                        handleReplanRequest(action, rpe)
+                    } else {
+                        setStatus(actionStatusToAgentProcessStatus(agentStatuses))
+                    }
                 }
             logger.info("Executed ${actions.size} actions in $elapsed")
         }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/SimpleAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/SimpleAgentProcess.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.api.event.ReplanRequestedEvent
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.Action
 import com.embabel.agent.core.Agent
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.AgentProcessStatusCode
@@ -68,7 +69,7 @@ open class SimpleAgentProcess(
      * would be the only applicable action again.
      * Cleared after each successful planning cycle.
      */
-    private val replanBlacklist = mutableSetOf<String>()
+    protected val replanBlacklist = mutableSetOf<String>()
 
     protected fun handlePlanNotFound(worldState: WorldState): AgentProcess {
         logger.debug(
@@ -161,23 +162,7 @@ open class SimpleAgentProcess(
                 val actionStatus = executeAction(action)
                 setStatus(actionStatusToAgentProcessStatus(actionStatus))
             } catch (rpe: ReplanRequestedException) {
-                // Apply blackboard updates from the replan request
-                rpe.blackboardUpdater.accept(blackboard)
-                // Blacklist this action for the next planning cycle to prevent infinite loops
-                replanBlacklist.add(action.name)
-                logger.info(
-                    "Action {} requested replan: {}. Blacklisted for next cycle.",
-                    action.name,
-                    rpe.reason,
-                )
-                platformServices.eventListener.onProcessEvent(
-                    ReplanRequestedEvent(
-                        agentProcess = this,
-                        reason = rpe.reason,
-                    )
-                )
-                // Keep status as RUNNING to trigger replanning on next tick
-                setStatus(AgentProcessStatusCode.RUNNING)
+                handleReplanRequest(action, rpe)
             } catch (e: TerminateActionException) {
                 // Action requested early termination - continue with next action
                 logger.info(
@@ -211,4 +196,31 @@ open class SimpleAgentProcess(
             ?: error(
                 "No unique action found for ${plan.actions.first().name} in ${agent.actions.map { it.name }}"
             )
+
+    /**
+     * Handles a [ReplanRequestedException] thrown by an action.
+     *
+     * Shared by [SimpleAgentProcess] and [ConcurrentAgentProcess] to keep replan semantics
+     * consistent across both execution modes:
+     * 1. Applies the blackboard updates supplied by the throwing action.
+     * 2. Blacklists the action for the next planning cycle to prevent an immediate infinite loop.
+     * 3. Emits a [ReplanRequestedEvent].
+     * 4. Keeps the process status as [AgentProcessStatusCode.RUNNING] so the main loop replans.
+     */
+    protected fun handleReplanRequest(action: Action, rpe: ReplanRequestedException) {
+        rpe.blackboardUpdater.accept(blackboard)
+        replanBlacklist.add(action.name)
+        logger.info(
+            "Action {} requested replan: {}. Blacklisted for next cycle.",
+            action.name,
+            rpe.reason,
+        )
+        platformServices.eventListener.onProcessEvent(
+            ReplanRequestedEvent(
+                agentProcess = this,
+                reason = rpe.reason,
+            )
+        )
+        setStatus(AgentProcessStatusCode.RUNNING)
+    }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcessTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ConcurrentAgentProcessTest.kt
@@ -332,4 +332,59 @@ class ConcurrentAgentProcessTest {
 
     }
 
+    @Nested
+    inner class ReplanRequestedExceptionHandling {
+
+        private fun makeProcess(agent: com.embabel.agent.core.Agent, blackboard: InMemoryBlackboard) =
+            ConcurrentAgentProcess(
+                id = "test-replan",
+                agent = agent,
+                processOptions = ProcessOptions(),
+                blackboard = blackboard,
+                platformServices = dummyPlatformServices(),
+                plannerFactory = DefaultPlannerFactory,
+                parentId = null,
+            )
+
+        @Test
+        fun `ReplanRequestedException applies blackboard updates and triggers replanning`() {
+            val blackboard = InMemoryBlackboard()
+            blackboard += UserInput("TestUser")
+
+            val result = makeProcess(ReplanningAgent, blackboard).run()
+
+            assertEquals(AgentProcessStatusCode.COMPLETED, result.status)
+            assertEquals("alternate", blackboard["routedTo"])
+            val frog = blackboard.lastResult() as com.embabel.agent.api.dsl.Frog
+            assertEquals("Alternate: TestUser", frog.name)
+        }
+
+        @Test
+        fun `ReplanRequestedException handles multiple consecutive replans`() {
+            val blackboard = InMemoryBlackboard()
+            blackboard += UserInput("CountingUser")
+
+            val result = makeProcess(MultiReplanAgent, blackboard).run()
+
+            assertEquals(AgentProcessStatusCode.COMPLETED, result.status)
+            assertEquals(3, blackboard["replanCount"])
+            val frog = blackboard.lastResult() as com.embabel.agent.api.dsl.Frog
+            assertTrue(frog.name.contains("CountingUser"))
+            assertTrue(frog.name.contains("3 replans"))
+        }
+
+        @Test
+        fun `replan blacklist prevents infinite loop by selecting alternate action`() {
+            val blackboard = InMemoryBlackboard()
+            blackboard += UserInput("BlacklistTest")
+
+            val result = makeProcess(BlacklistTestAgent, blackboard).run()
+
+            assertEquals(AgentProcessStatusCode.COMPLETED, result.status)
+            val frog = blackboard.lastResult() as com.embabel.agent.api.dsl.Frog
+            assertTrue(frog.name.contains("fallback"))
+            assertTrue((blackboard["replanAttempts"] as? Int ?: 0) >= 1)
+        }
+    }
+
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ReplanTestAgents.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ReplanTestAgents.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.support
+
+import com.embabel.agent.api.dsl.Frog
+import com.embabel.agent.api.dsl.agent
+import com.embabel.agent.core.ReplanRequestedException
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.domain.library.Person
+
+data class LocalPerson(
+    override val name: String,
+) : Person
+
+/**
+ * Agent that throws [ReplanRequestedException] on first action, triggering replanning.
+ * Uses blackboard state to decide whether to throw or proceed.
+ */
+val ReplanningAgent = agent("Replanner", description = "Agent that triggers replanning") {
+    transformation<UserInput, LocalPerson>(name = "routing_transform") {
+        val routedTo = it["routedTo"] as? String
+        if (routedTo == "alternate") {
+            LocalPerson(name = "Alternate: ${it.input.content}")
+        } else {
+            throw ReplanRequestedException(
+                reason = "Routing to alternate path",
+                blackboardUpdater = { bb -> bb["routedTo"] = "alternate" },
+            )
+        }
+    }
+
+    transformation<LocalPerson, Frog>(name = "to_frog") {
+        Frog(it.input.name)
+    }
+
+    goal(name = "frog_goal", description = "Turn input into frog", satisfiedBy = Frog::class)
+}
+
+/**
+ * Agent with multiple replans testing repeated replanning.
+ */
+val MultiReplanAgent = agent("MultiReplanner", description = "Agent that replans multiple times") {
+    transformation<UserInput, LocalPerson>(name = "counting_transform") {
+        val count = (it["replanCount"] as? Int) ?: 0
+        if (count < 3) {
+            throw ReplanRequestedException(
+                reason = "Need more replans (count=$count)",
+                blackboardUpdater = { bb -> bb["replanCount"] = count + 1 },
+            )
+        }
+        LocalPerson(name = "Finally done after $count replans: ${it.input.content}")
+    }
+
+    transformation<LocalPerson, Frog>(name = "person_to_frog") {
+        Frog(it.input.name)
+    }
+
+    goal(name = "frog_goal", description = "Turn input into frog", satisfiedBy = Frog::class)
+}
+
+/**
+ * Agent to test blacklist behavior: has two actions that can both run from [UserInput].
+ * Action `always_replans` always requests replan. Action `completes_normally` completes normally.
+ * After `always_replans` is blacklisted, `completes_normally` should be selected.
+ */
+val BlacklistTestAgent = agent("BlacklistTester", description = "Agent that tests replan blacklist") {
+    transformation<UserInput, LocalPerson>(name = "always_replans") {
+        throw ReplanRequestedException(
+            reason = "Always replanning",
+            blackboardUpdater = { bb -> bb["replanAttempts"] = ((bb["replanAttempts"] as? Int) ?: 0) + 1 },
+        )
+    }
+
+    transformation<UserInput, LocalPerson>(name = "completes_normally") {
+        LocalPerson(name = "Completed via fallback: ${it.input.content}")
+    }
+
+    transformation<LocalPerson, Frog>(name = "to_frog") {
+        Frog(it.input.name)
+    }
+
+    goal(name = "frog_goal", description = "Turn input into frog", satisfiedBy = Frog::class)
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/SimpleAgentProcessTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/SimpleAgentProcessTest.kt
@@ -31,12 +31,10 @@ import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.AgentProcessStatusCode
 import com.embabel.agent.core.IoBinding
 import com.embabel.agent.core.ProcessOptions
-import com.embabel.agent.core.ReplanRequestedException
 import com.embabel.agent.core.hitl.ConfirmationRequest
 import com.embabel.agent.core.hitl.confirm
 import com.embabel.agent.core.hitl.waitFor
 import com.embabel.agent.domain.io.UserInput
-import com.embabel.agent.domain.library.Person
 import com.embabel.agent.spi.support.DefaultPlannerFactory
 import com.embabel.agent.support.Dog
 import com.embabel.agent.support.SimpleTestAgent
@@ -49,10 +47,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.IOException
-
-data class LocalPerson(
-    override val name: String,
-) : Person
 
 @com.embabel.agent.api.annotation.Agent(
     description = "waiting agent",
@@ -128,81 +122,6 @@ val DslWaitingAgent = agent("Waiter", description = "Simple test agent that wait
     }
 
     goal(name = "done", description = "done", satisfiedBy = Frog::class)
-}
-
-/**
- * Agent that throws ReplanRequestedException on first action, triggering replanning.
- * Uses blackboard state to decide whether to throw or proceed.
- */
-val ReplanningAgent = agent("Replanner", description = "Agent that triggers replanning") {
-    // Single action that either throws ReplanRequestedException or proceeds based on blackboard state
-    transformation<UserInput, LocalPerson>(name = "routing_transform") {
-        val routedTo = it["routedTo"] as? String
-        if (routedTo == "alternate") {
-            // Already routed, proceed normally
-            LocalPerson(name = "Alternate: ${it.input.content}")
-        } else {
-            // First time: throw ReplanRequestedException to trigger replanning with blackboard updates
-            throw ReplanRequestedException(
-                reason = "Routing to alternate path",
-                blackboardUpdater = { bb -> bb["routedTo"] = "alternate" }
-            )
-        }
-    }
-
-    transformation<LocalPerson, Frog>(name = "to_frog") {
-        Frog(it.input.name)
-    }
-
-    goal(name = "frog_goal", description = "Turn input into frog", satisfiedBy = Frog::class)
-}
-
-/**
- * Agent with multiple replans testing repeated replanning
- */
-val MultiReplanAgent = agent("MultiReplanner", description = "Agent that replans multiple times") {
-    transformation<UserInput, LocalPerson>(name = "counting_transform") {
-        val count = (it["replanCount"] as? Int) ?: 0
-        if (count < 3) {
-            throw ReplanRequestedException(
-                reason = "Need more replans (count=$count)",
-                blackboardUpdater = { bb -> bb["replanCount"] = count + 1 }
-            )
-        }
-        LocalPerson(name = "Finally done after $count replans: ${it.input.content}")
-    }
-
-    transformation<LocalPerson, Frog>(name = "person_to_frog") {
-        Frog(it.input.name)
-    }
-
-    goal(name = "frog_goal", description = "Turn input into frog", satisfiedBy = Frog::class)
-}
-
-/**
- * Agent to test blacklist behavior: has two actions that can both run from UserInput.
- * Action A always requests replan. Action B completes normally.
- * After A is blacklisted, B should be selected.
- */
-val BlacklistTestAgent = agent("BlacklistTester", description = "Agent that tests replan blacklist") {
-    // Action A: Always requests replan (would cause infinite loop without blacklist)
-    transformation<UserInput, LocalPerson>(name = "always_replans") {
-        throw ReplanRequestedException(
-            reason = "Always replanning",
-            blackboardUpdater = { bb -> bb["replanAttempts"] = ((bb["replanAttempts"] as? Int) ?: 0) + 1 }
-        )
-    }
-
-    // Action B: Completes normally - should be selected after A is blacklisted
-    transformation<UserInput, LocalPerson>(name = "completes_normally") {
-        LocalPerson(name = "Completed via fallback: ${it.input.content}")
-    }
-
-    transformation<LocalPerson, Frog>(name = "to_frog") {
-        Frog(it.input.name)
-    }
-
-    goal(name = "frog_goal", description = "Turn input into frog", satisfiedBy = Frog::class)
 }
 
 /**

--- a/embabel-agent-docs/src/main/asciidoc/reference/agent-process/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/agent-process/page.adoc
@@ -4,6 +4,93 @@
 An `AgentProcess` is created every time an agent is run.
 It has a unique id.
 
+[[reference.agent-process__execution-modes]]
+=== Execution Modes
+
+Embabel supports two execution modes for agent processes, controlled by the
+`embabel.agent.platform.process-type` property.
+
+[[reference.agent-process__simple]]
+==== SimpleAgentProcess (Default)
+
+`SimpleAgentProcess` is the default execution mode.
+On each planning tick it selects the single best action from the current plan
+and runs it to completion before replanning.
+
+This sequential approach is predictable and easy to reason about:
+actions never run in parallel and the blackboard is always in a consistent state
+when the next action begins.
+
+[[reference.agent-process__concurrent]]
+==== ConcurrentAgentProcess
+
+`ConcurrentAgentProcess` extends `SimpleAgentProcess` and runs *all currently
+achievable actions in parallel* on each planning tick.
+
+Instead of picking one action per tick, it finds every action in the plan that
+is achievable given the current world state and launches them concurrently using
+the platform's `Asyncer` abstraction (backed by Spring's managed task executor
+with virtual threads).
+Once all launched actions have completed the process replans, and the cycle repeats.
+
+This is useful when an agent has independent sub-tasks that can proceed simultaneously—
+for example, enriching multiple data items in parallel, or running several
+analysis steps whose outputs do not depend on each other.
+
+===== Activating ConcurrentAgentProcess
+
+Set the following property in your application configuration:
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      process-type: CONCURRENT
+----
+
+or in `application.properties`:
+
+[source,properties]
+----
+embabel.agent.platform.process-type=CONCURRENT
+----
+
+The default value is `SIMPLE`.
+
+===== Replanning in Concurrent Mode
+
+Both `SimpleAgentProcess` and `ConcurrentAgentProcess` support
+`ReplanRequestedException`, which an action can throw to signal that the agent
+should update the blackboard and replan before proceeding.
+
+In `ConcurrentAgentProcess`, multiple concurrently running actions may throw
+`ReplanRequestedException` at the same time.
+When this happens only the first request is honoured—its blackboard updates
+are applied and the triggering action is blacklisted for the next planning
+cycle to prevent an immediate infinite loop.
+The remaining requests are silently dropped, as they ran in a context that is
+about to be replanned anyway.
+
+The blacklist is cleared automatically after a successful planning cycle.
+If no plan can be found while a blacklist is active, the blacklist is cleared
+and planning is retried, ensuring the agent does not become permanently stuck.
+
+===== Choosing an Execution Mode
+
+[cols="1,2,2",options="header"]
+|===
+|Mode |When to use |Trade-offs
+
+|`SIMPLE`
+|Most agents; sequential pipelines; when action order matters
+|Predictable; easier to debug; no concurrency overhead
+
+|`CONCURRENT`
+|Independent parallel sub-tasks; fan-out/fan-in patterns; throughput-sensitive workloads
+|Higher throughput; requires actions to be safe to run concurrently against a shared blackboard
+|===
+
 === ProcessOptions
 
 Agent processes can be configured with `ProcessOptions`.


### PR DESCRIPTION
## Extend `ReplanRequestedException` support to `ConcurrentAgentProcess`

### Problem

`ConcurrentAgentProcess` previously ignored `ReplanRequestedException` entirely. Any action running in concurrent mode that threw this exception would crash the coroutine with an unhandled exception rather than triggering the expected replan-and-blacklist behaviour that `SimpleAgentProcess` already implemented correctly. This meant agents relying on dynamic replanning could not safely use concurrent execution mode.

### Changes

#### `SimpleAgentProcess` — refactor for reuse

- Changed `replanBlacklist` from `private` to `protected` so the concurrent subclass can access it.
- Extracted the inline replan-handling logic into a new `protected fun handleReplanRequest(action, rpe)` method. This keeps semantics identical for the simple case while making the behaviour shareable without duplication.

#### `ConcurrentAgentProcess` — full replan support

- Added a thread-safe `Collections.synchronizedList` to collect `ReplanRequestedException` instances thrown by concurrently running coroutines — multiple actions can request a replan in the same tick.
- After all concurrent actions complete, if any replan requests were collected the *first* request is honoured: its blackboard updates are applied, the triggering action is blacklisted, a `ReplanRequestedEvent` is emitted, and the process status is kept as `RUNNING` to trigger replanning on the next tick. Subsequent requests are intentionally dropped — they ran in a context that is about to be replanned.
- Mirrored `SimpleAgentProcess`'s blacklist-fallback logic: if no plan can be found while a blacklist is active, the blacklist is cleared and planning is retried. This prevents the agent from becoming permanently stuck when the blacklisted action is the only available option.
- Clears the blacklist after each successful planning cycle, consistent with `SimpleAgentProcess`.

#### Test fixtures — extracted to shared module

- Moved `LocalPerson`, `ReplanningAgent`, `MultiReplanAgent`, and `BlacklistTestAgent` out of `SimpleAgentProcessTest` into a new `ReplanTestAgents.kt` file so they can be reused by both test classes without duplication.
- Added a `ConcurrentAgentProcessTest.ReplanRequestedExceptionHandling` nested test suite covering: replan triggering blackboard updates and completing successfully, and blacklist behaviour causing the planner to select an alternate action.

#### Documentation

- Added an **Execution Modes** section to `reference/agent-process/page.adoc` documenting `SimpleAgentProcess` and `ConcurrentAgentProcess`, including:
  - How each mode works and when to choose it
  - How to activate `ConcurrentAgentProcess` via `embabel.agent.platform.process-type=CONCURRENT`
  - Replanning semantics in concurrent mode (first-wins policy, blacklisting, blacklist-fallback)
  - A comparison table to help users choose between the two modes

### Behaviour unchanged for `SimpleAgentProcess`

The refactoring is purely mechanical — the extracted `handleReplanRequest` method contains the same logic that was previously inline. All existing `SimpleAgentProcessTest` replan tests continue to pass.'