### PR TITLE
Fix metadata getting nuked instead of merged

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/Chunk.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/Chunk.kt
@@ -168,5 +168,5 @@ private data class ChunkImpl(
 ) : Chunk {
 
     override fun withAdditionalMetadata(metadata: Map<String, Any?>): Chunk =
-        this.copy(metadata = metadata)
+        this.copy(metadata = this.metadata + metadata)
 }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/store/AbstractChunkingContentElementRepository.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/store/AbstractChunkingContentElementRepository.kt
@@ -70,7 +70,7 @@ abstract class AbstractChunkingContentElementRepository(
         val chunker = ContentChunker(chunkerConfig, chunkTransformer)
         val rootMetadata = root.metadata
         val chunks = chunker.chunk(root)
-            .map { it.withAdditionalMetadata(rootMetadata + it.metadata) }
+            .map { it.withAdditionalMetadata(rootMetadata) }
             .map { enhance(it) }
         logger.info(
             "Chunked document {} into {} chunks",

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/ingestion/ContentChunkerTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/ingestion/ContentChunkerTest.kt
@@ -569,7 +569,7 @@ class ContentChunkerTest {
         val countingTransformer = object : ChunkTransformer {
             override fun transform(chunk: Chunk, context: ChunkTransformationContext): Chunk {
                 transformCallCount.add(chunk.id)
-                return chunk.withAdditionalMetadata(chunk.metadata + mapOf("transformed" to true))
+                return chunk.withAdditionalMetadata(mapOf("transformed" to true))
             }
         }
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChainedChunkTransformerTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChainedChunkTransformerTest.kt
@@ -122,11 +122,11 @@ class ChainedChunkTransformerTest {
         )
         val addMetaA = object : ChunkTransformer {
             override fun transform(chunk: Chunk, context: ChunkTransformationContext): Chunk =
-                chunk.withAdditionalMetadata(chunk.metadata + mapOf("transformer_a" to true))
+                chunk.withAdditionalMetadata(mapOf("transformer_a" to true))
         }
         val addMetaB = object : ChunkTransformer {
             override fun transform(chunk: Chunk, context: ChunkTransformationContext): Chunk =
-                chunk.withAdditionalMetadata(chunk.metadata + mapOf("transformer_b" to true))
+                chunk.withAdditionalMetadata(mapOf("transformer_b" to true))
         }
         val transformer = ChainedChunkTransformer(listOf(addMetaA, addMetaB))
 
@@ -212,7 +212,7 @@ class ChainedChunkTransformerTest {
         val incrementCount = object : ChunkTransformer {
             override fun transform(chunk: Chunk, context: ChunkTransformationContext): Chunk {
                 val currentCount = chunk.metadata["count"] as Int
-                return chunk.withAdditionalMetadata(chunk.metadata + mapOf("count" to currentCount + 1))
+                return chunk.withAdditionalMetadata(mapOf("count" to currentCount + 1))
             }
         }
         val transformer = ChainedChunkTransformer(listOf(incrementCount, incrementCount, incrementCount))
@@ -252,7 +252,7 @@ class ChainedChunkTransformerTest {
         )
         val addSectionTitle = object : ChunkTransformer {
             override fun transform(chunk: Chunk, context: ChunkTransformationContext): Chunk =
-                chunk.withAdditionalMetadata(chunk.metadata + mapOf("section_title" to context.section.title))
+                chunk.withAdditionalMetadata(mapOf("section_title" to context.section.title))
         }
         val transformer = ChainedChunkTransformer(listOf(addSectionTitle))
 


### PR DESCRIPTION
# Fix Chunk.withAdditionalMetadata to merge instead of replace

## Motivation

`ChunkImpl.withAdditionalMetadata` was replacing all existing metadata with the supplied map instead of merging into it. Callers had to work around this by manually pre-merging `chunk.metadata + newEntries`, which is error-prone and contradicts the method name ("additional" implies additive).

## Changes

- **`Chunk.kt`** — `withAdditionalMetadata` now merges: `this.copy(metadata = this.metadata + metadata)`. New entries override existing keys with the same name; existing keys not in the new map are preserved.
- **`AbstractChunkingContentElementRepository.kt`** — removed redundant `+ it.metadata` merge at the call site, since the method now handles it.
- **`ContentChunkerTest.kt`**, **`ChainedChunkTransformerTest.kt`** — simplified 5 call sites that were manually pre-merging `chunk.metadata + mapOf(...)` to just pass the new entries.

## Approach

The method is called `withAdditionalMetadata` but was replacing metadata instead of adding to it. 

**Two options:** 

* rename the method to match the replace behavior, or fix the implementation to match the name. 
* Since every caller was already pre-merging to get additive behavior, fixing the implementation and simplifying the callers is the natural choice.

## Impact assessment

Checked all call sites across `embabel-agent`, `guide`, `embabel-rag-neo-drivine`, and `embabel-rag-pgvector`. No breaking changes: callers either operate on fresh chunks (merge = replace), add non-overlapping keys, or were already doing the defensive pre-merge which becomes harmless (idempotent) after the fix.

## Verification

Build and run `embabel-agent-rag-core` tests.