### PR TITLE
Add API for  perplexity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ When asked to edit a particular .adoc file, look for a parallel file with a name
 
 For example, if you are asked to edit `tools.adoc`, look for `.tools.adoc` for specific instructions about how to go
 about it.
-Thus you will be given a combination of user instructions such as ("edit tools.adoc to cover the FooBar tool in
+Thus, you will be given a combination of user instructions such as ("edit tools.adoc to cover the FooBar tool in
 FooBar.kt").
 You will follow the user instruction but bear in mind the instructions in any .tools.adoc file.
 If there is no .<filename>.adoc file, follow the general instructions in this document.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/PerplexityAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/PerplexityAiModels.kt
@@ -20,13 +20,41 @@ class PerplexityAiModels {
     companion object {
 
         const val PROVIDER = "Perplexity AI"
+        // Values are taken from https://docs.perplexity.ai/docs/agent-api/models.
+        // Perplexity Models.
+        const val SONAR = "perplexity/sonar"
+        // Supported 3rd party models as of May 5th 2026.
 
-        const val SONAR = "sonar"
+        // Anthropic models.
+        const val ANTHROPIC_CLAUDE_OPUS_4_7 = "anthropic/claude-opus-4-7"
+        const val ANTHROPIC_CLAUDE_OPUS_4_6 = "anthropic/claude-opus-4-6"
+        const val ANTHROPIC_CLAUDE_OPUS_4_5 = "anthropic/claude-opus-4-5"
+        const val ANTHROPIC_CLAUDE_SONNET_4_6 = "anthropic/claude-sonnet-4-6"
+        const val ANTHROPIC_CLAUDE_SONNET_4_5 = "anthropic/claude-sonnet-4-5"
+        const val ANTHROPIC_CLAUDE_HAIKU_4_5 = "anthropic/claude-haiku-4-5"
 
-        const val SONAR_PRO = "sonar-pro"
+        // OpenAI models.
+        const val OPEN_AI_GPT_5_5 = "openai/gpt-5.5"
+        const val OPEN_AI_GPT_5_4 = "openai/gpt-5.4"
+        const val OPEN_AI_GPT_5_4_MINI = "openai/gpt-5.4-mini"
+        const val OPEN_AI_GPT_5_4_NANO = "openai/gpt-5.4-nano"
+        const val OPEN_AI_GPT_5_2 = "openai/gpt-5.2"
+        const val OPEN_AI_GPT_5_1 = "openai/gpt-5.1"
+        const val OPEN_AI_GPT_5 = "openai/gpt-5"
+        const val OPEN_AI_GPT_5_MINI = "openai/gpt-5-mini"
 
-        const val SONAR_REASONING = "sonar-reasoning"
+        // Google Gemini models.
+        const val GOOGLE_GEMINI_3_1_PRO = "google/gemini-3.1-pro-preview"
+        const val GOOGLE_GEMINI_3_FLASH = "google/gemini-3-flash-preview"
 
-        const val SONAR_DEEP_RESERACH = "sonar-deep-research"
+        // NVIDIA models.
+        const val NVIDIA_NEMOTRON_3_SUPER_120B = "nvidia/nemotron-3-super-120b-a12b"
+
+        // XAI models
+        const val xAI_GROK_4_3 = "xai/grok-4.3"
+        const val xAI_GROK_4_2_REASONING = "xai/grok-4.20-reasoning"
+        const val xAI_GROK_4_2_NON_REASONING = "xai/grok-4.20-non-reasoning"
+        const val xAI_GROK_4_2_MULTI_AGENT = "xai/grok-4.20-multi-agent"
+        const val xAI_GROK_4_1_FAST_NON_REASONING = "xai/grok-4-1-fast-non-reasoning"
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/PerplexityAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/PerplexityAiModels.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.models
+
+class PerplexityAiModels {
+
+    companion object {
+
+        const val PROVIDER = "Perplexity AI"
+
+        const val SONAR = "sonar"
+
+        const val SONAR_PRO = "sonar-pro"
+
+        const val SONAR_REASONING = "sonar-reasoning"
+
+        const val SONAR_DEEP_RESERACH = "sonar-deep-research"
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.embabel.agent</groupId>
+		<artifactId>embabel-agent-autoconfigure</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>embabel-agent-perplexity-ai-autoconfigure</artifactId>
+	<packaging>jar</packaging>
+	<name>Embabel Agent Autoconfiguration Models PerplexityAI</name>
+	<description>PerplexityAI Models for Embabel Agent API</description>
+	<url>https://github.com/embabel/embabel-agent</url>
+
+	<scm>
+		<url>https://github.com/embabel/embabel-agent</url>
+		<connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+		<developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.embabel.agent</groupId>
+			<artifactId>embabel-agent-api</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.embabel.agent</groupId>
+			<artifactId>embabel-agent-test-internal</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/perplexityai/AgentPerplexityAiAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/perplexityai/AgentPerplexityAiAutoConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.perplexityai;
+
+import com.embabel.agent.config.models.perplexityai.PerplexityAiModelsConfig;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Autoconfiguration for perplexity AI models in the Embabel Agent system.
+ * <p>
+ * This class serves as a Spring Boot autoconfiguration entry point that:
+ * - Imports the [PerplexityAIModelsConfig] configuration to dynamically register Perplexity AI model beans.
+ */
+@AutoConfiguration
+@AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
+@Import(PerplexityAiModelsConfig.class)
+public class AgentPerplexityAiAutoConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(AgentPerplexityAiAutoConfiguration.class);
+
+    @PostConstruct
+    public void logEvent() {
+        logger.info("AgentPerplexityAiAutoConfiguration about to proceed...");
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoader.kt
@@ -87,7 +87,7 @@ class PerplexityAiModelLoader(
 
 	companion object {
 		/**
-		 * Default path to the Anthropic models YAML configuration file.
+		 * Default path to the Perplexity models YAML configuration file.
 		 */
 		private const val DEFAULT_CONFIG_PATH = "classpath:models/perplexity-ai-models.yml"
 	}

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoader.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.perplexityai
+
+import com.embabel.common.ai.autoconfig.AbstractYamlModelLoader
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadata
+import com.embabel.common.ai.autoconfig.LlmAutoConfigProvider
+import com.embabel.common.ai.model.PerTokenPricingModel
+import org.springframework.core.io.DefaultResourceLoader
+import org.springframework.core.io.ResourceLoader
+import java.time.LocalDate
+
+/**
+ * Container for Perplexity AI model definitions loaded from YAML.
+ *
+ * Implements [LlmAutoConfigProvider] to supply Perplexity AI-specific model metadata
+ * for auto-configuration purposes.
+ *
+ * @property models list of Perplexity AI model definitions
+ */
+data class PerplexityAiModelDefinitions(
+	override val models: List<PerplexityAiModelDefinition> = emptyList()
+) : LlmAutoConfigProvider<PerplexityAiModelDefinition>
+
+/**
+ * Perplexity AI-specific model definition.
+ *
+ * Implements [LlmAutoConfigMetadata] with Perplexity AI-specific features
+ * like thinking mode and custom parameter defaults.
+ *
+ * @property name the unique name of the model
+ * @property modelId the Perplexity AI API model identifier
+ * @property displayName optional human-readable name
+ * @property knowledgeCutoffDate optional knowledge cutoff date
+ * @property pricingModel optional per-token pricing information
+ * @property maxTokens maximum tokens for completion (default 8192)
+ * @property temperature sampling temperature (default 1.0)
+ * @property topP nucleus sampling parameter
+ */
+data class PerplexityAiModelDefinition(
+	override val name: String,
+	override val modelId: String,
+	override val displayName: String? = null,
+	override val knowledgeCutoffDate: LocalDate? = null,
+	override val pricingModel: PerTokenPricingModel? = null,
+	val maxTokens: Int = 32768,
+	val temperature: Double = 1.0,
+	val topP: Double? = null,
+) : LlmAutoConfigMetadata
+
+class PerplexityAiModelLoader(
+	resourceLoader: ResourceLoader = DefaultResourceLoader(),
+	configPath: String = DEFAULT_CONFIG_PATH
+) : AbstractYamlModelLoader<PerplexityAiModelDefinitions>(resourceLoader, configPath) {
+
+	override fun getProviderClass() = PerplexityAiModelDefinitions::class
+
+	override fun createEmptyProvider() = PerplexityAiModelDefinitions()
+
+	override fun getProviderName() = "Perplexity AI"
+
+	override fun validateModels(provider: PerplexityAiModelDefinitions) {
+		provider.models.forEach { model ->
+			validateCommonFields(model)
+			require(model.maxTokens > 0) { "Max tokens must be positive for model ${model.name}" }
+            require(model.temperature in 0.0..2.0) {
+                "Temperature must be between 0 and 2 for model ${model.name}"
+            }
+			model.topP?.let {
+				require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }
+			}
+		}
+	}
+
+	companion object {
+		/**
+		 * Default path to the Anthropic models YAML configuration file.
+		 */
+		private const val DEFAULT_CONFIG_PATH = "classpath:models/perplexity-ai-models.yml"
+	}
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoader.kt
@@ -46,7 +46,7 @@ data class PerplexityAiModelDefinitions(
  * @property displayName optional human-readable name
  * @property knowledgeCutoffDate optional knowledge cutoff date
  * @property pricingModel optional per-token pricing information
- * @property maxTokens maximum tokens for completion (default 8192)
+ * @property maxTokens maximum tokens for completion (default 16384)
  * @property temperature sampling temperature (default 1.0)
  * @property topP nucleus sampling parameter
  */
@@ -56,7 +56,9 @@ data class PerplexityAiModelDefinition(
 	override val displayName: String? = null,
 	override val knowledgeCutoffDate: LocalDate? = null,
 	override val pricingModel: PerTokenPricingModel? = null,
-	val maxTokens: Int = 32768,
+	/* No default value is specified in the doc https://docs.perplexity.ai/docs/agent-api/models.
+	* Hence, reused the value from openai models.*/
+	val maxTokens: Int = 16384,
 	val temperature: Double = 1.0,
 	val topP: Double? = null,
 ) : LlmAutoConfigMetadata

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelsConfig.kt
@@ -206,7 +206,7 @@ class PerplexityAiModelsConfig(
             logger.info("Using custom Perplexity AI chat completions path : {}", completionsPath)
             builder.completionsPath(completionsPath)
         } else {
-            builder.completionsPath("/v1/sonar")
+            builder.completionsPath("/v1/agent")
         }
         // add observation registry to rest and web client builders
         builder

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelsConfig.kt
@@ -204,7 +204,7 @@ class PerplexityAiModelsConfig(
         }
         if (!completionsPath.isNullOrBlank()) {
             logger.info("Using custom Perplexity AI chat completions path : {}", completionsPath)
-            builder.completionsPath(baseUrl)
+            builder.completionsPath(completionsPath)
         } else {
             builder.completionsPath("/v1/sonar")
         }

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelsConfig.kt
@@ -58,6 +58,11 @@ class PerplexityAiProperties : RetryProperties {
     var apiKey: String? = null
 
     /**
+     * Path for chat completions endpoint.
+     */
+    var completionsPath: String? = null
+
+    /**
      * Maximum number of attempts.
      */
     override var maxAttempts: Int = 10
@@ -90,6 +95,8 @@ class PerplexityAiModelsConfig(
     private val envBaseUrl: String?,
     @param:Value("\${PERPLEXITY_API_KEY:#{null}}")
     private val envApiKey: String?,
+    @param:Value("\${PERPLEXITY_COMPLETION_PATH:#{null}}")
+    private val envCompletionsPath: String?,
     private val properties: PerplexityAiProperties,
     private val observationRegistry: ObjectProvider<ObservationRegistry>,
     private val configurableBeanFactory: ConfigurableBeanFactory,
@@ -98,6 +105,7 @@ class PerplexityAiModelsConfig(
     private val logger = LoggerFactory.getLogger(PerplexityAiModelsConfig::class.java)
 
     private val baseUrl: String? = envBaseUrl ?: properties.baseUrl
+    private val completionsPath: String? = envCompletionsPath ?: properties.completionsPath
     private val apiKey: String = envApiKey ?: properties.apiKey
     ?: error("Perplexity AI API key required: set PERPLEXITY_API_KEY env var or embabel.agent.platform.models.perplexityai.api-key")
 
@@ -191,6 +199,14 @@ class PerplexityAiModelsConfig(
         if (!baseUrl.isNullOrBlank()) {
             logger.info("Using custom Perplexity AI base URL: {}", baseUrl)
             builder.baseUrl(baseUrl)
+        } else {
+            builder.baseUrl("https://api.perplexity.ai")
+        }
+        if (!completionsPath.isNullOrBlank()) {
+            logger.info("Using custom Perplexity AI chat completions path : {}", completionsPath)
+            builder.completionsPath(baseUrl)
+        } else {
+            builder.completionsPath("/v1/sonar")
         }
         // add observation registry to rest and web client builders
         builder

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelsConfig.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.perplexityai
+
+import com.embabel.agent.api.models.PerplexityAiModels
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.common.RetryProperties
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadataLoader
+import com.embabel.common.ai.autoconfig.ProviderInitialization
+import com.embabel.common.ai.autoconfig.RegisteredModel
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.OptionsConverter
+import com.embabel.common.ai.model.PerTokenPricingModel
+import io.micrometer.observation.ObservationRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.ai.openai.OpenAiChatModel
+import org.springframework.ai.openai.OpenAiChatOptions
+import org.springframework.ai.openai.api.OpenAiApi
+import org.springframework.ai.model.tool.ToolCallingManager
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * Configuration properties for Perplexity AI models.
+ * These properties control retry behavior when calling Perplexity AI APIs.
+ */
+@ConfigurationProperties(prefix = "embabel.agent.platform.models.perplexityai")
+class PerplexityAiProperties : RetryProperties {
+    /**
+     * Base URL for Perplexity AI API requests.
+     */
+    var baseUrl: String? = null
+
+    /**
+     * API key for authenticating with Perplexity AI services.
+     */
+    var apiKey: String? = null
+
+    /**
+     * Maximum number of attempts.
+     */
+    override var maxAttempts: Int = 10
+
+    /**
+     * Initial backoff interval (in milliseconds).
+     */
+    override var backoffMillis: Long = 5_000L
+
+    /**
+     * Backoff interval multiplier.
+     */
+    override var backoffMultiplier: Double = 5.0
+
+    /**
+     * Maximum backoff interval (in milliseconds).
+     */
+    override var backoffMaxInterval: Long = 180_000L
+}
+
+/**
+ * Configuration for well-known PerplexityAI language and embedding models.
+ * Provides bean definitions for various models with their corresponding
+ * capabilities, knowledge cutoff dates, and pricing models.
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(PerplexityAiProperties::class)
+class PerplexityAiModelsConfig(
+    @param:Value("\${PERPLEXITY_BASE_URL:#{null}}")
+    private val envBaseUrl: String?,
+    @param:Value("\${PERPLEXITY_API_KEY:#{null}}")
+    private val envApiKey: String?,
+    private val properties: PerplexityAiProperties,
+    private val observationRegistry: ObjectProvider<ObservationRegistry>,
+    private val configurableBeanFactory: ConfigurableBeanFactory,
+    private val modelLoader: LlmAutoConfigMetadataLoader<PerplexityAiModelDefinitions> = PerplexityAiModelLoader(),
+) {
+    private val logger = LoggerFactory.getLogger(PerplexityAiModelsConfig::class.java)
+
+    private val baseUrl: String? = envBaseUrl ?: properties.baseUrl
+    private val apiKey: String = envApiKey ?: properties.apiKey
+    ?: error("Perplexity AI API key required: set PERPLEXITY_API_KEY env var or embabel.agent.platform.models.perplexityai.api-key")
+
+    init {
+        logger.info("Perplexity AI models are available: {}", properties)
+    }
+
+    @Bean
+    fun perplexityAiModelsInitializer(): ProviderInitialization {
+        val registeredLlms = buildList {
+            modelLoader
+                .loadAutoConfigMetadata().models.forEach { modelDef ->
+                    try {
+                        val llm = createPerplexityAiLlm(modelDef)
+
+                        // Register as singleton bean with the configured bean name
+                        configurableBeanFactory.registerSingleton(modelDef.name, llm)
+                        add(RegisteredModel(beanName = modelDef.name, modelId = modelDef.modelId))
+
+                        logger.info(
+                            "Registered Perplexity AI model bean: {} -> {}",
+                            modelDef.name, modelDef.modelId
+                        )
+
+                    } catch (e: Exception) {
+                        logger.error(
+                            "Failed to create model: {} ({})",
+                            modelDef.name, modelDef.modelId, e
+                        )
+                        throw e
+                    }
+                }
+        }
+
+        return ProviderInitialization(
+            provider = PerplexityAiModels.PROVIDER,
+            registeredLlms = registeredLlms,
+        ).also { logger.info(it.summary()) }
+    }
+
+    /**
+     * Creates an individual Perplexity AI model from configuration.
+     */
+    private fun createPerplexityAiLlm(modelDef: PerplexityAiModelDefinition): LlmService<*> {
+        // Spring AI integrates with Perplexity AI by reusing the existing OpenAI client.
+        // See https://docs.spring.io/spring-ai/reference/api/chat/perplexity-chat.html.
+        val perplexityChatModel = OpenAiChatModel
+            .builder()
+            .defaultOptions(createDefaultOptions(modelDef))
+            .openAiApi(createPerplexityAiApi())
+            .toolCallingManager(
+                ToolCallingManager.builder()
+                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+                    .build()
+            )
+            .retryTemplate(properties.retryTemplate("perplexity-ai-${modelDef.modelId}"))
+            .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+            .build()
+
+        return SpringAiLlmService(
+            name = modelDef.modelId,
+            chatModel = perplexityChatModel,
+            provider = PerplexityAiModels.PROVIDER,
+            optionsConverter = PerplexityAiOptionsConverter,
+            knowledgeCutoffDate = modelDef.knowledgeCutoffDate,
+            pricingModel = modelDef.pricingModel?.let {
+                PerTokenPricingModel(
+                    usdPer1mInputTokens = it.usdPer1mInputTokens,
+                    usdPer1mOutputTokens = it.usdPer1mOutputTokens,
+                )
+            }
+        )
+    }
+
+    /**
+     * Creates default options for a model based on YAML configuration.
+     */
+    private fun createDefaultOptions(modelDef: PerplexityAiModelDefinition): OpenAiChatOptions {
+        return OpenAiChatOptions.builder()
+            .model(modelDef.modelId)
+            .maxTokens(modelDef.maxTokens)
+            .temperature(modelDef.temperature)
+            .apply {
+                modelDef.topP?.let { topP(it) }
+            }
+            .build()
+    }
+
+    private fun createPerplexityAiApi(): OpenAiApi {
+        val builder = OpenAiApi.builder().apiKey(apiKey)
+        if (!baseUrl.isNullOrBlank()) {
+            logger.info("Using custom Perplexity AI base URL: {}", baseUrl)
+            builder.baseUrl(baseUrl)
+        }
+        // add observation registry to rest and web client builders
+        builder
+            .restClientBuilder(
+                RestClient.builder()
+                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+            )
+        builder
+            .webClientBuilder(
+                WebClient.builder()
+                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+            )
+
+        return builder.build()
+    }
+}
+
+object PerplexityAiOptionsConverter : OptionsConverter<OpenAiChatOptions> {
+
+    override fun convertOptions(options: LlmOptions): OpenAiChatOptions =
+        OpenAiChatOptions.builder()
+            .temperature(options.temperature)
+            .topP(options.topP)
+            .maxTokens(options.maxTokens)
+            .build()
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2025-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.embabel.agent.autoconfigure.models.perplexityai.AgentPerplexityAiAutoConfiguration

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/resources/models/perplexity-ai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/resources/models/perplexity-ai-models.yml
@@ -2,15 +2,199 @@
 # perplexity-ai-models.yml
 # ============================================
 #
-# Verified against docs.perplexity.ai on 2026-04-12
+# Verified against docs.perplexity.ai on 2026-05-05.
 #
-# Using official Perplexity AI API aliases for supported chat/code/reasoning models
+# Values are taken from https://docs.perplexity.ai/docs/agent-api/models.
 
 models:
-  - name: "sonar"
-    model_id: "sonar"
+  # ========================================
+  # Perplexity own model.
+  # ========================================
+  - name: "perplexity/sonar"
+    model_id: "perplexity/sonar"
     display_name: "Sonar"
-    max_tokens: 127072
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 2.5
+
+  # Supported 3rd party models.
+
+  # ========================================
+  # Supported Anthropic models.
+  # ========================================
+  - name: "anthropic/claude-opus-4-7"
+    model_id: "anthropic/claude-opus-4-7"
+    display_name: "Claude Opus 4.7"
+    pricing_model:
+      usd_per1m_input_tokens: 5
+      usd_per1m_output_tokens: 25
+
+  - name: "anthropic/claude-opus-4-6"
+    model_id: "anthropic/claude-opus-4-6"
+    display_name: "Claude Opus 4.6"
+    pricing_model:
+      usd_per1m_input_tokens: 5
+      usd_per1m_output_tokens: 25
+
+  - name: "anthropic/claude-opus-4-5"
+    model_id: "anthropic/claude-opus-4-5"
+    display_name: "Claude Opus 4.5"
+    pricing_model:
+      usd_per1m_input_tokens: 5
+      usd_per1m_output_tokens: 25
+
+  - name: "anthropic/claude-sonnet-4-6"
+    model_id: "anthropic/claude-sonnet-4-6"
+    display_name: "Claude Sonnet 4.6"
+    pricing_model:
+      usd_per1m_input_tokens: 3
+      usd_per1m_output_tokens: 15
+
+  - name: "anthropic/claude-sonnet-4-5"
+    model_id: "anthropic/claude-sonnet-4-5"
+    display_name: "Claude Sonnet 4.5"
+    pricing_model:
+      usd_per1m_input_tokens: 3
+      usd_per1m_output_tokens: 15
+
+  - name: "anthropic/claude-haiku-4-5"
+    model_id: "anthropic/claude-haiku-4-5"
+    display_name: "Claude Haiku 4.5"
     pricing_model:
       usd_per1m_input_tokens: 1
-      usd_per1m_output_tokens: 1
+      usd_per1m_output_tokens: 5
+
+  # ========================================
+  # Supported OpenAI models.
+  # ========================================
+
+  - name: "openai/gpt-5.5"
+    model_id: "openai/gpt-5.5"
+    display_name: "Openai GPT 5.5"
+    pricing_model:
+      usd_per1m_input_tokens: 5
+      usd_per1m_output_tokens: 30
+
+  - name: "openai/gpt-5.4"
+    model_id: "openai/gpt-5.4"
+    display_name: "Openai GPT 5.4"
+    pricing_model:
+      usd_per1m_input_tokens: 2.5
+      usd_per1m_output_tokens: 15
+
+  - name: "openai/gpt-5.4-mini"
+    model_id: "openai/gpt-5.4-mini"
+    display_name: "Openai GPT 5.4 Mini"
+    pricing_model:
+      usd_per1m_input_tokens: 0.75
+      usd_per1m_output_tokens: 4.5
+
+  - name: "openai/gpt-5.4-nano"
+    model_id: "openai/gpt-5.4-nano"
+    display_name: "Openai GPT 5.4 nano"
+    pricing_model:
+      usd_per1m_input_tokens: 0.2
+      usd_per1m_output_tokens: 1.25
+
+  - name: "openai/gpt-5.2"
+    model_id: "openai/gpt-5.2"
+    display_name: "Openai GPT 5.2"
+    pricing_model:
+      usd_per1m_input_tokens: 1.75
+      usd_per1m_output_tokens: 14
+
+  - name: "openai/gpt-5.1"
+    model_id: "openai/gpt-5.1"
+    display_name: "Openai GPT 5.1"
+    pricing_model:
+      usd_per1m_input_tokens: 1.25
+      usd_per1m_output_tokens: 10
+
+  - name: "openai/gpt-5"
+    model_id: "openai/gpt-5"
+    display_name: "Openai GPT 5"
+    pricing_model:
+      usd_per1m_input_tokens: 1.25
+      usd_per1m_output_tokens: 10
+
+  - name: "openai/gpt-5-mini"
+    model_id: "openai/gpt-5-mini"
+    display_name: "Openai GPT 5 Mini"
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 2
+
+  # ========================================
+  # Supported Google models.
+  # ========================================
+
+  - name: "google/gemini-3.1-pro-preview"
+    model_id: "google/gemini-3.1-pro-preview"
+    display_name: "Google Gemini 3.1 Pro"
+    pricing_model:
+      usd_per1m_input_tokens: 4
+      usd_per1m_output_tokens: 18
+
+  - name: "google/gemini-3-flash-preview"
+    model_id: "google/gemini-3-flash-preview"
+    display_name: "Google Gemini 3 Flash"
+    pricing_model:
+      usd_per1m_input_tokens: 0.5
+      usd_per1m_output_tokens: 3
+
+  # ========================================
+  # Supported NVIDIA models.
+  # ========================================
+
+  - name: "nvidia/nemotron-3-super-120b-a12b"
+    model_id: "nvidia/nemotron-3-super-120b-a12b"
+    display_name: "Nvidia Nemotron 3 Super 120B"
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 2.5
+
+  # ========================================
+  # Supported xAI models.
+  # ========================================
+
+  - name: "xai/grok-4.3"
+    model_id: "xai/grok-4.3"
+    display_name: "xAI Grok 4.3"
+    pricing_model:
+      usd_per1m_input_tokens: 1.25
+      usd_per1m_output_tokens: 2.5
+
+  - name: "xai/grok-4.20-reasoning"
+    model_id: "xai/grok-4.20-reasoning"
+    display_name: "xAI Grok 4.2 Reasoning"
+    pricing_model:
+      usd_per1m_input_tokens: 1.25
+      usd_per1m_output_tokens: 2.5
+
+  - name: "xai/grok-4.20-non-reasoning"
+    model_id: "xai/grok-4.20-non-reasoning"
+    display_name: "xAI Grok 4.2 Non Reasoning"
+    pricing_model:
+      usd_per1m_input_tokens: 1.25
+      usd_per1m_output_tokens: 2.5
+
+  - name: "xai/grok-4.20-multi-agent"
+    model_id: "xai/grok-4.20-multi-agent"
+    display_name: "xAI Grok 4.2 Multi-Agent"
+    pricing_model:
+      usd_per1m_input_tokens: 1.25
+      usd_per1m_output_tokens: 2.5
+
+  - name: "xai/grok-4.20-reasoning"
+    model_id: "xai/grok-4.20-reasoning"
+    display_name: "xAI Grok 4.2 Reasoning"
+    pricing_model:
+      usd_per1m_input_tokens: 1.25
+      usd_per1m_output_tokens: 2.5
+
+  - name: "xai/grok-4-1-fast-non-reasoning"
+    model_id: "xai/grok-4-1-fast-non-reasoning"
+    display_name: "xAI Grok 4.1 Fat Non Reasoning"
+    pricing_model:
+      usd_per1m_input_tokens: 0.2
+      usd_per1m_output_tokens: 0.5

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/resources/models/perplexity-ai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/resources/models/perplexity-ai-models.yml
@@ -185,13 +185,6 @@ models:
       usd_per1m_input_tokens: 1.25
       usd_per1m_output_tokens: 2.5
 
-  - name: "xai/grok-4.20-reasoning"
-    model_id: "xai/grok-4.20-reasoning"
-    display_name: "xAI Grok 4.2 Reasoning"
-    pricing_model:
-      usd_per1m_input_tokens: 1.25
-      usd_per1m_output_tokens: 2.5
-
   - name: "xai/grok-4-1-fast-non-reasoning"
     model_id: "xai/grok-4-1-fast-non-reasoning"
     display_name: "xAI Grok 4.1 Fat Non Reasoning"

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/resources/models/perplexity-ai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/main/resources/models/perplexity-ai-models.yml
@@ -1,0 +1,16 @@
+# ============================================
+# perplexity-ai-models.yml
+# ============================================
+#
+# Verified against docs.perplexity.ai on 2026-04-12
+#
+# Using official Perplexity AI API aliases for supported chat/code/reasoning models
+
+models:
+  - name: "sonar"
+    model_id: "sonar"
+    display_name: "Sonar"
+    max_tokens: 127072
+    pricing_model:
+      usd_per1m_input_tokens: 1
+      usd_per1m_output_tokens: 1

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoaderTest.kt
@@ -74,7 +74,7 @@ class PerplexityAiModelLoaderTest {
         val result = loader.loadAutoConfigMetadata()
 
         // Assert
-        assertEquals(24, result.models.size, "Should load exactly 24 Perplexity AI models")
+        assertEquals(23, result.models.size, "Should load exactly 23 Perplexity AI models")
 
         val expectedModels = listOf(
             "perplexity/sonar",

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoaderTest.kt
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.perplexityai
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.DefaultResourceLoader
+import java.io.File
+import java.nio.file.Files
+
+class PerplexityAiModelLoaderTest {
+
+    @Test
+    fun `should load valid model definitions from default YAML file`() {
+        // Arrange
+        val loader = PerplexityAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isNotEmpty(), "Should load at least one model")
+
+        // Verify the first model has required fields
+        val firstModel = result.models.first()
+        assertNotNull(firstModel.name)
+        assertNotNull(firstModel.modelId)
+        assertTrue(firstModel.name.isNotBlank(), "Model name should not be blank")
+        assertTrue(firstModel.modelId.isNotBlank(), "Model ID should not be blank")
+    }
+
+    @Test
+    fun `should validate all loaded models have correct default values`() {
+        // Arrange
+        val loader = PerplexityAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        result.models.forEach { model ->
+            // Verify defaults
+            assertTrue(model.maxTokens > 0, "Max tokens should be positive for ${model.name}")
+            assertTrue(model.temperature in 0.0..2.0, "Temperature should be in valid range for ${model.name}")
+
+            // Verify optional fields when present
+            model.topP?.let {
+                assertTrue(it in 0.0..1.0, "Top P should be between 0 and 1 for ${model.name}")
+            }
+        }
+    }
+
+    @Test
+    fun `should load all 1 expected Perplexity AI model`() {
+
+        // Arrange
+        val loader = PerplexityAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size, "Should load exactly 1 Perplexity AI models")
+
+        val expectedModels = listOf(
+            "sonar"
+        )
+        expectedModels.forEach { expectedName ->
+            assertTrue(result.models.any { it.name == expectedName }, "Should have model: $expectedName")
+        }
+    }
+
+    @Test
+    fun `should verify specific known models are loaded`() {
+        // Arrange
+        val loader = PerplexityAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify some known Perplexity AI models are present
+        val modelNames = result.models.map { it.name }
+        assertTrue(modelNames.isNotEmpty(), "Should have loaded model names")
+
+        // Verify at least one model has pricing info
+        assertTrue(result.models.any { it.pricingModel != null },
+            "At least one model should have pricing information")
+    }
+
+    @Test
+    fun `should return empty definitions when file does not exist`() {
+        // Arrange
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "classpath:nonexistent-file.yml"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isEmpty(), "Should return empty list when file not found")
+    }
+
+    @Test
+    fun `should handle invalid YAML gracefully`() {
+        // Arrange
+        val tempFile = Files.createTempFile("invalid", ".yml").toFile()
+        tempFile.writeText("invalid: yaml: content: ][")
+        tempFile.deleteOnExit()
+
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertNotNull(result)
+        assertTrue(result.models.isEmpty(), "Should return empty list on parse error")
+    }
+
+    @Test
+    fun `should validate model with invalid maxTokens`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                max_tokens: -100
+        """.trimIndent())
+
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for negative maxTokens")
+    }
+
+    @Test
+    fun `should validate model with invalid temperature`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                temperature: 3.0
+        """.trimIndent())
+
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for temperature out of range")
+    }
+
+    @Test
+    fun `should validate model with invalid topP`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: test-id
+                top_p: 1.5
+        """.trimIndent())
+
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for topP out of range")
+    }
+
+    @Test
+    fun `should validate model with blank name`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: ""
+                model_id: test-id
+        """.trimIndent())
+
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act & Assert
+        val result = loader.loadAutoConfigMetadata()
+        assertTrue(result.models.isEmpty(), "Should fail validation for blank name")
+    }
+
+    @Test
+    fun `should load valid model with all optional fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: test-model
+                model_id: sonar-test
+                display_name: Test Model
+                max_tokens: 4096
+                temperature: 0.7
+                top_p: 0.9
+                pricing_model:
+                  usd_per1m_input_tokens: 10.0
+                  usd_per1m_output_tokens: 20.0
+        """.trimIndent())
+
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size)
+        val model = result.models.first()
+        assertEquals("test-model", model.name)
+        assertEquals("sonar-test", model.modelId)
+        assertEquals("Test Model", model.displayName)
+        assertEquals(4096, model.maxTokens)
+        assertEquals(0.7, model.temperature)
+        assertEquals(0.9, model.topP)
+        assertNotNull(model.pricingModel)
+        assertEquals(10.0, model.pricingModel?.usdPer1mInputTokens)
+        assertEquals(20.0, model.pricingModel?.usdPer1mOutputTokens)
+    }
+
+    @Test
+    fun `should load multiple models correctly`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: model-1
+                model_id: sonar-1
+                max_tokens: 2000
+              - name: model-2
+                model_id: sonar-2
+                max_tokens: 4000
+        """.trimIndent())
+
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(2, result.models.size)
+        assertEquals("model-1", result.models[0].name)
+        assertEquals("model-2", result.models[1].name)
+        assertEquals(2000, result.models[0].maxTokens)
+        assertEquals(4000, result.models[1].maxTokens)
+    }
+
+    @Test
+    fun `should load model with minimal fields`() {
+        // Arrange
+        val tempFile = createTempYamlFile("""
+            models:
+              - name: minimal-model
+                model_id: sonar-minimal
+        """.trimIndent())
+
+        val loader = PerplexityAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}"
+        )
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert
+        assertEquals(1, result.models.size)
+        val model = result.models.first()
+        assertEquals("minimal-model", model.name)
+        assertEquals("sonar-minimal", model.modelId)
+        assertNull(model.displayName)
+        assertEquals(32768, model.maxTokens) // Default value
+        assertEquals(1.0, model.temperature) // Default value
+        assertNull(model.topP)
+        assertNull(model.pricingModel)
+    }
+
+    private fun createTempYamlFile(content: String): File {
+        val tempFile = Files.createTempFile("test-sonar-ai", ".yml").toFile()
+        tempFile.writeText(content)
+        tempFile.deleteOnExit()
+        return tempFile
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-perplexity-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/perplexityai/PerplexityAiModelLoaderTest.kt
@@ -74,10 +74,32 @@ class PerplexityAiModelLoaderTest {
         val result = loader.loadAutoConfigMetadata()
 
         // Assert
-        assertEquals(1, result.models.size, "Should load exactly 1 Perplexity AI models")
+        assertEquals(24, result.models.size, "Should load exactly 24 Perplexity AI models")
 
         val expectedModels = listOf(
-            "sonar"
+            "perplexity/sonar",
+            "anthropic/claude-opus-4-7",
+            "anthropic/claude-opus-4-6",
+            "anthropic/claude-opus-4-5",
+            "anthropic/claude-sonnet-4-6",
+            "anthropic/claude-sonnet-4-5",
+            "anthropic/claude-haiku-4-5",
+            "openai/gpt-5.5",
+            "openai/gpt-5.4",
+            "openai/gpt-5.4-mini",
+            "openai/gpt-5.4-nano",
+            "openai/gpt-5.2",
+            "openai/gpt-5.1",
+            "openai/gpt-5",
+            "openai/gpt-5-mini",
+            "google/gemini-3.1-pro-preview",
+            "google/gemini-3-flash-preview",
+            "nvidia/nemotron-3-super-120b-a12b",
+            "xai/grok-4.3",
+            "xai/grok-4.20-reasoning",
+            "xai/grok-4.20-non-reasoning",
+            "xai/grok-4.20-multi-agent",
+            "xai/grok-4-1-fast-non-reasoning"
         )
         expectedModels.forEach { expectedName ->
             assertTrue(result.models.any { it.name == expectedName }, "Should have model: $expectedName")
@@ -306,7 +328,7 @@ class PerplexityAiModelLoaderTest {
         assertEquals("minimal-model", model.name)
         assertEquals("sonar-minimal", model.modelId)
         assertNull(model.displayName)
-        assertEquals(32768, model.maxTokens) // Default value
+        assertEquals(16384, model.maxTokens) // Default value
         assertEquals(1.0, model.temperature) // Default value
         assertNull(model.topP)
         assertNull(model.pricingModel)

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -39,6 +39,7 @@
         <module>models/embabel-agent-google-genai-autoconfigure</module>
         <module>models/embabel-agent-minimax-autoconfigure</module>
         <module>models/embabel-agent-mistral-ai-autoconfigure</module>
+        <module>models/embabel-agent-perplexity-ai-autoconfigure</module>
         <module>models/embabel-agent-onnx-autoconfigure</module>
     </modules>
 

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -192,6 +192,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-perplexity-ai-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-mcpserver</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -336,6 +336,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-perplexity-ai</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-lmstudio</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -76,7 +76,7 @@ open class OpenAiCompatibleModelFactory(
          * Validates against [OpenAiModels.GPT_41_MINI] by default.
          */
         fun openAi(apiKey: String): ByokSpec =
-            ByokSpec(null, apiKey, OpenAiModels.GPT_41_MINI, OpenAiModels.PROVIDER)
+            ByokSpec(null, apiKey,  null,OpenAiModels.GPT_41_MINI, OpenAiModels.PROVIDER)
 
         /**
          * Returns a [ByokSpec] for DeepSeek (OpenAI-compatible endpoint).
@@ -85,7 +85,7 @@ open class OpenAiCompatibleModelFactory(
          * Note: uses the OpenAI wire protocol, not the native Spring AI DeepSeek client.
          */
         fun deepSeek(apiKey: String): ByokSpec =
-            ByokSpec("https://api.deepseek.com", apiKey, DeepSeekModels.DEEPSEEK_CHAT, DeepSeekModels.PROVIDER)
+            ByokSpec("https://api.deepseek.com", apiKey, null, DeepSeekModels.DEEPSEEK_CHAT, DeepSeekModels.PROVIDER)
 
         /**
          * Returns a [ByokSpec] for Mistral AI (OpenAI-compatible endpoint).
@@ -94,7 +94,7 @@ open class OpenAiCompatibleModelFactory(
          * Note: uses the OpenAI wire protocol, not the native Spring AI Mistral client.
          */
         fun mistral(apiKey: String): ByokSpec =
-            ByokSpec("https://api.mistral.ai", apiKey, MistralAiModels.MINISTRAL_8B, MistralAiModels.PROVIDER)
+            ByokSpec("https://api.mistral.ai", apiKey, null, MistralAiModels.MINISTRAL_8B, MistralAiModels.PROVIDER)
 
         /**
          * Returns a [ByokSpec] for Google Gemini (OpenAI-compatible endpoint).
@@ -104,6 +104,7 @@ open class OpenAiCompatibleModelFactory(
             ByokSpec(
                 "https://generativelanguage.googleapis.com/v1beta/openai",
                 apiKey,
+                null,
                 GoogleGenAiModels.GEMINI_2_5_FLASH,
                 GoogleGenAiModels.PROVIDER,
             )
@@ -115,7 +116,7 @@ open class OpenAiCompatibleModelFactory(
          * Note: uses the OpenAI wire protocol, not the native Spring AI Perplexity client.
          */
         fun perplexity(apiKey: String): ByokSpec =
-            ByokSpec("https://api.perplexity.ai", apiKey, PerplexityAiModels.SONAR, PerplexityAiModels.PROVIDER)
+            ByokSpec("https://api.perplexity.ai", apiKey, "/v1/sonar", PerplexityAiModels.SONAR, PerplexityAiModels.PROVIDER)
 
         /**
          * Returns a [ByokSpec] for a custom OpenAI-compatible provider.
@@ -129,6 +130,7 @@ open class OpenAiCompatibleModelFactory(
          *     OpenAiCompatibleModelFactory.byok(
          *         baseUrl = "https://api.myprovider.com",
          *         apiKey = apiKey,
+         *         completionsPath = "mypath",
          *         validationModel = "my-model-small",
          *         validationProvider = "MyProvider",
          *     )
@@ -137,9 +139,10 @@ open class OpenAiCompatibleModelFactory(
         fun byok(
             baseUrl: String?,
             apiKey: String,
+            completionsPath: String?,
             validationModel: String,
             validationProvider: String,
-        ): ByokSpec = ByokSpec(baseUrl, apiKey, validationModel, validationProvider)
+        ): ByokSpec = ByokSpec(baseUrl, apiKey, completionsPath, validationModel, validationProvider)
     }
 
     /**
@@ -153,6 +156,7 @@ open class OpenAiCompatibleModelFactory(
     class ByokSpec internal constructor(
         private val baseUrl: String?,
         private val apiKey: String,
+        private val completionsPath: String?,
         private val validationModel: String,
         private val validationProvider: String,
         private val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
@@ -168,10 +172,10 @@ open class OpenAiCompatibleModelFactory(
          * ```
          */
         fun validating(model: String, provider: String): ByokSpec =
-            ByokSpec(baseUrl, apiKey, model, provider, observationRegistry)
+            ByokSpec(baseUrl, apiKey, completionsPath,model, provider, observationRegistry)
 
         override fun buildValidated(): LlmService<*> =
-            OpenAiCompatibleModelFactory(baseUrl, apiKey, null, null, observationRegistry = observationRegistry)
+            OpenAiCompatibleModelFactory(baseUrl, apiKey, completionsPath, null, observationRegistry = observationRegistry)
                 .buildValidated(
                     model = validationModel,
                     pricingModel = PricingModel.ALL_YOU_CAN_EAT,

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.api.models.DeepSeekModels
 import com.embabel.agent.api.models.GoogleGenAiModels
 import com.embabel.agent.api.models.MistralAiModels
 import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.api.models.PerplexityAiModels
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.chat.UserMessage
@@ -106,6 +107,15 @@ open class OpenAiCompatibleModelFactory(
                 GoogleGenAiModels.GEMINI_2_5_FLASH,
                 GoogleGenAiModels.PROVIDER,
             )
+
+        /**
+         * Returns a [ByokSpec] for Perplexity AI (OpenAI-compatible endpoint).
+         * Validates against [PerplexityAiModels.SONAR] by default.
+         *
+         * Note: uses the OpenAI wire protocol, not the native Spring AI Perplexity client.
+         */
+        fun perplexity(apiKey: String): ByokSpec =
+            ByokSpec("https://api.perplexity.ai", apiKey, PerplexityAiModels.SONAR, PerplexityAiModels.PROVIDER)
 
         /**
          * Returns a [ByokSpec] for a custom OpenAI-compatible provider.

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -116,7 +116,7 @@ open class OpenAiCompatibleModelFactory(
          * Note: uses the OpenAI wire protocol, not the native Spring AI Perplexity client.
          */
         fun perplexity(apiKey: String): ByokSpec =
-            ByokSpec("https://api.perplexity.ai", apiKey, "/v1/sonar", PerplexityAiModels.SONAR, PerplexityAiModels.PROVIDER)
+            ByokSpec("https://api.perplexity.ai", apiKey, "/v1/agent", PerplexityAiModels.SONAR, PerplexityAiModels.PROVIDER)
 
         /**
          * Returns a [ByokSpec] for a custom OpenAI-compatible provider.

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokIT.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokIT.kt
@@ -56,4 +56,13 @@ class OpenAiCompatibleModelFactoryByokIT {
             .buildValidated()
         assertNotNull(service)
     }
+
+    @Test
+    @EnabledIfEnvironmentVariable(named = "PERPLEXITY_API_KEY", matches = ".+")
+    fun `perplexity buildValidated succeeds with valid key`() {
+        val service = OpenAiCompatibleModelFactory.perplexity(System.getenv("PERPLEXITY_API_KEY"))
+            .buildValidated()
+        assertNotNull(service)
+    }
+
 }

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
@@ -52,6 +52,7 @@ class OpenAiCompatibleModelFactoryByokSpecTest {
             OpenAiCompatibleModelFactory.byok(
                 baseUrl = "https://api.example.com",
                 apiKey = "key",
+                completionsPath = "path",
                 validationModel = "my-model",
                 validationProvider = "MyProvider",
             )
@@ -74,11 +75,13 @@ class OpenAiCompatibleModelFactoryByokSpecTest {
         val deepSeekSpec = OpenAiCompatibleModelFactory.deepSeek("key")
         val mistralSpec = OpenAiCompatibleModelFactory.mistral("key")
         val geminiSpec = OpenAiCompatibleModelFactory.gemini("key")
+        val perplexitySpec = OpenAiCompatibleModelFactory.perplexity("key")
 
         // Each spec should construct without error (no network call at this stage)
         assertInstanceOf(ByokFactory::class.java, openAiSpec)
         assertInstanceOf(ByokFactory::class.java, deepSeekSpec)
         assertInstanceOf(ByokFactory::class.java, mistralSpec)
         assertInstanceOf(ByokFactory::class.java, geminiSpec)
+        assertInstanceOf(ByokFactory::class.java, perplexitySpec)
     }
 }

--- a/embabel-agent-starters/embabel-agent-starter-perplexity-ai/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-perplexity-ai/pom.xml
@@ -27,7 +27,6 @@
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-perplexity-ai-autoconfigure</artifactId>
-            <version>0.4.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/embabel-agent-starters/embabel-agent-starter-perplexity-ai/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-perplexity-ai/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>0.4.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-starter-perplexity-ai</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent PerplexityAI Starter</name>
+    <description>Embabel Agent PerplexityAI Starter</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-perplexity-ai-autoconfigure</artifactId>
+            <version>0.4.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -38,6 +38,7 @@
         <module>embabel-agent-starter-google-genai</module>
         <module>embabel-agent-starter-minimax</module>
         <module>embabel-agent-starter-mistral-ai</module>
+        <module>embabel-agent-starter-perplexity-ai</module>
         <module>embabel-agent-starter-a2a</module>
         <module>embabel-agent-starter-webmvc</module>
         <module>embabel-agent-starter-onnx</module>


### PR DESCRIPTION
 - Add an an API to connect  with  Perplexity SONAR (https://docs.perplexity.ai/docs/sonar/quickstart#generating-an-api-key)  apis 
 - Perplexity is an OpenAI compatible model
 
- Tested locally with `OpenAiCompatibleModelFactoryByokIT.perplexity buildValidated succeeds with valid key` 