### PR TITLE
Accomodate rename of embabel-agent-rag-graph

### DIFF
--- a/.github/workflows/deploy-snapshots.yml
+++ b/.github/workflows/deploy-snapshots.yml
@@ -56,7 +56,7 @@ jobs:
           - embabel/embabel-llm-database
           - embabel/impromptu
           - embabel/flicker
-          - embabel/embabel-agent-rag-neo-drivine
+          - embabel/embabel-agent-rag-graph
           - embabel/embabel-rag-pgvector
           - embabel/embabel-chat-store
           - embabel/embabel-air

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -109,7 +109,7 @@ internal class VectorSearchTools @JvmOverloads constructor(
  *   needed to fully answer it — for example, a chunk mentioning a term defined in the
  *   enclosing section heading.
  *
- * Existing implementations (e.g., `embabel-agent-rag-neo-drivine`) apply sequence order
+ * Existing implementations (e.g., `embabel-agent-rag-graph`) apply sequence order
  * based on the graph structure of ingested content.
  */
 internal class ResultExpanderTools @JvmOverloads constructor(


### PR DESCRIPTION
Rename `embabel-agent-rag-neo-drivine` references to `embabel-agent-rag-graph` (snapshot deploy trigger + KDoc).                                                                                              
                                                                    