### PR TITLE
Prohibit OperationContext constructor injection in @Agent beans (#1538)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -170,6 +170,8 @@ class AgentMetadataReader(
             )
             return null
         }
+        rejectOperationContextConstructorInjection(targetType)
+
         val getterGoals = findGoalGetters(targetType).map { getGoal(it, instance) }
         val actionMethods = findActionMethods(targetType)
         val conditionMethods = findConditionMethods(targetType)
@@ -703,6 +705,46 @@ class AgentMetadataReader(
                 name = goalAnnotation.export.name.ifBlank { null },
                 startingInputTypes = goalAnnotation.export.startingInputTypes.map { it.java }.toSet(),
             )
+        )
+    }
+}
+
+/**
+ * Throws [IllegalStateException] if the @Agent class injects [OperationContext] or any
+ * subtype (e.g. [ExecutingOperationContext]) via a constructor parameter.
+ *
+ * [OperationContext] is action-scoped: it carries the context of a specific running
+ * operation and must be declared as an @Action method parameter so the framework can
+ * supply the correct per-invocation instance. Injecting it into a Spring bean
+ * constructor binds it permanently to a placeholder process created at wiring time,
+ * causing LLM invocations and cost tracking to be attributed to the wrong process.
+ *
+ * Correct pattern (Kotlin):
+ * ```
+ * @Action
+ * fun greet(input: UserInput, ai: Ai): String { ... }
+ * ```
+ *
+ * Correct pattern (Java):
+ * ```java
+ * @Action
+ * public String greet(UserInput userInput, Ai ai) { ... }
+ * ```
+ */
+private fun rejectOperationContextConstructorInjection(agentClass: Class<*>) {
+    val illegalParams = agentClass.constructors
+        .flatMap { it.parameters.toList() }
+        .filter { OperationContext::class.java.isAssignableFrom(it.type) }
+
+    if (illegalParams.isNotEmpty()) {
+        val paramDescriptions = illegalParams.joinToString { "'${it.type.simpleName}'" }
+        throw IllegalStateException(
+            "@Agent class '${agentClass.simpleName}' injects $paramDescriptions via its constructor. " +
+                "OperationContext is action-scoped and cannot be constructor-injected: it would be " +
+                "permanently bound to a placeholder process created at Spring wiring time, not the " +
+                "process actually executing the action. " +
+                "Declare it as an @Action method parameter instead, or use Ai directly: " +
+                "fun myAction(input: UserInput, ai: Ai): MyOutput"
         )
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderMetadataTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderMetadataTest.kt
@@ -76,6 +76,47 @@ class AgentMetadataReaderMetadataTest {
             assertNotNull(reader.createAgentMetadata(ValidActionWithDeserializationInInterfaceGoal()))
         }
 
+        @Test
+        fun `ExecutingOperationContext constructor injection throws IllegalStateException`() {
+            val reader = AgentMetadataReader()
+            val placeholder = com.embabel.agent.test.integration.IntegrationTestUtils
+                .dummyAgentProcessRunning(com.embabel.agent.api.dsl.agent(name = "p", description = "p") {})
+            val ex = assertThrows(IllegalStateException::class.java) {
+                reader.createAgentMetadata(
+                    AgentWithExecutingOperationContextConstructorInjection(
+                        com.embabel.agent.api.common.ExecutingOperationContext(
+                            name = "test",
+                            agentProcess = placeholder,
+                        )
+                    )
+                )
+            }
+            assertTrue(ex.message!!.contains("AgentWithExecutingOperationContextConstructorInjection"))
+            assertTrue(ex.message!!.contains("ExecutingOperationContext"))
+            assertTrue(ex.message!!.contains("@Action"))
+        }
+
+        @Test
+        fun `OperationContext constructor injection throws IllegalStateException`() {
+            val reader = AgentMetadataReader()
+            val placeholder = com.embabel.agent.test.integration.IntegrationTestUtils
+                .dummyAgentProcessRunning(com.embabel.agent.api.dsl.agent(name = "p", description = "p") {})
+            val ex = assertThrows(IllegalStateException::class.java) {
+                reader.createAgentMetadata(
+                    AgentWithOperationContextConstructorInjection(
+                        com.embabel.agent.api.common.OperationContext(
+                            processContext = placeholder.processContext,
+                            operation = com.embabel.agent.core.InjectedType.named("test"),
+                            toolGroups = emptySet(),
+                        )
+                    )
+                )
+            }
+            assertTrue(ex.message!!.contains("AgentWithOperationContextConstructorInjection"))
+            assertTrue(ex.message!!.contains("OperationContext"))
+            assertTrue(ex.message!!.contains("@Action"))
+        }
+
     }
 
     @Nested

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
@@ -834,3 +834,25 @@ class AgentWithDuplicateActionNames {
     fun respond(userInput: UserInput, person: PersonWithReverseTool): PersonWithReverseTool =
         PersonWithReverseTool(person.name + " " + userInput.content)
 }
+
+// ---------------------------------------------------------------------------
+// Agents used to verify that OperationContext constructor injection is prohibited
+// ---------------------------------------------------------------------------
+
+@Agent(description = "illegally injects ExecutingOperationContext via constructor")
+class AgentWithExecutingOperationContextConstructorInjection(
+    @Suppress("UNUSED_PARAMETER") context: com.embabel.agent.api.common.ExecutingOperationContext,
+) {
+    @AchievesGoal(description = "goal")
+    @Action
+    fun act(input: UserInput): PersonWithReverseTool = PersonWithReverseTool(input.content)
+}
+
+@Agent(description = "illegally injects OperationContext via constructor")
+class AgentWithOperationContextConstructorInjection(
+    @Suppress("UNUSED_PARAMETER") context: OperationContext,
+) {
+    @AchievesGoal(description = "goal")
+    @Action
+    fun act(input: UserInput): PersonWithReverseTool = PersonWithReverseTool(input.content)
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextProcessContextResolutionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/OperationContextProcessContextResolutionTest.kt
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.common
+
+import com.embabel.agent.api.annotation.AchievesGoal
+import com.embabel.agent.api.annotation.Action
+import com.embabel.agent.api.annotation.Agent
+import com.embabel.agent.api.annotation.support.AgentMetadataReader
+import com.embabel.agent.api.dsl.agent
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.AgentProcess.Companion.withCurrent
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.InjectedType
+import com.embabel.agent.core.LlmInvocation
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.Usage
+import com.embabel.agent.core.support.InMemoryBlackboard
+import com.embabel.agent.core.support.SimpleAgentProcess
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.spi.support.DefaultPlannerFactory
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.common.ai.model.LlmMetadata
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.time.Instant
+
+
+// ILLEGAL: constructor-injects ExecutingOperationContext
+@Agent(description = "Illegally injects ExecutingOperationContext via constructor", scan = false)
+class AgentWithExecutingOperationContextCtor(
+    @Suppress("UNUSED_PARAMETER") context: ExecutingOperationContext,
+) {
+    @AchievesGoal(description = "goal")
+    @Action
+    fun act(input: UserInput): String = "done"
+}
+
+// ILLEGAL: constructor-injects base OperationContext
+@Agent(description = "Illegally injects OperationContext via constructor", scan = false)
+class AgentWithOperationContextCtor(
+    @Suppress("UNUSED_PARAMETER") context: OperationContext,
+) {
+    @AchievesGoal(description = "goal")
+    @Action
+    fun act(input: UserInput): String = "done"
+}
+
+// LEGAL: injects Ai as an @Action parameter (the correct pattern)
+@Agent(description = "Correctly declares Ai as an @Action parameter", scan = false)
+class AgentWithAiActionParam {
+    @AchievesGoal(description = "goal")
+    @Action
+    fun act(input: UserInput, ai: Ai): String = "done"
+}
+
+// LEGAL: injects nothing (plain action)
+@Agent(description = "Plain agent with no special injection", scan = false)
+class AgentWithNoInjection {
+    @AchievesGoal(description = "goal")
+    @Action
+    fun act(input: UserInput): String = "done"
+}
+
+// Used by the LLM-attribution integration test
+@Agent(description = "Records LLM invocation via @Action OperationContext parameter", scan = false)
+class ActionParamRecordingAgent {
+
+    @AchievesGoal(description = "Record an invocation")
+    @Action
+    fun record(input: UserInput, context: OperationContext): String {
+        // Correctly receives OperationContext as an @Action parameter.
+        // The framework supplies the correct per-invocation instance here.
+        context.processContext.agentProcess.recordLlmInvocation(
+            LlmInvocation(
+                llmMetadata = LlmMetadata(name = "test-model", provider = "test", pricingModel = null),
+                usage = Usage(promptTokens = 10, completionTokens = 5, nativeUsage = null),
+                timestamp = Instant.now(),
+                runningTime = Duration.ofMillis(50),
+            )
+        )
+        return "recorded for ${input.content}"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+/**
+ * Tests for the prohibition of [OperationContext] constructor injection in @Agent beans,
+ * and the correct alternative pattern of declaring it as an @Action method parameter.
+ *
+ * Background — the bug (issue #1538):
+ * Injecting OperationContext via a Spring bean constructor permanently binds it to a
+ * placeholder process ("vigorous_nobel") created at wiring time. When the framework
+ * later executes an action under a real process ("cool_dirac"), LLM invocations are
+ * attributed to the wrong process, causing costInfoString() to report 0 tokens.
+ *
+ * Resolution: [AgentMetadataReader] now throws [IllegalStateException] at agent
+ * creation time when it detects OperationContext in a constructor, with a clear
+ * message pointing to the @Action parameter pattern.
+ */
+class OperationContextProcessContextResolutionTest {
+
+    // ------------------------------------------------------------------
+    // Prohibition tests — AgentMetadataReader must reject illegal patterns
+    // ------------------------------------------------------------------
+
+    @Nested
+    inner class ConstructorInjectionProhibition {
+
+        private val reader = AgentMetadataReader()
+
+        @Test
+        fun `ExecutingOperationContext constructor injection is rejected at agent creation`() {
+            val ex = assertThrows<IllegalStateException> {
+                reader.createAgentMetadata(
+                    AgentWithExecutingOperationContextCtor(
+                        ExecutingOperationContext(
+                            name = "test",
+                            agentProcess = makePlaceholder(),
+                        )
+                    )
+                )
+            }
+            assertTrue(
+                ex.message!!.contains("AgentWithExecutingOperationContextCtor"),
+                "Error message must name the offending class, got: ${ex.message}",
+            )
+            assertTrue(
+                ex.message!!.contains("ExecutingOperationContext"),
+                "Error message must name the offending type, got: ${ex.message}",
+            )
+            assertTrue(
+                ex.message!!.contains("@Action"),
+                "Error message must point to the @Action parameter pattern, got: ${ex.message}",
+            )
+        }
+
+        @Test
+        fun `base OperationContext constructor injection is rejected at agent creation`() {
+            val ex = assertThrows<IllegalStateException> {
+                reader.createAgentMetadata(
+                    AgentWithOperationContextCtor(
+                        OperationContext(
+                            processContext = makePlaceholder().processContext,
+                            operation = InjectedType.named("test"),
+                            toolGroups = emptySet(),
+                        )
+                    )
+                )
+            }
+            assertTrue(ex.message!!.contains("AgentWithOperationContextCtor"))
+            assertTrue(ex.message!!.contains("OperationContext"))
+            assertTrue(ex.message!!.contains("@Action"))
+        }
+
+        @Test
+        fun `agent with Ai as action parameter is accepted`() {
+            val result = reader.createAgentMetadata(AgentWithAiActionParam())
+            assertTrue(result != null, "Valid agent must be accepted by AgentMetadataReader")
+        }
+
+        @Test
+        fun `agent with no special injection is accepted`() {
+            val result = reader.createAgentMetadata(AgentWithNoInjection())
+            assertTrue(result != null, "Valid agent must be accepted by AgentMetadataReader")
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Unit tests — verify the thread-local behaviour that @Action
+    // parameter injection relies on under the hood
+    // ------------------------------------------------------------------
+
+    @Nested
+    inner class ThreadLocalBehaviour {
+
+        private fun makeProcess(id: String) = SimpleAgentProcess(
+            id = id,
+            parentId = null,
+            agent = agent(name = id, description = "placeholder agent for $id") {},
+            blackboard = InMemoryBlackboard(),
+            processOptions = ProcessOptions(),
+            platformServices = dummyPlatformServices(),
+            plannerFactory = DefaultPlannerFactory,
+        )
+
+        @Test
+        fun `AgentProcess withCurrent sets and clears the thread-local correctly`() {
+            val process = makeProcess("test-process")
+
+            assertEquals(null, AgentProcess.get(), "Thread-local should be null before withCurrent")
+
+            process.withCurrent {
+                assertEquals("test-process", AgentProcess.get()?.id)
+            }
+
+            assertEquals(null, AgentProcess.get(), "Thread-local should be null after withCurrent exits")
+        }
+
+        @Test
+        fun `withCurrent restores previous thread-local on exit`() {
+            val outer = makeProcess("outer")
+            val inner = makeProcess("inner")
+
+            outer.withCurrent {
+                inner.withCurrent {
+                    assertEquals("inner", AgentProcess.get()?.id)
+                }
+                assertEquals("outer", AgentProcess.get()?.id)
+            }
+            assertEquals(null, AgentProcess.get())
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Integration test — @Action parameter injection correctly attributes
+    // LLM invocations to the executing process
+    // ------------------------------------------------------------------
+
+    @Nested
+    inner class ActionParameterInjectionIntegration {
+
+        /**
+         * Verifies that when OperationContext is declared as an @Action method parameter
+         * (the correct pattern), LLM invocations are attributed to the executing process
+         * and costInfoString() reports non-zero.
+         *
+         * This is the positive counterpart to the prohibition tests: it confirms that
+         * the recommended fix actually works.
+         */
+        @Test
+        fun `OperationContext as action parameter correctly attributes LLM invocations to executing process`() {
+            val ps = dummyPlatformServices()
+
+            val agentMeta = AgentMetadataReader().createAgentMetadata(ActionParamRecordingAgent())
+                as com.embabel.agent.core.Agent
+
+            val executingProcess = SimpleAgentProcess(
+                id = "cool_dirac",
+                parentId = null,
+                agent = agentMeta,
+                blackboard = InMemoryBlackboard().apply { this += UserInput("Hello") },
+                processOptions = ProcessOptions(),
+                platformServices = ps,
+                plannerFactory = DefaultPlannerFactory,
+            )
+
+            executingProcess.run()
+
+            assertEquals(AgentProcessStatusCode.COMPLETED, executingProcess.status)
+            assertEquals(
+                1,
+                executingProcess.llmInvocations.size,
+                "cool_dirac must have 1 LLM invocation when OperationContext is an @Action parameter",
+            )
+            val costInfo = executingProcess.costInfoString(verbose = true)
+            assertTrue(costInfo.contains("1 calls")) {
+                "costInfoString must report 1 call, got: $costInfo"
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+private fun makePlaceholder() = SimpleAgentProcess(
+    id = "vigorous_nobel",
+    parentId = null,
+    agent = agent(name = "placeholder", description = "placeholder") {},
+    blackboard = InMemoryBlackboard(),
+    processOptions = ProcessOptions(),
+    platformServices = dummyPlatformServices(),
+    plannerFactory = DefaultPlannerFactory,
+)


### PR DESCRIPTION
This pull request introduces a strict prohibition on injecting `OperationContext` (or its subtype `ExecutingOperationContext`) via constructor parameters in `@Agent` classes, addressing a critical bug where LLM usage and cost tracking could be attributed to the wrong process. The enforcement is implemented in the `AgentMetadataReader`, with comprehensive tests and clear error messaging guiding developers to use the correct pattern—declaring `OperationContext` as an `@Action` method parameter. Additional positive and negative test cases are provided to ensure the correct behavior and prevent regressions.

**Enforcement of OperationContext Injection Rules:**

* Added a check in `AgentMetadataReader` to throw an `IllegalStateException` if an `@Agent` class attempts to inject `OperationContext` or `ExecutingOperationContext` via its constructor, with a detailed error message explaining the correct usage pattern. [[1]](diffhunk://#diff-9d5c2d8d9cc2524641b6e7f20048c4cc87c11951e7527fe18fbac88720c7f0e3R173-R174) [[2]](diffhunk://#diff-9d5c2d8d9cc2524641b6e7f20048c4cc87c11951e7527fe18fbac88720c7f0e3R712-R751)

**Test Coverage for Injection Patterns:**

* Added new agent classes and tests to verify that constructor injection of `OperationContext` or `ExecutingOperationContext` is rejected, and that the error message is informative and specific. [[1]](diffhunk://#diff-759c0f90305669b1ba34f29c36fe47606027fd2547f76d2552d251faa60b0a7bR79-R119) [[2]](diffhunk://#diff-144904769e9e651c66d855db4579edc90364a1ca92fd42e416947ce78e65b863R837-R858)
* Introduced a dedicated test suite (`OperationContextProcessContextResolutionTest.kt`) that covers both illegal and legal injection patterns, including integration tests to confirm that LLM invocations are correctly attributed when using the recommended `@Action` parameter pattern.