### PR TITLE
Issue/1607

### DIFF
--- a/embabel-agent-a2a/src/main/kotlin/com/embabel/agent/a2a/server/support/A2AStreamingHandler.kt
+++ b/embabel-agent-a2a/src/main/kotlin/com/embabel/agent/a2a/server/support/A2AStreamingHandler.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.a2a.server.support
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Qualifier
 import io.a2a.spec.Message
 import io.a2a.spec.SendStreamingMessageResponse
 import io.a2a.spec.StreamingEventKind
@@ -36,6 +37,7 @@ import java.util.concurrent.TimeUnit
  */
 @Service
 class A2AStreamingHandler(
+    @Qualifier("embabelJacksonObjectMapper")
     private val objectMapper: ObjectMapper,
     private val taskStateManager: TaskStateManager
 ) {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -105,7 +105,7 @@ class AgentPlatformConfiguration(
     @ConditionalOnMissingBean(ColorPalette::class)
     fun defaultColorPalette(): ColorPalette = DefaultColorPalette()
 
-    @Bean
+    @Bean(defaultCandidate = false)
     @ConditionalOnMissingBean(name = ["embabelJacksonObjectMapper"])
     fun embabelJacksonObjectMapper(builder: Jackson2ObjectMapperBuilder): ObjectMapper {
         return builder.createXmlMapper(false).build()

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -50,6 +50,7 @@ import com.embabel.common.core.thinking.spi.extractAllThinkingBlocks
 import com.embabel.common.textio.template.TemplateRenderer
 import com.fasterxml.jackson.databind.DatabindException
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Qualifier
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.micrometer.observation.ObservationRegistry
@@ -106,6 +107,7 @@ internal class ChatClientLlmOperations(
     llmOperationsPromptsProperties: LlmOperationsPromptsProperties = LlmOperationsPromptsProperties(),
     private val applicationContext: ApplicationContext? = null,
     autoLlmSelectionCriteriaResolver: AutoLlmSelectionCriteriaResolver = AutoLlmSelectionCriteriaResolver.DEFAULT,
+    @Qualifier("embabelJacksonObjectMapper")
     objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule()),
     observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
     private val customizers: List<ChatClientCustomizer> = emptyList(),


### PR DESCRIPTION
This pull request updates the way `ObjectMapper` dependencies are injected in both the `A2AStreamingHandler` and `ChatClientLlmOperations` classes. The main improvement is the explicit use of the `@Qualifier("embabelJacksonObjectMapper")` annotation to ensure the correct, custom-configured Jackson `ObjectMapper` is used in these components.

**Dependency injection improvements:**

* Added `@Qualifier("embabelJacksonObjectMapper")` annotation to the `objectMapper` parameter in the constructor of `A2AStreamingHandler` to ensure the correct Jackson `ObjectMapper` bean is injected. (`embabel-agent-a2a/src/main/kotlin/com/embabel/agent/a2a/server/support/A2AStreamingHandler.kt`) [[1]](diffhunk://#diff-89f6675edeab6f84b3bc36277d2ec59d23e33f2c75cdca48c3b0292be07b3373R19) [[2]](diffhunk://#diff-89f6675edeab6f84b3bc36277d2ec59d23e33f2c75cdca48c3b0292be07b3373R40)
* Added `@Qualifier("embabelJacksonObjectMapper")` annotation to the `objectMapper` parameter in the constructor of `ChatClientLlmOperations` for consistent and explicit dependency resolution. (`embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt`) [[1]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200R53) [[2]](diffhunk://#diff-da347cac528197bdc020664092b8190e9e8a75b63a3d09ff3cc714cc8b030200R110)