### PR TITLE
Fix docker autoconfigure test to simulate unavailable endpoint (#1568)

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/docker/DockerLocalModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/docker/DockerLocalModelsConfig.kt
@@ -79,8 +79,9 @@ class DockerConnectionProperties {
 
 /**
  * Docker local models
- * This class will always be loaded, but models won't be loaded
- * from the Docker endpoint unless the "docker" profile is set.
+ * This class will always be loaded and models will be auto-discovered
+ * from the Docker endpoint on startup. If the endpoint is unreachable,
+ * discovery fails silently and no models are registered.
  * Model names will be precisely as reported from
  * http://localhost:12434/engines/v1/models (assuming default port).
  */

--- a/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/docker/AgentDockerModelsAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/docker/AgentDockerModelsAutoConfigurationTest.java
@@ -150,7 +150,7 @@ class AgentDockerModelsAutoConfigurationTest {
    @Test
    void providerInitializationHasEmptyModelListWhenDockerUnavailable() {
 
-      contextRunner.run(context -> {
+      contextRunner.withPropertyValues("embabel.agent.models.docker.base-url=http://localhost:1").run(context -> {
          final ProviderInitialization initialization = context.getBean(ProviderInitialization.class);
          assertThat(initialization.getRegisteredLlms()).isEmpty();
          assertThat(initialization.getRegisteredEmbeddings()).isEmpty();


### PR DESCRIPTION
This pull request updates the Docker local models auto-discovery behavior and its corresponding test to reflect that model discovery now always runs at startup, and fails silently if the Docker endpoint is unreachable. The test is updated to explicitly simulate an unreachable Docker endpoint.

Behavioral change to Docker model discovery:

* Updated the documentation in `DockerLocalModelsConfig` to clarify that models are now always auto-discovered from the Docker endpoint at startup, and that if the endpoint is unreachable, discovery fails silently and no models are registered.

Test update:

* Modified the test `providerInitializationHasEmptyModelListWhenDockerUnavailable` to explicitly set the Docker base URL to an unreachable endpoint, ensuring the test accurately reflects the new silent failure behavior.