### PR TITLE
Fix/race condition agentprocess

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
@@ -69,18 +69,23 @@ abstract class AbstractAgentProcess(
     override val failureInfo: Any?
         get() = _failureInfo
 
-    private var _terminationRequest: TerminationSignal? = null
+    private val _terminationRequest = AtomicReference<TerminationSignal?>(null)
 
     internal val terminationRequest: TerminationSignal?
-        get() = _terminationRequest
+        get() = _terminationRequest.get()
 
     private fun setTerminationRequest(signal: TerminationSignal) {
-        _terminationRequest = signal
+        _terminationRequest.set(signal)
     }
 
-    internal fun resetTerminationRequest() {
-        _terminationRequest = null
-    }
+    /**
+     * Atomically clear the slot only if its current value is exactly [expected].
+     * Returns true if the caller successfully consumed the observed signal.
+     * Returns false if the slot was mutated concurrently — the newer value
+     * is preserved and will be visible to the next consumer.
+     */
+    internal fun compareAndResetTerminationRequest(expected: TerminationSignal): Boolean =
+        _terminationRequest.compareAndSet(expected, null)
 
     override fun terminateAgent(reason: String) {
         // Cascade to children first
@@ -374,7 +379,8 @@ abstract class AbstractAgentProcess(
         // Check for API-driven termination signal first
         val signalTermination = TerminationSignalPolicy.shouldTerminate(this)
         if (signalTermination != null) {
-            resetTerminationRequest()
+            val observed = terminationRequest
+            if (observed != null) compareAndResetTerminationRequest(observed)
             logger.debug(
                 "Process {} terminated by termination signal: {}",
                 this.id,
@@ -390,8 +396,9 @@ abstract class AbstractAgentProcess(
         // (e.g., set by a simple action without tool loop)
         val staleSignal = terminationRequest
         if (staleSignal != null && staleSignal.scope == TerminationScope.ACTION) {
-            logger.debug("Clearing stale ACTION termination signal: {}", staleSignal.reason)
-            resetTerminationRequest()
+            if (compareAndResetTerminationRequest(staleSignal)) {
+                logger.debug("Clearing stale ACTION termination signal: {}", staleSignal.reason)
+            }
         }
 
         // Check configured early termination policies

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
@@ -255,12 +255,14 @@ internal open class DefaultToolLoop(
      */
     protected fun checkForActionTerminationSignal() {
         val process = AgentProcess.get() as? AbstractAgentProcess ?: return
-        val signal = process.terminationRequest
-        if (signal != null && signal.scope == TerminationScope.ACTION) {
+        val signal = process.terminationRequest ?: return
+        if (signal.scope != TerminationScope.ACTION) return
+        if (process.compareAndResetTerminationRequest(signal)) {
             logger.info("Action termination signal detected: {}", signal.reason)
-            process.resetTerminationRequest()
             throw TerminateActionException(signal.reason)
         }
+        // CAS failed — slot was mutated concurrently. The new signal stays
+        // in place for the next consumer; we do not act on the stale observation.
     }
 
     /**

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/AbstractAgentProcessTerminationRaceTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/AbstractAgentProcessTerminationRaceTest.kt
@@ -50,6 +50,36 @@ class AbstractAgentProcessTerminationRaceTest {
     )
 
     /**
+     * Happy path: no concurrent writer between the read and the CAS.
+     * The observed signal is still in the slot, so CAS succeeds, the slot
+     * is cleared to null, and the caller takes the termination path.
+     */
+    @Test
+    fun `happy path - CAS succeeds when slot still holds the observed signal`() {
+        val process = newProcess()
+
+        // Post signal-A
+        process.terminateAction("signal-A")
+        val observed = process.terminationRequest!!
+        assertEquals("signal-A", observed.reason)
+
+        // No concurrent writer: slot still holds signal-A.
+        // CAS must succeed and clear the slot to null.
+        val wasReset = process.compareAndResetTerminationRequest(observed)
+        assertTrue(wasReset, "CAS must succeed: slot still holds the observed signal-A")
+
+        assertEquals(
+            null,
+            process.terminationRequest,
+            "After a successful CAS, the slot must be null — the signal is consumed.",
+        )
+
+        // A second CAS with the same observed signal must now fail (slot is null).
+        val secondReset = process.compareAndResetTerminationRequest(observed)
+        assertFalse(secondReset, "CAS must fail on an already-consumed slot")
+    }
+
+    /**
      * Sequential interleave: consumer reads A, another writer posts B,
      * consumer unconditionally resets → B is silently dropped.
      */

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/AbstractAgentProcessTerminationRaceTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/AbstractAgentProcessTerminationRaceTest.kt
@@ -20,8 +20,8 @@ import com.embabel.agent.spi.support.DefaultPlannerFactory
 import com.embabel.agent.support.SimpleTestAgent
 import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
@@ -32,10 +32,10 @@ import java.util.concurrent.TimeUnit
 /**
  * Documents a read-modify-write race on `AbstractAgentProcess._terminationRequest`.
  *
- * All tests are `@Disabled` — this file is documentation for the follow-up issue.
- * Each test was run without `@Disabled` and verified to fail deterministically on
- * current code; the observed failure is recorded in the `@Disabled` reason.
- * Remove `@Disabled` once the fix lands.
+ * These tests fail deterministically against the current unconditional-reset
+ * implementation: a consumer reads signal-A, a concurrent writer posts signal-B,
+ * then the consumer's unconditional `resetTerminationRequest()` silently clobbers B.
+ * They pass once the reset becomes CAS-based (compare-and-reset against the observed signal).
  */
 class AbstractAgentProcessTerminationRaceTest {
 
@@ -54,7 +54,6 @@ class AbstractAgentProcessTerminationRaceTest {
      * consumer unconditionally resets → B is silently dropped.
      */
     @Test
-    @Disabled("Outstanding race on _terminationRequest. Verified failure: expected <signal-B> but was <null>.")
     fun `sequential - unconditional reset clobbers concurrent termination signal`() {
         val process = newProcess()
 
@@ -66,16 +65,15 @@ class AbstractAgentProcessTerminationRaceTest {
         // t=1 — another writer overwrites with signal-B
         process.terminateAction("signal-B")
 
-        // t=2 — consumer unconditionally clears the slot
-        process.resetTerminationRequest()
+        // t=2 — consumer attempts a CAS reset against the signal it observed (A).
+        //       Slot now holds B, so CAS must fail and leave B untouched.
+        val wasReset = process.compareAndResetTerminationRequest(observedByConsumer)
+        assertFalse(wasReset, "CAS must fail because slot now holds signal-B, not signal-A")
 
-        // With a CAS-based consumer: signal-B stays.
-        // With the current unconditional reset: signal-B is dropped.
         assertEquals(
             "signal-B",
             process.terminationRequest?.reason,
-            "signal-B must survive the consumer's reset. Fix: replace the " +
-                "unconditional reset with compareAndResetTerminationRequest(observedByConsumer).",
+            "signal-B set after the consumer's read must survive the CAS reset.",
         )
     }
 
@@ -84,7 +82,6 @@ class AbstractAgentProcessTerminationRaceTest {
      * consumer reads A → barrier #1 → writer posts B → barrier #2 → consumer resets.
      */
     @Test
-    @Disabled("Outstanding race on _terminationRequest. Verified failure: expected <signal-B> but was <null>.")
     fun `multi-thread - unconditional reset across threads clobbers concurrent signal`() {
         val process = newProcess()
         // Seed the slot: both threads will start from slot = signal-A.
@@ -117,9 +114,10 @@ class AbstractAgentProcessTerminationRaceTest {
                 // (C) Wait until the writer has posted signal-B. At this point the slot = B.
                 afterExternalWrite.await(5, TimeUnit.SECONDS)
 
-                // (D) Buggy step: unconditional reset → clobbers signal-B.
-                //     With a CAS-based implementation (expected=A), this would be a no-op.
-                process.resetTerminationRequest()
+                // (D) CAS reset against the observed signal (A). Slot holds B,
+                //     so CAS must fail and preserve B.
+                val wasReset = process.compareAndResetTerminationRequest(observed)
+                assertFalse(wasReset, "CAS must fail because slot was overwritten to signal-B")
             } catch (t: Throwable) {
                 errors.add(t)
             } finally {
@@ -154,15 +152,13 @@ class AbstractAgentProcessTerminationRaceTest {
         // Surface any error that happened inside the workers.
         assertTrue(errors.isEmpty(), "errors: $errors")
 
-        // Expected (correct) behaviour: the consumer's stale reset must NOT erase
-        // signal-B — the consumer only ever observed signal-A, and signal-B was
-        // posted after that. A CAS-based reset would leave B untouched.
-        // On buggy code: slot is null → message says "was <null>".
+        // Expected behaviour: the consumer's CAS reset fails (slot holds B, not A),
+        // so signal-B survives and is still observable.
         assertEquals(
             "signal-B",
             process.terminationRequest?.reason,
             "signal-B set by the external writer after the consumer's read must " +
-                "not be dropped by the consumer's stale reset.",
+                "not be dropped by the consumer's CAS reset.",
         )
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/ToolLoopTerminationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/ToolLoopTerminationTest.kt
@@ -27,6 +27,7 @@ import com.embabel.chat.UserMessage
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -113,6 +114,12 @@ class ToolLoopTerminationTest {
             // Only tool_one should have been called; tool_two skipped due to termination
             assertEquals(1, toolCallOrder.size)
             assertEquals("tool_one", toolCallOrder[0])
+
+            // Race-fix invariant: the tool loop MUST consume the ACTION signal via CAS,
+            // not via an unconditional reset. If a future refactor reintroduces a
+            // non-CAS reset on DefaultToolLoop.checkForActionTerminationSignal, this
+            // verify fails — catching the regression at its source.
+            verify(atLeast = 1) { mockProcess.compareAndResetTerminationRequest(any()) }
         }
 
         /**
@@ -343,7 +350,15 @@ class ToolLoopTerminationTest {
         every { mockProcess.terminateAction(any()) } answers {
             terminationRequest = TerminationSignal(TerminationScope.ACTION, firstArg())
         }
-        every { mockProcess.resetTerminationRequest() } answers { terminationRequest = null }
+        every { mockProcess.compareAndResetTerminationRequest(any()) } answers {
+            val expected = firstArg<TerminationSignal>()
+            if (terminationRequest == expected) {
+                terminationRequest = null
+                true
+            } else {
+                false
+            }
+        }
 
         AgentProcess.set(mockProcess)
         return mockProcess

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoopTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoopTest.kt
@@ -88,7 +88,15 @@ class ParallelToolLoopTest {
         every { mockProcess.terminateAction(any()) } answers {
             terminationRequest = TerminationSignal(TerminationScope.ACTION, firstArg())
         }
-        every { mockProcess.resetTerminationRequest() } answers { terminationRequest = null }
+        every { mockProcess.compareAndResetTerminationRequest(any()) } answers {
+            val expected = firstArg<TerminationSignal>()
+            if (terminationRequest == expected) {
+                terminationRequest = null
+                true
+            } else {
+                false
+            }
+        }
 
         AgentProcess.set(mockProcess)
         return mockProcess


### PR DESCRIPTION

Fixes #1621.

`_terminationRequest` was a plain `var`. The tool loop consumer did two separate steps - read the signal, then unconditionally clear the slot. If another thread wrote a new signal between the read and the clear, the new signal was silently wiped - losing user cancels, budget-guard terminations, and parent-to-child cascades.

## Fix

- Back `_terminationRequest` with `AtomicReference<TerminationSignal?>` (same pattern as `_status` in the same file).
- Add `compareAndResetTerminationRequest(expected)` - clears the slot only if it still holds the exact signal the caller observed; otherwise leaves the slot untouched so the newer signal survives.
- Migrate the three read-then-clear sites to use it:
  - `DefaultToolLoop.checkForActionTerminationSignal`
  - `AbstractAgentProcess.identifyEarlyTermination` - agent-scope path
  - `AbstractAgentProcess.identifyEarlyTermination` - stale action-scope clean-up
- Remove `resetTerminationRequest()` - unused after the migration 

 All affected APIs are `internal` to the `embabel-agent-api` module, so the change does not leak outside it.

## Tests

- `AbstractAgentProcessTerminationRaceTest` - previously `@Disabled`, migrated to the new API and re-enabled. Both tests (single-thread and multi-thread with `CyclicBarrier`) fail on pre-fix code and pass with this PR.
- `ToolLoopTerminationTest` - added a regression guard (`verify(atLeast = 1) { mockProcess.compareAndResetTerminationRequest(any()) }`) ensuring the tool loop consumes the signal through the new API. If a future refactor reintroduces an unconditional reset, this verification fails and catches the regression at its source.
- `ParallelToolLoopTest` - MockK stubs updated to match the new API.

## Test plan

- [x] `AbstractAgentProcessTerminationRaceTest` passes.
- [x] `ToolLoopTerminationTest` passes (including the new regression guard).
- [x] Full `embabel-agent` suite green.