### PR TITLE
Pin BC version for Tika vulnerability.

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -396,6 +396,35 @@
                 <artifactId>opentelemetry-semconv</artifactId>
                 <version>1.29.0-alpha</version>
             </dependency>
+
+            <!--
+                Bouncy Castle pin: workaround for CVE-2025-14813 (issue #1638).
+                tika-parsers-standard-package 3.3.0 pulls in bcprov-jdk18on 1.83 transitively
+                via tika-parser-crypto-module. Tika main has moved to BC 1.84 but no patch
+                release is out yet. Pinning all four BC artifacts together to avoid mixing
+                1.83/1.84 on the classpath.
+                REMOVE this block once we upgrade to a Tika release that ships BC >= 1.84.
+            -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcjmail-jdk18on</artifactId>
+                <version>1.84</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -15,6 +15,10 @@
     <description>Embabel Agent BOM</description>
     <url>https://github.com/embabel/embabel-agent</url>
 
+    <properties>
+        <bouncycastle.version>1.84</bouncycastle.version>
+    </properties>
+
     <scm>
         <url>https://github.com/embabel/embabel-agent</url>
         <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
@@ -398,32 +402,19 @@
             </dependency>
 
             <!--
-                Bouncy Castle pin: workaround for CVE-2025-14813 (issue #1638).
+                Bouncy Castle BOM: workaround for CVE-2025-14813 (issue #1638).
                 tika-parsers-standard-package 3.3.0 pulls in bcprov-jdk18on 1.83 transitively
                 via tika-parser-crypto-module. Tika main has moved to BC 1.84 but no patch
-                release is out yet. Pinning all four BC artifacts together to avoid mixing
-                1.83/1.84 on the classpath.
-                REMOVE this block once we upgrade to a Tika release that ships BC >= 1.84.
+                release is out yet. Importing the BC BOM aligns all bc-*-jdk18on artifacts on
+                a single version, avoiding 1.83/1.84 mixes on the classpath.
+                REMOVE this import once we upgrade to a Tika release that ships BC >= 1.84.
             -->
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk18on</artifactId>
-                <version>1.84</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk18on</artifactId>
-                <version>1.84</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcutil-jdk18on</artifactId>
-                <version>1.84</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcjmail-jdk18on</artifactId>
-                <version>1.84</version>
+                <artifactId>bc-jdk18on-bom</artifactId>
+                <version>${bouncycastle.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Pins all four `org.bouncycastle:*-jdk18on` artifacts to 1.84 in `embabel-agent-dependencies` to clear CVE-2025-14813.                                                                                                    
                                                                                                                                                           
Workaround until Tika ships a release with BC >= 1.84 — the pin block is commented for removal at that point.                                                                                                            
                                                                                                                                                           
Fixes #1638                                          