### PR TITLE
Add metadata to Tool.Definition

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/LlmTool.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/LlmTool.kt
@@ -45,7 +45,22 @@ annotation class LlmTool(
      * Leave empty for tools that should always be exposed.
      */
     val category: String = "",
+
+    /**
+     * Application-level metadata entries merged into [com.embabel.agent.api.tool.Tool.Definition.metadata].
+     * Used for routing, categorization, feature flags, etc. — not sent to the LLM.
+     *
+     * Example: `@LlmTool(metadata = [LlmTool.Meta(key = "conversational", value = "true")])`
+     */
+    val metadata: Array<Meta> = [],
 ) {
+
+    /**
+     * A key-value metadata entry for use in [LlmTool.metadata].
+     */
+    @Target()
+    @Retention(AnnotationRetention.RUNTIME)
+    annotation class Meta(val key: String, val value: String)
 
     /**
      * Describes a tool parameter. Apply to method parameters.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodTool.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodTool.kt
@@ -48,6 +48,10 @@ internal sealed class MethodTool(
 
     override val metadata: Tool.Metadata = Tool.Metadata(returnDirect = annotation.returnDirect)
 
+    /** Annotation metadata entries parsed into a map for [Tool.Definition.metadata]. */
+    protected val annotationMetadata: Map<String, Any> =
+        annotation.metadata.associate { it.key to it.value }
+
     override fun call(input: String): Tool.Result =
         callWithContext(input, ToolCallContext.EMPTY)
 
@@ -172,6 +176,7 @@ internal class KotlinMethodTool(
             name = name,
             description = annotation.description,
             inputSchema = MethodInputSchema(parameterInfos),
+            metadata = annotationMetadata,
         )
     }
 
@@ -248,6 +253,7 @@ internal class JavaMethodTool(
             name = name,
             description = annotation.description,
             inputSchema = MethodInputSchema(parameterInfos),
+            metadata = annotationMetadata,
         )
     }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/Tool.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/Tool.kt
@@ -82,27 +82,58 @@ interface Tool : ToolInfo {
         /** Schema describing the input parameters. */
         val inputSchema: InputSchema
 
+        /**
+         * Extensible key-value metadata for application-level concerns
+         * (routing, categorization, feature flags, etc.).
+         * Not sent to the LLM — used by the tool framework and hosting application.
+         */
+        val metadata: Map<String, Any> get() = emptyMap()
+
         fun withParameter(parameter: Parameter): Definition =
             SimpleDefinition(
                 name = name,
                 description = description,
                 inputSchema = inputSchema.withParameter(parameter),
+                metadata = metadata,
             )
+
+        /**
+         * Return a copy of this definition with the given metadata entries merged in.
+         * Existing keys are overwritten by the new values.
+         */
+        fun withMetadata(entries: Map<String, Any>): Definition =
+            SimpleDefinition(
+                name = name,
+                description = description,
+                inputSchema = inputSchema,
+                metadata = metadata + entries,
+            )
+
+        /**
+         * Return a copy of this definition with a single metadata entry added.
+         */
+        fun withMetadata(key: String, value: Any): Definition =
+            withMetadata(mapOf(key to value))
 
         companion object {
 
+            @JvmStatic
+            @JvmOverloads
             operator fun invoke(
                 name: String,
                 description: String,
                 inputSchema: InputSchema,
-            ): Definition = SimpleDefinition(name, description, inputSchema)
+                metadata: Map<String, Any> = emptyMap(),
+            ): Definition = SimpleDefinition(name, description, inputSchema, metadata)
 
             @JvmStatic
+            @JvmOverloads
             fun create(
                 name: String,
                 description: String,
                 inputSchema: InputSchema,
-            ): Definition = SimpleDefinition(name, description, inputSchema)
+                metadata: Map<String, Any> = emptyMap(),
+            ): Definition = SimpleDefinition(name, description, inputSchema, metadata)
         }
     }
 
@@ -603,6 +634,20 @@ interface Tool : ToolInfo {
      * @return A new Tool with the note appended to its description
      */
     fun withNote(note: String): Tool = DescribedTool(this, "${definition.description}. $note")
+
+    /**
+     * Create a new tool with additional definition metadata entries merged in.
+     * Existing keys are overwritten by the new values.
+     *
+     * @param entries metadata key-value pairs to merge
+     * @return A new Tool with the updated definition metadata
+     */
+    fun withDefinitionMetadata(entries: Map<String, Any>): Tool = MetadataTaggedTool(this, entries)
+
+    /**
+     * Create a new tool with a single definition metadata entry added.
+     */
+    fun withDefinitionMetadata(key: String, value: Any): Tool = withDefinitionMetadata(mapOf(key to value))
 }
 
 /**
@@ -618,6 +663,7 @@ private class RenamedTool(
         name = customName,
         description = delegate.definition.description,
         inputSchema = delegate.definition.inputSchema,
+        metadata = delegate.definition.metadata,
     )
 
     override val metadata: Tool.Metadata
@@ -637,7 +683,23 @@ private class DescribedTool(
         name = delegate.definition.name,
         description = customDescription,
         inputSchema = delegate.definition.inputSchema,
+        metadata = delegate.definition.metadata,
     )
+
+    override val metadata: Tool.Metadata
+        get() = delegate.metadata
+}
+
+/**
+ * A tool wrapper that merges additional definition metadata.
+ * Implements [DelegatingTool] to support unwrapping in injection strategies.
+ */
+private class MetadataTaggedTool(
+    override val delegate: Tool,
+    entries: Map<String, Any>,
+) : DelegatingTool {
+
+    override val definition: Tool.Definition = delegate.definition.withMetadata(entries)
 
     override val metadata: Tool.Metadata
         get() = delegate.metadata
@@ -649,6 +711,7 @@ private data class SimpleDefinition(
     override val name: String,
     override val description: String,
     override val inputSchema: Tool.InputSchema,
+    override val metadata: Map<String, Any> = emptyMap(),
 ) : Tool.Definition
 
 private data class SimpleInputSchema(

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/tool/ToolFromInstanceJavaTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/tool/ToolFromInstanceJavaTest.java
@@ -425,4 +425,63 @@ class ToolFromInstanceJavaTest {
             assertFalse(required.contains("title"), "'title' must NOT be in required: " + required);
         }
     }
+
+    // --- Java annotation metadata fixtures ---
+
+    static class JavaToolWithMetadata {
+        @LlmTool(description = "A tagged tool", metadata = {
+                @LlmTool.Meta(key = "conversational", value = "true"),
+                @LlmTool.Meta(key = "tier", value = "premium"),
+        })
+        String taggedTool() {
+            return "tagged";
+        }
+    }
+
+    static class JavaToolWithoutMetadata {
+        @LlmTool(description = "A plain tool")
+        String plainTool() {
+            return "plain";
+        }
+    }
+
+    @Nested
+    class JavaAnnotationMetadata {
+
+        @Test
+        void javaAnnotationMetadataIsCapturedOnDefinition() {
+            var tools = Tool.fromInstance(new JavaToolWithMetadata());
+            var tool = tools.getFirst();
+
+            assertEquals("true", tool.getDefinition().getMetadata().get("conversational"));
+            assertEquals("premium", tool.getDefinition().getMetadata().get("tier"));
+            assertEquals(2, tool.getDefinition().getMetadata().size());
+        }
+
+        @Test
+        void javaToolWithNoMetadataHasEmptyMap() {
+            var tools = Tool.fromInstance(new JavaToolWithoutMetadata());
+            var tool = tools.getFirst();
+
+            assertTrue(tool.getDefinition().getMetadata().isEmpty());
+        }
+
+        @Test
+        void withMetadataSingleEntryFromJava() {
+            var def = Tool.Definition.create("test", "desc", Tool.InputSchema.empty());
+            var updated = def.withMetadata("key", "value");
+
+            assertTrue(def.getMetadata().isEmpty());
+            assertEquals("value", updated.getMetadata().get("key"));
+        }
+
+        @Test
+        void withMetadataMapFromJava() {
+            var def = Tool.Definition.create("test", "desc", Tool.InputSchema.empty());
+            var updated = def.withMetadata(java.util.Map.of("a", "1", "b", "2"));
+
+            assertEquals(2, updated.getMetadata().size());
+            assertEquals("1", updated.getMetadata().get("a"));
+        }
+    }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/ToolTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/ToolTest.kt
@@ -48,6 +48,26 @@ class ToolTest {
         }
     }
 
+    class ToolsWithMetadata {
+        @LlmTool(
+            description = "A conversational tool",
+            metadata = [LlmTool.Meta(key = "conversational", value = "true")],
+        )
+        fun chatTool(): String = "hello"
+
+        @LlmTool(
+            description = "A tool with multiple metadata entries",
+            metadata = [
+                LlmTool.Meta(key = "tier", value = "premium"),
+                LlmTool.Meta(key = "category", value = "analytics"),
+            ],
+        )
+        fun analyticsTool(): String = "data"
+
+        @LlmTool(description = "A tool with no metadata")
+        fun plainTool(): String = "plain"
+    }
+
     class NumericTools {
         @LlmTool(description = "Multiply two longs")
         fun multiplyLongs(
@@ -944,6 +964,201 @@ class ToolTest {
             val result = sumTool.call("""{"a": "hello", "b": "3"}""")
 
             assertTrue(result is Tool.Result.Error)
+        }
+    }
+
+    @Nested
+    inner class DefinitionMetadata {
+
+        @Test
+        fun `default metadata is empty`() {
+            val definition = Tool.Definition("test", "desc", Tool.InputSchema.empty())
+            assertTrue(definition.metadata.isEmpty())
+        }
+
+        @Test
+        fun `metadata can be set via constructor`() {
+            val definition = Tool.Definition(
+                "test", "desc", Tool.InputSchema.empty(),
+                metadata = mapOf("conversational" to "true", "tier" to "premium"),
+            )
+            assertEquals("true", definition.metadata["conversational"])
+            assertEquals("premium", definition.metadata["tier"])
+        }
+
+        @Test
+        fun `withMetadata merges entries`() {
+            val original = Tool.Definition("test", "desc", Tool.InputSchema.empty())
+            val updated = original.withMetadata(mapOf("key1" to "val1", "key2" to "val2"))
+
+            assertTrue(original.metadata.isEmpty())
+            assertEquals("val1", updated.metadata["key1"])
+            assertEquals("val2", updated.metadata["key2"])
+        }
+
+        @Test
+        fun `withMetadata single key-value`() {
+            val definition = Tool.Definition("test", "desc", Tool.InputSchema.empty())
+                .withMetadata("conversational", "true")
+
+            assertEquals("true", definition.metadata["conversational"])
+            assertEquals(1, definition.metadata.size)
+        }
+
+        @Test
+        fun `withMetadata overwrites existing keys`() {
+            val original = Tool.Definition(
+                "test", "desc", Tool.InputSchema.empty(),
+                metadata = mapOf("key" to "old"),
+            )
+            val updated = original.withMetadata("key", "new")
+
+            assertEquals("old", original.metadata["key"])
+            assertEquals("new", updated.metadata["key"])
+        }
+
+        @Test
+        fun `withMetadata preserves name description and schema`() {
+            val schema = Tool.InputSchema.of(
+                Tool.Parameter.string("param1", "A parameter"),
+            )
+            val original = Tool.Definition("myTool", "My description", schema)
+            val updated = original.withMetadata("key", "value")
+
+            assertEquals("myTool", updated.name)
+            assertEquals("My description", updated.description)
+            assertEquals(1, updated.inputSchema.parameters.size)
+        }
+
+        @Test
+        fun `withParameter preserves metadata`() {
+            val original = Tool.Definition(
+                "test", "desc", Tool.InputSchema.empty(),
+                metadata = mapOf("tier" to "premium"),
+            )
+            val updated = original.withParameter(Tool.Parameter.string("city", "City name"))
+
+            assertEquals("premium", updated.metadata["tier"])
+            assertEquals(1, updated.inputSchema.parameters.size)
+        }
+    }
+
+    @Nested
+    inner class AnnotationMetadata {
+
+        @Test
+        fun `annotation metadata is captured on tool definition`() {
+            val tools = Tool.fromInstance(ToolsWithMetadata())
+            val chatTool = tools.find { it.definition.name == "chatTool" }!!
+
+            assertEquals("true", chatTool.definition.metadata["conversational"])
+        }
+
+        @Test
+        fun `multiple annotation metadata entries are captured`() {
+            val tools = Tool.fromInstance(ToolsWithMetadata())
+            val analyticsTool = tools.find { it.definition.name == "analyticsTool" }!!
+
+            assertEquals("premium", analyticsTool.definition.metadata["tier"])
+            assertEquals("analytics", analyticsTool.definition.metadata["category"])
+            assertEquals(2, analyticsTool.definition.metadata.size)
+        }
+
+        @Test
+        fun `tool with no annotation metadata has empty metadata`() {
+            val tools = Tool.fromInstance(ToolsWithMetadata())
+            val plainTool = tools.find { it.definition.name == "plainTool" }!!
+
+            assertTrue(plainTool.definition.metadata.isEmpty())
+        }
+
+        @Test
+        fun `existing tools without metadata annotation have empty metadata`() {
+            val tools = Tool.fromInstance(WeatherTools())
+            for (tool in tools) {
+                assertTrue(tool.definition.metadata.isEmpty())
+            }
+        }
+    }
+
+    @Nested
+    inner class ToolWithDefinitionMetadata {
+
+        private fun baseTool() = Tool.of(
+            name = "test_tool",
+            description = "A test tool",
+            inputSchema = Tool.InputSchema.of(
+                Tool.Parameter.string("param", "A param"),
+            ),
+            metadata = Tool.Metadata(returnDirect = true),
+        ) { Tool.Result.text("ok") }
+
+        @Test
+        fun `withDefinitionMetadata adds entries`() {
+            val tool = baseTool().withDefinitionMetadata("tier", "premium")
+
+            assertEquals("premium", tool.definition.metadata["tier"])
+            assertEquals("test_tool", tool.definition.name)
+            assertEquals("A test tool", tool.definition.description)
+        }
+
+        @Test
+        fun `withDefinitionMetadata map variant`() {
+            val tool = baseTool().withDefinitionMetadata(mapOf("a" to "1", "b" to "2"))
+
+            assertEquals("1", tool.definition.metadata["a"])
+            assertEquals("2", tool.definition.metadata["b"])
+        }
+
+        @Test
+        fun `withDefinitionMetadata preserves tool metadata`() {
+            val tool = baseTool().withDefinitionMetadata("key", "value")
+
+            assertTrue(tool.metadata.returnDirect)
+        }
+
+        @Test
+        fun `withDefinitionMetadata preserves input schema`() {
+            val tool = baseTool().withDefinitionMetadata("key", "value")
+
+            assertEquals(1, tool.definition.inputSchema.parameters.size)
+            assertEquals("param", tool.definition.inputSchema.parameters.first().name)
+        }
+
+        @Test
+        fun `withDefinitionMetadata tool is callable`() {
+            val tool = baseTool().withDefinitionMetadata("key", "value")
+            val result = tool.call("{}")
+
+            assertTrue(result is Tool.Result.Text)
+            assertEquals("ok", (result as Tool.Result.Text).content)
+        }
+
+        @Test
+        fun `withName preserves definition metadata`() {
+            val original = baseTool().withDefinitionMetadata("tier", "premium")
+            val renamed = original.withName("new_name")
+
+            assertEquals("new_name", renamed.definition.name)
+            assertEquals("premium", renamed.definition.metadata["tier"])
+        }
+
+        @Test
+        fun `withDescription preserves definition metadata`() {
+            val original = baseTool().withDefinitionMetadata("tier", "premium")
+            val described = original.withDescription("New description")
+
+            assertEquals("New description", described.definition.description)
+            assertEquals("premium", described.definition.metadata["tier"])
+        }
+
+        @Test
+        fun `withNote preserves definition metadata`() {
+            val original = baseTool().withDefinitionMetadata("tier", "premium")
+            val noted = original.withNote("extra info")
+
+            assertTrue(noted.definition.description.contains("extra info"))
+            assertEquals("premium", noted.definition.metadata["tier"])
         }
     }
 }


### PR DESCRIPTION
Add metadata to `Tool.Definition`. This is useful for various downstream tool usages: for example, grouping that may be understood by an application using Embabel.