### PR TITLE
Disable DockerSkillScriptExecutionEngineTest on Windows

### DIFF
--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngineTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngineTest.kt
@@ -18,7 +18,9 @@ package com.embabel.agent.skills.script
 import com.embabel.agent.tools.file.FileTools
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.EnabledIf
+import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
@@ -30,6 +32,7 @@ import kotlin.time.Duration.Companion.seconds
  * These tests require Docker to be installed and running.
  * They use the standard ubuntu:22.04 image which should be widely available.
  */
+@DisabledOnOs(OS.WINDOWS)
 class DockerSkillScriptExecutionEngineTest {
 
     @TempDir
@@ -41,7 +44,6 @@ class DockerSkillScriptExecutionEngineTest {
 
         @JvmStatic
         fun isDockerAvailable(): Boolean {
-            if (System.getProperty("os.name").lowercase().contains("win")) return false
             return try {
                 val process = ProcessBuilder("docker", "version")
                     .redirectErrorStream(true)


### PR DESCRIPTION
This pull request makes improvements to the `DockerSkillScriptExecutionEngineTest` test class to ensure compatibility and reliability across different operating systems. The main focus is to prevent the test from running on Windows, where Docker-based tests may not be supported or may behave inconsistently.

Test stability and OS compatibility:

* Added the `@DisabledOnOs(OS.WINDOWS)` annotation to the `DockerSkillScriptExecutionEngineTest` class to automatically skip these tests on Windows systems.
* Removed the manual Windows OS check from the `isDockerAvailable()` method, as the class-level annotation now handles this logic.

Test imports cleanup:

* Added imports for `DisabledOnOs` and `OS` to support the new annotation.