### PR TITLE
Expose internal types for use outside of the module

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodTool.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodTool.kt
@@ -78,70 +78,16 @@ internal sealed class MethodTool(
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun parseArguments(input: String): Map<String, Any?> {
-        if (input.isBlank()) return emptyMap()
-        return try {
-            objectMapper.readValue(input, Map::class.java) as Map<String, Any?>
-        } catch (e: Exception) {
-            logger.warn("Failed to parse tool input as JSON: {}", e.message)
-            emptyMap()
-        }
-    }
+    private fun parseArguments(input: String): Map<String, Any?> =
+        ToolCallSupport.parseArguments(input, objectMapper, logger)
 
     protected abstract fun invokeMethod(args: Map<String, Any?>, context: ToolCallContext): Any?
 
-    private fun convertResult(result: Any?): Tool.Result {
-        return when (result) {
-            null -> Tool.Result.text("")
-            is String -> Tool.Result.text(result)
-            is Tool.Result -> result
-            else -> {
-                // Convert to JSON string and preserve the original object as an artifact
-                // so that ArtifactSinkingTool can capture it for tool chaining
-                try {
-                    Tool.Result.withArtifact(objectMapper.writeValueAsString(result), result)
-                } catch (_: Exception) {
-                    Tool.Result.withArtifact(result.toString(), result)
-                }
-            }
-        }
-    }
+    private fun convertResult(result: Any?): Tool.Result =
+        ToolCallSupport.convertResult(result, objectMapper)
 
-    protected fun convertToExpectedType(
-        value: Any,
-        targetType: Type,
-    ): Any {
-        // If already correct type, return as-is
-        if (targetType is Class<*> && targetType.isInstance(value)) {
-            return value
-        }
-
-        // Handle numeric conversions from JSON.
-        // Jackson often returns Int/Double, but LLMs may also send numbers as strings
-        // (e.g. "5" instead of 5), so we coerce string-wrapped numbers too.
-        return when (targetType) {
-            Int::class.java, Integer::class.java ->
-                (value as? Number)?.toInt() ?: (value as? String)?.toIntOrNull() ?: value
-            Long::class.java, java.lang.Long::class.java ->
-                (value as? Number)?.toLong() ?: (value as? String)?.toLongOrNull() ?: value
-            Double::class.java, java.lang.Double::class.java ->
-                (value as? Number)?.toDouble() ?: (value as? String)?.toDoubleOrNull() ?: value
-            Float::class.java, java.lang.Float::class.java ->
-                (value as? Number)?.toFloat() ?: (value as? String)?.toFloatOrNull() ?: value
-            Boolean::class.java, java.lang.Boolean::class.java -> value as? Boolean ?: value.toString().toBoolean()
-            String::class.java -> value.toString()
-            else -> {
-                // For complex types, try to convert via ObjectMapper
-                try {
-                    objectMapper.convertValue(value, objectMapper.constructType(targetType))
-                } catch (e: Exception) {
-                    logger.warn("Failed to convert {} to {}: {}", value, targetType, e.message)
-                    value
-                }
-            }
-        }
-    }
+    protected fun convertToExpectedType(value: Any, targetType: Type): Any =
+        ToolCallSupport.convertToType(value, targetType, objectMapper, logger)
 }
 
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/ToolCallSupport.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/ToolCallSupport.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.tool
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.jetbrains.annotations.ApiStatus
+import org.slf4j.Logger
+import java.lang.reflect.Type
+
+/**
+ * Shared utility functions for [Tool] implementations that invoke methods via reflection.
+ *
+ * Centralises JSON argument parsing, return value serialisation, and parameter type
+ * coercion so that [MethodTool] and other reflective tool implementations share a
+ * single, tested implementation.
+ */
+@ApiStatus.Internal
+object ToolCallSupport {
+
+    /**
+     * Parses a JSON input string into a name→value map.
+     * Returns an empty map if [input] is blank or cannot be parsed.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun parseArguments(input: String, objectMapper: ObjectMapper, logger: Logger): Map<String, Any?> {
+        if (input.isBlank()) return emptyMap()
+        return try {
+            objectMapper.readValue(input, Map::class.java) as Map<String, Any?>
+        } catch (e: Exception) {
+            logger.warn("Failed to parse tool input as JSON: {}", e.message)
+            emptyMap()
+        }
+    }
+
+    /**
+     * Converts a method return value to a [Tool.Result].
+     * - `null` → empty text result
+     * - [String] → text result
+     * - [Tool.Result] → returned as-is
+     * - anything else → serialised to JSON with the original object as an artifact,
+     *   so that artifact-sinking decorators can capture it for tool chaining
+     */
+    fun convertResult(result: Any?, objectMapper: ObjectMapper): Tool.Result =
+        when (result) {
+            null -> Tool.Result.text("")
+            is String -> Tool.Result.text(result)
+            is Tool.Result -> result
+            // Convert to JSON string and preserve the original object as an artifact
+            // so that ArtifactSinkingTool can capture it for tool chaining
+            else -> try {
+                Tool.Result.withArtifact(objectMapper.writeValueAsString(result), result)
+            } catch (_: Exception) {
+                Tool.Result.withArtifact(result.toString(), result)
+            }
+        }
+
+    /**
+     * Coerces [value] (typically from a JSON parse) to [targetType].
+     *
+     * Jackson deserialises JSON numbers as [Int] or [Double]; LLMs may also send
+     * numbers as quoted strings (e.g. `"5"` instead of `5`). Both cases are handled.
+     * For complex types the [ObjectMapper] is used as a fallback.
+     */
+    fun convertToType(value: Any, targetType: Type, objectMapper: ObjectMapper, logger: Logger): Any {
+        if (targetType is Class<*> && targetType.isInstance(value)) return value
+        return when (targetType) {
+            Int::class.java, Integer::class.java ->
+                (value as? Number)?.toInt() ?: (value as? String)?.toIntOrNull() ?: value
+            Long::class.java, java.lang.Long::class.java ->
+                (value as? Number)?.toLong() ?: (value as? String)?.toLongOrNull() ?: value
+            Double::class.java, java.lang.Double::class.java ->
+                (value as? Number)?.toDouble() ?: (value as? String)?.toDoubleOrNull() ?: value
+            Float::class.java, java.lang.Float::class.java ->
+                (value as? Number)?.toFloat() ?: (value as? String)?.toFloatOrNull() ?: value
+            Boolean::class.java, java.lang.Boolean::class.java ->
+                value as? Boolean ?: value.toString().toBoolean()
+            String::class.java -> value.toString()
+            else -> try {
+                objectMapper.convertValue(value, objectMapper.constructType(targetType))
+            } catch (e: Exception) {
+                logger.warn("Failed to convert {} to {}: {}", value, targetType, e.message)
+                value
+            }
+        }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/VictoolsSchemaGenerator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/VictoolsSchemaGenerator.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.api.tool
 
+import com.embabel.agent.api.tool.Tool.InputSchema
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
@@ -23,6 +24,8 @@ import com.github.victools.jsonschema.generator.OptionPreset
 import com.github.victools.jsonschema.generator.SchemaGenerator
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
 import com.github.victools.jsonschema.generator.SchemaVersion
+import org.jetbrains.annotations.ApiStatus
+import java.lang.reflect.Method
 import java.lang.reflect.Type
 
 /**
@@ -110,7 +113,7 @@ internal object VictoolsSchemaGenerator {
  * This schema generates proper JSON Schema with `items` property for arrays,
  * which is required by OpenAI and other LLM providers.
  */
-internal class MethodInputSchema(
+class MethodInputSchema internal constructor(
     private val parameterInfos: List<VictoolsSchemaGenerator.ParameterInfo>,
 ) : Tool.InputSchema {
 
@@ -159,5 +162,27 @@ internal class MethodInputSchema(
 
             else -> Tool.ParameterType.OBJECT
         }
+    }
+
+    companion object {
+
+        /**
+         * Creates an [InputSchema] from all parameters of [method].
+         */
+        @ApiStatus.Internal
+        fun fromMethod(
+            method: Method,
+        ): InputSchema {
+            val parameterInfos = method.parameters.map { param ->
+                VictoolsSchemaGenerator.ParameterInfo(
+                    name = param.name,
+                    type = param.parameterizedType,
+                    description = param.name,
+                    required = true,
+                )
+            }
+            return MethodInputSchema(parameterInfos)
+        }
+
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/MethodInputSchemaTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/MethodInputSchemaTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.tool
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class MethodInputSchemaTest {
+
+    // Sample methods used as fixtures — compiled with -parameters so names are preserved
+    @Suppress("unused")
+    private fun noParams(): String = ""
+
+    @Suppress("unused")
+    private fun oneParam(name: String): String = name
+
+    @Suppress("unused")
+    private fun multipleParams(id: Long, active: Boolean, score: Double): String = ""
+
+    @Suppress("unused")
+    private fun listParam(tags: List<String>): String = ""
+
+    private fun method(name: String) =
+        this::class.java.getDeclaredMethod(name, *when (name) {
+            "noParams" -> emptyArray()
+            "oneParam" -> arrayOf(String::class.java)
+            "multipleParams" -> arrayOf(Long::class.java, Boolean::class.java, Double::class.java)
+            "listParam" -> arrayOf(List::class.java)
+            else -> throw IllegalArgumentException("Unknown fixture method: $name")
+        })
+
+    @Nested
+    inner class Parameters {
+
+        @Test
+        fun `no parameters produces empty parameter list`() {
+            val schema = MethodInputSchema.fromMethod(method("noParams"))
+            assertTrue(schema.parameters.isEmpty())
+        }
+
+        @Test
+        fun `single parameter is reflected`() {
+            val schema = MethodInputSchema.fromMethod(method("oneParam"))
+            assertEquals(1, schema.parameters.size)
+            val param = schema.parameters.single()
+            assertEquals("name", param.name)
+            assertEquals(Tool.ParameterType.STRING, param.type)
+            assertTrue(param.required)
+        }
+
+        @Test
+        fun `multiple parameters are all present and in order`() {
+            val schema = MethodInputSchema.fromMethod(method("multipleParams"))
+            assertEquals(3, schema.parameters.size)
+            assertEquals(listOf("id", "active", "score"), schema.parameters.map { it.name })
+        }
+
+        @Test
+        fun `all parameters are required`() {
+            val schema = MethodInputSchema.fromMethod(method("multipleParams"))
+            assertTrue(schema.parameters.all { it.required })
+        }
+
+        @Test
+        fun `list parameter maps to ARRAY type`() {
+            val schema = MethodInputSchema.fromMethod(method("listParam"))
+            assertEquals(Tool.ParameterType.ARRAY, schema.parameters.single().type)
+        }
+    }
+
+    @Nested
+    inner class JsonSchema {
+
+        @Test
+        fun `no-parameter method produces schema with empty properties`() {
+            val json = MethodInputSchema.fromMethod(method("noParams")).toJsonSchema()
+            assertTrue(json.contains("\"properties\":{}"), "Expected empty properties in: $json")
+        }
+
+        @Test
+        fun `single parameter appears in JSON schema`() {
+            val json = MethodInputSchema.fromMethod(method("oneParam")).toJsonSchema()
+            assertTrue(json.contains("\"name\""), "Expected 'name' property in: $json")
+        }
+
+        @Test
+        fun `required array contains all parameter names`() {
+            val json = MethodInputSchema.fromMethod(method("multipleParams")).toJsonSchema()
+            assertTrue(json.contains("\"id\""), "Expected 'id' in: $json")
+            assertTrue(json.contains("\"active\""), "Expected 'active' in: $json")
+            assertTrue(json.contains("\"score\""), "Expected 'score' in: $json")
+        }
+    }
+}


### PR DESCRIPTION
This PR annotates several types with @ApiStatus.Internal, instead of using the internal keyword.