### PR TITLE
Introduce `LoopMemo`, allowing a tool to check if it's the first time it has been invoked during a tool loop

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/LoopMemo.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/LoopMemo.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.tool
+
+import java.util.Collections
+import java.util.LinkedHashMap
+
+/**
+ * Memoisation helper for "is this the first time we've done X in the current
+ * agentic loop?" — the canonical pattern for one-shot tool work that should
+ * be paid once per LLM tool-loop iteration regardless of how many times the
+ * LLM invokes the host tool.
+ *
+ * Use cases:
+ *
+ * - A skill-activation tool returns its body on the first call but a stern
+ *   "already activated this turn" message on repeat calls (avoiding
+ *   gateway-confusion loops where the LLM keeps trying different arg shapes).
+ * - A `describe(namespace)` tool prepends bulky code-writing guidance on the
+ *   first describe per loop only — subsequent describes carry just the
+ *   namespace body since the LLM already has the guidance in conversation
+ *   history.
+ * - Any other "if I've already kicked this off this turn, don't redo it"
+ *   gating where the dedup is loop-scoped (NOT process-scoped — different
+ *   loops in the same agent process get distinct ids).
+ *
+ * Backed by a thread-safe bounded LRU set keyed on the loop id read from
+ * [ToolCallContext.loopId]. When [maxTracked] entries is exceeded the
+ * oldest is evicted — exact upper bound, no transient overshoot under
+ * concurrent writers.
+ *
+ * Fallback when the context has no loop id (callers that didn't set one —
+ * bare tests, out-of-loop invocations): [firstTimeIn] always returns
+ * `true`, on the safe-but-occasionally-noisy assumption that emitting the
+ * one-shot work is the less-bad failure mode vs swallowing it forever.
+ *
+ * Example:
+ * ```kotlin
+ * private val memo = LoopMemo()
+ *
+ * override fun call(input: String, context: ToolCallContext): Tool.Result =
+ *     if (memo.firstTimeIn(context)) Tool.Result.text(skillBody)
+ *     else Tool.Result.text("Already activated this turn — see prior result.")
+ * ```
+ */
+class LoopMemo @JvmOverloads constructor(
+    /**
+     * Cap on the number of distinct loop ids tracked. When exceeded, the
+     * oldest id is evicted (true LRU via [LinkedHashMap.removeEldestEntry]).
+     * Default 1024 — comfortable for thousands of conversations against an
+     * assistant restart cadence of days, with ~130 KB worst-case memory.
+     */
+    private val maxTracked: Int = DEFAULT_MAX_TRACKED,
+) {
+
+    private val seen: MutableSet<String> = boundedLruSet(maxTracked)
+
+    /**
+     * Returns `true` the first time [context]'s [ToolCallContext.loopId] is
+     * seen by this memo, `false` on subsequent calls within the same loop.
+     * When the context has no loop id, returns `true` every call.
+     *
+     * Thread-safe — concurrent calls with the same loop id agree on which
+     * one is "first" (gets `true`) and which are repeats (get `false`).
+     */
+    fun firstTimeIn(context: ToolCallContext): Boolean {
+        val id = context.loopId() ?: return true
+        return seen.add(id)
+    }
+
+    companion object {
+        const val DEFAULT_MAX_TRACKED: Int = 1024
+    }
+}
+
+/**
+ * Thread-safe bounded LRU [MutableSet] backed by a [LinkedHashMap] with
+ * [LinkedHashMap.removeEldestEntry] eviction. Used by [LoopMemo] for
+ * loop-id tracking; could be lifted to public if other tools want the same
+ * pattern, but for now it's the implementation detail of one helper.
+ *
+ * Synchronized at the set level — single-op atomicity is enough since we
+ * never iterate, only `add`.
+ */
+private fun <T> boundedLruSet(maxSize: Int): MutableSet<T> =
+    Collections.synchronizedSet(
+        Collections.newSetFromMap(
+            object : LinkedHashMap<T, Boolean>(64, 0.75f, false) {
+                override fun removeEldestEntry(eldest: Map.Entry<T, Boolean>?): Boolean = size > maxSize
+            }
+        )
+    )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/ToolCallContext.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/ToolCallContext.kt
@@ -63,6 +63,22 @@ class ToolCallContext private constructor(
      */
     fun toMap(): Map<String, Any> = entries.toMap()
 
+    /**
+     * Unique identifier of the agentic-loop iteration in which this tool
+     * call is happening, or `null` when the calling action did not set one.
+     *
+     * Set by the action that builds the LLM rendering chain via
+     * `.withToolCallContext(mapOf(LOOP_ID_KEY to <fresh uuid>))`. Every
+     * `Tool.call` within that loop receives the same id; a different loop
+     * gets a different id.
+     *
+     * Read by per-loop one-shot tools (skill activation, code-writing rule
+     * emission, "already kicked off the X workflow this turn" guards) — see
+     * [LoopMemo] for the canonical "first time this loop" memoisation
+     * helper that sits on top of this.
+     */
+    fun loopId(): String? = get(LOOP_ID_KEY)
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is ToolCallContext) return false
@@ -74,6 +90,13 @@ class ToolCallContext private constructor(
     override fun toString(): String = "ToolCallContext($entries)"
 
     companion object {
+
+        /**
+         * Well-known [ToolCallContext] key for the agentic-loop identifier.
+         * See [loopId] for the read path and [LoopMemo] for the canonical
+         * "have I already done X this loop?" helper that consumes it.
+         */
+        const val LOOP_ID_KEY: String = "embabel.toolLoopId"
 
         @JvmField
         val EMPTY = ToolCallContext(emptyMap())

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -100,6 +100,15 @@ data class ToolishRag @JvmOverloads constructor(
     val metadataFilter: PropertyFilter? = null,
     val entityFilter: EntityFilter? = null,
     val maxZoomOutChars: Int = ResultExpanderTools.DEFAULT_MAX_ZOOM_OUT_CHARS,
+    /**
+     * Progressively-disclosed guidance appended to the unfold response when
+     * the LLM invokes this tool. Right home for search-strategy notes
+     * (vector vs text, retry-with-synonyms, result-shape) that don't need
+     * to pay the system-prompt tax every turn — they only matter once the
+     * LLM has decided to descend.
+     * See [com.embabel.agent.api.tool.progressive.UnfoldingTool.childToolUsageNotes].
+     */
+    val childToolUsageNotes: String? = null,
 ) : LlmReference, DelegatingTool, EagerSearch<ToolishRag> {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -236,6 +245,7 @@ data class ToolishRag @JvmOverloads constructor(
             name = name,
             description = description,
             innerTools = tools(),
+            childToolUsageNotes = childToolUsageNotes,
         )
     }
 

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/Skills.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/Skills.kt
@@ -17,7 +17,9 @@ package com.embabel.agent.skills
 
 import com.embabel.agent.api.annotation.LlmTool
 import com.embabel.agent.api.reference.LlmReference
+import com.embabel.agent.api.tool.LoopMemo
 import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.api.tool.ToolCallContext
 import com.embabel.agent.skills.script.NoOpExecutionEngine
 import com.embabel.agent.skills.script.SkillScriptExecutionEngine
 import com.embabel.agent.skills.support.*
@@ -318,17 +320,62 @@ data class Skills @JvmOverloads constructor(
      * LLM sees in its catalog. Calling the tool returns the skill body
      * (instructions + resource manifest + script-tool names) as the tool
      * result. No unfold, no preamble, no swap.
+     *
+     * **Loop-scoped repeat suppression.** A naive persistent activation tool
+     * (no swap, no removal) creates a loop trap: the LLM treats it as a
+     * gateway, calls it repeatedly with API-shaped args
+     * (`{"owner":"x","repo":"y"}`) and gets the same body each time, hoping
+     * a different shape will produce data. The fix is two-pronged:
+     *
+     * 1. The `description` carries an explicit "no args, one call" cue
+     *    so the LLM doesn't see this as a parameterised gateway.
+     * 2. On the second+ call within a single agentic loop (per
+     *    [ToolCallContext.LOOP_ID_KEY]) the tool returns a stern
+     *    short-circuit message instead of re-emitting the body — explicitly
+     *    redirecting the LLM to call `execute_javascript` / etc per the
+     *    body it already received in the prior tool result.
+     *
+     * The body remains in the LLM's conversation history from the first
+     * call, so re-emitting on every repeat would just waste tokens AND
+     * reinforce the wrong mental model.
      */
     private inner class SkillActivationTool(private val skill: LoadedSkill) : Tool {
 
+        /**
+         * Per-loop dedup: if the LLM calls this activation tool a second
+         * time within the same agentic loop, return a stern short-circuit
+         * instead of re-emitting the body. See [LoopMemo].
+         */
+        private val activations = LoopMemo()
+
         override val definition = Tool.Definition(
             name = sanitizeToolName(skill.name),
-            description = skill.description,
+            description = """
+                ${skill.description}
+
+                (Skill activator: takes NO arguments. Returns instructions only — call
+                ONCE per turn, then follow the body's guidance to call execute_javascript
+                / execute_python / a script tool.)
+            """.trimIndent(),
             inputSchema = Tool.InputSchema.empty(),
         )
 
-        override fun call(input: String): Tool.Result {
+        override fun call(input: String): Tool.Result =
+            call(input, ToolCallContext.EMPTY)
+
+        override fun call(input: String, context: ToolCallContext): Tool.Result {
             activatedSkillNames.add(skill.name)
+            if (!activations.firstTimeIn(context)) {
+                return Tool.Result.text(
+                    """
+                        Skill '${skill.name}' was already activated this turn — its
+                        instructions are in your previous tool result. To actually
+                        perform the operation the user asked for, call execute_javascript
+                        (or execute_python / a script tool) per those instructions.
+                        Do NOT call this tool again.
+                    """.trimIndent()
+                )
+            }
             return Tool.Result.text(skillBody(skill))
         }
     }

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/Skills.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/Skills.kt
@@ -260,42 +260,85 @@ data class Skills @JvmOverloads constructor(
     }
 
     /**
-     * Return each loaded skill as its own [LlmReference]. The LLM sees one
-     * top-level tool per skill in its catalog with that skill's name and
-     * description visible up front. Invoking the per-skill wrapper unfolds
-     * to reveal `listResources`, `readResource`, and that skill's script
-     * tools — and the unfold response delivers the skill's full body
-     * (instructions + resource manifest) via `childToolUsageNotes`.
+     * Return each loaded skill as its own [LlmReference] PLUS one shared
+     * reference for the bundled-resource helpers (`listResources` /
+     * `readResource`). The LLM sees one top-level tool per skill in its
+     * catalog — a [SkillActivationTool] whose name and description match
+     * the skill — and invoking it returns the skill body directly as the
+     * tool result.
      *
-     * **One round-trip per skill use**: the LLM picks the wrapper, gets the
-     * body and child tools in the same response, and proceeds. There is no
-     * separate `activate` step — the act of choosing the wrapper IS the
-     * activation. (`activate` is still available as a top-level tool when
-     * `Skills` is consumed directly as an [LlmReference] for the rare case
-     * a caller wants to re-fetch a body without re-unfolding the wrapper.)
+     * This is a **plain Tool**, not an [com.embabel.agent.api.tool.progressive.UnfoldingTool]:
+     * no preamble, no inner-tool swap, no removal-from-catalog after
+     * invocation. Why: the unfolding pattern's "Tools now available: X. You
+     * MUST call one of these tools." preamble fits a tool-grouping facade,
+     * but a skill's operative path is `execute_javascript` (already in the
+     * catalog at the top level). The unfold preamble was misdirecting
+     * models into calling auxiliary tools (`listResources`/`readResource`)
+     * instead of following the body's guidance to call `execute_*`. Removed
+     * the unfold layer; the body is now the lead, not a footnote.
+     *
+     * Activation cost: 1 round-trip — the LLM calls the per-skill tool,
+     * gets the body, and proceeds. The tool persists in the catalog so
+     * re-activation is a no-op re-call rather than a "tool no longer
+     * exists" surprise.
      */
     fun asIndividualReferences(): List<LlmReference> {
         if (skills.isEmpty()) return emptyList()
-        val sharedResourceTools = Tool.fromInstance(this@Skills)
-            .filter { it.definition.name != "activate" }
-        return skills.map { skill ->
-            val perSkillTools = sharedResourceTools + skill.getScriptTools(scriptExecutionEngine)
+
+        val perSkill = skills.map { skill ->
             LlmReference.of(
                 name = skill.name,
                 description = skill.description,
-                tools = perSkillTools,
+                tools = listOf<Tool>(SkillActivationTool(skill)) +
+                    skill.getScriptTools(scriptExecutionEngine),
                 notes = "",
-            ).withUnfolding(childToolUsageNotes = skillUnfoldBody(skill))
+            )
+        }
+
+        // Single shared reference holding listResources / readResource —
+        // both take the skill name as a parameter, so one set covers every
+        // loaded skill and we avoid N copies of the same two tools in the
+        // catalog. `activate` is excluded because per-skill activation is
+        // now done via the per-skill tool above.
+        val sharedResourceTools = Tool.fromInstance(this@Skills)
+            .filter { it.definition.name != "activate" }
+        val sharedRef = LlmReference.of(
+            name = "skill_resources",
+            description = "Inspect bundled files (references, scripts, assets) for any loaded skill.",
+            tools = sharedResourceTools,
+            notes = "",
+        )
+
+        return perSkill + sharedRef
+    }
+
+    /**
+     * Plain [Tool] returned for each loaded skill. The tool's `name` and
+     * `description` come from the skill's frontmatter — this is what the
+     * LLM sees in its catalog. Calling the tool returns the skill body
+     * (instructions + resource manifest + script-tool names) as the tool
+     * result. No unfold, no preamble, no swap.
+     */
+    private inner class SkillActivationTool(private val skill: LoadedSkill) : Tool {
+
+        override val definition = Tool.Definition(
+            name = sanitizeToolName(skill.name),
+            description = skill.description,
+            inputSchema = Tool.InputSchema.empty(),
+        )
+
+        override fun call(input: String): Tool.Result {
+            activatedSkillNames.add(skill.name)
+            return Tool.Result.text(skillBody(skill))
         }
     }
 
     /**
-     * Build the body delivered via `childToolUsageNotes` when the LLM unfolds
-     * a per-skill wrapper. Mirrors what [activate] returns, but as a pure
-     * function (no `activatedSkillNames` side effect — this is constructed
-     * eagerly per reference, not per LLM call).
+     * Build the body returned when the LLM activates a skill. Mirrors what
+     * [activate] returns, but as a pure function (no `activatedSkillNames`
+     * side effect — that's tracked at the call site).
      */
-    private fun skillUnfoldBody(skill: LoadedSkill): String {
+    private fun skillBody(skill: LoadedSkill): String {
         val activationText = skill.getActivationText()
         val scriptTools = skill.getScriptTools(scriptExecutionEngine)
         if (scriptTools.isEmpty()) return activationText
@@ -307,6 +350,15 @@ data class Skills @JvmOverloads constructor(
             |${scriptTools.joinToString("\n") { "- ${it.definition.name}" }}
         """.trimMargin()
     }
+
+    /**
+     * Lower-case + replace `-` with `_`. Mirrors the sanitization the
+     * framework applies when wrapping a skill in an [com.embabel.agent.api.tool.progressive.UnfoldingTool]
+     * via [LlmReference.toolPrefix], so existing prompts and acceptance
+     * tests that reference e.g. `github_workflows` keep matching.
+     */
+    private fun sanitizeToolName(name: String): String =
+        name.replace('-', '_').lowercase()
 
     /**
      * Match by canonical form: case-insensitive, hyphens and underscores

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/SkillsTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/SkillsTest.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.skills
 
+import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.skills.script.ScriptExecutionResult
 import com.embabel.agent.skills.script.ScriptLanguage
 import com.embabel.agent.skills.script.SkillScript
@@ -532,7 +533,7 @@ class SkillsTest {
     // asIndividualReferences() tests
 
     @Test
-    fun `asIndividualReferences returns one reference per skill`() {
+    fun `asIndividualReferences returns one per-skill reference plus a shared resource reference`() {
         val skillDir1 = createSkillDirectory("skill-a")
         val skillDir2 = createSkillDirectory("skill-b")
         val skills = Skills(
@@ -552,11 +553,13 @@ class SkillsTest {
 
         val refs = skills.asIndividualReferences()
 
-        assertEquals(2, refs.size)
+        // N per-skill refs + 1 shared resource ref
+        assertEquals(3, refs.size)
         assertEquals("skill-a", refs[0].name)
         assertEquals("First skill", refs[0].description)
         assertEquals("skill-b", refs[1].name)
         assertEquals("Second skill", refs[1].description)
+        assertEquals("skill_resources", refs[2].name)
     }
 
     @Test
@@ -569,24 +572,85 @@ class SkillsTest {
     }
 
     @Test
-    fun `asIndividualReferences each reference has tools`() {
-        val skillDir = createSkillDirectory("my-skill")
+    fun `asIndividualReferences each per-skill reference exposes a single activation tool with the skill name`() {
+        val skillDir = createSkillDirectory("github-workflows")
         val skills = Skills(
             name = "test",
             description = "test",
             skills = listOf(
                 LoadedSkill(
-                    skillMetadata = SkillDefinition(name = "my-skill", description = "A skill"),
+                    skillMetadata = SkillDefinition(
+                        name = "github-workflows",
+                        description = "GitHub workflows",
+                        instructions = "Use gateway.gh.* via execute_javascript.",
+                    ),
                     basePath = skillDir,
                 ),
             ),
         )
 
         val refs = skills.asIndividualReferences()
-        val tools = refs[0].tools()
+        val perSkillRef = refs[0]
+        val tools = perSkillRef.tools()
 
-        // Should have tools (at minimum the unfolding wrapper)
-        assertTrue(tools.isNotEmpty(), "Each skill reference should have tools")
+        // Skill with no scripts → exactly one activation tool. Its name is
+        // sanitized (hyphens → underscores) so it matches what the framework
+        // would produce for a wrapper, keeping prompts/tests stable.
+        assertEquals(1, tools.size)
+        assertEquals("github_workflows", tools[0].definition.name)
+        assertEquals("GitHub workflows", tools[0].definition.description)
+    }
+
+    @Test
+    fun `activation tool returns the skill body when called`() {
+        val skillDir = createSkillDirectory("my-skill")
+        val skills = Skills(
+            name = "test",
+            description = "test",
+            skills = listOf(
+                LoadedSkill(
+                    skillMetadata = SkillDefinition(
+                        name = "my-skill",
+                        description = "A skill",
+                        instructions = "# Instructions\n\nDo the thing.",
+                    ),
+                    basePath = skillDir,
+                ),
+            ),
+        )
+
+        val activationTool = skills.asIndividualReferences()[0].tools()[0]
+        val result = activationTool.call("{}")
+
+        val text = (result as Tool.Result.Text).content
+        assertTrue(text.contains("# Skill: my-skill"), "Body should include the skill header")
+        assertTrue(text.contains("Do the thing."), "Body should include the instructions")
+    }
+
+    @Test
+    fun `shared resource reference exposes listResources and readResource`() {
+        val skillDir = createSkillDirectory("any-skill")
+        val skills = Skills(
+            name = "test",
+            description = "test",
+            skills = listOf(
+                LoadedSkill(
+                    skillMetadata = SkillDefinition(name = "any-skill", description = "x"),
+                    basePath = skillDir,
+                ),
+            ),
+        )
+
+        val refs = skills.asIndividualReferences()
+        val sharedRef = refs.last()
+        val toolNames = sharedRef.tools().map { it.definition.name }.toSet()
+
+        assertEquals("skill_resources", sharedRef.name)
+        assertTrue("listResources" in toolNames, "listResources should be in shared ref, was $toolNames")
+        assertTrue("readResource" in toolNames, "readResource should be in shared ref, was $toolNames")
+        // activate is intentionally NOT exposed — body delivery happens via
+        // the per-skill activation tool.
+        assertTrue("activate" !in toolNames, "activate should not be in shared ref, was $toolNames")
     }
 
     // Helper methods

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/SkillsTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/SkillsTest.kt
@@ -598,7 +598,11 @@ class SkillsTest {
         // would produce for a wrapper, keeping prompts/tests stable.
         assertEquals(1, tools.size)
         assertEquals("github_workflows", tools[0].definition.name)
-        assertEquals("GitHub workflows", tools[0].definition.description)
+        // Description leads with the skill's frontmatter description, then
+        // appends a "Skill activator: takes NO arguments..." cue so the LLM
+        // doesn't misread it as a parameterised gateway.
+        assertTrue(tools[0].definition.description.startsWith("GitHub workflows"))
+        assertTrue(tools[0].definition.description.contains("NO arguments"))
     }
 
     @Test
@@ -625,6 +629,73 @@ class SkillsTest {
         val text = (result as Tool.Result.Text).content
         assertTrue(text.contains("# Skill: my-skill"), "Body should include the skill header")
         assertTrue(text.contains("Do the thing."), "Body should include the instructions")
+    }
+
+    @Test
+    fun `activation tool short-circuits a second call within the same loop`() {
+        val skillDir = createSkillDirectory("github-workflows")
+        val skills = Skills(
+            name = "test",
+            description = "test",
+            skills = listOf(
+                LoadedSkill(
+                    skillMetadata = SkillDefinition(
+                        name = "github-workflows",
+                        description = "GitHub workflows",
+                        instructions = "Use gateway.gh.* via execute_javascript.",
+                    ),
+                    basePath = skillDir,
+                ),
+            ),
+        )
+        val tool = skills.asIndividualReferences()[0].tools()[0]
+        val ctx = com.embabel.agent.api.tool.ToolCallContext.of(com.embabel.agent.api.tool.ToolCallContext.LOOP_ID_KEY to "loop-A")
+
+        val first = (tool.call("{}", ctx) as Tool.Result.Text).content
+        val second = (tool.call("{}", ctx) as Tool.Result.Text).content
+
+        // First call → full body. Second call (same loop) → short-circuit
+        // message that explicitly redirects to execute_javascript.
+        assertTrue(first.contains("Use gateway.gh.*"), "First call should return body")
+        assertTrue(
+            second.contains("already activated this turn"),
+            "Second call same loop should short-circuit, was: $second",
+        )
+        assertTrue(second.contains("execute_javascript"))
+    }
+
+    @Test
+    fun `activation tool emits body again for a different loop id`() {
+        val skillDir = createSkillDirectory("github-workflows")
+        val skills = Skills(
+            name = "test",
+            description = "test",
+            skills = listOf(
+                LoadedSkill(
+                    skillMetadata = SkillDefinition(
+                        name = "github-workflows",
+                        description = "GitHub workflows",
+                        instructions = "Use gateway.gh.* via execute_javascript.",
+                    ),
+                    basePath = skillDir,
+                ),
+            ),
+        )
+        val tool = skills.asIndividualReferences()[0].tools()[0]
+
+        val first = (tool.call(
+            "{}",
+            com.embabel.agent.api.tool.ToolCallContext.of(com.embabel.agent.api.tool.ToolCallContext.LOOP_ID_KEY to "loop-A"),
+        ) as Tool.Result.Text).content
+        val second = (tool.call(
+            "{}",
+            com.embabel.agent.api.tool.ToolCallContext.of(com.embabel.agent.api.tool.ToolCallContext.LOOP_ID_KEY to "loop-B"),
+        ) as Tool.Result.Text).content
+
+        // Different loop ids ⇒ both calls emit the body. Per-loop dedup
+        // is intentionally per-loop, not per-conversation-forever.
+        assertTrue(first.contains("Use gateway.gh.*"))
+        assertTrue(second.contains("Use gateway.gh.*"), "Different loop should re-emit body, was: $second")
     }
 
     @Test


### PR DESCRIPTION
This is useful for efficiency. For example, some tools share information _once_ and should not repeat it even if asked.

This is used to improve the efficiency of skills.