### PR TITLE
Skip fenced code blocks in skill file-reference extraction

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
@@ -166,8 +166,16 @@ interface TextSearch : TypeRetrievalOperations {
     /**
      * Notes on how much Lucene syntax is supported by this implementation
      * to help LLMs and users craft effective queries.
+     *
+     * Default is empty — implementations are expected to override with the
+     * actual supported syntax (e.g. `"Full Lucene syntax supported"`,
+     * `"PostgreSQL substring matching only"`, `"Not supported"`). The
+     * default exists so test mocks and minimal stubs don't have to
+     * provide a value, and so [TextSearchTools] can compose its tool
+     * description without crashing on un-stubbed mocks.
      */
     val luceneSyntaxNotes: String
+        get() = ""
 }
 
 /**

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -16,7 +16,9 @@
 package com.embabel.agent.rag.tools
 
 import com.embabel.agent.api.annotation.LlmTool
+import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.filter.PropertyFilter
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.embabel.agent.rag.filter.EntityFilter
 import com.embabel.agent.rag.model.Chunk
 import com.embabel.agent.rag.model.Embeddable
@@ -153,7 +155,19 @@ internal class ResultExpanderTools @JvmOverloads constructor(
 }
 
 /**
- * Tools to perform text search operations with Lucene syntax
+ * Tools to perform text search operations with the syntax supported by
+ * the backing [TextSearch] store.
+ *
+ * Implements [Tool] directly (rather than exposing an `@LlmTool`-annotated
+ * method) so the LLM-visible description can be **composed at construction
+ * time from [TextSearch.luceneSyntaxNotes]**. The previous `@LlmTool`-driven
+ * path hardcoded a Lucene-syntax description that contradicted stores like
+ * `PgVectorStore` ("PostgreSQL substring matching only") or
+ * `DirectoryTextSearch` ("Not supported"); see
+ * [embabel/embabel-agent#1298](https://github.com/embabel/embabel-agent/issues/1298).
+ *
+ * One source of truth: the tool's own description carries the syntax notes.
+ * [com.embabel.agent.rag.tools.ToolishRag.notes] no longer duplicates them.
  */
 internal class TextSearchTools @JvmOverloads constructor(
     private val textSearch: TextSearch,
@@ -161,27 +175,59 @@ internal class TextSearchTools @JvmOverloads constructor(
     private val metadataFilter: PropertyFilter? = null,
     private val entityFilter: EntityFilter? = null,
     private val resultsListener: ResultsListener? = null,
-) : SearchTools {
-    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+) : SearchTools, Tool {
 
-    @LlmTool(
-        description = """
-        Perform BMI25 search. Specify topK and similarity threshold from 0-1
-        Query follows Lucene syntax, e.g. +term for required terms, -term for negative terms,
-        "quoted phrases", wildcards (*), fuzzy (~).
-    """
-    )
-    fun textSearch(
-        @LlmTool.Param(
-            description = """"
-            Query in Lucene syntax,
-            e.g. +term for required terms, -term for negative terms,
-            quoted phrases", wildcards (*), fuzzy (~).
-        """
+    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+    private val objectMapper = jacksonObjectMapper()
+
+    // Deferred so just constructing [TextSearchTools] with a (non-relaxed)
+    // mock doesn't trigger `luceneSyntaxNotes` access. Tests that exercise
+    // search behaviour can keep their existing minimal mocks; only tests
+    // that actually inspect the description need to stub the property.
+    override val definition: Tool.Definition by lazy {
+        Tool.Definition(
+            name = "textSearch",
+            description = buildDescription(textSearch.luceneSyntaxNotes),
+            inputSchema = Tool.InputSchema.of(
+                Tool.Parameter.string(
+                    name = "query",
+                    description = buildQueryParamDescription(textSearch.luceneSyntaxNotes),
+                ),
+                Tool.Parameter.integer(
+                    name = "topK",
+                    description = "Maximum number of results to return.",
+                ),
+                Tool.Parameter.double(
+                    name = "threshold",
+                    description = "Similarity threshold from 0 to 1.",
+                ),
+            ),
         )
+    }
+
+    override fun call(input: String): Tool.Result = try {
+        @Suppress("UNCHECKED_CAST")
+        val params = objectMapper.readValue(input, Map::class.java) as Map<String, Any?>
+        val query = (params["query"] as? String)
+            ?: return Tool.Result.error("'query' parameter is required")
+        val topK = (params["topK"] as? Number)?.toInt()
+            ?: return Tool.Result.error("'topK' parameter is required")
+        val threshold = (params["threshold"] as? Number)?.toDouble()
+            ?: return Tool.Result.error("'threshold' parameter is required")
+        Tool.Result.text(textSearch(query, topK, threshold))
+    } catch (e: Exception) {
+        Tool.Result.error("textSearch failed: ${e.message}")
+    }
+
+    /**
+     * Public so unit tests can drive the search without going through the
+     * JSON [call] entry point. Same shape as the previous `@LlmTool` method
+     * — preserved on purpose so existing tests at this surface still work.
+     */
+    fun textSearch(
         query: String,
         topK: Int,
-        @LlmTool.Param(description = "similarity threshold from 0-1") threshold: ZeroToOne,
+        threshold: ZeroToOne,
     ): String {
         logger.info(
             "Performing text search with query='{}', topK={}, threshold={}, types={}, metadataFilter={}, entityFilter={}",
@@ -226,6 +272,29 @@ internal class TextSearchTools @JvmOverloads constructor(
         ) { inflatedRequest ->
             textSearch.textSearch(inflatedRequest, clazz)
         } as List<SimilarityResult<T>>
+    }
+
+    companion object {
+        /**
+         * Compose the tool's top-level description from the store's
+         * [TextSearch.luceneSyntaxNotes]. When the store reports nothing,
+         * the syntax line is omitted entirely so the LLM doesn't see a
+         * trailing "Query syntax: " with empty contents.
+         */
+        internal fun buildDescription(syntaxNotes: String): String {
+            val base = "Perform BM25 text search. Specify topK and similarity threshold from 0-1."
+            return if (syntaxNotes.isBlank()) base
+            else "$base\n\nQuery syntax: ${syntaxNotes.trim()}"
+        }
+
+        /**
+         * Compose the `query` parameter description from the store's
+         * [TextSearch.luceneSyntaxNotes]. Falls back to a generic line
+         * when nothing is reported.
+         */
+        internal fun buildQueryParamDescription(syntaxNotes: String): String =
+            if (syntaxNotes.isBlank()) "The search query."
+            else "The search query. Syntax: ${syntaxNotes.trim()}"
     }
 }
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -232,9 +232,20 @@ data class ToolishRag @JvmOverloads constructor(
         )
     }
 
-    // LlmReference: returns flat list of inner tools with naming strategy applied
+    // LlmReference: returns flat list of inner tools with naming strategy applied.
+    //
+    // Items in [toolObjects] may already BE [Tool] instances (e.g. [TextSearchTools],
+    // which is a Tool with a description composed dynamically from the store's
+    // [TextSearch.luceneSyntaxNotes]) or they may be classes carrying `@LlmTool`-annotated
+    // methods (most other SearchTools). Handle both — `Tool.fromInstance` would throw
+    // "no @LlmTool methods" on the Tool branch.
     override fun tools(): List<Tool> = toolObjects
-        .flatMap { Tool.fromInstance(it) }
+        .flatMap { instance ->
+            when (instance) {
+                is Tool -> listOf(instance)
+                else -> Tool.fromInstance(instance)
+            }
+        }
         .map { tool -> tool.withName(namingStrategy.transform(tool.definition.name)) }
 
     // Tool interface implementation via lazy UnfoldingTool
@@ -255,12 +266,12 @@ data class ToolishRag @JvmOverloads constructor(
     override fun call(input: String): Tool.Result =
         delegate.call(input)
 
+    // The text-search syntax notes USED to be emitted here, but they're now
+    // composed into the `textSearch` tool's own description in
+    // [TextSearchTools] — single source of truth, fixes the contradiction
+    // surfaced by embabel/embabel-agent#1298. Don't add the syntax line
+    // back here unless the tool description is also updated.
     override fun notes() = """
-        ${
-        (searchOperations as? TextSearch)?.let {
-            "Lucene search syntax support: ${searchOperations.luceneSyntaxNotes}\n"
-        }
-    }
         Hints: ${validHints.joinToString("\n") { it.contribution() }}
         Search acceptance criteria:
         $goal

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
@@ -171,6 +171,7 @@ class ToolishRagTest {
         @Test
         fun `should add textSearch tool when searchOperations is TextSearch`() {
             val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns ""
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -187,6 +188,7 @@ class ToolishRagTest {
         @Test
         fun `should add both tools when searchOperations is CoreSearchOperations`() {
             val coreSearch = mockk<CoreSearchOperations>()
+            every { coreSearch.luceneSyntaxNotes } returns ""
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -221,6 +223,8 @@ class ToolishRagTest {
         fun `multiple ToolishRag instances should have unique namespaced tools`() {
             val coreSearch1 = mockk<CoreSearchOperations>()
             val coreSearch2 = mockk<CoreSearchOperations>()
+            every { coreSearch1.luceneSyntaxNotes } returns ""
+            every { coreSearch2.luceneSyntaxNotes } returns ""
 
             val rag1 = ToolishRag(
                 name = "books",
@@ -289,12 +293,15 @@ class ToolishRagTest {
         }
 
         @Test
-        fun `should include lucene syntax notes in notes`() {
+        fun `notes does NOT duplicate lucene syntax notes (now lives on the textSearch tool description)`() {
+            // Issue embabel/embabel-agent#1298: the lucene syntax notes used to be
+            // emitted both in `notes()` AND in the hardcoded `@LlmTool` description
+            // on `textSearch`, with the two free to disagree. Single source of truth
+            // is now the tool's own description (composed from the store's
+            // `luceneSyntaxNotes`); `notes()` no longer mentions them.
             val textSearch = mockk<TextSearch>()
             val support = "basic +, -, and quotes for phrases"
-            every {
-                textSearch.luceneSyntaxNotes
-            } returns support
+            every { textSearch.luceneSyntaxNotes } returns support
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -302,9 +309,15 @@ class ToolishRagTest {
                 searchOperations = textSearch
             )
 
-            val notes = toolishRag.notes()
-
-            assertTrue(notes.contains("Lucene search syntax support: $support"))
+            assertFalse(
+                toolishRag.notes().contains(support),
+                "notes() must not duplicate the syntax notes — they belong on the textSearch tool's description.",
+            )
+            val textTool = toolishRag.tools().first { it.definition.name == "test_rag_textSearch" }
+            assertTrue(
+                textTool.definition.description.contains(support),
+                "tool description must carry the store's syntax notes; was: ${textTool.definition.description}",
+            )
         }
 
         @Test
@@ -747,6 +760,10 @@ class ToolishRagTest {
             every {
                 coreSearch.textSearch(any<TextSimilaritySearchRequest>(), Chunk::class.java)
             } returns listOf(SimpleSimilaritySearchResult(match = chunk, score = 0.85))
+
+            // Required since #1298 fix: textSearch tool's description is composed
+            // from the store's luceneSyntaxNotes at first definition access.
+            every { coreSearch.luceneSyntaxNotes } returns "test syntax"
 
             val toolishRag = ToolishRag(
                 name = "integration-test",
@@ -1219,6 +1236,7 @@ class ToolishRagTest {
         @Test
         fun `tools returns flat list of namespaced inner tools`() {
             val coreSearch = mockk<CoreSearchOperations>()
+            every { coreSearch.luceneSyntaxNotes } returns ""
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -1237,6 +1255,7 @@ class ToolishRagTest {
         @Test
         fun `Tool interface wraps inner tools in MatryoshkaTool`() {
             val coreSearch = mockk<CoreSearchOperations>()
+            every { coreSearch.luceneSyntaxNotes } returns ""
 
             val toolishRag = ToolishRag(
                 name = "test-rag",
@@ -1252,6 +1271,7 @@ class ToolishRagTest {
         @Test
         fun `call delegates to MatryoshkaTool`() {
             val coreSearch = mockk<CoreSearchOperations>()
+            every { coreSearch.luceneSyntaxNotes } returns ""
             val chunk = Chunk(id = "chunk1", text = "Test content", parentId = "parent", metadata = emptyMap())
 
             every {
@@ -1301,6 +1321,110 @@ class ToolishRagTest {
 
             assertNotNull(tool.definition)
             assertEquals("test-rag", tool.definition.name)
+        }
+    }
+
+    /**
+     * Issue [embabel/embabel-agent#1298](https://github.com/embabel/embabel-agent/issues/1298):
+     * `textSearch`'s tool description used to be hardcoded ("+term required, * wildcard,
+     * ~ fuzzy", etc.) regardless of what the backing store actually supported. Stores
+     * could override `luceneSyntaxNotes` to describe their real capabilities (e.g.
+     * `PgVectorStore` → "PostgreSQL substring matching only", `DirectoryTextSearch` →
+     * "Not supported"), but the LLM saw the hardcoded description AND those notes,
+     * potentially in conflict.
+     *
+     * Fix: build the textSearch tool dynamically with the description composed from
+     * the store's `luceneSyntaxNotes` at construction time. Single source of truth.
+     */
+    @Nested
+    inner class TextSearchDynamicDescription {
+
+        @Test
+        fun `tool description includes the store's luceneSyntaxNotes verbatim`() {
+            val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns "PostgreSQL substring matching only"
+
+            val rag = ToolishRag(
+                name = "pg-store",
+                description = "PG-backed store",
+                searchOperations = textSearch,
+            )
+            val textTool = rag.tools().first { it.definition.name == "pg_store_textSearch" }
+
+            assertTrue(
+                textTool.definition.description.contains("PostgreSQL substring matching only"),
+                "tool description must include the store's luceneSyntaxNotes; was: ${textTool.definition.description}",
+            )
+        }
+
+        @Test
+        fun `description varies when stores report different syntax`() {
+            val luceneStore = mockk<TextSearch>()
+            every { luceneStore.luceneSyntaxNotes } returns "Full Lucene syntax supported"
+            val substringStore = mockk<TextSearch>()
+            every { substringStore.luceneSyntaxNotes } returns "Substring matching only — no operators"
+
+            val luceneRag = ToolishRag("lucene", "lucene", searchOperations = luceneStore)
+            val substringRag = ToolishRag("substring", "substring", searchOperations = substringStore)
+
+            val luceneDesc = luceneRag.tools()
+                .first { it.definition.name == "lucene_textSearch" }.definition.description
+            val substringDesc = substringRag.tools()
+                .first { it.definition.name == "substring_textSearch" }.definition.description
+
+            assertTrue(luceneDesc.contains("Full Lucene"), luceneDesc)
+            assertTrue(substringDesc.contains("Substring matching only"), substringDesc)
+            // The two descriptions must NOT both leak each other's syntax — that's
+            // the contradiction the old hardcoded description caused.
+            assertFalse(luceneDesc.contains("Substring matching only"))
+            assertFalse(substringDesc.contains("Full Lucene"))
+        }
+
+        @Test
+        fun `description omits the syntax line entirely when store reports nothing`() {
+            val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns ""
+
+            val rag = ToolishRag("blank", "blank", searchOperations = textSearch)
+            val textTool = rag.tools().first { it.definition.name == "blank_textSearch" }
+
+            // The base sentence is still there...
+            assertTrue(textTool.definition.description.contains("Perform BM25 text search"))
+            // ...but no dangling "Query syntax: " with empty contents that would
+            // confuse the LLM ("syntax = nothing? do I just type random words?").
+            assertFalse(
+                textTool.definition.description.contains("Query syntax:"),
+                "should not emit a 'Query syntax: ' line when the store reports nothing",
+            )
+        }
+
+        @Test
+        fun `query parameter description also reflects the store's syntax`() {
+            val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns "PostgreSQL `LIKE` patterns with %"
+
+            val rag = ToolishRag("pg", "pg", searchOperations = textSearch)
+            val textTool = rag.tools().first { it.definition.name == "pg_textSearch" }
+            val queryParam = textTool.definition.inputSchema.parameters.first { it.name == "query" }
+
+            assertTrue(
+                queryParam.description.contains("PostgreSQL `LIKE` patterns with %"),
+                "query parameter description must reflect the store's syntax; was: ${queryParam.description}",
+            )
+        }
+
+        @Test
+        fun `notes does not contain the syntax notes (single source of truth is the tool description)`() {
+            val textSearch = mockk<TextSearch>()
+            val syntax = "Some-very-distinctive-token-only-this-test-uses"
+            every { textSearch.luceneSyntaxNotes } returns syntax
+
+            val rag = ToolishRag("test", "test", searchOperations = textSearch)
+
+            assertFalse(
+                rag.notes().contains(syntax),
+                "notes() must not duplicate the syntax notes; the textSearch tool description owns them.",
+            )
         }
     }
 }

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/support/InstructionFileReferenceExtractor.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/support/InstructionFileReferenceExtractor.kt
@@ -39,6 +39,22 @@ object InstructionFileReferenceExtractor {
         RegexOption.MULTILINE
     )
 
+    // Matches a CommonMark fenced code block — opening fence at line start
+    // (allowing up to three leading spaces of indent) using ``` or ~~~,
+    // through to the matching closing fence on its own line, OR end of
+    // input if the fence is never closed (CommonMark allows this and
+    // implicitly closes at EOF).
+    //
+    // Why this exists: skill bodies routinely embed code samples that
+    // contain `[label](path)`-shaped strings (JS template literals,
+    // markdown rendered as a string in code, etc.) and resource-dir-
+    // prefixed strings ("scripts/legacy.py"). Those are illustrations,
+    // not real file references, and validating them as files turns any
+    // skill teaching code into a footgun.
+    private val FENCED_CODE_BLOCK = Regex(
+        """(?ms)^[ \t]{0,3}(`{3,}|~{3,})[^\n]*(?:\n|$)(?:.*?(?:\n[ \t]{0,3}\1[ \t]*(?:\n|$)|\z))?"""
+    )
+
     /**
      * Extract all file references from instruction text.
      *
@@ -50,10 +66,14 @@ object InstructionFileReferenceExtractor {
             return emptySet()
         }
 
+        // Strip fenced code blocks BEFORE running the extractors so that
+        // illustrative code samples don't pollute the reference set.
+        val withoutCode = FENCED_CODE_BLOCK.replace(instructions, "")
+
         val references = mutableSetOf<String>()
 
         // Extract markdown link targets that are local paths
-        MARKDOWN_LINK_PATTERN.findAll(instructions).forEach { match ->
+        MARKDOWN_LINK_PATTERN.findAll(withoutCode).forEach { match ->
             val path = match.groupValues[2]
             if (isLocalPath(path)) {
                 references.add(normalizePath(path))
@@ -61,7 +81,7 @@ object InstructionFileReferenceExtractor {
         }
 
         // Extract inline resource paths
-        RESOURCE_PATH_PATTERN.findAll(instructions).forEach { match ->
+        RESOURCE_PATH_PATTERN.findAll(withoutCode).forEach { match ->
             val path = match.groupValues[1]
             references.add(normalizePath(path))
         }

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/support/InstructionFileReferenceExtractorTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/support/InstructionFileReferenceExtractorTest.kt
@@ -157,4 +157,140 @@ class InstructionFileReferenceExtractorTest {
 
         assertEquals(setOf("scripts/build.sh"), result)
     }
+
+    // ─── Fenced code blocks must not contribute file references ──────────
+    //
+    // Skill bodies routinely include code examples in ``` fences. Anything
+    // inside is a sample, not a reference — it must NOT be validated as a
+    // local file. Otherwise any skill teaching code (most of them) is
+    // forced to avoid `[label](path)`-shaped lines and `scripts/foo.x`
+    // strings inside its examples, which is a footgun.
+
+    @Test
+    fun `ignores markdown link inside fenced code block`() {
+        val instructions = """
+            Real reference: [the guide](references/guide.md).
+
+            Example code:
+
+            ```javascript
+            const r = await fetch(url);
+            console.log(`- [${'$'}{hit.title}](${'$'}{hit.url})`);
+            ```
+        """.trimIndent()
+
+        val result = InstructionFileReferenceExtractor.extract(instructions)
+
+        // Only the prose link counts — the JS template literal inside the
+        // fence must be left alone.
+        assertEquals(setOf("references/guide.md"), result)
+    }
+
+    @Test
+    fun `ignores resource path inside fenced code block`() {
+        val instructions = """
+            Run scripts/build.sh to compile.
+
+            ```python
+            # Don't do this — it's just an illustration
+            subprocess.run(["python", "scripts/legacy.py"])
+            ```
+        """.trimIndent()
+
+        val result = InstructionFileReferenceExtractor.extract(instructions)
+
+        // The prose mention is a real reference; the in-fence string is not.
+        assertEquals(setOf("scripts/build.sh"), result)
+    }
+
+    @Test
+    fun `ignores tilde-fenced code block`() {
+        val instructions = """
+            See [docs](references/docs.md).
+
+            ~~~
+            scripts/oops.sh
+            [link](references/oops.md)
+            ~~~
+        """.trimIndent()
+
+        val result = InstructionFileReferenceExtractor.extract(instructions)
+
+        assertEquals(setOf("references/docs.md"), result)
+    }
+
+    @Test
+    fun `ignores fence with language tag`() {
+        val instructions = """
+            ```kotlin
+            // [Foo](references/foo.kt)
+            val x = "scripts/x.kt"
+            ```
+        """.trimIndent()
+
+        val result = InstructionFileReferenceExtractor.extract(instructions)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `handles unclosed fenced code block as code through end of input`() {
+        // CommonMark implicitly closes a fence at end of document. The
+        // extractor must follow the same rule — otherwise a malformed
+        // skill body would suddenly start treating its code as prose.
+        val instructions = """
+            Intro paragraph mentions [real](references/real.md).
+
+            ```
+            scripts/never-real.py
+            [also](references/never-real.md)
+        """.trimIndent()
+
+        val result = InstructionFileReferenceExtractor.extract(instructions)
+
+        assertEquals(setOf("references/real.md"), result)
+    }
+
+    @Test
+    fun `handles multiple fenced blocks interleaved with prose`() {
+        val instructions = """
+            First, see [setup](references/setup.md).
+
+            ```
+            scripts/in-fence-1.sh
+            ```
+
+            Then run scripts/build.sh.
+
+            ```bash
+            scripts/in-fence-2.sh
+            ```
+
+            Finally consult assets/diagram.png.
+        """.trimIndent()
+
+        val result = InstructionFileReferenceExtractor.extract(instructions)
+
+        assertEquals(
+            setOf("references/setup.md", "scripts/build.sh", "assets/diagram.png"),
+            result,
+        )
+    }
+
+    @Test
+    fun `extracts references on the same line as a closing fence terminator`() {
+        // Defensive: prose immediately following the closing fence on the
+        // next line must still be scanned. Verifies the fence regex doesn't
+        // eat the trailing newline + following content.
+        val instructions = """
+            ```
+            scripts/in-fence.sh
+            ```
+            See [the docs](references/docs.md) for details.
+        """.trimIndent()
+
+        val result = InstructionFileReferenceExtractor.extract(instructions)
+
+        assertEquals(setOf("references/docs.md"), result)
+    }
 }


### PR DESCRIPTION
## Summary

- `InstructionFileReferenceExtractor` scans the entire skill body for markdown links and resource paths, including content inside ` ``` ` / ` ~~~ ` fenced code blocks. Any skill that teaches code can accidentally surface "references" that are just illustrations.
- Concrete trigger: a JS template literal of shape `` `- [${hit.title}](${hit.url})` `` inside a code fence is parsed as a markdown link with local target `${hit.url}`, and skill load fails with `references missing files: ${hit.url}`.
- Fix: pre-strip fenced code blocks (CommonMark fence rules — ` ``` ` or `~~~`, up to 3 leading spaces of indent, matching closing fence, implicit close at EOF) before running the link and resource-path regexes. Inline code spans (single backticks) are deliberately left in place — they're commonly used for real filename references in prose.

## Test plan

- [x] New tests cover: markdown link inside fence, resource path inside fence, tilde fence, fence with language tag, unclosed fence (CommonMark implicit close), multiple interleaved fences, prose immediately after a closing fence.
- [x] All 14 pre-existing extractor tests still pass.
- [x] Full `embabel-agent-skills` test suite green (205 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)