### PR TITLE
Align TestStarNewsFinder description with actual goal (#1616)

### DIFF
--- a/embabel-agent-a2a/src/test/kotlin/com/embabel/agent/a2a/example/simple/horoscope/kotlin/TestStarNewsFinder.kt
+++ b/embabel-agent-a2a/src/test/kotlin/com/embabel/agent/a2a/example/simple/horoscope/kotlin/TestStarNewsFinder.kt
@@ -76,10 +76,11 @@ data class Writeup(
 ) : HasContent
 
 /**
- * An agent that finds personalized news stories based on a person's star sign.
+ * An agent that writes a personalised, amusing writeup for a person by combining
+ * their daily horoscope with relevant current news stories.
  */
 @Agent(
-    description = "Find news based on a person's star sign",
+    description = "Write an amusing personalised writeup combining a person's horoscope and current news stories",
     scan = true,
     beanName = "KotlinStarNewsFinder",
 )

--- a/embabel-agent-api/src/test/java/com/embabel/example/simple/horoscope/java/TestStarNewsFinder.java
+++ b/embabel-agent-api/src/test/java/com/embabel/example/simple/horoscope/java/TestStarNewsFinder.java
@@ -35,11 +35,12 @@ import java.util.stream.Collectors;
 
 
 /**
- * Find news based on a person's star sign
+ * Writes an amusing personalised writeup combining a person's horoscope
+ * and relevant current news stories.
  */
 @Agent(
         name = "JavaTestStarNewsFinder",
-        description = "Find news based on a person's star sign",
+        description = "Write an amusing personalised writeup combining a person's horoscope and current news stories",
         beanName = "javaTestStarNewsFinder",
         scan = false)
 public class TestStarNewsFinder {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/example/simple/horoscope/kotlin/TestStarNewsFinder.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/example/simple/horoscope/kotlin/TestStarNewsFinder.kt
@@ -76,10 +76,11 @@ data class Writeup(
 ) : HasContent
 
 /**
- * An agent that finds personalized news stories based on a person's star sign.
+ * An agent that writes a personalised, amusing writeup for a person by combining
+ * their daily horoscope with relevant current news stories.
  */
 @Agent(
-    description = "Find news based on a person's star sign",
+    description = "Write an amusing personalised writeup combining a person's horoscope and current news stories",
     scan = true,
     beanName = "KotlinStarNewsFinder",
 )


### PR DESCRIPTION
This pull request updates the documentation and metadata for the `StarNewsFinder` agent examples in both Java and Kotlin. The changes clarify that the agent now creates a personalized, amusing writeup by combining a person's horoscope with relevant news stories, rather than just finding news based on star sign.

**Documentation and metadata updates:**

* Updated the agent description and class-level comments in the Kotlin example (`TestStarNewsFinder.kt`) to reflect that the agent writes a personalized, amusing writeup combining horoscope and current news stories, instead of only finding news by star sign. [[1]](diffhunk://#diff-1ef7747632bf45b1ba65b40f4b787846f72185561faa075e0fa479613e12fcc8L79-R83) [[2]](diffhunk://#diff-2933b8ab1cbd7cac8d9e4d9adf9a326878dded1828c7c21320cfb6146dc9b704L79-R83)
* Updated the agent description and class-level comments in the Java example (`TestStarNewsFinder.java`) with the same clarification.