### PR TITLE
Update repository_dispatch type in maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,7 +7,7 @@
 name: Build
 on:
   repository_dispatch:
-    types: [common-snapshots-deployed]
+    types: [agent-snapshots-deployed]
   push:
   pull_request:
     types: [ opened, synchronize, reopened ]


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The event type that triggers the workflow via `repository_dispatch` has been changed to better reflect its purpose.

- Updated the `.github/workflows/maven.yml` workflow to trigger on the `agent-snapshots-deployed` event type instead of `common-snapshots-deployed` for `repository_dispatch` events.