### PR TITLE
Add a configurable policy on empty responses

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/config/ToolLoopConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/config/ToolLoopConfiguration.kt
@@ -54,6 +54,7 @@ data class ToolLoopConfiguration(
     val maxIterations: Int = 20,
     val parallel: ParallelModeProperties = ParallelModeProperties(),
     val toolNotFound: ToolNotFoundProperties = ToolNotFoundProperties(),
+    val emptyResponse: EmptyResponseProperties = EmptyResponseProperties(),
 ) {
 
     /**
@@ -136,5 +137,38 @@ data class ToolLoopConfiguration(
         val maxRetries: Int = 3,
         /** Minimum tool name length for fuzzy matching */
         val minFuzzyLength: Int = 3,
+    )
+
+    /**
+     * Properties for empty-response handling.
+     *
+     * When an LLM (typically a weak open-weights chat model) returns
+     * blank text with no tool calls, the loop can either exit with
+     * empty content (current behaviour) or feed a synthetic nudge back
+     * to the LLM to give it one more chance.
+     *
+     * `maxRetries: 0` (the default) preserves the existing behaviour —
+     * the loop exits and the rendering layer surfaces
+     * [com.embabel.chat.EmptyLlmResponseException]. Any value > 0
+     * activates the retry policy with the configured nudge message.
+     */
+    data class EmptyResponseProperties(
+        /**
+         * Maximum consecutive empty-response retries before throwing
+         * [com.embabel.chat.EmptyLlmResponseException]. `0` (default)
+         * disables the retry path entirely and falls back to the
+         * existing exit-and-let-caller-handle behaviour.
+         */
+        val maxRetries: Int = 0,
+        /**
+         * Message appended to the conversation as a synthetic
+         * [com.embabel.chat.UserMessage] to nudge the LLM. Only used
+         * when [maxRetries] > 0.
+         */
+        val nudgeMessage: String =
+            "Your previous turn produced no response. " +
+                "Take ONE concrete action that progresses toward answering the user's most recent question — " +
+                "either call a tool to gather what you still need, or write the answer using the information you already have. " +
+                "Do not stay silent.",
     )
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolLoopFactoryConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/ToolLoopFactoryConfiguration.kt
@@ -18,6 +18,9 @@ package com.embabel.agent.spi.config.spring
 import com.embabel.agent.api.common.Asyncer
 import com.embabel.agent.api.tool.config.ToolLoopConfiguration
 import com.embabel.agent.spi.loop.AutoCorrectionPolicy
+import com.embabel.agent.spi.loop.EmptyResponsePolicy
+import com.embabel.agent.spi.loop.ExitOnEmptyPolicy
+import com.embabel.agent.spi.loop.RetryWithFeedbackPolicy
 import com.embabel.agent.spi.loop.ToolLoopFactory
 import com.embabel.agent.spi.loop.ToolNotFoundPolicy
 import org.slf4j.LoggerFactory
@@ -51,8 +54,24 @@ class ToolLoopFactoryConfiguration(
     )
 
     @Bean
-    fun toolLoopFactory(asyncer: Asyncer, toolNotFoundPolicy: ToolNotFoundPolicy): ToolLoopFactory {
+    @ConditionalOnMissingBean
+    fun emptyResponsePolicy(): EmptyResponsePolicy =
+        if (config.emptyResponse.maxRetries > 0) {
+            RetryWithFeedbackPolicy(
+                maxRetries = config.emptyResponse.maxRetries,
+                message = config.emptyResponse.nudgeMessage,
+            )
+        } else {
+            ExitOnEmptyPolicy
+        }
+
+    @Bean
+    fun toolLoopFactory(
+        asyncer: Asyncer,
+        toolNotFoundPolicy: ToolNotFoundPolicy,
+        emptyResponsePolicy: EmptyResponsePolicy = ExitOnEmptyPolicy,
+    ): ToolLoopFactory {
         logger.info("Creating ToolLoopFactory with type: {}, using injected Asyncer", config.type)
-        return ToolLoopFactory.create(config, asyncer, toolNotFoundPolicy)
+        return ToolLoopFactory.create(config, asyncer, toolNotFoundPolicy, emptyResponsePolicy)
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/EmptyResponsePolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/EmptyResponsePolicy.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.loop
+
+import com.embabel.chat.EmptyLlmResponseException
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Determines how the tool loop responds when the LLM returns a blank
+ * text response with no tool calls. This is a known failure mode of weak
+ * open-weights models (gpt-oss-20b, qwen, etc.) after a tool call when
+ * they don't know how to proceed — see [EmptyLlmResponseException].
+ *
+ * Without a policy, the tool loop exits with empty content and the
+ * caller surfaces a generic "no response" message. With a policy the
+ * loop can either feed the model a synthetic nudge so it gets one more
+ * chance, throw immediately, or preserve the current exit-and-let-caller
+ * handle behaviour.
+ *
+ * @see RetryWithFeedbackPolicy
+ * @see ExitOnEmptyPolicy
+ */
+interface EmptyResponsePolicy {
+
+    /**
+     * Handle a blank-text-no-tool-calls response from the LLM.
+     *
+     * @return the action the tool loop should take
+     */
+    fun handle(): EmptyResponseAction
+
+    /**
+     * Called whenever the LLM returns a non-blank response, allowing
+     * stateful policies to reset internal counters.
+     */
+    fun onNonEmpty() {
+        // No-op default for stateless policies
+    }
+}
+
+/**
+ * Action returned by [EmptyResponsePolicy.handle].
+ */
+sealed class EmptyResponseAction {
+
+    /**
+     * Exit the loop with the empty response (current behaviour). The
+     * caller — typically the rendering layer — will throw
+     * [EmptyLlmResponseException] when it tries to wrap blank text in
+     * an [com.embabel.chat.AssistantMessage].
+     */
+    data object Exit : EmptyResponseAction()
+
+    /**
+     * Append [message] to the conversation as a [com.embabel.chat.UserMessage]
+     * and re-prompt the LLM in the same loop. Lets weak models get one
+     * more chance to produce an answer, bounded by the policy's own
+     * retry counter.
+     */
+    data class FeedbackToModel(val message: String) : EmptyResponseAction()
+
+    /**
+     * Throw [EmptyLlmResponseException] immediately from inside the
+     * loop. Use when retry is not desired and a typed exception is
+     * preferred over the silent-exit default.
+     */
+    data object Throw : EmptyResponseAction()
+}
+
+/**
+ * Re-prompt the LLM with [message] up to [maxRetries] times before
+ * giving up. After exhaustion returns [EmptyResponseAction.Throw] so
+ * the caller sees the typed exception rather than blank content.
+ *
+ * Counter is shared across calls and reset by [onNonEmpty]. Safe for
+ * concurrent use as a Spring singleton.
+ */
+class RetryWithFeedbackPolicy(
+    private val maxRetries: Int = DEFAULT_MAX_RETRIES,
+    private val message: String = DEFAULT_MESSAGE,
+) : EmptyResponsePolicy {
+
+    private val consecutiveEmpties = AtomicInteger(0)
+
+    override fun handle(): EmptyResponseAction {
+        val attempts = consecutiveEmpties.incrementAndGet()
+        return if (attempts > maxRetries) {
+            EmptyResponseAction.Throw
+        } else {
+            EmptyResponseAction.FeedbackToModel(message)
+        }
+    }
+
+    override fun onNonEmpty() {
+        consecutiveEmpties.set(0)
+    }
+
+    companion object {
+        const val DEFAULT_MAX_RETRIES = 1
+        const val DEFAULT_MESSAGE: String =
+            "Your previous turn produced no response. " +
+                "Take ONE concrete action that progresses toward answering the user's most recent question — " +
+                "either call a tool to gather what you still need, or write the answer using the information you already have. " +
+                "Do not stay silent."
+    }
+}
+
+/**
+ * Preserve the current behaviour: exit the loop with empty content and
+ * let the rendering layer surface the typed [EmptyLlmResponseException].
+ * This is the default to keep the upgrade backwards-compatible.
+ */
+object ExitOnEmptyPolicy : EmptyResponsePolicy {
+
+    override fun handle(): EmptyResponseAction = EmptyResponseAction.Exit
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/ToolLoopFactory.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/ToolLoopFactory.kt
@@ -69,6 +69,7 @@ interface ToolLoopFactory {
         toolCallInspectors: List<ToolCallInspector>,
         toolCallContext: ToolCallContext,
         toolNotFoundPolicy: ToolNotFoundPolicy? = null,
+        emptyResponsePolicy: EmptyResponsePolicy? = null,
     ): ToolLoop
 
     companion object {
@@ -82,8 +83,9 @@ interface ToolLoopFactory {
             config: ToolLoopConfiguration,
             asyncer: Asyncer,
             defaultToolNotFoundPolicy: ToolNotFoundPolicy,
+            defaultEmptyResponsePolicy: EmptyResponsePolicy = ExitOnEmptyPolicy,
         ): ToolLoopFactory =
-            ConfigurableToolLoopFactory(config, asyncer, defaultToolNotFoundPolicy)
+            ConfigurableToolLoopFactory(config, asyncer, defaultToolNotFoundPolicy, defaultEmptyResponsePolicy)
     }
 }
 
@@ -97,6 +99,7 @@ internal class ConfigurableToolLoopFactory(
     private val config: ToolLoopConfiguration,
     private val asyncer: Asyncer,
     private val defaultToolNotFoundPolicy: ToolNotFoundPolicy,
+    private val defaultEmptyResponsePolicy: EmptyResponsePolicy = ExitOnEmptyPolicy,
 ) : ToolLoopFactory {
 
     override fun create(
@@ -110,8 +113,10 @@ internal class ConfigurableToolLoopFactory(
         toolCallInspectors: List<ToolCallInspector>,
         toolCallContext: ToolCallContext,
         toolNotFoundPolicy: ToolNotFoundPolicy?,
+        emptyResponsePolicy: EmptyResponsePolicy?,
     ): ToolLoop {
-        val policy = toolNotFoundPolicy ?: defaultToolNotFoundPolicy
+        val tnfPolicy = toolNotFoundPolicy ?: defaultToolNotFoundPolicy
+        val erPolicy = emptyResponsePolicy ?: defaultEmptyResponsePolicy
         return when (config.type) {
             ToolLoopType.DEFAULT -> DefaultToolLoop(
                 llmMessageSender = llmMessageSender,
@@ -123,7 +128,8 @@ internal class ConfigurableToolLoopFactory(
                 toolLoopTransformers = toolLoopTransformers,
                 toolCallInspectors = toolCallInspectors,
                 toolCallContext = toolCallContext,
-                toolNotFoundPolicy = policy,
+                toolNotFoundPolicy = tnfPolicy,
+                emptyResponsePolicy = erPolicy,
             )
             ToolLoopType.PARALLEL -> ParallelToolLoop(
                 llmMessageSender = llmMessageSender,
@@ -137,7 +143,8 @@ internal class ConfigurableToolLoopFactory(
                 asyncer = asyncer,
                 parallelConfig = config.parallel,
                 toolCallContext = toolCallContext,
-                toolNotFoundPolicy = policy,
+                toolNotFoundPolicy = tnfPolicy,
+                emptyResponsePolicy = erPolicy,
             )
         }
     }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
@@ -31,6 +31,9 @@ import com.embabel.agent.core.BlackboardUpdater
 import com.embabel.agent.core.ReplanRequestedException
 import com.embabel.agent.core.Usage
 import com.embabel.agent.spi.loop.AutoCorrectionPolicy
+import com.embabel.agent.spi.loop.EmptyResponseAction
+import com.embabel.agent.spi.loop.EmptyResponsePolicy
+import com.embabel.agent.spi.loop.ExitOnEmptyPolicy
 import com.embabel.agent.spi.loop.LlmMessageSender
 import com.embabel.agent.spi.loop.MaxIterationsExceededException
 import com.embabel.agent.spi.loop.ToolCallResult
@@ -41,9 +44,11 @@ import com.embabel.agent.spi.loop.ToolLoopResult
 import com.embabel.agent.spi.loop.ToolNotFoundAction
 import com.embabel.agent.spi.loop.ToolNotFoundPolicy
 import com.embabel.chat.AssistantMessageWithToolCalls
+import com.embabel.chat.EmptyLlmResponseException
 import com.embabel.chat.Message
 import com.embabel.chat.ToolCall
 import com.embabel.chat.ToolResultMessage
+import com.embabel.chat.UserMessage
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 
@@ -72,6 +77,7 @@ internal open class DefaultToolLoop(
     protected val toolCallInspectors: List<ToolCallInspector> = emptyList(),
     private val toolCallContext: ToolCallContext = ToolCallContext.EMPTY,
     protected val toolNotFoundPolicy: ToolNotFoundPolicy = AutoCorrectionPolicy(),
+    protected val emptyResponsePolicy: EmptyResponsePolicy = ExitOnEmptyPolicy,
 ) : ToolLoop {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -136,6 +142,33 @@ internal open class DefaultToolLoop(
 
             if (!hasToolCalls(transformedResponse)) {
                 /* -------------------------------------------------
+                 * Empty-response policy — give weak models one more
+                 * chance before exiting the loop with blank content.
+                 * Failure mode common to gpt-oss-20b / qwen after a
+                 * tool call: model returns blank text with no further
+                 * tool calls. Default policy is [ExitOnEmptyPolicy]
+                 * which preserves prior behaviour; opt-in policies
+                 * like [RetryWithFeedbackPolicy] feed a synthetic
+                 * nudge into the conversation and re-loop.
+                 * ------------------------------------------------- */
+                if (transformedResponse.content.isBlank()) {
+                    when (val action = emptyResponsePolicy.handle()) {
+                        is EmptyResponseAction.FeedbackToModel -> {
+                            logger.info(
+                                "Empty LLM response at iteration {} — feeding back to model",
+                                state.iterations,
+                            )
+                            state.conversationHistory.add(UserMessage(action.message))
+                            continue
+                        }
+                        EmptyResponseAction.Throw -> throw EmptyLlmResponseException()
+                        EmptyResponseAction.Exit -> { /* fall through */ }
+                    }
+                } else {
+                    emptyResponsePolicy.onNonEmpty()
+                }
+
+                /* -------------------------------------------------
                  * Apply afterIteration callbacks for early exit - START
                  * LLM returned final answer without tool calls.
                  * Call afterIteration with empty toolCalls for consistency,
@@ -160,6 +193,9 @@ internal open class DefaultToolLoop(
                 logCompletion(state.iterations)
                 return buildResult(transformedResponse.content, outputParser, state)
             }
+
+            // Tool calls present — model is making progress; reset empty-response counter.
+            emptyResponsePolicy.onNonEmpty()
 
             val assistantMessage = transformedResponse as AssistantMessageWithToolCalls
             val shouldContinue = processToolCalls(assistantMessage.toolCalls, state)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoop.kt
@@ -28,6 +28,8 @@ import com.embabel.agent.api.tool.config.ToolLoopConfiguration.ParallelModePrope
 import com.embabel.agent.core.BlackboardUpdater
 import com.embabel.agent.core.ReplanRequestedException
 import com.embabel.agent.spi.loop.AutoCorrectionPolicy
+import com.embabel.agent.spi.loop.EmptyResponsePolicy
+import com.embabel.agent.spi.loop.ExitOnEmptyPolicy
 import com.embabel.agent.spi.loop.LlmMessageSender
 import com.embabel.agent.spi.loop.ToolInjectionStrategy
 import com.embabel.agent.spi.loop.ToolNotFoundAction
@@ -78,6 +80,7 @@ internal class ParallelToolLoop(
     private val parallelConfig: ParallelModeProperties,
     toolCallContext: ToolCallContext = ToolCallContext.EMPTY,
     toolNotFoundPolicy: ToolNotFoundPolicy = AutoCorrectionPolicy(),
+    emptyResponsePolicy: EmptyResponsePolicy = ExitOnEmptyPolicy,
 ) : DefaultToolLoop(
     llmMessageSender = llmMessageSender,
     objectMapper = objectMapper,
@@ -89,6 +92,7 @@ internal class ParallelToolLoop(
     toolCallInspectors = toolCallInspectors,
     toolCallContext = toolCallContext,
     toolNotFoundPolicy = toolNotFoundPolicy,
+    emptyResponsePolicy = emptyResponsePolicy,
 ) {
 
     private val logger = LoggerFactory.getLogger(javaClass)

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/EmptyResponsePolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/EmptyResponsePolicyTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.loop
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class EmptyResponsePolicyTest {
+
+    @Nested
+    inner class RetryWithFeedbackPolicyTest {
+
+        @Test
+        fun `returns feedback on first empty response`() {
+            val policy = RetryWithFeedbackPolicy()
+            val action = policy.handle()
+            assertTrue(action is EmptyResponseAction.FeedbackToModel)
+            val feedback = action as EmptyResponseAction.FeedbackToModel
+            assertTrue(feedback.message.isNotBlank())
+        }
+
+        @Test
+        fun `uses configured message`() {
+            val policy = RetryWithFeedbackPolicy(message = "Try again, please.")
+            val action = policy.handle() as EmptyResponseAction.FeedbackToModel
+            assertEquals("Try again, please.", action.message)
+        }
+
+        @Test
+        fun `throws after max retries exceeded`() {
+            val policy = RetryWithFeedbackPolicy(maxRetries = 2)
+            assertTrue(policy.handle() is EmptyResponseAction.FeedbackToModel)   // 1
+            assertTrue(policy.handle() is EmptyResponseAction.FeedbackToModel)   // 2
+            assertTrue(policy.handle() is EmptyResponseAction.Throw)             // 3 > maxRetries=2
+        }
+
+        @Test
+        fun `counter resets on non-empty response`() {
+            val policy = RetryWithFeedbackPolicy(maxRetries = 1)
+            assertTrue(policy.handle() is EmptyResponseAction.FeedbackToModel)   // 1
+            policy.onNonEmpty()
+            assertTrue(policy.handle() is EmptyResponseAction.FeedbackToModel)   // 1 again, not exhausted
+        }
+
+        @Test
+        fun `default max retries is 1`() {
+            assertEquals(1, RetryWithFeedbackPolicy.DEFAULT_MAX_RETRIES)
+        }
+
+        @Test
+        fun `zero max retries throws on first attempt`() {
+            val policy = RetryWithFeedbackPolicy(maxRetries = 0)
+            assertTrue(policy.handle() is EmptyResponseAction.Throw)
+        }
+
+        @Test
+        fun `is thread-safe across concurrent handle calls`() {
+            val policy = RetryWithFeedbackPolicy(maxRetries = 100)
+            val threads = (1..10).map {
+                Thread {
+                    repeat(20) { policy.handle() }
+                }
+            }
+            threads.forEach { it.start() }
+            threads.forEach { it.join() }
+            // After 200 calls (10 threads × 20 calls) and maxRetries=100, the
+            // 101st handle would Throw; we just assert no IllegalState / race
+            // by reaching Throw deterministically on the next call.
+            val next = policy.handle()
+            assertTrue(next is EmptyResponseAction.Throw)
+        }
+    }
+
+    @Nested
+    inner class ExitOnEmptyPolicyTest {
+
+        @Test
+        fun `returns Exit on every call`() {
+            val policy = ExitOnEmptyPolicy
+            assertEquals(EmptyResponseAction.Exit, policy.handle())
+            assertEquals(EmptyResponseAction.Exit, policy.handle())
+            assertEquals(EmptyResponseAction.Exit, policy.handle())
+        }
+
+        @Test
+        fun `onNonEmpty is a no-op`() {
+            val policy = ExitOnEmptyPolicy
+            policy.onNonEmpty()
+            assertEquals(EmptyResponseAction.Exit, policy.handle())
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/ToolLoopTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/ToolLoopTest.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.core.Usage
 import com.embabel.agent.spi.loop.support.DefaultToolLoop
 import com.embabel.chat.AssistantMessage
 import com.embabel.chat.AssistantMessageWithToolCalls
+import com.embabel.chat.EmptyLlmResponseException
 import com.embabel.chat.Message
 import com.embabel.chat.ToolCall
 import com.embabel.chat.ToolResultMessage
@@ -1361,6 +1362,118 @@ class ToolLoopAdditionalTests {
             assertEquals(1, injectedToolCalled.size)
             assertEquals(1, result.injectedTools.size)
             assertEquals("injected_tool", result.injectedTools[0].definition.name)
+        }
+    }
+
+    @Nested
+    inner class EmptyResponsePolicyIntegrationTest {
+
+        @Test
+        fun `default policy exits the loop with blank content (backwards-compat)`() {
+            val mockCaller = MockLlmMessageSender(
+                responses = listOf(
+                    // Blank text, no tool calls — the failure-mode response
+                    MockLlmMessageSender.textResponse(" "),
+                )
+            )
+
+            val toolLoop = DefaultToolLoop(
+                llmMessageSender = mockCaller,
+                objectMapper = objectMapper,
+            )
+
+            val result = toolLoop.execute(
+                initialMessages = listOf(UserMessage("anything")),
+                initialTools = emptyList(),
+                outputParser = { it },
+            )
+
+            // Existing behaviour: the loop returns blank; rendering layer
+            // is responsible for throwing EmptyLlmResponseException.
+            assertEquals(" ", result.result)
+            assertEquals(1, result.totalIterations)
+        }
+
+        @Test
+        fun `RetryWithFeedbackPolicy re-prompts and uses the second response`() {
+            val mockCaller = MockLlmMessageSender(
+                responses = listOf(
+                    MockLlmMessageSender.textResponse(" "),               // empty — triggers retry
+                    MockLlmMessageSender.textResponse("Recovered answer"), // succeeds on retry
+                )
+            )
+
+            val toolLoop = DefaultToolLoop(
+                llmMessageSender = mockCaller,
+                objectMapper = objectMapper,
+                emptyResponsePolicy = RetryWithFeedbackPolicy(maxRetries = 1),
+            )
+
+            val result = toolLoop.execute(
+                initialMessages = listOf(UserMessage("question")),
+                initialTools = emptyList(),
+                outputParser = { it },
+            )
+
+            assertEquals("Recovered answer", result.result)
+            assertEquals(2, result.totalIterations)
+            // Synthetic nudge was inserted into history between the empty
+            // response and the recovered one.
+            val nudges = result.conversationHistory.filterIsInstance<UserMessage>()
+                .filter { it.content.contains("no response", ignoreCase = true) }
+            assertEquals(1, nudges.size)
+        }
+
+        @Test
+        fun `RetryWithFeedbackPolicy throws after exhausting retries`() {
+            val mockCaller = MockLlmMessageSender(
+                responses = listOf(
+                    MockLlmMessageSender.textResponse(" "),  // 1 — retry
+                    MockLlmMessageSender.textResponse(" "),  // 2 — retry exhausted, throw
+                )
+            )
+
+            val toolLoop = DefaultToolLoop(
+                llmMessageSender = mockCaller,
+                objectMapper = objectMapper,
+                emptyResponsePolicy = RetryWithFeedbackPolicy(maxRetries = 1),
+            )
+
+            assertThrows<EmptyLlmResponseException> {
+                toolLoop.execute(
+                    initialMessages = listOf(UserMessage("question")),
+                    initialTools = emptyList(),
+                    outputParser = { it },
+                )
+            }
+        }
+
+        @Test
+        fun `tool-call response between empties resets the retry counter`() {
+            val mockTool = MockTool("ping", "Pong") { Tool.Result.text("pong") }
+
+            val mockCaller = MockLlmMessageSender(
+                responses = listOf(
+                    MockLlmMessageSender.textResponse(" "),                          // 1 — retry
+                    MockLlmMessageSender.toolCallResponse("c1", "ping", "{}"),       // tool call → reset counter
+                    MockLlmMessageSender.textResponse(" "),                          // 1 again — retry
+                    MockLlmMessageSender.textResponse("Final answer"),               // succeeds
+                )
+            )
+
+            val toolLoop = DefaultToolLoop(
+                llmMessageSender = mockCaller,
+                objectMapper = objectMapper,
+                emptyResponsePolicy = RetryWithFeedbackPolicy(maxRetries = 1),
+            )
+
+            val result = toolLoop.execute(
+                initialMessages = listOf(UserMessage("question")),
+                initialTools = listOf(mockTool),
+                outputParser = { it },
+            )
+
+            assertEquals("Final answer", result.result)
         }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/ParallelToolLoopGuardRailIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/ParallelToolLoopGuardRailIT.java
@@ -234,7 +234,8 @@ class ParallelToolLoopGuardRailIT {
                     ToolLoopType.DEFAULT,
                     20,
                     new ToolLoopConfiguration.ParallelModeProperties(),
-                    new ToolLoopConfiguration.ToolNotFoundProperties()
+                    new ToolLoopConfiguration.ToolNotFoundProperties(),
+                    new ToolLoopConfiguration.EmptyResponseProperties(1, "Retry Please")
             );
             ReflectionTestUtils.setField(toolLoopFactory, "config", sequentialConfig);
 
@@ -254,7 +255,8 @@ class ParallelToolLoopGuardRailIT {
                     ToolLoopType.PARALLEL,
                     20,
                     new ToolLoopConfiguration.ParallelModeProperties(),
-                    new ToolLoopConfiguration.ToolNotFoundProperties()
+                    new ToolLoopConfiguration.ToolNotFoundProperties(),
+                    new ToolLoopConfiguration.EmptyResponseProperties(1, "Retry Please")
             );
             ReflectionTestUtils.setField(toolLoopFactory, "config", parallelConfig);
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
@@ -274,7 +274,45 @@ From `ToolLoopConfiguration` - configuration for tool loop execution.
 |`60s`
 |Timeout for entire batch of parallel tools
 
+|`embabel.agent.platform.toolloop.empty-response.max-retries`
+|Int
+|`0`
+|Maximum consecutive empty-response retries before throwing `EmptyLlmResponseException`. `0` (default) preserves existing behaviour — the loop exits with blank content. Any value `> 0` activates `RetryWithFeedbackPolicy`.
+
+|`embabel.agent.platform.toolloop.empty-response.nudge-message`
+|String
+|_(see below)_
+|Message appended to the conversation as a synthetic `UserMessage` when the LLM goes silent. Only used when `max-retries > 0`. Default nudges the model to take one concrete action.
+
 |===
+
+[[reference.configuration.empty-response]]
+====== Empty-Response Handling
+
+Weak open-weights chat models (such as `gpt-oss-20b` or some Qwen variants) occasionally return blank text with no further tool calls after a tool result, when the model has run out of ideas about what to do next.
+Without intervention the tool loop exits with empty content, which the rendering layer surfaces as `EmptyLlmResponseException`.
+
+The `empty-response` configuration controls whether the loop gives the model a second chance.
+Setting `max-retries: 1` activates `RetryWithFeedbackPolicy`: when an empty response is detected the loop appends the configured nudge message as a synthetic `UserMessage` and re-invokes the LLM in the same loop iteration.
+The retry counter is reset on any non-empty response, so retries are bounded per consecutive failure rather than cumulative across the whole loop.
+
+Example for a deployment running a smaller chat model:
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      toolloop:
+        max-iterations: 30        # raise to give retries headroom
+        empty-response:
+          max-retries: 1          # one nudge before throwing
+----
+
+For most deployments using strong frontier models the default (`max-retries: 0`) is correct — empty responses are rare, and the typed exception lets callers handle the case explicitly.
+This setting is provided to make small / local model deployments more robust without forcing every caller to wrap LLM invocations in their own retry logic.
+
+For programmatic configuration (custom retry counts or messages), inject your own `EmptyResponsePolicy` bean — the auto-configuration honours `@ConditionalOnMissingBean`.
 
 ===== Process ID Generation
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/llms/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/llms/page.adoc
@@ -26,6 +26,19 @@ Simple tool calls are fine, but complex orchestration is another indicator you'l
 TIP: Trial and error is your friend.
 Embabel makes it easy to switch LLMs; try the cheapest thing that could work and switch if it doesn't.
 
+[[reference.llms.smaller-models]]
+==== Tuning for Smaller and Local Models
+
+A core goal of Embabel is to make agentic flows work well across the full range of LLMs, so you can choose the cheapest, smallest, or most private model that does the job — rather than always reaching for a frontier model.
+Smaller chat models behave differently from frontier models in ways that the framework can compensate for:
+
+- **Silent failures after tool calls.** Weaker open-weights models (e.g. `gpt-oss-20b`, some Qwen variants) sometimes return blank text with no further tool calls when they don't know how to proceed. Without intervention the tool loop exits with empty content. Activate `embabel.agent.platform.toolloop.empty-response.max-retries: 1` to feed a synthetic nudge back to the model and give it one more chance — see <<reference.configuration.empty-response>>.
+- **Tool-name confusion.** Smaller models more frequently call tools by approximate names. The default `AutoCorrectionPolicy` handles this by feeding back a "did you mean X?" suggestion; tune `embabel.agent.platform.toolloop.tool-not-found.max-retries` if your model needs more attempts.
+- **Iteration headroom.** Recovery costs LLM calls. If you enable retry policies, raise `embabel.agent.platform.toolloop.max-iterations` so a turn that needs an extra round trip doesn't run out of budget.
+
+These settings are off-by-default so existing deployments using strong models behave exactly as before.
+Turn them on per-deployment when the model you've picked benefits from them.
+
 
 [[reference.llms.custom-integration]]
 ==== Advanced: Custom LLM Integration


### PR DESCRIPTION
Smaller models such as `gpt-oss-20b` sometimes get confused after skill disclosure or with extensive tool lists and return an empty response. This previously resulted in an exception, breaking callers or forcing them to retry an entire invocation.

This PR adds `EmptyResponsePolicy` to handle this case, allowing retry.

This PR is backward compatible, unless the new (documented) configuration property is used.