### PR TITLE
Fixes #1298, resolving inconsistency in Lucene search syntax

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
@@ -166,8 +166,16 @@ interface TextSearch : TypeRetrievalOperations {
     /**
      * Notes on how much Lucene syntax is supported by this implementation
      * to help LLMs and users craft effective queries.
+     *
+     * Default is empty — implementations are expected to override with the
+     * actual supported syntax (e.g. `"Full Lucene syntax supported"`,
+     * `"PostgreSQL substring matching only"`, `"Not supported"`). The
+     * default exists so test mocks and minimal stubs don't have to
+     * provide a value, and so [TextSearchTools] can compose its tool
+     * description without crashing on un-stubbed mocks.
      */
     val luceneSyntaxNotes: String
+        get() = ""
 }
 
 /**

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -16,7 +16,9 @@
 package com.embabel.agent.rag.tools
 
 import com.embabel.agent.api.annotation.LlmTool
+import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.filter.PropertyFilter
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.embabel.agent.rag.filter.EntityFilter
 import com.embabel.agent.rag.model.Chunk
 import com.embabel.agent.rag.model.Embeddable
@@ -153,7 +155,19 @@ internal class ResultExpanderTools @JvmOverloads constructor(
 }
 
 /**
- * Tools to perform text search operations with Lucene syntax
+ * Tools to perform text search operations with the syntax supported by
+ * the backing [TextSearch] store.
+ *
+ * Implements [Tool] directly (rather than exposing an `@LlmTool`-annotated
+ * method) so the LLM-visible description can be **composed at construction
+ * time from [TextSearch.luceneSyntaxNotes]**. The previous `@LlmTool`-driven
+ * path hardcoded a Lucene-syntax description that contradicted stores like
+ * `PgVectorStore` ("PostgreSQL substring matching only") or
+ * `DirectoryTextSearch` ("Not supported"); see
+ * [embabel/embabel-agent#1298](https://github.com/embabel/embabel-agent/issues/1298).
+ *
+ * One source of truth: the tool's own description carries the syntax notes.
+ * [com.embabel.agent.rag.tools.ToolishRag.notes] no longer duplicates them.
  */
 internal class TextSearchTools @JvmOverloads constructor(
     private val textSearch: TextSearch,
@@ -161,27 +175,59 @@ internal class TextSearchTools @JvmOverloads constructor(
     private val metadataFilter: PropertyFilter? = null,
     private val entityFilter: EntityFilter? = null,
     private val resultsListener: ResultsListener? = null,
-) : SearchTools {
-    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+) : SearchTools, Tool {
 
-    @LlmTool(
-        description = """
-        Perform BMI25 search. Specify topK and similarity threshold from 0-1
-        Query follows Lucene syntax, e.g. +term for required terms, -term for negative terms,
-        "quoted phrases", wildcards (*), fuzzy (~).
-    """
-    )
-    fun textSearch(
-        @LlmTool.Param(
-            description = """"
-            Query in Lucene syntax,
-            e.g. +term for required terms, -term for negative terms,
-            quoted phrases", wildcards (*), fuzzy (~).
-        """
+    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+    private val objectMapper = jacksonObjectMapper()
+
+    // Deferred so just constructing [TextSearchTools] with a (non-relaxed)
+    // mock doesn't trigger `luceneSyntaxNotes` access. Tests that exercise
+    // search behaviour can keep their existing minimal mocks; only tests
+    // that actually inspect the description need to stub the property.
+    override val definition: Tool.Definition by lazy {
+        Tool.Definition(
+            name = "textSearch",
+            description = buildDescription(textSearch.luceneSyntaxNotes),
+            inputSchema = Tool.InputSchema.of(
+                Tool.Parameter.string(
+                    name = "query",
+                    description = buildQueryParamDescription(textSearch.luceneSyntaxNotes),
+                ),
+                Tool.Parameter.integer(
+                    name = "topK",
+                    description = "Maximum number of results to return.",
+                ),
+                Tool.Parameter.double(
+                    name = "threshold",
+                    description = "Similarity threshold from 0 to 1.",
+                ),
+            ),
         )
+    }
+
+    override fun call(input: String): Tool.Result = try {
+        @Suppress("UNCHECKED_CAST")
+        val params = objectMapper.readValue(input, Map::class.java) as Map<String, Any?>
+        val query = (params["query"] as? String)
+            ?: return Tool.Result.error("'query' parameter is required")
+        val topK = (params["topK"] as? Number)?.toInt()
+            ?: return Tool.Result.error("'topK' parameter is required")
+        val threshold = (params["threshold"] as? Number)?.toDouble()
+            ?: return Tool.Result.error("'threshold' parameter is required")
+        Tool.Result.text(textSearch(query, topK, threshold))
+    } catch (e: Exception) {
+        Tool.Result.error("textSearch failed: ${e.message}")
+    }
+
+    /**
+     * Public so unit tests can drive the search without going through the
+     * JSON [call] entry point. Same shape as the previous `@LlmTool` method
+     * — preserved on purpose so existing tests at this surface still work.
+     */
+    fun textSearch(
         query: String,
         topK: Int,
-        @LlmTool.Param(description = "similarity threshold from 0-1") threshold: ZeroToOne,
+        threshold: ZeroToOne,
     ): String {
         logger.info(
             "Performing text search with query='{}', topK={}, threshold={}, types={}, metadataFilter={}, entityFilter={}",
@@ -226,6 +272,29 @@ internal class TextSearchTools @JvmOverloads constructor(
         ) { inflatedRequest ->
             textSearch.textSearch(inflatedRequest, clazz)
         } as List<SimilarityResult<T>>
+    }
+
+    companion object {
+        /**
+         * Compose the tool's top-level description from the store's
+         * [TextSearch.luceneSyntaxNotes]. When the store reports nothing,
+         * the syntax line is omitted entirely so the LLM doesn't see a
+         * trailing "Query syntax: " with empty contents.
+         */
+        internal fun buildDescription(syntaxNotes: String): String {
+            val base = "Perform BM25 text search. Specify topK and similarity threshold from 0-1."
+            return if (syntaxNotes.isBlank()) base
+            else "$base\n\nQuery syntax: ${syntaxNotes.trim()}"
+        }
+
+        /**
+         * Compose the `query` parameter description from the store's
+         * [TextSearch.luceneSyntaxNotes]. Falls back to a generic line
+         * when nothing is reported.
+         */
+        internal fun buildQueryParamDescription(syntaxNotes: String): String =
+            if (syntaxNotes.isBlank()) "The search query."
+            else "The search query. Syntax: ${syntaxNotes.trim()}"
     }
 }
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -232,9 +232,20 @@ data class ToolishRag @JvmOverloads constructor(
         )
     }
 
-    // LlmReference: returns flat list of inner tools with naming strategy applied
+    // LlmReference: returns flat list of inner tools with naming strategy applied.
+    //
+    // Items in [toolObjects] may already BE [Tool] instances (e.g. [TextSearchTools],
+    // which is a Tool with a description composed dynamically from the store's
+    // [TextSearch.luceneSyntaxNotes]) or they may be classes carrying `@LlmTool`-annotated
+    // methods (most other SearchTools). Handle both — `Tool.fromInstance` would throw
+    // "no @LlmTool methods" on the Tool branch.
     override fun tools(): List<Tool> = toolObjects
-        .flatMap { Tool.fromInstance(it) }
+        .flatMap { instance ->
+            when (instance) {
+                is Tool -> listOf(instance)
+                else -> Tool.fromInstance(instance)
+            }
+        }
         .map { tool -> tool.withName(namingStrategy.transform(tool.definition.name)) }
 
     // Tool interface implementation via lazy UnfoldingTool
@@ -255,12 +266,12 @@ data class ToolishRag @JvmOverloads constructor(
     override fun call(input: String): Tool.Result =
         delegate.call(input)
 
+    // The text-search syntax notes USED to be emitted here, but they're now
+    // composed into the `textSearch` tool's own description in
+    // [TextSearchTools] — single source of truth, fixes the contradiction
+    // surfaced by embabel/embabel-agent#1298. Don't add the syntax line
+    // back here unless the tool description is also updated.
     override fun notes() = """
-        ${
-        (searchOperations as? TextSearch)?.let {
-            "Lucene search syntax support: ${searchOperations.luceneSyntaxNotes}\n"
-        }
-    }
         Hints: ${validHints.joinToString("\n") { it.contribution() }}
         Search acceptance criteria:
         $goal

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
@@ -171,6 +171,7 @@ class ToolishRagTest {
         @Test
         fun `should add textSearch tool when searchOperations is TextSearch`() {
             val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns ""
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -187,6 +188,7 @@ class ToolishRagTest {
         @Test
         fun `should add both tools when searchOperations is CoreSearchOperations`() {
             val coreSearch = mockk<CoreSearchOperations>()
+            every { coreSearch.luceneSyntaxNotes } returns ""
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -221,6 +223,8 @@ class ToolishRagTest {
         fun `multiple ToolishRag instances should have unique namespaced tools`() {
             val coreSearch1 = mockk<CoreSearchOperations>()
             val coreSearch2 = mockk<CoreSearchOperations>()
+            every { coreSearch1.luceneSyntaxNotes } returns ""
+            every { coreSearch2.luceneSyntaxNotes } returns ""
 
             val rag1 = ToolishRag(
                 name = "books",
@@ -289,12 +293,15 @@ class ToolishRagTest {
         }
 
         @Test
-        fun `should include lucene syntax notes in notes`() {
+        fun `notes does NOT duplicate lucene syntax notes (now lives on the textSearch tool description)`() {
+            // Issue embabel/embabel-agent#1298: the lucene syntax notes used to be
+            // emitted both in `notes()` AND in the hardcoded `@LlmTool` description
+            // on `textSearch`, with the two free to disagree. Single source of truth
+            // is now the tool's own description (composed from the store's
+            // `luceneSyntaxNotes`); `notes()` no longer mentions them.
             val textSearch = mockk<TextSearch>()
             val support = "basic +, -, and quotes for phrases"
-            every {
-                textSearch.luceneSyntaxNotes
-            } returns support
+            every { textSearch.luceneSyntaxNotes } returns support
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -302,9 +309,15 @@ class ToolishRagTest {
                 searchOperations = textSearch
             )
 
-            val notes = toolishRag.notes()
-
-            assertTrue(notes.contains("Lucene search syntax support: $support"))
+            assertFalse(
+                toolishRag.notes().contains(support),
+                "notes() must not duplicate the syntax notes — they belong on the textSearch tool's description.",
+            )
+            val textTool = toolishRag.tools().first { it.definition.name == "test_rag_textSearch" }
+            assertTrue(
+                textTool.definition.description.contains(support),
+                "tool description must carry the store's syntax notes; was: ${textTool.definition.description}",
+            )
         }
 
         @Test
@@ -747,6 +760,10 @@ class ToolishRagTest {
             every {
                 coreSearch.textSearch(any<TextSimilaritySearchRequest>(), Chunk::class.java)
             } returns listOf(SimpleSimilaritySearchResult(match = chunk, score = 0.85))
+
+            // Required since #1298 fix: textSearch tool's description is composed
+            // from the store's luceneSyntaxNotes at first definition access.
+            every { coreSearch.luceneSyntaxNotes } returns "test syntax"
 
             val toolishRag = ToolishRag(
                 name = "integration-test",
@@ -1219,6 +1236,7 @@ class ToolishRagTest {
         @Test
         fun `tools returns flat list of namespaced inner tools`() {
             val coreSearch = mockk<CoreSearchOperations>()
+            every { coreSearch.luceneSyntaxNotes } returns ""
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -1237,6 +1255,7 @@ class ToolishRagTest {
         @Test
         fun `Tool interface wraps inner tools in MatryoshkaTool`() {
             val coreSearch = mockk<CoreSearchOperations>()
+            every { coreSearch.luceneSyntaxNotes } returns ""
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -1252,6 +1271,7 @@ class ToolishRagTest {
         @Test
         fun `call delegates to MatryoshkaTool`() {
             val coreSearch = mockk<CoreSearchOperations>()
+            every { coreSearch.luceneSyntaxNotes } returns ""
             val chunk = Chunk(id = "chunk1", text = "Test content", parentId = "parent", metadata = emptyMap())
 
             every {
@@ -1301,6 +1321,110 @@ class ToolishRagTest {
 
             assertNotNull(tool.definition)
             assertEquals("test-rag", tool.definition.name)
+        }
+    }
+
+    /**
+     * Issue [embabel/embabel-agent#1298](https://github.com/embabel/embabel-agent/issues/1298):
+     * `textSearch`'s tool description used to be hardcoded ("+term required, * wildcard,
+     * ~ fuzzy", etc.) regardless of what the backing store actually supported. Stores
+     * could override `luceneSyntaxNotes` to describe their real capabilities (e.g.
+     * `PgVectorStore` → "PostgreSQL substring matching only", `DirectoryTextSearch` →
+     * "Not supported"), but the LLM saw the hardcoded description AND those notes,
+     * potentially in conflict.
+     *
+     * Fix: build the textSearch tool dynamically with the description composed from
+     * the store's `luceneSyntaxNotes` at construction time. Single source of truth.
+     */
+    @Nested
+    inner class TextSearchDynamicDescription {
+
+        @Test
+        fun `tool description includes the store's luceneSyntaxNotes verbatim`() {
+            val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns "PostgreSQL substring matching only"
+
+            val rag = ToolishRag(
+                name = "pg-store",
+                description = "PG-backed store",
+                searchOperations = textSearch,
+            )
+            val textTool = rag.tools().first { it.definition.name == "pg_store_textSearch" }
+
+            assertTrue(
+                textTool.definition.description.contains("PostgreSQL substring matching only"),
+                "tool description must include the store's luceneSyntaxNotes; was: ${textTool.definition.description}",
+            )
+        }
+
+        @Test
+        fun `description varies when stores report different syntax`() {
+            val luceneStore = mockk<TextSearch>()
+            every { luceneStore.luceneSyntaxNotes } returns "Full Lucene syntax supported"
+            val substringStore = mockk<TextSearch>()
+            every { substringStore.luceneSyntaxNotes } returns "Substring matching only — no operators"
+
+            val luceneRag = ToolishRag("lucene", "lucene", searchOperations = luceneStore)
+            val substringRag = ToolishRag("substring", "substring", searchOperations = substringStore)
+
+            val luceneDesc = luceneRag.tools()
+                .first { it.definition.name == "lucene_textSearch" }.definition.description
+            val substringDesc = substringRag.tools()
+                .first { it.definition.name == "substring_textSearch" }.definition.description
+
+            assertTrue(luceneDesc.contains("Full Lucene"), luceneDesc)
+            assertTrue(substringDesc.contains("Substring matching only"), substringDesc)
+            // The two descriptions must NOT both leak each other's syntax — that's
+            // the contradiction the old hardcoded description caused.
+            assertFalse(luceneDesc.contains("Substring matching only"))
+            assertFalse(substringDesc.contains("Full Lucene"))
+        }
+
+        @Test
+        fun `description omits the syntax line entirely when store reports nothing`() {
+            val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns ""
+
+            val rag = ToolishRag("blank", "blank", searchOperations = textSearch)
+            val textTool = rag.tools().first { it.definition.name == "blank_textSearch" }
+
+            // The base sentence is still there...
+            assertTrue(textTool.definition.description.contains("Perform BM25 text search"))
+            // ...but no dangling "Query syntax: " with empty contents that would
+            // confuse the LLM ("syntax = nothing? do I just type random words?").
+            assertFalse(
+                textTool.definition.description.contains("Query syntax:"),
+                "should not emit a 'Query syntax: ' line when the store reports nothing",
+            )
+        }
+
+        @Test
+        fun `query parameter description also reflects the store's syntax`() {
+            val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns "PostgreSQL `LIKE` patterns with %"
+
+            val rag = ToolishRag("pg", "pg", searchOperations = textSearch)
+            val textTool = rag.tools().first { it.definition.name == "pg_textSearch" }
+            val queryParam = textTool.definition.inputSchema.parameters.first { it.name == "query" }
+
+            assertTrue(
+                queryParam.description.contains("PostgreSQL `LIKE` patterns with %"),
+                "query parameter description must reflect the store's syntax; was: ${queryParam.description}",
+            )
+        }
+
+        @Test
+        fun `notes does not contain the syntax notes (single source of truth is the tool description)`() {
+            val textSearch = mockk<TextSearch>()
+            val syntax = "Some-very-distinctive-token-only-this-test-uses"
+            every { textSearch.luceneSyntaxNotes } returns syntax
+
+            val rag = ToolishRag("test", "test", searchOperations = textSearch)
+
+            assertFalse(
+                rag.notes().contains(syntax),
+                "notes() must not duplicate the syntax notes; the textSearch tool description owns them.",
+            )
         }
     }
 }


### PR DESCRIPTION
Resolves inconsistency in Lucene search syntax disclosure by converting `ToolishRag` to a `Tool` rather than using annotations. 

Not yet tested against downstream projects.