### PR TITLE
Introduction of Ephemeral Agent Process

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/termination/TerminationExtensions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/termination/TerminationExtensions.kt
@@ -29,18 +29,44 @@ import com.embabel.agent.core.support.AbstractAgentProcess
  * Request graceful termination of the entire agent process.
  * Convenience extension that delegates to [AgentProcess.terminateAgent].
  *
+ * Kotlin usage:
+ * ```kotlin
+ * processContext.terminateAgent("reason")
+ * ```
+ *
+ * Java usage:
+ * ```java
+ * import static com.embabel.agent.api.termination.Termination.terminateAgent;
+ *
+ * terminateAgent(processContext, "reason");
+ * ```
+ *
  * @param reason Human-readable explanation for termination
  * @see AgentProcess.terminateAgent
  */
+@JvmName("terminateAgent")
 fun ProcessContext.terminateAgent(reason: String) = agentProcess.terminateAgent(reason)
 
 /**
  * Request graceful termination of the current action only.
  * Convenience extension that delegates to [AgentProcess.terminateAction].
  *
+ * Kotlin usage:
+ * ```kotlin
+ * processContext.terminateAction("reason")
+ * ```
+ *
+ * Java usage:
+ * ```java
+ * import static com.embabel.agent.api.termination.Termination.terminateAction;
+ *
+ * terminateAction(processContext, "reason");
+ * ```
+ *
  * @param reason Human-readable explanation for termination
  * @see AgentProcess.terminateAction
  */
+@JvmName("terminateAction")
 fun ProcessContext.terminateAction(reason: String) = agentProcess.terminateAction(reason)
 
 /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/AgentProcessRepository.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/AgentProcessRepository.kt
@@ -41,3 +41,69 @@ interface AgentProcessRepository {
 
     fun delete(agentProcess: AgentProcess)
 }
+
+/**
+ * Abstract base class for AgentProcessRepository implementations that enforces
+ * ephemeral process handling.
+ *
+ * Ephemeral processes (marked with `processOptions.ephemeral = true`) are not persisted
+ * and cannot spawn child processes. This class uses the template method pattern to
+ * prevent persistence of ephemeral processes while allowing implementations to
+ * customize actual persistence logic.
+ *
+ * Implementations should:
+ * - Extend this class instead of implementing AgentProcessRepository directly
+ * - Override [doSave] and [doUpdate] instead of [save] and [update]
+ * - The final [save] and [update] methods will handle ephemeral checks automatically
+ */
+abstract class AbstractAgentProcessRepository : AgentProcessRepository {
+
+    private val logger = org.slf4j.LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Save a new agent process.
+     * This method checks if the process is ephemeral and logs an error if persistence
+     * is attempted. Non-ephemeral processes are delegated to [doSave].
+     */
+    final override fun save(agentProcess: AgentProcess): AgentProcess {
+        if (agentProcess.processOptions.ephemeral) {
+            logger.error(
+                "Attempted to save ephemeral AgentProcess [id={}]. " +
+                "Ephemeral processes are not persisted and do not support wait states. " +
+                "Operation skipped.",
+                agentProcess.id
+            )
+            return agentProcess
+        }
+        return doSave(agentProcess)
+    }
+
+    /**
+     * Update an existing agent process.
+     * This method checks if the process is ephemeral and logs an error if persistence
+     * is attempted. Non-ephemeral processes are delegated to [doUpdate].
+     */
+    final override fun update(agentProcess: AgentProcess) {
+        if (agentProcess.processOptions.ephemeral) {
+            logger.error(
+                "Attempted to update ephemeral AgentProcess [id={}]. " +
+                "Ephemeral processes are not persisted. Operation skipped.",
+                agentProcess.id
+            )
+            return
+        }
+        doUpdate(agentProcess)
+    }
+
+    /**
+     * Perform the actual save operation for non-ephemeral processes.
+     * Implementations should override this method instead of [save].
+     */
+    protected abstract fun doSave(agentProcess: AgentProcess): AgentProcess
+
+    /**
+     * Perform the actual update operation for non-ephemeral processes.
+     * Implementations should override this method instead of [update].
+     */
+    protected abstract fun doUpdate(agentProcess: AgentProcess)
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/AgentProcessRepository.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/AgentProcessRepository.kt
@@ -68,9 +68,11 @@ abstract class AbstractAgentProcessRepository : AgentProcessRepository {
     final override fun save(agentProcess: AgentProcess): AgentProcess {
         if (agentProcess.processOptions.ephemeral) {
             logger.error(
-                "Attempted to save ephemeral AgentProcess [id={}]. " +
-                "Ephemeral processes are not persisted and do not support wait states. " +
-                "Operation skipped.",
+                """
+                Attempted to save ephemeral AgentProcess [id={}].
+                Ephemeral processes are not persisted and do not support wait states.
+                Operation skipped.
+                """.trimIndent(),
                 agentProcess.id
             )
             return agentProcess
@@ -86,8 +88,11 @@ abstract class AbstractAgentProcessRepository : AgentProcessRepository {
     final override fun update(agentProcess: AgentProcess) {
         if (agentProcess.processOptions.ephemeral) {
             logger.error(
-                "Attempted to update ephemeral AgentProcess [id={}]. " +
-                "Ephemeral processes are not persisted. Operation skipped.",
+                """
+                Attempted to update ephemeral AgentProcess [id={}].
+                Ephemeral processes are not persisted.
+                Operation skipped.
+                """.trimIndent(),
                 agentProcess.id
             )
             return

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
@@ -204,6 +204,9 @@ constructor(
  * to the budget.
  * @param verbosity detailed verbosity settings for logging etc.
  * @param prune whether to prune the agent to only relevant actions
+ * @param ephemeral whether this process is ephemeral (not persisted). Ephemeral processes
+ * do not support wait states, cannot spawn child processes, and will not be saved to the repository.
+ * This is useful when the Ai interface is injected into non-agent classes that don't need persistence.
  * @param listeners additional listeners (beyond platform event listeners) to receive events from this process.
  * @param outputChannel custom output channel to use for this process.
  * @param plannerType the type of planner to use for this process. Defaults to GOAP planner.
@@ -223,6 +226,7 @@ data class ProcessOptions @JvmOverloads constructor(
         earlyTerminationPolicy = budget.earlyTerminationPolicy(),
     ),
     val prune: Boolean = false,
+    val ephemeral: Boolean = false,
     val listeners: List<AgenticEventListener> = emptyList(),
     val outputChannel: OutputChannel = DevNullOutputChannel,
     val plannerType: PlannerType = PlannerType.GOAP,
@@ -267,6 +271,9 @@ data class ProcessOptions @JvmOverloads constructor(
 
     fun withPrune(prune: Boolean): ProcessOptions =
         this.copy(prune = prune)
+
+    fun withEphemeral(ephemeral: Boolean): ProcessOptions =
+        this.copy(ephemeral = ephemeral)
 
     /**
      * Add additional listeners to this process.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
@@ -211,8 +211,10 @@ open class DefaultAgentPlatform(
     ): AgentProcess {
         // Ephemeral processes cannot spawn child processes
         require(!parentAgentProcess.processOptions.ephemeral) {
-            "Ephemeral AgentProcess [id=${parentAgentProcess.id}] cannot spawn child processes. " +
-            "Ephemeral processes do not support wait states or persistence."
+            """
+            Ephemeral AgentProcess [id=${parentAgentProcess.id}] cannot spawn child processes.
+            Ephemeral processes do not support wait states or persistence.
+            """.trimIndent()
         }
 
         val childBlackboard = parentAgentProcess.processContext.blackboard.spawn()

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
@@ -209,6 +209,12 @@ open class DefaultAgentPlatform(
         agent: Agent,
         parentAgentProcess: AgentProcess,
     ): AgentProcess {
+        // Ephemeral processes cannot spawn child processes
+        require(!parentAgentProcess.processOptions.ephemeral) {
+            "Ephemeral AgentProcess [id=${parentAgentProcess.id}] cannot spawn child processes. " +
+            "Ephemeral processes do not support wait states or persistence."
+        }
+
         val childBlackboard = parentAgentProcess.processContext.blackboard.spawn()
         val processOptions = parentAgentProcess.processContext.processOptions
         val childAgentProcess = SimpleAgentProcess(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/InMemoryAgentProcessRepository.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/InMemoryAgentProcessRepository.kt
@@ -15,8 +15,8 @@
  */
 package com.embabel.agent.spi.support
 
+import com.embabel.agent.core.AbstractAgentProcessRepository
 import com.embabel.agent.core.AgentProcess
-import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.spi.config.spring.ProcessRepositoryProperties
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -30,7 +30,7 @@ import kotlin.concurrent.write
  */
 class InMemoryAgentProcessRepository(
     private val properties: ProcessRepositoryProperties = ProcessRepositoryProperties(),
-) : AgentProcessRepository {
+) : AbstractAgentProcessRepository() {
 
     private val map: ConcurrentHashMap<String, AgentProcess> = ConcurrentHashMap()
     private val accessOrder: ConcurrentLinkedQueue<String> = ConcurrentLinkedQueue()
@@ -45,7 +45,7 @@ class InMemoryAgentProcessRepository(
         map.values.filter { it.parentId == parentId }
     }
 
-    override fun save(agentProcess: AgentProcess): AgentProcess = lock.write {
+    override fun doSave(agentProcess: AgentProcess): AgentProcess = lock.write {
         val processId = agentProcess.id
 
         // If this process already exists, remove it from access order to re-add at end
@@ -65,7 +65,7 @@ class InMemoryAgentProcessRepository(
         agentProcess
     }
 
-    override fun update(agentProcess: AgentProcess) {
+    override fun doUpdate(agentProcess: AgentProcess) {
         // Nothing to do here as the reference is already updated in memory
     }
 

--- a/embabel-agent-api/src/test/java/com/embabel/agent/core/ProcessOptionsBuilderTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/core/ProcessOptionsBuilderTest.java
@@ -20,6 +20,7 @@ import com.embabel.agent.api.channel.OutputChannel;
 import com.embabel.agent.api.common.PlannerType;
 import com.embabel.agent.api.event.AgenticEventListener;
 import com.embabel.agent.core.support.InMemoryBlackboard;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -325,6 +326,31 @@ class ProcessOptionsBuilderTest {
 
         assertNotNull(control.getEarlyTerminationPolicy());
         assertEquals("FirstOfEarlyTerminationPolicy", control.getEarlyTerminationPolicy().getName());
+    }
+
+    @Nested
+    class EphemeralProcessTests {
+
+        @Test
+        void defaultEphemeralIsFalse() {
+            assertFalse(ProcessOptions.DEFAULT.getEphemeral());
+        }
+
+        @Test
+        void withEphemeralTrue() {
+            var po = ProcessOptions.DEFAULT.withEphemeral(true);
+
+            assertTrue(po.getEphemeral());
+        }
+
+        @Test
+        void withEphemeralFalse() {
+            var po = ProcessOptions.DEFAULT
+                    .withEphemeral(true)
+                    .withEphemeral(false);
+
+            assertFalse(po.getEphemeral());
+        }
     }
 
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/subagent/SubagentExecutionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/subagent/SubagentExecutionTest.kt
@@ -394,4 +394,58 @@ class SubagentExecutionTest {
             }
         }
     }
+
+    @Nested
+    inner class EphemeralProcessTests {
+
+        @Test
+        fun `ephemeral process cannot spawn child process`() {
+            val agent = reader.createAgentMetadata(OuterAgentViaSubprocessInvocation()) as CoreAgent
+            val ap = IntegrationTestUtils.dummyAgentPlatform()
+
+            // Create ephemeral parent process
+            val ephemeralProcess = ap.createAgentProcess(
+                agent,
+                ProcessOptions().withEphemeral(true),
+                mapOf("it" to UserInput("test"))
+            )
+
+            // Attempt to run should fail when trying to spawn child
+            val exception = assertThrows(IllegalArgumentException::class.java) {
+                ephemeralProcess.run()
+            }
+
+            // Verify exception message
+            assertTrue(
+                exception.message?.contains("Ephemeral AgentProcess") == true,
+                "Exception should mention ephemeral process: ${exception.message}"
+            )
+            assertTrue(
+                exception.message?.contains("cannot spawn child processes") == true,
+                "Exception should mention child spawn restriction: ${exception.message}"
+            )
+        }
+
+        @Test
+        fun `non-ephemeral process can spawn child normally`() {
+            val agent = reader.createAgentMetadata(OuterAgentViaSubprocessInvocation()) as CoreAgent
+            val ap = IntegrationTestUtils.dummyAgentPlatform()
+
+            // Create normal (non-ephemeral) parent process
+            val normalProcess = ap.createAgentProcess(
+                agent,
+                ProcessOptions().withEphemeral(false),
+                mapOf("it" to UserInput("test"))
+            )
+
+            // Should complete successfully
+            normalProcess.run()
+            assertEquals(AgentProcessStatusCode.COMPLETED, normalProcess.status)
+
+            // Verify child was created
+            val repository = normalProcess.processContext.platformServices.agentProcessRepository
+            val children = repository.findByParentId(normalProcess.id)
+            assertTrue(children.isNotEmpty(), "Should have child process")
+        }
+    }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/InMemoryAgentProcessRepositoryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/InMemoryAgentProcessRepositoryTest.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.spi.support
 
 import com.embabel.agent.spi.config.spring.ProcessRepositoryProperties
 import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.ProcessOptions
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.*
@@ -44,6 +45,7 @@ class InMemoryAgentProcessRepositoryTest {
         every { parentId } returns null
         every { isRootProcess } returns true
         every { this@mockk.finished } returns finished
+        every { processOptions } returns ProcessOptions.DEFAULT
     }
 
     /**
@@ -58,6 +60,7 @@ class InMemoryAgentProcessRepositoryTest {
         every { this@mockk.parentId } returns parentId
         every { isRootProcess } returns false
         every { this@mockk.finished } returns finished
+        every { processOptions } returns ProcessOptions.DEFAULT
     }
 
     @Test
@@ -383,6 +386,79 @@ class InMemoryAgentProcessRepositoryTest {
             assertNotNull(repository.findById("child"))
             assertNotNull(repository.findById("grandchild"))
             assertNotNull(repository.findById("new-root"))
+        }
+    }
+
+    @Nested
+    inner class EphemeralProcessTests {
+
+        /**
+         * Create a mock ephemeral root process.
+         */
+        private fun mockEphemeralProcess(
+            id: String,
+            finished: Boolean = true,
+        ): AgentProcess = mockk {
+            every { this@mockk.id } returns id
+            every { parentId } returns null
+            every { isRootProcess } returns true
+            every { this@mockk.finished } returns finished
+            every { processOptions } returns ProcessOptions.DEFAULT.withEphemeral(true)
+        }
+
+        @Test
+        fun `ephemeral process is not saved to repository`() {
+            val ephemeralProcess = mockEphemeralProcess("ephemeral-1")
+
+            // Attempt to save ephemeral process
+            val result = repository.save(ephemeralProcess)
+
+            // Should return the process unchanged
+            assertEquals(ephemeralProcess, result)
+
+            // But should NOT be in the repository
+            assertEquals(0, repository.size())
+            assertNull(repository.findById("ephemeral-1"))
+        }
+
+        @Test
+        fun `ephemeral process update is ignored`() {
+            val ephemeralProcess = mockEphemeralProcess("ephemeral-1")
+
+            // Attempt to update ephemeral process
+            repository.update(ephemeralProcess)
+
+            // Should not be in the repository
+            assertEquals(0, repository.size())
+            assertNull(repository.findById("ephemeral-1"))
+        }
+
+        @Test
+        fun `non-ephemeral process is saved normally`() {
+            val normalProcess = mockRootProcess("normal-1")
+
+            val result = repository.save(normalProcess)
+
+            assertEquals(normalProcess, result)
+            assertEquals(1, repository.size())
+            assertNotNull(repository.findById("normal-1"))
+        }
+
+        @Test
+        fun `mix of ephemeral and non-ephemeral processes`() {
+            val ephemeralProcess = mockEphemeralProcess("ephemeral-1")
+            val normalProcess1 = mockRootProcess("normal-1")
+            val normalProcess2 = mockRootProcess("normal-2")
+
+            repository.save(ephemeralProcess)
+            repository.save(normalProcess1)
+            repository.save(normalProcess2)
+
+            // Only non-ephemeral processes should be stored
+            assertEquals(2, repository.size())
+            assertNull(repository.findById("ephemeral-1"))
+            assertNotNull(repository.findById("normal-1"))
+            assertNotNull(repository.findById("normal-2"))
         }
     }
 }

--- a/embabel-agent-docs/src/main/asciidoc/reference/agent-process/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/agent-process/page.adoc
@@ -106,6 +106,7 @@ Allows fine grained control over logging prompts, LLM returns and detailed plann
 * `control`: Control options, determining whether the agent should be terminated as a last resort. `EarlyTerminationPolicy` can based on an absolute number of actions or a maximum budget.
 * Delays: Both operations (actions) and tools can have delays.
 This is useful to avoid rate limiting.
+* `ephemaral`: blocks Agent Process from persisting in Agent Process Repository and from spawning child processes (light-weighted agent process)
 * `toolCallContext`: Out-of-band metadata (e.g., auth tokens, tenant IDs, correlation IDs) passed to all tool invocations during the process.
 This context propagates through the entire tool pipeline—including decorator chains and MCP tools—without being exposed to the LLM.
 Set via `withToolCallContext()`:


### PR DESCRIPTION
## Overview

- Add Ephemeral tag to ProcessOptions
- Block Ephemeal process from Agent Repo save / update
- Block Ephemeral process from spawning child processes
- Update tests
- Unrelated - expose kotlin extension function  ProcessContext.terminateAgent to Java

Please refer to issue #698 


## Details

- Introduced AbstractAgentProcessRepository with ```save``` and ```update``` as final API
- inside ```save / update```  - block ephemeral process from agent process persisting  and
- proceed with protected API ```doSave ``` and ```doUpdate```
-  Rename ```save / update``` to ```doSave``` and ```doUpdate``` in ```InMemoryAgentProcessRepository```
- inside ```rceateChildProcess``` in ```DefaultAgentPlatform``` block ephemeral Agent Process from spawning children


