### PR TITLE
Action Retry with Exception Classification as  Retriable / Non-Retriable

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionExceptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionExceptions.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core
+
+/**
+ * Marker interface for exceptions that should trigger action retry.
+ *
+ * Exceptions implementing this interface are considered transient/recoverable
+ * and will be retried according to the action's QoS retry policy.
+ *
+ * Use this for temporary failures that may succeed on retry:
+ * - Network timeouts
+ * - Temporary service unavailability
+ * - Rate limiting
+ * - Transient database connection errors
+ *
+ * Example:
+ * ```kotlin
+ * class TemporaryApiFailureException(message: String)
+ *     : RuntimeException(message), RetryableException
+ * ```
+ *
+ * @see NonRetryableException
+ * @see ActionException
+ */
+interface RetryableException
+
+/**
+ * Marker interface for exceptions that should NOT trigger action retry.
+ *
+ * Exceptions implementing this interface are considered permanent/non-recoverable
+ * and will cause the action to fail immediately without retry attempts.
+ *
+ * Use this for deterministic failures that won't change on retry:
+ * - Validation errors
+ * - Business rule violations
+ * - Invalid input that won't change on retry
+ * - Resource not found errors (404)
+ * - Authentication failures (401)
+ *
+ * Example:
+ * ```kotlin
+ * class InvalidInputException(message: String)
+ *     : RuntimeException(message), NonRetryableException
+ * ```
+ *
+ * @see RetryableException
+ * @see ActionException
+ */
+interface NonRetryableException
+
+/**
+ * Base class for action execution exceptions with built-in retry classification.
+ *
+ * Provides convenient base classes for retryable and non-retryable exceptions
+ * without requiring users to implement marker interfaces directly.
+ *
+ * Example usage:
+ * ```java
+ * @Action
+ * public Result processOrder(Order order) {
+ *     if (!order.isValid()) {
+ *         // Won't be retried
+ *         throw new ActionException.NonRetryable("Invalid order: " + order.id);
+ *     }
+ *
+ *     try {
+ *         return externalApi.submit(order);
+ *     } catch (TimeoutException e) {
+ *         // Will be retried
+ *         throw new ActionException.Retryable("API timeout", e);
+ *     }
+ * }
+ * ```
+ *
+ * @see RetryableException
+ * @see NonRetryableException
+ */
+sealed class ActionException(
+    message: String,
+    cause: Throwable? = null
+) : RuntimeException(message, cause) {
+
+    /**
+     * Transient failure that can be retried.
+     *
+     * Use for temporary failures like:
+     * - Network timeouts
+     * - Rate limiting (429 errors)
+     * - Temporary resource unavailability
+     * - Connection failures
+     * - Database deadlocks
+     *
+     * @param message Human-readable error description
+     * @param cause Optional underlying exception
+     */
+    class Retryable(message: String, cause: Throwable? = null)
+        : ActionException(message, cause), RetryableException
+
+    /**
+     * Permanent failure that should not be retried.
+     *
+     * Use for deterministic failures like:
+     * - Validation errors
+     * - Business rule violations
+     * - Invalid parameters
+     * - Resource not found (404 errors)
+     * - Authentication failures (401 errors)
+     * - Authorization failures (403 errors)
+     *
+     * @param message Human-readable error description
+     * @param cause Optional underlying exception
+     */
+    class NonRetryable(message: String, cause: Throwable? = null)
+        : ActionException(message, cause), NonRetryableException
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionExceptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionExceptions.kt
@@ -16,80 +16,57 @@
 package com.embabel.agent.core
 
 /**
- * Marker interface for exceptions that should trigger action retry.
- *
- * Exceptions implementing this interface are considered transient/recoverable
- * and will be retried according to the action's QoS retry policy.
- *
- * Use this for temporary failures that may succeed on retry:
- * - Network timeouts
- * - Temporary service unavailability
- * - Rate limiting
- * - Transient database connection errors
- *
- * Example:
- * ```kotlin
- * class TemporaryApiFailureException(message: String)
- *     : RuntimeException(message), RetryableException
- * ```
- *
- * @see NonRetryableException
- * @see ActionException
- */
-interface RetryableException
-
-/**
- * Marker interface for exceptions that should NOT trigger action retry.
- *
- * Exceptions implementing this interface are considered permanent/non-recoverable
- * and will cause the action to fail immediately without retry attempts.
- *
- * Use this for deterministic failures that won't change on retry:
- * - Validation errors
- * - Business rule violations
- * - Invalid input that won't change on retry
- * - Resource not found errors (404)
- * - Authentication failures (401)
- *
- * Example:
- * ```kotlin
- * class InvalidInputException(message: String)
- *     : RuntimeException(message), NonRetryableException
- * ```
- *
- * @see RetryableException
- * @see ActionException
- */
-interface NonRetryableException
-
-/**
  * Base class for action execution exceptions with built-in retry classification.
  *
  * Provides convenient base classes for retryable and non-retryable exceptions
  * without requiring users to implement marker interfaces directly.
  *
+ * This class is open to allow users to create domain-specific exception hierarchies:
+ * ```kotlin
+ * import com.embabel.agent.core.ActionException
+ *
+ * // Extend ActionException for domain-specific exceptions
+ * class ValidationException(message: String)
+ *     : ActionException.Permanent(message)
+ *
+ * class ApiTimeoutException(message: String, cause: Throwable? = null)
+ *     : ActionException.Transient(message, cause)
+ *
+ * // Or implement marker interfaces directly
+ * import com.embabel.agent.core.NonRetryable
+ * import com.embabel.agent.core.Retryable
+ *
+ * class CustomValidationError(message: String)
+ *     : RuntimeException(message), NonRetryable
+ *
+ * class CustomTimeoutError(message: String)
+ *     : RuntimeException(message), Retryable
+ * ```
+ *
  * Example usage:
  * ```java
+ * import com.embabel.agent.core.ActionException;
+ *
  * @Action
  * public Result processOrder(Order order) {
  *     if (!order.isValid()) {
  *         // Won't be retried
- *         throw new ActionException.NonRetryable("Invalid order: " + order.id);
+ *         throw new ActionException.Permanent("Invalid order: " + order.id);
  *     }
  *
  *     try {
  *         return externalApi.submit(order);
  *     } catch (TimeoutException e) {
  *         // Will be retried
- *         throw new ActionException.Retryable("API timeout", e);
+ *         throw new ActionException.Transient("API timeout", e);
  *     }
  * }
  * ```
  *
- * @see RetryableException
- * @see NonRetryableException
+ * @see Retryable
+ * @see NonRetryable
  */
-sealed class ActionException(
+open class ActionException(
     message: String,
     cause: Throwable? = null
 ) : RuntimeException(message, cause) {
@@ -107,8 +84,8 @@ sealed class ActionException(
      * @param message Human-readable error description
      * @param cause Optional underlying exception
      */
-    class Retryable(message: String, cause: Throwable? = null)
-        : ActionException(message, cause), RetryableException
+    open class Transient(message: String, cause: Throwable? = null)
+        : ActionException(message, cause), Retryable
 
     /**
      * Permanent failure that should not be retried.
@@ -124,6 +101,6 @@ sealed class ActionException(
      * @param message Human-readable error description
      * @param cause Optional underlying exception
      */
-    class NonRetryable(message: String, cause: Throwable? = null)
-        : ActionException(message, cause), NonRetryableException
+    open class Permanent(message: String, cause: Throwable? = null)
+        : ActionException(message, cause), NonRetryable
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/Retry.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/Retry.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core
+
+/**
+ * Marker interface indicating that an operation should be retried on failure.
+ *
+ * Can be applied to exceptions, commands, actions, or any operation that may
+ * fail transiently and should be retried according to the configured retry policy.
+ *
+ * Common use cases:
+ * - Network timeouts
+ * - Temporary service unavailability
+ * - Rate limiting (429 errors)
+ * - Transient database connection errors
+ *
+ * Example usage:
+ * ```kotlin
+ * import com.embabel.agent.core.Retryable
+ *
+ * class ApiTimeoutException(message: String)
+ *     : RuntimeException(message), Retryable
+ * ```
+ *
+ * @see NonRetryable
+ * @see ActionException
+ */
+interface Retryable
+
+/**
+ * Marker interface indicating that an operation should NOT be retried on failure.
+ *
+ * Can be applied to exceptions, commands, actions, or any operation that fails
+ * deterministically and will not succeed on retry.
+ *
+ * Common use cases:
+ * - Validation errors
+ * - Business rule violations
+ * - Invalid input parameters
+ * - Resource not found (404 errors)
+ * - Authentication failures (401 errors)
+ * - Authorization failures (403 errors)
+ *
+ * Example usage:
+ * ```kotlin
+ * import com.embabel.agent.core.NonRetryable
+ *
+ * class ValidationException(message: String)
+ *     : RuntimeException(message), NonRetryable
+ * ```
+ *
+ * @see Retryable
+ * @see ActionException
+ */
+interface NonRetryable

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
@@ -557,7 +557,19 @@ abstract class AbstractAgentProcess(
                 val effectiveAction = action.withEffectiveQos(platformServices.actionQosProperties())
                 effectiveAction.qos
                     .retryTemplate("Action-${action.name}")
-                    .execute<ActionStatus, Throwable> {
+                    .execute<ActionStatus, Throwable> { context ->
+                        // Clear effect conditions on retry (not first attempt)
+                        if (context.retryCount > 0) {
+                            logger.debug(
+                                "Retry attempt {} for action {}, clearing effect conditions",
+                                context.retryCount,
+                                action.name
+                            )
+                            action.effects.forEach { (condition, _) ->
+                                blackboard.setCondition(condition, false)
+                            }
+                        }
+
                         effectiveAction.execute(
                             processContext = processContext,
                         )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
@@ -18,9 +18,9 @@ package com.embabel.agent.spi.support.springai
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.tool.ToolControlFlowSignal
-import com.embabel.agent.core.NonRetryableException
+import com.embabel.agent.core.NonRetryable
 import com.embabel.agent.core.ReplanRequestedException
-import com.embabel.agent.core.RetryableException
+import com.embabel.agent.core.Retryable
 import org.springframework.ai.retry.NonTransientAiException
 import org.springframework.ai.retry.TransientAiException
 import org.springframework.retry.RetryContext
@@ -62,10 +62,10 @@ internal class SpringAiRetryPolicy(
         // Check entire exception cause chain for markers
         var current: Throwable? = lastException
         while (current != null) {
-            if (current is NonRetryableException) {
+            if (current is NonRetryable) {
                 return false
             }
-            if (current is RetryableException) {
+            if (current is Retryable) {
                 return true
             }
             current = current.cause

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
@@ -18,7 +18,9 @@ package com.embabel.agent.spi.support.springai
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.NonRetryableException
 import com.embabel.agent.core.ReplanRequestedException
+import com.embabel.agent.core.RetryableException
 import org.springframework.ai.retry.NonTransientAiException
 import org.springframework.ai.retry.TransientAiException
 import org.springframework.retry.RetryContext
@@ -51,21 +53,32 @@ internal class SpringAiRetryPolicy(
     }
 
     override fun canRetry(context: RetryContext): Boolean {
-        if (context.retryCount == 0) {
-            // First attempt, always retry
-            return true
-        }
         if (context.retryCount >= maxAttempts) {
             return false
         }
 
-        return when (val lastException = context.lastThrowable) {
+        val lastException = context.lastThrowable ?: return true
+
+        // Check entire exception cause chain for markers
+        var current: Throwable? = lastException
+        while (current != null) {
+            if (current is NonRetryableException) {
+                return false
+            }
+            if (current is RetryableException) {
+                return true
+            }
+            current = current.cause
+        }
+
+        return when (lastException) {
             // Control flow signals - not errors to retry
             is ReplanRequestedException -> false
             is TerminateActionException -> false
             is TerminateAgentException -> false
             is ToolControlFlowSignal -> false  // Catch-all for other control flow signals
 
+            // Spring AI markers
             is TransientAiException -> true
 
             is NonTransientAiException -> {
@@ -75,12 +88,14 @@ internal class SpringAiRetryPolicy(
                 }
             }
 
+            // Common programming errors that should never be retried
             is IllegalArgumentException -> false
-
             is IllegalStateException -> false
-
             is UnsupportedOperationException -> false
+            is NullPointerException -> false
+            is ClassCastException -> false
 
+            // Default: retry unknown exceptions (backward compatible)
             else -> true
         }
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ActionExceptionsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ActionExceptionsTest.kt
@@ -29,93 +29,93 @@ import org.junit.jupiter.api.Test
 class ActionExceptionsTest {
 
     @Nested
-    inner class RetryableExceptionTests {
+    inner class TransientTests {
 
         @Test
-        fun `ActionException Retryable implements RetryableException`() {
-            val exception = ActionException.Retryable("test message")
-            assertTrue(exception is RetryableException)
+        fun `ActionException Transient implements Retryable`() {
+            val exception = ActionException.Transient("test message")
+            assertTrue(exception is Retryable)
         }
 
         @Test
-        fun `ActionException Retryable extends RuntimeException`() {
-            val exception = ActionException.Retryable("test message")
+        fun `ActionException Transient extends RuntimeException`() {
+            val exception = ActionException.Transient("test message")
             assertTrue(exception is RuntimeException)
         }
 
         @Test
-        fun `ActionException Retryable preserves message`() {
+        fun `ActionException Transient preserves message`() {
             val message = "timeout error"
-            val exception = ActionException.Retryable(message)
+            val exception = ActionException.Transient(message)
             assertEquals(message, exception.message)
         }
 
         @Test
-        fun `ActionException Retryable without cause`() {
-            val exception = ActionException.Retryable("error")
+        fun `ActionException Transient without cause`() {
+            val exception = ActionException.Transient("error")
             assertNull(exception.cause)
         }
 
         @Test
-        fun `ActionException Retryable with cause`() {
+        fun `ActionException Transient with cause`() {
             val cause = RuntimeException("root cause")
-            val exception = ActionException.Retryable("wrapped error", cause)
+            val exception = ActionException.Transient("wrapped error", cause)
             assertSame(cause, exception.cause)
             assertEquals("wrapped error", exception.message)
         }
 
         @Test
-        fun `custom RetryableException implementation`() {
-            class CustomRetryable(message: String) : RuntimeException(message), RetryableException
+        fun `custom Retryable implementation`() {
+            class CustomRetryable(message: String) : RuntimeException(message), Retryable
 
             val exception = CustomRetryable("custom")
-            assertTrue(exception is RetryableException)
+            assertTrue(exception is Retryable)
             assertTrue(exception is RuntimeException)
         }
     }
 
     @Nested
-    inner class NonRetryableExceptionTests {
+    inner class PermanentTests {
 
         @Test
-        fun `ActionException NonRetryable implements NonRetryableException`() {
-            val exception = ActionException.NonRetryable("test message")
-            assertTrue(exception is NonRetryableException)
+        fun `ActionException Permanent implements NonRetryable`() {
+            val exception = ActionException.Permanent("test message")
+            assertTrue(exception is NonRetryable)
         }
 
         @Test
-        fun `ActionException NonRetryable extends RuntimeException`() {
-            val exception = ActionException.NonRetryable("test message")
+        fun `ActionException Permanent extends RuntimeException`() {
+            val exception = ActionException.Permanent("test message")
             assertTrue(exception is RuntimeException)
         }
 
         @Test
-        fun `ActionException NonRetryable preserves message`() {
+        fun `ActionException Permanent preserves message`() {
             val message = "validation error"
-            val exception = ActionException.NonRetryable(message)
+            val exception = ActionException.Permanent(message)
             assertEquals(message, exception.message)
         }
 
         @Test
-        fun `ActionException NonRetryable without cause`() {
-            val exception = ActionException.NonRetryable("error")
+        fun `ActionException Permanent without cause`() {
+            val exception = ActionException.Permanent("error")
             assertNull(exception.cause)
         }
 
         @Test
-        fun `ActionException NonRetryable with cause`() {
+        fun `ActionException Permanent with cause`() {
             val cause = IllegalArgumentException("invalid input")
-            val exception = ActionException.NonRetryable("wrapped error", cause)
+            val exception = ActionException.Permanent("wrapped error", cause)
             assertSame(cause, exception.cause)
             assertEquals("wrapped error", exception.message)
         }
 
         @Test
-        fun `custom NonRetryableException implementation`() {
-            class CustomNonRetryable(message: String) : RuntimeException(message), NonRetryableException
+        fun `custom NonRetryable implementation`() {
+            class CustomNonRetryable(message: String) : RuntimeException(message), NonRetryable
 
             val exception = CustomNonRetryable("custom")
-            assertTrue(exception is NonRetryableException)
+            assertTrue(exception is NonRetryable)
             assertTrue(exception is RuntimeException)
         }
     }
@@ -124,26 +124,25 @@ class ActionExceptionsTest {
     inner class ActionExceptionHierarchyTests {
 
         @Test
-        fun `ActionException Retryable is subclass of ActionException`() {
-            val exception = ActionException.Retryable("test")
+        fun `ActionException Transient is subclass of ActionException`() {
+            val exception = ActionException.Transient("test")
             assertInstanceOf(ActionException::class.java, exception)
         }
 
         @Test
-        fun `ActionException NonRetryable is subclass of ActionException`() {
-            val exception = ActionException.NonRetryable("test")
+        fun `ActionException Permanent is subclass of ActionException`() {
+            val exception = ActionException.Permanent("test")
             assertInstanceOf(ActionException::class.java, exception)
         }
 
         @Test
-        fun `ActionException is sealed class`() {
-            // Verify we can't create other subclasses outside the package
-            // This is enforced by Kotlin's sealed class mechanism
-            val retryable = ActionException.Retryable("test")
-            val nonRetryable = ActionException.NonRetryable("test")
+        fun `ActionException is open class allowing extension`() {
+            // ActionException is open to allow users to create domain-specific hierarchies
+            val transient = ActionException.Transient("test")
+            val permanent = ActionException.Permanent("test")
 
-            assertTrue(retryable is ActionException)
-            assertTrue(nonRetryable is ActionException)
+            assertTrue(transient is ActionException)
+            assertTrue(permanent is ActionException)
         }
     }
 
@@ -151,32 +150,32 @@ class ActionExceptionsTest {
     inner class JavaInteropTests {
 
         @Test
-        fun `ActionException Retryable works from Java`() {
+        fun `ActionException Transient works from Java`() {
             // Simulating Java usage pattern
-            val exception = ActionException.Retryable("message")
+            val exception = ActionException.Transient("message")
             assertTrue(exception.message == "message")
             assertNull(exception.cause)
         }
 
         @Test
-        fun `ActionException Retryable with cause works from Java`() {
+        fun `ActionException Transient with cause works from Java`() {
             val cause = RuntimeException("cause")
-            val exception = ActionException.Retryable("message", cause)
+            val exception = ActionException.Transient("message", cause)
             assertEquals("message", exception.message)
             assertSame(cause, exception.cause)
         }
 
         @Test
-        fun `ActionException NonRetryable works from Java`() {
-            val exception = ActionException.NonRetryable("message")
+        fun `ActionException Permanent works from Java`() {
+            val exception = ActionException.Permanent("message")
             assertEquals("message", exception.message)
             assertNull(exception.cause)
         }
 
         @Test
-        fun `ActionException NonRetryable with cause works from Java`() {
+        fun `ActionException Permanent with cause works from Java`() {
             val cause = IllegalArgumentException("cause")
-            val exception = ActionException.NonRetryable("message", cause)
+            val exception = ActionException.Permanent("message", cause)
             assertEquals("message", exception.message)
             assertSame(cause, exception.cause)
         }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ActionExceptionsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ActionExceptionsTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for ActionException and retry marker interfaces.
+ */
+class ActionExceptionsTest {
+
+    @Nested
+    inner class RetryableExceptionTests {
+
+        @Test
+        fun `ActionException Retryable implements RetryableException`() {
+            val exception = ActionException.Retryable("test message")
+            assertTrue(exception is RetryableException)
+        }
+
+        @Test
+        fun `ActionException Retryable extends RuntimeException`() {
+            val exception = ActionException.Retryable("test message")
+            assertTrue(exception is RuntimeException)
+        }
+
+        @Test
+        fun `ActionException Retryable preserves message`() {
+            val message = "timeout error"
+            val exception = ActionException.Retryable(message)
+            assertEquals(message, exception.message)
+        }
+
+        @Test
+        fun `ActionException Retryable without cause`() {
+            val exception = ActionException.Retryable("error")
+            assertNull(exception.cause)
+        }
+
+        @Test
+        fun `ActionException Retryable with cause`() {
+            val cause = RuntimeException("root cause")
+            val exception = ActionException.Retryable("wrapped error", cause)
+            assertSame(cause, exception.cause)
+            assertEquals("wrapped error", exception.message)
+        }
+
+        @Test
+        fun `custom RetryableException implementation`() {
+            class CustomRetryable(message: String) : RuntimeException(message), RetryableException
+
+            val exception = CustomRetryable("custom")
+            assertTrue(exception is RetryableException)
+            assertTrue(exception is RuntimeException)
+        }
+    }
+
+    @Nested
+    inner class NonRetryableExceptionTests {
+
+        @Test
+        fun `ActionException NonRetryable implements NonRetryableException`() {
+            val exception = ActionException.NonRetryable("test message")
+            assertTrue(exception is NonRetryableException)
+        }
+
+        @Test
+        fun `ActionException NonRetryable extends RuntimeException`() {
+            val exception = ActionException.NonRetryable("test message")
+            assertTrue(exception is RuntimeException)
+        }
+
+        @Test
+        fun `ActionException NonRetryable preserves message`() {
+            val message = "validation error"
+            val exception = ActionException.NonRetryable(message)
+            assertEquals(message, exception.message)
+        }
+
+        @Test
+        fun `ActionException NonRetryable without cause`() {
+            val exception = ActionException.NonRetryable("error")
+            assertNull(exception.cause)
+        }
+
+        @Test
+        fun `ActionException NonRetryable with cause`() {
+            val cause = IllegalArgumentException("invalid input")
+            val exception = ActionException.NonRetryable("wrapped error", cause)
+            assertSame(cause, exception.cause)
+            assertEquals("wrapped error", exception.message)
+        }
+
+        @Test
+        fun `custom NonRetryableException implementation`() {
+            class CustomNonRetryable(message: String) : RuntimeException(message), NonRetryableException
+
+            val exception = CustomNonRetryable("custom")
+            assertTrue(exception is NonRetryableException)
+            assertTrue(exception is RuntimeException)
+        }
+    }
+
+    @Nested
+    inner class ActionExceptionHierarchyTests {
+
+        @Test
+        fun `ActionException Retryable is subclass of ActionException`() {
+            val exception = ActionException.Retryable("test")
+            assertInstanceOf(ActionException::class.java, exception)
+        }
+
+        @Test
+        fun `ActionException NonRetryable is subclass of ActionException`() {
+            val exception = ActionException.NonRetryable("test")
+            assertInstanceOf(ActionException::class.java, exception)
+        }
+
+        @Test
+        fun `ActionException is sealed class`() {
+            // Verify we can't create other subclasses outside the package
+            // This is enforced by Kotlin's sealed class mechanism
+            val retryable = ActionException.Retryable("test")
+            val nonRetryable = ActionException.NonRetryable("test")
+
+            assertTrue(retryable is ActionException)
+            assertTrue(nonRetryable is ActionException)
+        }
+    }
+
+    @Nested
+    inner class JavaInteropTests {
+
+        @Test
+        fun `ActionException Retryable works from Java`() {
+            // Simulating Java usage pattern
+            val exception = ActionException.Retryable("message")
+            assertTrue(exception.message == "message")
+            assertNull(exception.cause)
+        }
+
+        @Test
+        fun `ActionException Retryable with cause works from Java`() {
+            val cause = RuntimeException("cause")
+            val exception = ActionException.Retryable("message", cause)
+            assertEquals("message", exception.message)
+            assertSame(cause, exception.cause)
+        }
+
+        @Test
+        fun `ActionException NonRetryable works from Java`() {
+            val exception = ActionException.NonRetryable("message")
+            assertEquals("message", exception.message)
+            assertNull(exception.cause)
+        }
+
+        @Test
+        fun `ActionException NonRetryable with cause works from Java`() {
+            val cause = IllegalArgumentException("cause")
+            val exception = ActionException.NonRetryable("message", cause)
+            assertEquals("message", exception.message)
+            assertSame(cause, exception.cause)
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ActionRetryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ActionRetryTest.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.support
+
+import com.embabel.agent.api.annotation.AchievesGoal
+import com.embabel.agent.api.annotation.Action
+import com.embabel.agent.api.annotation.Agent
+import com.embabel.agent.api.annotation.support.ActionQosPropertyProvider
+import com.embabel.agent.api.annotation.support.AgentMetadataReader
+import com.embabel.agent.api.annotation.support.DefaultActionMethodManager
+import com.embabel.agent.api.annotation.support.DefaultActionQosProvider
+import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.api.common.PlannerType
+import com.embabel.agent.core.ActionException
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.spi.config.spring.AgentPlatformProperties
+import com.embabel.agent.test.integration.IntegrationTestUtils
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.util.concurrent.atomic.AtomicInteger
+import com.embabel.agent.core.Agent as CoreAgent
+
+/**
+ * Integration tests for action retry behavior.
+ */
+class ActionRetryTest {
+
+    @Nested
+    inner class RetryExceptionTests {
+
+        private val propertyProvider: ActionQosPropertyProvider = Mockito.mock(ActionQosPropertyProvider::class.java)
+        private val fastReader: AgentMetadataReader
+
+        init {
+            Mockito.`when`(propertyProvider.getBound("\${fast-retry}"))
+                .thenReturn(AgentPlatformProperties.ActionQosProperties.ActionProperties(
+                    maxAttempts = 5,
+                    backoffMillis = 20
+                ))
+            fastReader = AgentMetadataReader(
+                actionMethodManager = DefaultActionMethodManager(
+                    actionQosProvider = DefaultActionQosProvider(propertyProvider = propertyProvider)
+                )
+            )
+        }
+
+        @Test
+        fun `RetryableException enables retry`() {
+            val instance = RetryableSuccessAgent()
+            val agent = fastReader.createAgentMetadata(instance) as CoreAgent
+
+            val agentProcess = IntegrationTestUtils.dummyAgentPlatform().createAgentProcess(
+                agent,
+                ProcessOptions.DEFAULT.withPlannerType(PlannerType.UTILITY),
+                mapOf("input" to TestInput("test"))
+            )
+
+            agentProcess.run()
+
+            // Should succeed after 2 attempts
+            assertEquals(2, instance.attempts.get())
+        }
+
+        @Test
+        fun `NonRetryableException stops immediately`() {
+            val instance = NonRetryableAgent()
+            val agent = fastReader.createAgentMetadata(instance) as CoreAgent
+
+            val agentProcess = IntegrationTestUtils.dummyAgentPlatform().createAgentProcess(
+                agent,
+                ProcessOptions.DEFAULT.withPlannerType(PlannerType.UTILITY),
+                mapOf("input" to TestInput("test"))
+            )
+
+            // NonRetryableException should be re-thrown without retry
+            try {
+                agentProcess.run()
+            } catch (e: ActionException.NonRetryable) {
+                // Expected - exception should propagate after first failure
+            }
+
+            // Should only try once (no retry)
+            assertEquals(1, instance.attempts.get())
+        }
+    }
+
+    @Nested
+    inner class EffectConditionTests {
+
+        private val propertyProvider: ActionQosPropertyProvider = Mockito.mock(ActionQosPropertyProvider::class.java)
+        private val fastReader: AgentMetadataReader
+
+        init {
+            Mockito.`when`(propertyProvider.getBound("\${fast-retry}"))
+                .thenReturn(AgentPlatformProperties.ActionQosProperties.ActionProperties(
+                    maxAttempts = 5,
+                    backoffMillis = 20
+                ))
+            fastReader = AgentMetadataReader(
+                actionMethodManager = DefaultActionMethodManager(
+                    actionQosProvider = DefaultActionQosProvider(propertyProvider = propertyProvider)
+                )
+            )
+        }
+
+        @Test
+        fun `effect conditions cleared on retry`() {
+            val instance = EffectConditionAgent()
+            val agent = fastReader.createAgentMetadata(instance) as CoreAgent
+
+            val agentProcess = IntegrationTestUtils.dummyAgentPlatform().createAgentProcess(
+                agent,
+                ProcessOptions.DEFAULT.withPlannerType(PlannerType.UTILITY),
+                mapOf("input" to TestInput("test"))
+            )
+
+            agentProcess.run()
+
+            // Should succeed after 2 attempts
+            assertEquals(2, instance.attempts.get())
+            // Effect condition (in post) should be cleared on retry
+            assertEquals(false, instance.effectConditionState)
+            // Other condition (NOT in post) should remain unchanged
+            assertEquals(true, instance.otherConditionState)
+        }
+    }
+
+    // Test domain classes
+    data class TestInput(val value: String)
+    data class TestOutput(val result: String)
+
+    // Test agent classes
+
+    @Agent(description = "Agent with retryable that succeeds")
+    internal class RetryableSuccessAgent {
+        val attempts = AtomicInteger(0)
+
+        @Action(
+            description = "Fails once then succeeds",
+            actionRetryPolicyExpression = "\${fast-retry}"
+        )
+        @AchievesGoal(description = "Process")
+        fun process(input: TestInput): TestOutput {
+            val attempt = attempts.incrementAndGet()
+
+            if (attempt == 1) {
+                throw ActionException.Retryable("First attempt fails")
+            }
+
+            return TestOutput("Success on attempt $attempt")
+        }
+    }
+
+    @Agent(description = "Agent with non-retryable error")
+    internal class NonRetryableAgent {
+        val attempts = AtomicInteger(0)
+
+        @Action(
+            description = "Non-retryable action",
+            actionRetryPolicyExpression = "\${fast-retry}"
+        )
+        @AchievesGoal(description = "Process")
+        fun process(input: TestInput): TestOutput {
+            attempts.incrementAndGet()
+            throw ActionException.NonRetryable("Validation error")
+        }
+    }
+
+    @Agent(description = "Agent with effect conditions")
+    internal class EffectConditionAgent {
+        val attempts = AtomicInteger(0)
+        var effectConditionState: Boolean? = null
+        var otherConditionState: Boolean? = null
+
+        @Action(
+            description = "Action with post-condition",
+            post = ["dataProcessed"],
+            actionRetryPolicyExpression = "\${fast-retry}"
+        )
+        @AchievesGoal(description = "Process")
+        fun process(input: TestInput, context: OperationContext): TestOutput {
+            val attempt = attempts.incrementAndGet()
+
+            if (attempt == 1) {
+                // First attempt sets both conditions then fails
+                context.setCondition("dataProcessed", true)
+                context.setCondition("otherCondition", true)
+                throw ActionException.Retryable("First attempt fails")
+            }
+
+            // On retry, only effect condition (in post) should be cleared
+            effectConditionState = context.getCondition("dataProcessed")
+            otherConditionState = context.getCondition("otherCondition")
+            return TestOutput("Success on attempt $attempt")
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ActionRetryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ActionRetryTest.kt
@@ -60,7 +60,7 @@ class ActionRetryTest {
         }
 
         @Test
-        fun `RetryableException enables retry`() {
+        fun `Retryable exception enables retry`() {
             val instance = RetryableSuccessAgent()
             val agent = fastReader.createAgentMetadata(instance) as CoreAgent
 
@@ -77,7 +77,7 @@ class ActionRetryTest {
         }
 
         @Test
-        fun `NonRetryableException stops immediately`() {
+        fun `NonRetryable exception stops immediately`() {
             val instance = NonRetryableAgent()
             val agent = fastReader.createAgentMetadata(instance) as CoreAgent
 
@@ -87,10 +87,10 @@ class ActionRetryTest {
                 mapOf("input" to TestInput("test"))
             )
 
-            // NonRetryableException should be re-thrown without retry
+            // NonRetryable exception should be re-thrown without retry
             try {
                 agentProcess.run()
-            } catch (e: ActionException.NonRetryable) {
+            } catch (e: ActionException.Permanent) {
                 // Expected - exception should propagate after first failure
             }
 
@@ -159,7 +159,7 @@ class ActionRetryTest {
             val attempt = attempts.incrementAndGet()
 
             if (attempt == 1) {
-                throw ActionException.Retryable("First attempt fails")
+                throw ActionException.Transient("First attempt fails")
             }
 
             return TestOutput("Success on attempt $attempt")
@@ -177,7 +177,7 @@ class ActionRetryTest {
         @AchievesGoal(description = "Process")
         fun process(input: TestInput): TestOutput {
             attempts.incrementAndGet()
-            throw ActionException.NonRetryable("Validation error")
+            throw ActionException.Permanent("Validation error")
         }
     }
 
@@ -200,7 +200,7 @@ class ActionRetryTest {
                 // First attempt sets both conditions then fails
                 context.setCondition("dataProcessed", true)
                 context.setCondition("otherCondition", true)
-                throw ActionException.Retryable("First attempt fails")
+                throw ActionException.Transient("First attempt fails")
             }
 
             // On retry, only effect condition (in post) should be cleared

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicyTest.kt
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.springai
+
+import com.embabel.agent.api.tool.TerminateActionException
+import com.embabel.agent.api.tool.TerminateAgentException
+import com.embabel.agent.core.ActionException
+import com.embabel.agent.core.NonRetryableException
+import com.embabel.agent.core.ReplanRequestedException
+import com.embabel.agent.core.RetryableException
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.ai.retry.NonTransientAiException
+import org.springframework.ai.retry.TransientAiException
+import org.springframework.retry.RetryContext
+import org.springframework.retry.context.RetryContextSupport
+
+/**
+ * Tests for SpringAiRetryPolicy retry decision logic.
+ */
+class SpringAiRetryPolicyTest {
+
+    private val policy = SpringAiRetryPolicy(maxAttempts = 3)
+
+    private fun createContext(retryCount: Int, throwable: Throwable?): RetryContext {
+        val context = RetryContextSupport(null)
+        repeat(retryCount) {
+            context.registerThrowable(throwable)
+        }
+        return context
+    }
+
+    @Test
+    fun `first attempt always retries`() {
+        val context = createContext(0, null)
+        assertTrue(policy.canRetry(context))
+    }
+
+    @Test
+    fun `exceeding maxAttempts stops retry`() {
+        val context = createContext(3, RuntimeException("error"))
+        assertFalse(policy.canRetry(context))
+    }
+
+    @Nested
+    inner class ControlFlowSignalsTests {
+
+        @Test
+        fun `TerminateActionException does not retry`() {
+            val context = createContext(1, TerminateActionException("test"))
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `TerminateAgentException does not retry`() {
+            val context = createContext(1, TerminateAgentException("test"))
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `ReplanRequestedException does not retry`() {
+            val context = createContext(1, ReplanRequestedException("test"))
+            assertFalse(policy.canRetry(context))
+        }
+    }
+
+    @Nested
+    inner class ExplicitMarkersTests {
+
+        @Test
+        fun `NonRetryableException does not retry`() {
+            val exception = ActionException.NonRetryable("validation error")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `RetryableException retries`() {
+            val exception = ActionException.Retryable("timeout")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context))
+        }
+
+        @Test
+        fun `custom NonRetryableException implementation does not retry`() {
+            class CustomNonRetryable(message: String) : RuntimeException(message), NonRetryableException
+
+            val exception = CustomNonRetryable("custom error")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `custom RetryableException implementation retries`() {
+            class CustomRetryable(message: String) : RuntimeException(message), RetryableException
+
+            val exception = CustomRetryable("custom error")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context))
+        }
+
+        @Test
+        fun `wrapped NonRetryableException in cause chain does not retry`() {
+            val rootCause = ActionException.NonRetryable("validation error")
+            val wrapped = RuntimeException("wrapped", rootCause)
+            val context = createContext(1, wrapped)
+            assertFalse(policy.canRetry(context), "Wrapped NonRetryableException should be detected in cause chain")
+        }
+
+        @Test
+        fun `wrapped RetryableException in cause chain retries`() {
+            val rootCause = ActionException.Retryable("timeout")
+            val wrapped = RuntimeException("wrapped", rootCause)
+            val context = createContext(1, wrapped)
+            assertTrue(policy.canRetry(context), "Wrapped RetryableException should be detected in cause chain")
+        }
+
+        @Test
+        fun `deeply nested NonRetryableException in cause chain does not retry`() {
+            val rootCause = ActionException.NonRetryable("validation error")
+            val wrapped1 = RuntimeException("level 1", rootCause)
+            val wrapped2 = IllegalStateException("level 2", wrapped1)
+            val wrapped3 = RuntimeException("level 3", wrapped2)
+            val context = createContext(1, wrapped3)
+            assertFalse(policy.canRetry(context), "Deeply nested NonRetryableException should be detected")
+        }
+    }
+
+    @Nested
+    inner class SpringAiExceptionsTests {
+
+        @Test
+        fun `TransientAiException retries`() {
+            val exception = TransientAiException("transient error")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context))
+        }
+
+        @Test
+        fun `NonTransientAiException without rate limit does not retry`() {
+            val exception = NonTransientAiException("permanent error")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `NonTransientAiException with rate limit retries`() {
+            val exception = NonTransientAiException("rate limit exceeded")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context))
+        }
+
+        @Test
+        fun `NonTransientAiException with rate-limit retries`() {
+            val exception = NonTransientAiException("rate-limit error")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context))
+        }
+    }
+
+    @Nested
+    inner class ProgrammingErrorsTests {
+
+        @Test
+        fun `IllegalArgumentException does not retry`() {
+            val exception = IllegalArgumentException("invalid argument")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `IllegalStateException does not retry`() {
+            val exception = IllegalStateException("invalid state")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `UnsupportedOperationException does not retry`() {
+            val exception = UnsupportedOperationException("not supported")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `NullPointerException does not retry`() {
+            val exception = NullPointerException("null reference")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `ClassCastException does not retry`() {
+            val exception = ClassCastException("invalid cast")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+    }
+
+    @Nested
+    inner class BackwardCompatibilityTests {
+
+        @Test
+        fun `unknown exception retries by default`() {
+            class CustomException(message: String) : RuntimeException(message)
+
+            val exception = CustomException("unknown error")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context), "Unknown exceptions should retry for backward compatibility")
+        }
+
+        @Test
+        fun `IOException retries by default`() {
+            val exception = java.io.IOException("network error")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context))
+        }
+
+        @Test
+        fun `generic RuntimeException retries by default`() {
+            val exception = RuntimeException("generic error")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context))
+        }
+    }
+
+    @Nested
+    inner class PriorityTests {
+
+        @Test
+        fun `explicit NonRetryableException marker takes precedence over default retry`() {
+            // Even though RuntimeException normally retries, the marker should take precedence
+            val exception = ActionException.NonRetryable("should not retry")
+            val context = createContext(1, exception)
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `explicit RetryableException marker takes precedence over programming error check`() {
+            // Create a retryable exception that extends IllegalArgumentException
+            class RetryableIllegalArg(message: String) : IllegalArgumentException(message), RetryableException
+
+            val exception = RetryableIllegalArg("should retry despite being IllegalArgument")
+            val context = createContext(1, exception)
+            assertTrue(policy.canRetry(context), "Explicit RetryableException marker should take precedence")
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicyTest.kt
@@ -16,11 +16,11 @@
 package com.embabel.agent.spi.support.springai
 
 import com.embabel.agent.api.tool.TerminateActionException
+import com.embabel.agent.core.NonRetryable
+import com.embabel.agent.core.Retryable
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.core.ActionException
-import com.embabel.agent.core.NonRetryableException
 import com.embabel.agent.core.ReplanRequestedException
-import com.embabel.agent.core.RetryableException
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
@@ -83,22 +83,22 @@ class SpringAiRetryPolicyTest {
     inner class ExplicitMarkersTests {
 
         @Test
-        fun `NonRetryableException does not retry`() {
-            val exception = ActionException.NonRetryable("validation error")
+        fun `NonRetryable does not retry`() {
+            val exception = ActionException.Permanent("validation error")
             val context = createContext(1, exception)
             assertFalse(policy.canRetry(context))
         }
 
         @Test
-        fun `RetryableException retries`() {
-            val exception = ActionException.Retryable("timeout")
+        fun `Retryable retries`() {
+            val exception = ActionException.Transient("timeout")
             val context = createContext(1, exception)
             assertTrue(policy.canRetry(context))
         }
 
         @Test
-        fun `custom NonRetryableException implementation does not retry`() {
-            class CustomNonRetryable(message: String) : RuntimeException(message), NonRetryableException
+        fun `custom NonRetryable implementation does not retry`() {
+            class CustomNonRetryable(message: String) : RuntimeException(message), NonRetryable
 
             val exception = CustomNonRetryable("custom error")
             val context = createContext(1, exception)
@@ -106,8 +106,8 @@ class SpringAiRetryPolicyTest {
         }
 
         @Test
-        fun `custom RetryableException implementation retries`() {
-            class CustomRetryable(message: String) : RuntimeException(message), RetryableException
+        fun `custom Retryable implementation retries`() {
+            class CustomRetryable(message: String) : RuntimeException(message), Retryable
 
             val exception = CustomRetryable("custom error")
             val context = createContext(1, exception)
@@ -115,29 +115,29 @@ class SpringAiRetryPolicyTest {
         }
 
         @Test
-        fun `wrapped NonRetryableException in cause chain does not retry`() {
-            val rootCause = ActionException.NonRetryable("validation error")
+        fun `wrapped NonRetryable in cause chain does not retry`() {
+            val rootCause = ActionException.Permanent("validation error")
             val wrapped = RuntimeException("wrapped", rootCause)
             val context = createContext(1, wrapped)
-            assertFalse(policy.canRetry(context), "Wrapped NonRetryableException should be detected in cause chain")
+            assertFalse(policy.canRetry(context), "Wrapped NonRetryable should be detected in cause chain")
         }
 
         @Test
-        fun `wrapped RetryableException in cause chain retries`() {
-            val rootCause = ActionException.Retryable("timeout")
+        fun `wrapped Retryable in cause chain retries`() {
+            val rootCause = ActionException.Transient("timeout")
             val wrapped = RuntimeException("wrapped", rootCause)
             val context = createContext(1, wrapped)
-            assertTrue(policy.canRetry(context), "Wrapped RetryableException should be detected in cause chain")
+            assertTrue(policy.canRetry(context), "Wrapped Retryable should be detected in cause chain")
         }
 
         @Test
-        fun `deeply nested NonRetryableException in cause chain does not retry`() {
-            val rootCause = ActionException.NonRetryable("validation error")
+        fun `deeply nested NonRetryable in cause chain does not retry`() {
+            val rootCause = ActionException.Permanent("validation error")
             val wrapped1 = RuntimeException("level 1", rootCause)
             val wrapped2 = IllegalStateException("level 2", wrapped1)
             val wrapped3 = RuntimeException("level 3", wrapped2)
             val context = createContext(1, wrapped3)
-            assertFalse(policy.canRetry(context), "Deeply nested NonRetryableException should be detected")
+            assertFalse(policy.canRetry(context), "Deeply nested NonRetryable should be detected")
         }
     }
 
@@ -243,21 +243,21 @@ class SpringAiRetryPolicyTest {
     inner class PriorityTests {
 
         @Test
-        fun `explicit NonRetryableException marker takes precedence over default retry`() {
+        fun `explicit NonRetryable marker takes precedence over default retry`() {
             // Even though RuntimeException normally retries, the marker should take precedence
-            val exception = ActionException.NonRetryable("should not retry")
+            val exception = ActionException.Permanent("should not retry")
             val context = createContext(1, exception)
             assertFalse(policy.canRetry(context))
         }
 
         @Test
-        fun `explicit RetryableException marker takes precedence over programming error check`() {
+        fun `explicit Retryable marker takes precedence over programming error check`() {
             // Create a retryable exception that extends IllegalArgumentException
-            class RetryableIllegalArg(message: String) : IllegalArgumentException(message), RetryableException
+            class RetryableIllegalArg(message: String) : IllegalArgumentException(message), Retryable
 
             val exception = RetryableIllegalArg("should retry despite being IllegalArgument")
             val context = createContext(1, exception)
-            assertTrue(policy.canRetry(context), "Explicit RetryableException marker should take precedence")
+            assertTrue(policy.canRetry(context), "Explicit Retryable marker should take precedence")
         }
     }
 }

--- a/embabel-agent-docs/src/main/asciidoc/reference/annotations/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/annotations/page.adoc
@@ -1636,3 +1636,151 @@ Both `RunSubagent` and `ActionContext.asSubProcess` achieve the same result, but
 
 TIP: Use `RunSubagent` when your action method only needs to delegate to a subagent.
 Use `ActionContext.asSubProcess()` when you need additional context operations.
+
+==== Action Exception Handling
+
+Exception handling within Action is governed by Retry Policy.
+
+All exceptions below, except `TransientAiException` are considered as non-retryable.
+More specifically, policy categorises non-retryable exception in the order:
+
+- ReplanRequestedException
+- TerminateActionException
+- TerminateAgentException
+- ToolControlFlowSignal
+- NonTransientAiException
+- IllegalArgumentException
+- IllegalStateException
+- UnsupportedOperationException
+- ClassCastException
+
+If exception does not belong to any of the exceptions from the list above - it gets mapped to retryable exception.
+
+Framework allows creating custom Retryable / NonRetryable exception in order for developers to exercise complete control over Action Retry.
+
+Embabel provides with two approaches for defining custom retryable and non-retryable exceptions:
+
+1. **Extend ActionException** - Convenient base classes with built-in retry classification
+2. **Implement marker interfaces** - Maximum flexibility for existing exception hierarchies
+
+===== Approach 1: Extending ActionException
+
+The recommended approach is to extend `ActionException.Transient` for retryable failures or `ActionException.Permanent` for non-retryable failures:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+  import com.embabel.agent.core.ActionException
+
+  // Transient failure - will be retried
+  class ApiTimeoutException(message: String, cause: Throwable? = null)
+      : ActionException.Transient(message, cause)
+
+  // Permanent failure - will not be retried
+  class ValidationException(message: String, cause: Throwable? = null)
+      : ActionException.Permanent(message, cause)
+----
+
+Java::
+ +
+[source,java]
+----
+import com.embabel.agent.core.ActionException;
+
+  // Transient failure - will be retried
+  public class ApiTimeoutException extends ActionException.Transient {
+      public ApiTimeoutException(String message) {
+          super(message);
+      }
+
+      public ApiTimeoutException(String message, Throwable cause) {
+          super(message, cause);
+      }
+  }
+
+  // Permanent failure - will not be retried
+  public class ValidationException extends ActionException.Permanent {
+      public ValidationException(String message) {
+          super(message);
+      }
+
+      public ValidationException(String message, Throwable cause) {
+          super(message, cause);
+      }
+  }
+----
+====
+
+===== Approach 2: Implementing Marker Interfaces
+
+  For existing exception hierarchies or when you need more control, implement the `Retryable` or `NonRetryable` marker interfaces directly:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+  import com.embabel.agent.core.Retryable
+  import com.embabel.agent.core.NonRetryable
+
+  // Transient failure - will be retried
+  class NetworkException(message: String, cause: Throwable? = null)
+      : RuntimeException(message, cause), Retryable
+
+  // Permanent failure - will not be retried
+  class InvalidOrderException(message: String)
+      : RuntimeException(message), NonRetryable
+----
+
+Java::
+ +
+[source,java]
+----
+import com.embabel.agent.core.Retryable;
+import com.embabel.agent.core.NonRetryable;
+
+  // Transient failure - will be retried
+  public class NetworkException extends RuntimeException implements Retryable {
+      public NetworkException(String message) {
+          super(message);
+      }
+
+      public NetworkException(String message, Throwable cause) {
+          super(message, cause);
+      }
+  }
+
+  // Permanent failure - will not be retried
+  public class InvalidOrderException extends RuntimeException implements NonRetryable {
+      public InvalidOrderException(String message) {
+          super(message);
+      }
+  }
+----
+====
+
+===== Common Use Cases
+
+**Transient Failures** (use `ActionException.Transient` or `Retryable`):
+
+- Network timeouts
+- Rate limiting (429 errors)
+- Temporary resource unavailability
+- Connection failures
+- Database deadlocks
+
+**Permanent Failures** (use `ActionException.Permanent` or `NonRetryable`):
+
+- Validation errors
+- Business rule violations
+- Invalid parameters
+- Resource not found (404 errors)
+- Authentication failures (401 errors)
+- Authorization failures (403 errors)
+
+
+


### PR DESCRIPTION
# Action Retry:   Exception Classification and Effect Condition Clearing 

Please refer to issue #1186 

* intoduce Retryable, NonRetryable interfaces
* factor exceptions above into Spring AI retry policy
* proper clear action conditions upon retry
                                                                                                           
                                                                                                                                                                                              
  ## Problem Statement                                                                                                                                                                        
                                                                                                                                                                                              
  The current retry mechanism has three critical issues:                                                                                                                                      
                                                                                                                                                                                              
  1. **Indiscriminate Retry**: LLM failures (should retry) and user code exceptions (mostly shouldn't retry) are treated the same way, causing unnecessary retry attempts for deterministic   
  failures like validation errors.                                                                                                                                                            
                                                                                                                                                                                              
  2. **Lack of User Control**: Users have no way to explicitly control retry behavior for their custom exceptions. All exceptions follow the same retry logic regardless of whether the       
  failure is transient or permanent.                                                                                                                                                          
                                                                                                                                                                                              
  3. **State Corruption on Retry**: When an action fails and retries, effect conditions (from `@Action(post = [...])`) set during the failed attempt persist, causing the planner to          
  incorrectly believe those conditions are satisfied.                                                                                                                                         
                                                                                                                                                                                              
  ## Solution                                                                                                                                                                                 
                                                                                                                                                                                              
  Implemented exception classification approach:                                                                                                                        
                                                                                                                                                                                              
  ### 1. Exception Markers for User Control                                                                                                                                                   
                                                                                                                                                                                              
  - `Retryable` interface - marks exceptions that should trigger retry                                                                                                               
  - `NonRetryable` interface - marks exceptions that should not retry                                                                                                                
  - `ActionException.Retryable` and `ActionException.NonRetryable` - convenient base classes                                                                                                  
                                                                                                                                                                                              
  Users can now explicitly control retry behavior:                                                                                                                                            
  ```kotlin                                                                                                                                                                                   
 * import com.embabel.agent.core.ActionException
 *
 * // Extend ActionException for domain-specific exceptions
 * class ValidationException(message: String)
 *     : ActionException.Permanent(message)
 *
 * class ApiTimeoutException(message: String, cause: Throwable? = null)
 *     : ActionException.Transient(message, cause)
 *
 * // Or implement marker interfaces directly
 * import com.embabel.agent.core.NonRetryable
 * import com.embabel.agent.core.Retryable
 *
 * class CustomValidationError(message: String)
 *     : RuntimeException(message), NonRetryable
 *
 * class CustomTimeoutError(message: String)
 *     : RuntimeException(message), Retryable
                                                                                                                                
   ```
                                                                                                                                                                                           
 ###  2. Enhanced Retry Policy                                                                                                                                                                    
                                                                                                                                                                                              
  Updated SpringAiRetryPolicy to check exception cause chains with priority-based classification:                                                                                             
  1. Explicit markers (Retryable, NonRetryable) - highest priority                                                                                                          
  2. Control flow signals (TerminateActionException, etc.) - never retry                                                                                                                      
  3. Spring AI markers (TransientAiException, rate-limited NonTransientAiException)                                                                                                           
  4. Programming errors (IllegalArgumentException, etc.) - never retry                                                                                                                        
  5. Unknown exceptions - retry by default (backward compatible)                                                                                                                              
                                                                                                                                                                                              
###  3. Effect Condition Clearing                                                                                                                                                                
                                                                                                                                                                                              
  Modified AbstractAgentProcess.executeAction() to clear effect conditions before retry attempts, preventing state corruption.                                                                
                                                                                                                                                                                              
 ##  Changes                                                                                                                                                                                     
                                                                                                                                                                                              
 ### New Files                                                                                                                                                                                   
                                                                                                                                                                                              
  - ActionExceptions.kt - Exception marker interfaces and sealed class                                                                                                                        
  - SpringAiRetryPolicyTest.kt - Unit tests for retry policy (6 nested classes, 19 tests)                                                                                                     
  - ActionExceptionsTest.kt - Unit tests for exception markers (4 nested classes, 19 tests)                                                                                                   
  - ActionRetryTest.kt - Integration tests for retry behavior (2 nested classes, 3 tests)                                                                                                     
                                                                                                                                                                                              
###  Modified Files                                                                                                                                                                              
                                                                                                                                                                                              
  - SpringAiRetryPolicy.kt - Added marker interface checks in cause chain traversal                                                                                                           
  - AbstractAgentProcess.kt - Clear effect conditions on retry (line 562-570)                                                                                                                 
                                                                                                                                                                                              
  Testing                                                                                                                                                                                     
                                                                                                                                                                                              
  All tests pass with 97%+ coverage:                                                                                                                                                          
  - Unit tests verify retry policy logic with all exception types                                                                                                                             
  - Agent Process  tests verify end-to-end retry behavior with fast backoff (20ms)                                                                                                               
  - Effect condition test validates selective clearing (only conditions in post array)                                                                                                        
                                                                                                                                                                                              
  Backward Compatibility                                                                                                                                                                      
                                                                                                                                                                                              
  ✅ Maintained - unknown exceptions still retry by default                                                                                                                                   
  ```                                                                                                                                                                                         
