### PR TITLE
#368 fix cost aggregation on AgentProcess with nested subprocesses

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/AgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/AgentProcess.kt
@@ -171,6 +171,29 @@ interface AgentProcess : Blackboard, Timestamped, Timed, OperationStatus<AgentPr
     fun recordLlmInvocation(llmInvocation: LlmInvocation)
 
     /**
+     * Cost of this process's own LLM invocations, excluding any child processes.
+     * See [cost] for the aggregate across the entire process subtree.
+     */
+    fun ownCost(): Double = llmInvocations.sumOf { it.cost() }
+
+    /**
+     * Token usage of this process's own LLM invocations, excluding any child processes.
+     * See [usage] for the aggregate across the entire process subtree.
+     */
+    fun ownUsage(): Usage {
+        val promptTokens = llmInvocations.sumOf { it.usage.promptTokens ?: 0 }
+        val completionTokens = llmInvocations.sumOf { it.usage.completionTokens ?: 0 }
+        return Usage(promptTokens, completionTokens, null)
+    }
+
+    /**
+     * Distinct LLMs used by this process's own invocations, excluding any child processes.
+     * See [modelsUsed] for the aggregate across the entire process subtree.
+     */
+    fun ownModelsUsed(): List<com.embabel.common.ai.model.LlmMetadata> =
+        llmInvocations.map { it.llmMetadata }.distinctBy { it.name }.sortedBy { it.name }
+
+    /**
      * Perform the next step only.
      * Return when an action has been completed and the process is ready to plan,
      * regardless of the result of the action.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
@@ -148,6 +148,82 @@ abstract class AbstractAgentProcess(
         _llmInvocations.add(llmInvocation)
     }
 
+    // --- Subtree aggregation (fix #368) ----------------------------------------
+    //
+    // When an AgentProcess spawns child processes, cost/usage/models reporting
+    // must reflect the *entire* subtree, not just this process's own LLM calls.
+    // Each override below follows the same pattern:
+    //     result = <own contribution> + Σ child.<same method>()
+    // The recursion walks the tree via `childProcesses()`, which resolves
+    // direct children at call time through the AgentProcess repository.
+
+    /**
+     * Direct children of this process (non-recursive).
+     * Resolved on every call — not cached — so children spawned later are picked up.
+     */
+    private fun childProcesses(): List<AgentProcess> =
+        platformServices.agentProcessRepository.findByParentId(id)
+
+    /** Total cost = own cost + sum of each child's total cost (recursive). */
+    override fun cost(): Double =
+        ownCost() + childProcesses().sumOf { it.cost() }
+
+    /**
+     * Total token usage aggregated across the whole subtree.
+     * Nulls from children with no invocations are coerced to 0.
+     */
+    override fun usage(): Usage {
+        val own = ownUsage()
+        val children = childProcesses()
+        return Usage(
+            (own.promptTokens ?: 0) + children.sumOf { it.usage().promptTokens ?: 0 },
+            (own.completionTokens ?: 0) + children.sumOf { it.usage().completionTokens ?: 0 },
+            null,
+        )
+    }
+
+    /**
+     * Distinct LLMs used anywhere in the subtree, sorted by name.
+     * `distinctBy { it.name }` removes duplicates when the same model is used
+     * at multiple levels.
+     */
+    override fun modelsUsed(): List<com.embabel.common.ai.model.LlmMetadata> =
+        (ownModelsUsed() + childProcesses().flatMap { it.modelsUsed() })
+            .distinctBy { it.name }.sortedBy { it.name }
+
+    /**
+     * Human-readable cost/usage summary. All figures come from the subtree-aware
+     * methods above, so the report reflects every nested child process.
+     */
+    override fun costInfoString(verbose: Boolean): String {
+        val totalUsage = usage()
+        val totalCalls = totalLlmInvocationCount()
+        return if (verbose)
+            """|LLMs used: ${modelsUsed().map { it.name }} across $totalCalls calls
+               |Prompt tokens: ${"%,d".format(totalUsage.promptTokens)},
+               |Completion tokens: ${"%,d".format(totalUsage.completionTokens)}
+               |Cost: $${"%.4f".format(cost())}
+               |""".trimMargin()
+        else "LLMs: ${modelsUsed().map { it.name }} across $totalCalls calls; " +
+                "prompt tokens: ${"%,d".format(totalUsage.promptTokens)}; completion tokens: ${
+                    "%,d".format(
+                        totalUsage.completionTokens
+                    )
+                }; cost: $${"%.4f".format(cost())}"
+    }
+
+    /**
+     * Total number of LLM invocations in the subtree.
+     * The `as? AbstractAgentProcess` cast lets the recursion continue for
+     * children that also inherit from this class. Other AgentProcess
+     * implementations fall back to their local `llmInvocations.size` — the
+     * deeper subtree (if any) is not counted, but reporting still works.
+     */
+    private fun totalLlmInvocationCount(): Int =
+        llmInvocations.size + childProcesses().sumOf { child ->
+            (child as? AbstractAgentProcess)?.totalLlmInvocationCount() ?: child.llmInvocations.size
+        }
+
     override val status: AgentProcessStatusCode
         get() = _status.get()
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/AgentProcessCostAggregationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/AgentProcessCostAggregationTest.kt
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.support
+
+import com.embabel.agent.api.common.PlatformServices
+import com.embabel.agent.core.Budget
+import com.embabel.agent.core.EarlyTerminationPolicy
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.Usage
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.support.DefaultPlannerFactory
+import com.embabel.agent.support.SimpleTestAgent
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.common.ai.model.LlmMetadata
+import com.embabel.common.ai.model.PricingModel
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for parent/child AgentProcess cost and token aggregation.
+ *
+ * Strategy: the parent remains a REAL [SimpleAgentProcess] so its real `cost()` /
+ * `usage()` / `modelsUsed()` / `costInfoString()` implementations are exercised.
+ * Children are instances of [FixedCostAgentProcess], a test-only subclass that
+ * overrides the aggregation methods to return fixed values. This decouples the
+ * aggregation-under-test from the `LlmInvocation` → `PricingModel.costOf()` chain
+ * (that chain is covered separately by `LlmInvocationHistoryTest`).
+ *
+ * Why this works end-to-end:
+ *   - Before the fix, the default `LlmInvocationHistory.cost()` on the parent sums
+ *     only its local `llmInvocations` and never calls `child.cost()` — so the stub
+ *     override is irrelevant and the parent returns its own local cost (= 0 in
+ *     these tests, since the parent has no recorded invocations). Tests fail.
+ *   - After the fix, the parent's overridden `cost()` walks children via
+ *     `platformServices.agentProcessRepository.findByParentId(id)` and calls
+ *     `child.cost()` on each — which returns the stub's fixed value. Tests pass.
+ *
+ * The recursion is genuinely exercised at the parent level: the test does not
+ * mock `findByParentId` or `PlatformServices`; it uses a real
+ * `InMemoryAgentProcessRepository` (via `dummyPlatformServices()`) and real save().
+ * Only the leaf value `child.cost()` is stubbed.
+ *
+ * Fixture:
+ *   parent (real SimpleAgentProcess, own cost = 0)
+ *     ├── child1 (FixedCostAgentProcess, fixedCost = 0.20, 300 prompt / 400 completion)
+ *     └── child2 (FixedCostAgentProcess, fixedCost = 0.30, 500 prompt / 600 completion)
+ *
+ * Expected totals after fix: cost = 0.50, prompt = 800, completion = 1000,
+ * totalTokens = 1800, models = [child1-llm, child2-llm].
+ */
+class AgentProcessCostAggregationTest {
+
+    private lateinit var platformServices: PlatformServices
+    private lateinit var parent: SimpleAgentProcess
+    private lateinit var child1: FixedCostAgentProcess
+    private lateinit var child2: FixedCostAgentProcess
+
+    @BeforeEach
+    fun setUp() {
+        platformServices = dummyPlatformServices()
+
+        parent = SimpleAgentProcess(
+            id = "parent",
+            parentId = null,
+            agent = SimpleTestAgent,
+            processOptions = ProcessOptions(),
+            blackboard = InMemoryBlackboard(),
+            platformServices = platformServices,
+            plannerFactory = DefaultPlannerFactory,
+        )
+        child1 = FixedCostAgentProcess(
+            id = "child-1",
+            parentId = "parent",
+            platformServices = platformServices,
+            fixedCost = 0.20,
+            fixedUsage = Usage(300, 400, null),
+            fixedModels = listOf(mockLlmMetadata("child1-llm")),
+        )
+        child2 = FixedCostAgentProcess(
+            id = "child-2",
+            parentId = "parent",
+            platformServices = platformServices,
+            fixedCost = 0.30,
+            fixedUsage = Usage(500, 600, null),
+            fixedModels = listOf(mockLlmMetadata("child2-llm")),
+        )
+
+        // Save into the real in-memory repo so findByParentId can resolve them.
+        platformServices.agentProcessRepository.save(parent)
+        platformServices.agentProcessRepository.save(child1)
+        platformServices.agentProcessRepository.save(child2)
+    }
+
+    @Nested
+    inner class CostAggregation {
+
+        @Test
+        fun `parent cost equals sum of children fixed costs when parent has no own cost`() {
+            // Before fix: 0.0 (only parent's own invocations, which are empty)
+            // After fix:  0.50 (0 own + 0.20 + 0.30)
+            assertEquals(
+                0.50, parent.cost(), 1e-9,
+                "BUG: parent.cost() must walk children and sum. " +
+                        "Expected 0.50 (0 own + 0.20 child1 + 0.30 child2), got ${parent.cost()}."
+            )
+        }
+
+        @Test
+        fun `leaf stub child reports its fixed cost`() {
+            // Baseline: a stub child returns its fixed value regardless of the bug.
+            assertEquals(0.20, child1.cost(), 1e-9)
+            assertEquals(0.30, child2.cost(), 1e-9)
+        }
+
+        @Test
+        fun `parent with no children reports its own local cost only`() {
+            // Baseline: a root process with no children. Must pass today and after the fix.
+            val isolatedPs = dummyPlatformServices()
+            val lonely = SimpleAgentProcess(
+                id = "lonely", parentId = null,
+                agent = SimpleTestAgent, processOptions = ProcessOptions(),
+                blackboard = InMemoryBlackboard(), platformServices = isolatedPs,
+                plannerFactory = DefaultPlannerFactory,
+            )
+            isolatedPs.agentProcessRepository.save(lonely)
+            // Zero invocations => zero cost. After fix, still zero because no children.
+            assertEquals(0.0, lonely.cost(), 1e-9)
+        }
+
+        @Test
+        fun `three-level tree aggregates recursively through a real intermediate process`() {
+            // parent (real) -> mid (real) -> leaf (stub).
+            // Only the leaf is stubbed. `parent.cost()` and `mid.cost()` both use the
+            // real (fixed) aggregation logic. This proves the fix walks more than one
+            // level: if the fix only summed direct children, mid's 0.10 child would be
+            // missed and parent.cost() would read only mid's own (= 0).
+            val isolatedPs = dummyPlatformServices()
+            val top = SimpleAgentProcess(
+                id = "top", parentId = null,
+                agent = SimpleTestAgent, processOptions = ProcessOptions(),
+                blackboard = InMemoryBlackboard(), platformServices = isolatedPs,
+                plannerFactory = DefaultPlannerFactory,
+            )
+            val mid = SimpleAgentProcess(
+                id = "mid", parentId = "top",
+                agent = SimpleTestAgent, processOptions = ProcessOptions(),
+                blackboard = InMemoryBlackboard(), platformServices = isolatedPs,
+                plannerFactory = DefaultPlannerFactory,
+            )
+            val leaf = FixedCostAgentProcess(
+                id = "leaf", parentId = "mid",
+                platformServices = isolatedPs,
+                fixedCost = 0.10,
+                fixedUsage = Usage(10, 20, null),
+                fixedModels = listOf(mockLlmMetadata("leaf-llm")),
+            )
+            isolatedPs.agentProcessRepository.save(top)
+            isolatedPs.agentProcessRepository.save(mid)
+            isolatedPs.agentProcessRepository.save(leaf)
+
+            // mid must itself correctly aggregate its direct child (leaf).
+            // Testing this intermediate level isolates the bug: if `mid.cost()` is
+            // already wrong (= 0), then `top.cost()` cannot be right by accident.
+            assertEquals(
+                0.10, mid.cost(), 1e-9,
+                "BUG: intermediate level aggregation. mid has leaf as direct child " +
+                        "with cost 0.10, expected mid.cost() = 0.10, got ${mid.cost()}."
+            )
+            assertEquals(
+                0.10, top.cost(), 1e-9,
+                "BUG: three-level aggregation. Expected 0.10 propagated from leaf, got ${top.cost()}."
+            )
+        }
+    }
+
+    @Nested
+    inner class TokenUsageAggregation {
+
+        @Test
+        fun `parent prompt tokens equal sum of children`() {
+            // Expected: 0 own + 300 + 500 = 800. Bug: 0.
+            assertEquals(
+                800, parent.usage().promptTokens,
+                "BUG: parent.usage().promptTokens must include children. " +
+                        "Expected 800, got ${parent.usage().promptTokens}."
+            )
+        }
+
+        @Test
+        fun `parent completion tokens equal sum of children`() {
+            // Expected: 0 own + 400 + 600 = 1000. Bug: 0.
+            assertEquals(
+                1000, parent.usage().completionTokens,
+                "BUG: parent.usage().completionTokens must include children. " +
+                        "Expected 1000, got ${parent.usage().completionTokens}."
+            )
+        }
+
+        @Test
+        fun `parent totalTokens equal sum of children`() {
+            // Expected: 800 + 1000 = 1800. Bug: 0.
+            assertEquals(
+                1800, parent.usage().totalTokens,
+                "BUG: parent.usage().totalTokens must include children. " +
+                        "Expected 1800, got ${parent.usage().totalTokens}."
+            )
+        }
+    }
+
+    @Nested
+    inner class ModelsUsedAggregation {
+
+        @Test
+        fun `parent modelsUsed includes children models distinct by name sorted`() {
+            // Expected: 2 child models, sorted. Bug: empty (parent has no own models).
+            val names = parent.modelsUsed().map { it.name }
+            assertEquals(
+                listOf("child1-llm", "child2-llm"), names,
+                "BUG: parent.modelsUsed() must include models used by children. " +
+                        "Expected [child1-llm, child2-llm], got $names."
+            )
+        }
+    }
+
+    @Nested
+    inner class CostInfoStringAggregation {
+
+        @Test
+        fun `costInfoString reflects total cost across children`() {
+            val info = parent.costInfoString(verbose = false)
+            // Expected after fix: cost = $0.5000. Bug: cost = $0.0000.
+            assertTrue(
+                info.contains("cost: \$0.5000"),
+                "BUG: expected 'cost: \$0.5000' in costInfoString, got: $info"
+            )
+        }
+    }
+
+    @Nested
+    inner class EarlyTerminationPolicyWithChildren {
+
+        @Test
+        fun `MaxCostEarlyTerminationPolicy must trigger when child costs push total over budget`() {
+            // Budget $0.40. Parent alone = $0.00 (no own invocations), but children total = $0.50.
+            // Policy MUST terminate. Current bug: returns null because it reads parent.cost() = 0.
+            val policy = EarlyTerminationPolicy.hardBudgetLimit(0.40)
+            val termination = policy.shouldTerminate(parent)
+            assertNotNull(
+                termination,
+                "BUG: hardBudgetLimit(0.40) must enforce budget across child processes. " +
+                        "Actual total child cost is \$0.50, parent own cost is \$0.00, " +
+                        "budget is \$0.40. Policy should have terminated but returned null."
+            )
+        }
+
+        @Test
+        fun `MaxTokensEarlyTerminationPolicy must trigger when child tokens push total over limit`() {
+            // Limit 1000. Parent own totalTokens = 0, children total = 1800. Policy MUST terminate.
+            val policy = EarlyTerminationPolicy.maxTokens(1000)
+            val termination = policy.shouldTerminate(parent)
+            assertNotNull(
+                termination,
+                "BUG: maxTokens(1000) must enforce token limit across child processes. " +
+                        "Actual total tokens is 1800, parent own tokens is 0, limit is 1000. " +
+                        "Policy should have terminated but returned null."
+            )
+        }
+
+        @Test
+        fun `Budget default FirstOf policy must enforce cost limit across children`() {
+            // Public API surface: the policy that gets wired by default into every ProcessOptions.
+            val budget = Budget(cost = 0.40, actions = 1000, tokens = 10_000)
+            val policy = budget.earlyTerminationPolicy()
+            val termination = policy.shouldTerminate(parent)
+            assertNotNull(
+                termination,
+                "BUG: Budget(cost=\$0.40).earlyTerminationPolicy() — the default policy wired " +
+                        "into every ProcessOptions — must enforce cost limits across child processes. " +
+                        "This is the concrete end-user impact: users who set a budget via " +
+                        "ProcessOptions.withBudget(Budget(cost = X)) can see X silently exceeded."
+            )
+        }
+
+        @Test
+        fun `Budget default FirstOf policy must enforce token limit across children`() {
+            val budget = Budget(cost = 100.0, actions = 1000, tokens = 1000)
+            val policy = budget.earlyTerminationPolicy()
+            val termination = policy.shouldTerminate(parent)
+            assertNotNull(
+                termination,
+                "BUG: Budget(tokens=1000).earlyTerminationPolicy() must enforce token limits " +
+                        "across child processes."
+            )
+        }
+    }
+
+    // ---- test helpers ------------------------------------------------------
+
+    /**
+     * A [SimpleAgentProcess] subclass that reports fixed cost/usage/models regardless
+     * of its internal `llmInvocations` list. Used as a deterministic leaf stub for
+     * aggregation tests: the parent's real aggregation logic calls `child.cost()`,
+     * which returns the value set at construction. The rest of [SimpleAgentProcess]
+     * behavior (construction, repository registration, id/parentId exposure) is
+     * preserved so the parent's `findByParentId` + dispatch path is exercised for real.
+     */
+    private class FixedCostAgentProcess(
+        id: String,
+        parentId: String?,
+        platformServices: PlatformServices,
+        private val fixedCost: Double,
+        private val fixedUsage: Usage = Usage(0, 0, null),
+        private val fixedModels: List<LlmMetadata> = emptyList(),
+    ) : SimpleAgentProcess(
+        id = id,
+        parentId = parentId,
+        agent = SimpleTestAgent,
+        processOptions = ProcessOptions(),
+        blackboard = InMemoryBlackboard(),
+        platformServices = platformServices,
+        plannerFactory = DefaultPlannerFactory,
+    ) {
+        override fun cost(): Double = fixedCost
+        override fun usage(): Usage = fixedUsage
+        override fun modelsUsed(): List<LlmMetadata> = fixedModels
+    }
+
+    private fun mockLlmMetadata(modelName: String): LlmMetadata {
+        val pricing = mockk<PricingModel>()
+        every { pricing.costOf(any()) } returns 0.0
+        val llm = mockk<LlmService<*>>()
+        every { llm.name } returns modelName
+        every { llm.pricingModel } returns pricing
+        return llm
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/AgentProcessCostAggregationUnderEvictionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/AgentProcessCostAggregationUnderEvictionTest.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.support
+
+import com.embabel.agent.api.common.PlatformServices
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.EarlyTerminationPolicy
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.Usage
+import com.embabel.agent.spi.config.spring.ProcessRepositoryProperties
+import com.embabel.agent.spi.support.DefaultPlannerFactory
+import com.embabel.agent.spi.support.InMemoryAgentProcessRepository
+import com.embabel.agent.spi.support.SpringContextPlatformServices
+import com.embabel.agent.support.SimpleTestAgent
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.common.ai.model.LlmMetadata
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Validates that subtree-aware cost aggregation (#368) stays correct when the
+ * `InMemoryAgentProcessRepository` is under eviction pressure.
+ *
+ * `AbstractAgentProcess.cost()/usage()/modelsUsed()` walk children through
+ * `agentProcessRepository.findByParentId(id)` — so an evicted child would silently
+ * drop from the total. `HierarchyAwareEvictionPolicy` prevents that by only ever
+ * evicting whole hierarchies, and only when every node is `finished`.
+ *
+ * These tests saturate `windowSize = 1` to force eviction attempts and assert
+ * aggregation stays correct. The last test pins the known limitation: if a whole
+ * finished hierarchy is legitimately evicted, a retained reference to its root no
+ * longer sees the children's cost.
+ */
+class AgentProcessCostAggregationUnderEvictionTest {
+
+    private fun servicesWithSingleRootWindow(): Pair<PlatformServices, InMemoryAgentProcessRepository> {
+        val repo = InMemoryAgentProcessRepository(ProcessRepositoryProperties(windowSize = 1))
+        val services = (dummyPlatformServices() as SpringContextPlatformServices).copy(
+            agentProcessRepository = repo,
+        )
+        return services to repo
+    }
+
+    /** SimpleAgentProcess that exposes setStatus for deterministic test scenarios. */
+    private open class StatusControllableProcess(
+        id: String,
+        parentId: String?,
+        platformServices: PlatformServices,
+    ) : SimpleAgentProcess(
+        id = id,
+        parentId = parentId,
+        agent = SimpleTestAgent,
+        processOptions = ProcessOptions(),
+        blackboard = InMemoryBlackboard(),
+        platformServices = platformServices,
+        plannerFactory = DefaultPlannerFactory,
+    ) {
+        fun setTestStatus(status: AgentProcessStatusCode) = setStatus(status)
+    }
+
+    /** Leaf process returning fixed aggregation values (no recursion into children). */
+    private class FixedCostLeaf(
+        id: String,
+        parentId: String?,
+        platformServices: PlatformServices,
+        private val fixedCost: Double,
+        private val fixedUsage: Usage = Usage(0, 0, null),
+        private val fixedModels: List<LlmMetadata> = emptyList(),
+    ) : StatusControllableProcess(id, parentId, platformServices) {
+        override fun cost(): Double = fixedCost
+        override fun usage(): Usage = fixedUsage
+        override fun modelsUsed(): List<LlmMetadata> = fixedModels
+    }
+
+    // ---- Invariants 1, 2, 3 — active hierarchy protected, aggregation correct --------------
+
+    @Test
+    fun `RUNNING parent hierarchy is never evicted and aggregation stays correct under repo pressure`() {
+        val (services, repo) = servicesWithSingleRootWindow()
+
+        val parent = StatusControllableProcess("parent", parentId = null, platformServices = services)
+        val child1 = FixedCostLeaf("c1", "parent", services, 0.20, Usage(100, 200, null))
+        val child2 = FixedCostLeaf("c2", "parent", services, 0.30, Usage(300, 400, null))
+        // Parent RUNNING = not finished, children finished — hierarchy is NOT fully finished.
+        parent.setTestStatus(AgentProcessStatusCode.RUNNING)
+        child1.setTestStatus(AgentProcessStatusCode.COMPLETED)
+        child2.setTestStatus(AgentProcessStatusCode.COMPLETED)
+
+        repo.save(parent)
+        repo.save(child1)
+        repo.save(child2)
+
+        // Saturate with other fully finished root hierarchies. FIFO eviction must stop at `parent`.
+        repeat(5) { i ->
+            val other = StatusControllableProcess("other-$i", parentId = null, platformServices = services)
+            other.setTestStatus(AgentProcessStatusCode.COMPLETED)
+            repo.save(other)
+        }
+
+        // Invariants 2 & 3 — subject hierarchy still in the repo.
+        assertNotNull(repo.findById("parent"), "RUNNING parent must not be evicted")
+        assertNotNull(repo.findById("c1"), "child of RUNNING parent must not be evicted")
+        assertNotNull(repo.findById("c2"), "child of RUNNING parent must not be evicted")
+
+        // Aggregation correct under pressure.
+        assertEquals(
+            0.50, parent.cost(), 1e-9,
+            "parent.cost() must aggregate children (own 0 + c1 0.20 + c2 0.30) under eviction pressure",
+        )
+        assertEquals(400, parent.usage().promptTokens, "prompt tokens aggregated from children")
+        assertEquals(600, parent.usage().completionTokens, "completion tokens aggregated from children")
+    }
+
+    @Test
+    fun `FINISHED parent with non-finished child keeps hierarchy protected by invariant 2`() {
+        val (services, repo) = servicesWithSingleRootWindow()
+
+        val parent = StatusControllableProcess("p", parentId = null, platformServices = services)
+        parent.setTestStatus(AgentProcessStatusCode.COMPLETED)
+        val stillRunningChild = FixedCostLeaf("rc", "p", services, 0.40, Usage(50, 60, null))
+        stillRunningChild.setTestStatus(AgentProcessStatusCode.RUNNING)
+
+        repo.save(parent)
+        repo.save(stillRunningChild)
+
+        // Saturate with fully finished roots. Because stillRunningChild is RUNNING,
+        // the entire hierarchy at `p` is still non-finished → eviction must not fire on it.
+        repeat(3) { i ->
+            val other = StatusControllableProcess("done-$i", parentId = null, platformServices = services)
+            other.setTestStatus(AgentProcessStatusCode.COMPLETED)
+            repo.save(other)
+        }
+
+        assertNotNull(repo.findById("p"), "parent with non-finished descendant must not be evicted")
+        assertNotNull(repo.findById("rc"), "non-finished descendant must not be evicted")
+        assertEquals(
+            0.40, parent.cost(), 1e-9,
+            "parent.cost() must still include the RUNNING child because eviction is blocked by invariant 2",
+        )
+    }
+
+    @Test
+    fun `EarlyTerminationPolicy MaxCost sees aggregated children cost correctly under eviction pressure`() {
+        val (services, repo) = servicesWithSingleRootWindow()
+
+        val parent = StatusControllableProcess("p", parentId = null, platformServices = services)
+        parent.setTestStatus(AgentProcessStatusCode.RUNNING)
+        val c1 = FixedCostLeaf("c1", "p", services, 0.30)
+        val c2 = FixedCostLeaf("c2", "p", services, 0.25)
+        c1.setTestStatus(AgentProcessStatusCode.COMPLETED)
+        c2.setTestStatus(AgentProcessStatusCode.COMPLETED)
+        repo.save(parent); repo.save(c1); repo.save(c2)
+
+        // Pressure.
+        repeat(5) { i ->
+            val other = StatusControllableProcess("other-$i", parentId = null, platformServices = services)
+            other.setTestStatus(AgentProcessStatusCode.COMPLETED)
+            repo.save(other)
+        }
+
+        // Budget 0.40 < aggregated children total 0.55 → policy must fire.
+        val result = EarlyTerminationPolicy.hardBudgetLimit(0.40).shouldTerminate(parent)
+        assertNotNull(
+            result,
+            "EarlyTerminationPolicy.MaxCost must see children cost via findByParentId even " +
+                    "when other hierarchies are under eviction pressure",
+        )
+    }
+
+    // ---- Known limitation ------------------------------------------------------------------
+
+    @Test
+    fun `known limitation - fully finished hierarchy is evicted and retained reference sees incomplete cost`() {
+        val (services, repo) = servicesWithSingleRootWindow()
+
+        // Fully finished hierarchy: parent + 2 children all COMPLETED.
+        val parent = StatusControllableProcess("p", parentId = null, platformServices = services)
+        val c1 = FixedCostLeaf("c1", "p", services, 0.20)
+        val c2 = FixedCostLeaf("c2", "p", services, 0.30)
+        parent.setTestStatus(AgentProcessStatusCode.COMPLETED)
+        c1.setTestStatus(AgentProcessStatusCode.COMPLETED)
+        c2.setTestStatus(AgentProcessStatusCode.COMPLETED)
+        repo.save(parent); repo.save(c1); repo.save(c2)
+
+        // A new finished root triggers eviction of the oldest fully finished hierarchy.
+        val other = StatusControllableProcess("other", parentId = null, platformServices = services)
+        other.setTestStatus(AgentProcessStatusCode.COMPLETED)
+        repo.save(other)
+
+        // Hierarchy evicted from repo (root + both children).
+        assertNull(repo.findById("p"), "fully finished hierarchy must be evicted")
+        assertNull(repo.findById("c1"), "children are evicted with their parent")
+        assertNull(repo.findById("c2"))
+
+        // Retained Java reference still usable, but children are no longer reachable.
+        // parent.cost() falls back to own cost (0) — the 0.50 from children is lost.
+        assertEquals(
+            0.0, parent.cost(), 1e-9,
+            "Known limitation: once the whole hierarchy is evicted, cost() on a retained " +
+                    "reference cannot find the children via findByParentId — aggregation is incomplete",
+        )
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/AgentProcessCostAggregationRealLlmIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/AgentProcessCostAggregationRealLlmIT.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.annotation.AchievesGoal
+import com.embabel.agent.api.annotation.Action
+import com.embabel.agent.api.annotation.Agent
+import com.embabel.agent.api.annotation.support.AgentMetadataReader
+import com.embabel.agent.api.common.ActionContext
+import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration
+import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.domain.io.UserInput
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * End-to-end integration test for parent/child AgentProcess cost aggregation
+ * with a real LLM call (gpt-4.1-mini, ~$0.001 per run).
+ *
+ * Since the aggregation logic in [com.embabel.agent.core.support.AbstractAgentProcess]
+ * is provider-agnostic, a single real-LLM IT on one provider is enough to validate
+ * the full pipeline (Spring wiring, YAML pricing, AgentPlatform, asSubProcess,
+ * InMemoryAgentProcessRepository, cost aggregation).
+ *
+ * Requires the `OPENAI_API_KEY` environment variable.
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.cheapest=gpt-4.1-mini",
+        "embabel.models.best=gpt-4.1-mini",
+        "embabel.models.default-llm=gpt-4.1-mini",
+        "embabel.agent.platform.llm-operations.prompts.defaultTimeout=240s",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("thinking")
+@ConfigurationPropertiesScan(basePackages = ["com.embabel.agent", "com.embabel.example"])
+@ComponentScan(
+    basePackages = ["com.embabel.agent", "com.embabel.example"],
+    excludeFilters = [
+        ComponentScan.Filter(
+            type = FilterType.REGEX,
+            pattern = [".*GlobalExceptionHandler.*"]
+        )
+    ]
+)
+@Import(AgentOpenAiAutoConfiguration::class)
+@ImportAutoConfiguration(AgentPlatformAutoConfiguration::class)
+class AgentProcessCostAggregationRealLlmIT {
+
+    private val logger = LoggerFactory.getLogger(AgentProcessCostAggregationRealLlmIT::class.java)
+
+    @Autowired
+    private lateinit var agentPlatform: AgentPlatform
+
+    data class FirstJoke(val text: String)
+    data class SecondJoke(val text: String)
+    data class TwoJokes(val first: FirstJoke, val second: SecondJoke)
+
+    @Agent(
+        name = "FirstJokeSubAgent",
+        description = "Subagent that generates the first joke via real LLM",
+        scan = false,
+    )
+    class FirstJokeSubAgent {
+
+        @Action
+        @AchievesGoal(description = "First joke generated")
+        fun generateJoke(input: UserInput, context: OperationContext): FirstJoke =
+            context.ai()
+                .withDefaultLlm()
+                .createObject(
+                    """
+                    Generate a one-line joke about: ${input.content}.
+                    Return JSON with a single field "text" containing the joke.
+                    Keep it under 20 words.
+                    """.trimIndent(),
+                    FirstJoke::class.java,
+                )
+    }
+
+    @Agent(
+        name = "SecondJokeSubAgent",
+        description = "Subagent that generates the second joke via real LLM",
+        scan = false,
+    )
+    class SecondJokeSubAgent {
+
+        @Action
+        @AchievesGoal(description = "Second joke generated")
+        fun generateJoke(input: UserInput, context: OperationContext): SecondJoke =
+            context.ai()
+                .withDefaultLlm()
+                .createObject(
+                    """
+                    Generate a DIFFERENT one-line joke about: ${input.content}.
+                    Return JSON with a single field "text" containing the joke.
+                    Keep it under 20 words.
+                    """.trimIndent(),
+                    SecondJoke::class.java,
+                )
+    }
+
+    @Agent(
+        name = "JokeParentAgent",
+        description = "Parent that delegates joke generation to two subagents",
+        scan = false,
+    )
+    class JokeParentAgent {
+
+        @Action
+        fun delegateToFirstSubagent(input: UserInput, context: ActionContext): FirstJoke {
+            val subAgent = AgentMetadataReader()
+                .createAgentMetadata(FirstJokeSubAgent()) as com.embabel.agent.core.Agent
+            return context.asSubProcess(FirstJoke::class.java, subAgent)
+        }
+
+        @Action
+        fun delegateToSecondSubagent(input: UserInput, context: ActionContext): SecondJoke {
+            val subAgent = AgentMetadataReader()
+                .createAgentMetadata(SecondJokeSubAgent()) as com.embabel.agent.core.Agent
+            return context.asSubProcess(SecondJoke::class.java, subAgent)
+        }
+
+        @Action
+        @AchievesGoal(description = "Both jokes delivered from subagents")
+        fun done(first: FirstJoke, second: SecondJoke): TwoJokes = TwoJokes(first, second)
+    }
+
+    @Test
+    fun `parent cost aggregates child cost with real OpenAI call`() {
+        val parentAgentDef = AgentMetadataReader()
+            .createAgentMetadata(JokeParentAgent()) as com.embabel.agent.core.Agent
+
+        val result = agentPlatform.runAgentFrom(
+            parentAgentDef,
+            ProcessOptions(),
+            mapOf("it" to UserInput("cats")),
+        )
+        val parent = result as AgentProcess
+
+        val children = agentPlatform.platformServices.agentProcessRepository.findByParentId(parent.id)
+        assertEquals(
+            2, children.size,
+            "Expected 2 child processes (one per delegate action), got ${children.size}"
+        )
+
+        val childrenCost = children.sumOf { it.cost() }
+        assertTrue(
+            childrenCost > 0.0,
+            "Children should have incurred real LLM cost (got \$$childrenCost). " +
+                    "If 0, pricing may not be wired for gpt-4.1-mini."
+        )
+
+        val parentOwnCost = parent.ownCost()
+        val expectedTotal = parentOwnCost + childrenCost
+
+        logger.info(
+            "parent.cost()={}, parent own={}, children={}, expected={}",
+            parent.cost(), parentOwnCost, childrenCost, expectedTotal,
+        )
+
+        assertEquals(
+            expectedTotal, parent.cost(), 1e-9,
+            "parent.cost() must aggregate child process costs. " +
+                    "Expected \$$expectedTotal (own \$$parentOwnCost + children \$$childrenCost), " +
+                    "got \$${parent.cost()}."
+        )
+
+        val parentOwnPromptTokens = parent.ownUsage().promptTokens ?: 0
+        val childrenPromptTokens = children.sumOf { it.usage().promptTokens ?: 0 }
+        assertEquals(
+            parentOwnPromptTokens + childrenPromptTokens,
+            parent.usage().promptTokens,
+            "parent.usage().promptTokens must aggregate children."
+        )
+    }
+}


### PR DESCRIPTION
### Summary

Fixes #368. When an `AgentProcess` spawns child processes, the parent's `cost()`, `usage()`, and `modelsUsed()` only reflected its own LLM invocations - so any cost/usage report on the parent was misleading and early termination policies (`hardBudgetLimit`, `maxTokens`, `Budget.earlyTerminationPolicy`) could let budgets be silently exceeded.

This PR makes the parent aggregate the full subtree: `result = own + Σ child.<same method>()`.

---

### Changes

| File | Description |
|---|---|
| `AgentProcess.kt` | New default methods `ownCost()` / `ownUsage()` / `ownModelsUsed()` exposing the local-only view |
| `AbstractAgentProcess.kt` | `cost()`, `usage()`, `modelsUsed()` and `costInfoString()` now walk child processes (via `agentProcessRepository.findByParentId`) and aggregate recursively. `costInfoString()` also reports the total LLM invocation count across the subtree |

### Impact on existing callers

> All benefit from the fix, no regressions expected.

- **`EarlyTerminationPolicy`** - budget/token limits now enforced across the subtree.
- **`EmbabelMetricsEventListener`** - metrics reflect true cost.
- **`AgentProcessTools`**, **`ShellCommands`**, **`formatProcessOutput`** - reporting reflects subtree totals.

---

### Test plan

- ✅ **Unit tests** - `AgentProcessCostAggregationTest`: leaf (no children), single level, 3-level tree (intermediate level asserted separately), multiple siblings, distinct-models aggregation, and `EarlyTerminationPolicy` / `Budget` end-to-end enforcement across children.
- ✅ **Integration test** - `AgentProcessCostAggregationRealLlmIT` with real LLM calls.

### Note

> `cost()` / `usage()` / `modelsUsed()` now recursively call `findByParentId` (one lookup per node in the subtree). In practice agent trees are shallow (a few levels, a handful of children) and the current `InMemoryAgentProcessRepository` makes each lookup a cheap map filter - no big impact.
> 
> Worth keeping in mind if a persistent (SQL, Redis) `AgentProcessRepository` is introduced later: that would turn each node lookup into a round-trip. The mitigation is straightforward - add a single `findDescendants(rootId)` bulk method to the repository and switch to a flat sum. Not needed today; flagged here as a pointer for the review.