### PR TITLE
Add IntelliJ Plugin information to User Guide

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
@@ -294,6 +294,19 @@ The following are modules intended for direct use (versus supporting infrastruct
 | Stable
 |===
 
+===== Developer Tooling
+
+[cols="2,1,3,2,1",options="header"]
+|===
+| Name | Location | Purpose | Notes | Status
+
+| `embabel-agent-intellij`
+| `embabel/embabel-agent-intellij`
+| IntelliJ IDEA plugin
+| IDE support for Embabel Agent development. See xref:reference.tooling_intellij[IntelliJ Plugin].
+| Stable
+|===
+
 ==== Experimental APIs
 
 While the status of modules may change over time, any module may contain clearly identified experimental functionality.

--- a/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
@@ -47,6 +47,8 @@ include::customizing/page.adoc[]
 
 include::integrations/page.adoc[]
 
+include::tooling/page.adoc[]
+
 include::agent_skills/page.adoc[]
 
 include::testing/page.adoc[]

--- a/embabel-agent-docs/src/main/asciidoc/reference/tooling/intellij.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/tooling/intellij.adoc
@@ -1,0 +1,93 @@
+[[reference.tooling_intellij]]
+=== IntelliJ IDEA Plugin
+
+The Embabel Agent IntelliJ IDEA plugin provides IDE-level support for developing agents with the Embabel framework.
+It integrates directly with the IntelliJ platform to give you a cleaner, warning-free development experience.
+
+[[reference.tooling_intellij__what]]
+==== What It Does
+
+When you annotate methods with Embabel's core annotations — `@Action`, `@Condition`, or `@Cost` — IntelliJ has no way of knowing that the framework will invoke those methods reflectively at runtime.
+Without the plugin, the IDE flags these methods as *unused*, producing false "never used" warnings throughout your agent code.
+
+The plugin registers an `ImplicitUsageProvider` with the IntelliJ platform that tells the IDE:
+
+[quote]
+Any method annotated with `@Action`, `@Condition`, or `@Cost` is implicitly used by the Embabel Agent framework — do not warn.
+
+This means you can write your agents cleanly without suppressing legitimate IDE inspections or littering your code with `@SuppressWarnings`.
+
+.Without the plugin
+[source,kotlin]
+----
+@Agent(description = "Summarizes news articles")
+class NewsAgent {
+
+    @Action  // ⚠ IntelliJ: "Method 'summarize' is never used"
+    fun summarize(article: RawArticle): ArticleSummary {
+        // ...
+    }
+}
+----
+
+.With the plugin
+[source,kotlin]
+----
+@Agent(description = "Summarizes news articles")
+class NewsAgent {
+
+    @Action  // ✅ No warning — plugin marks this as implicitly used
+    fun summarize(article: RawArticle): ArticleSummary {
+        // ...
+    }
+}
+----
+
+[[reference.tooling_intellij__install]]
+==== Installation
+
+The plugin is published to the https://plugins.jetbrains.com/plugin/31142-embabel-agent[JetBrains Marketplace] (plugin ID: `31142`).
+
+===== Via the IDE (Recommended)
+
+. Open IntelliJ IDEA.
+. Go to *Settings* → *Plugins* → *Marketplace* tab.
+. Search for *Embabel Agent*.
+. Click *Install*, then restart the IDE when prompted.
+
+===== Via the Marketplace Website
+
+. Visit https://plugins.jetbrains.com/plugin/31142-embabel-agent.
+. Click *Get*, then follow the browser prompt to open IntelliJ IDEA and install.
+
+[[reference.tooling_intellij__compatibility]]
+==== Compatibility
+
+[cols="1,2"]
+|===
+| Requirement | Value
+
+| Minimum IntelliJ IDEA version
+| 2023.3 (build `233`)
+
+| Maximum IntelliJ IDEA version
+| No upper cap — compatible with all future releases
+
+| JVM
+| 21+
+
+| Plugin ID
+| `com.embabel.agent.intellij-plugin`
+|===
+
+NOTE: The plugin targets IntelliJ IDEA (both Community and Ultimate editions).
+As of IDEA 2025.3, the Community and Ultimate editions were merged into a single unified distribution.
+
+[[reference.tooling_intellij__source]]
+==== Source & Contributing
+
+The plugin source is maintained in its own repository:
+https://github.com/embabel/embabel-agent-intellij
+
+Contributions are welcome.
+If you use additional Embabel annotations that should also be treated as implicitly used, please open an issue or pull request against that repository.

--- a/embabel-agent-docs/src/main/asciidoc/reference/tooling/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/tooling/page.adoc
@@ -1,0 +1,4 @@
+[[reference.tooling]]
+=== Developer Tooling
+
+include::intellij.adoc[]


### PR DESCRIPTION
This pull request adds documentation for the new Embabel Agent IntelliJ IDEA plugin and improves the organization of developer tooling documentation. The main changes introduce a dedicated section for developer tooling, provide detailed installation and usage instructions for the IntelliJ plugin, and update the module listing to reflect the new tooling.

**Documentation for Developer Tooling:**

* Added a new "Developer Tooling" section to the reference documentation, which includes detailed documentation for the Embabel Agent IntelliJ IDEA plugin, explaining its purpose, installation steps, compatibility, and contribution guidelines. (`embabel-agent-docs/src/main/asciidoc/reference/tooling/intellij.adoc`, `embabel-agent-docs/src/main/asciidoc/reference/tooling/page.adoc`) [[1]](diffhunk://#diff-46450fdae95a1c0d4ec90d4acc367a4345f38c8772b8edf7fe1e111438886c05R1-R93) [[2]](diffhunk://#diff-14b5f2893a2989166908f9c6534bcfda005f24a9fe3242e7efc7c8c6737891caR1-R4)
* Updated the module listing to include the new `embabel-agent-intellij` plugin under "Developer Tooling" with its location, purpose, and status. (`embabel-agent-docs/src/main/asciidoc/modules/page.adoc`)

**Documentation structure improvements:**

* Included the new developer tooling documentation in the main reference documentation flow. (`embabel-agent-docs/src/main/asciidoc/reference/reference.adoc`)