### PR TITLE
Use thread context classloader in JvmType.toClass()

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/JvmType.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/JvmType.kt
@@ -62,7 +62,7 @@ data class JvmType @JsonCreator constructor(
         if (className == "void") {
             Void.TYPE
         } else
-            Class.forName(className)
+            Class.forName(className, true, Thread.currentThread().getContextClassLoader())
     }
 
     @get:JsonIgnore

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/JvmTypeTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/JvmTypeTest.kt
@@ -875,4 +875,34 @@ class JvmTypeTest {
             )
         }
     }
+
+    @Test
+    fun `isAssignableFrom should use thread context classloader`() {
+        val loadedClasses = mutableListOf<String>()
+
+        val customClassLoader = object : ClassLoader(JvmTypeTest::class.java.classLoader) {
+            override fun loadClass(name: String, resolve: Boolean): Class<*> {
+                loadedClasses.add(name)
+                return super.loadClass(name, resolve)
+            }
+        }
+
+        val originalClassLoader = Thread.currentThread().contextClassLoader
+        try {
+            Thread.currentThread().contextClassLoader = customClassLoader
+
+            // Construct from class name so clazz lazy init uses the context classloader
+            val carType = JvmType(TestCar::class.java.name)
+            val vehicleType = JvmType(TestVehicle::class.java.name)
+
+            assertTrue(vehicleType.isAssignableFrom(carType),
+                "TestVehicle should be assignable from TestCar")
+            assertTrue(loadedClasses.contains(TestCar::class.java.name),
+                "Context classloader should have been used to load TestCar")
+            assertTrue(loadedClasses.contains(TestVehicle::class.java.name),
+                "Context classloader should have been used to load TestVehicle")
+        } finally {
+            Thread.currentThread().contextClassLoader = originalClassLoader
+        }
+    }
 }


### PR DESCRIPTION
Class.forName(name) uses the caller's classloader, which may miss classes loaded by the application classloader in multi-classloader environments. Passing the thread context classloader ensures resolution in the correct loading context.
