### PR TITLE
Upgrade Netty to version 4.2.13 Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <argLine/>
         <embabel-common.version>0.1.12-SNAPSHOT</embabel-common.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.2.13.Final</netty.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>
     </properties>


### PR DESCRIPTION
## Overview

Reported HIGH Vulnerability on NETTY:

https://github.com/advisories/GHSA-f6hv-jmp6-3vwv

Upgraded:

-        <netty.version>4.1.132.Final</netty.version>  - FROM
+        <netty.version>4.2.13.Final</netty.version>  -TO

```
/git/embabel-agent$ mvn dependency:tree|grep netty
[INFO] -----< com.embabel.agent:embabel-agent-netty-client-autoconfigure >-----
[INFO] --- maven-dependency-plugin:3.8.1:tree (default-cli) @ embabel-agent-netty-client-autoconfigure ---
[INFO] com.embabel.agent:embabel-agent-netty-client-autoconfigure:jar:0.4.0-SNAPSHOT
[INFO] +- io.projectreactor.netty:reactor-netty-http:jar:1.2.17:compile
[INFO] |  +- io.netty:netty-codec-http:jar:4.2.13.Final:compile
[INFO] |  |  +- io.netty:netty-common:jar:4.2.13.Final:compile
[INFO] |  |  +- io.netty:netty-buffer:jar:4.2.13.Final:compile
[INFO] |  |  +- io.netty:netty-transport:jar:4.2.13.Final:compile
[INFO] |  |  +- io.netty:netty-codec-base:jar:4.2.13.Final:compile
[INFO] |  |  +- io.netty:netty-codec-compression:jar:4.2.13.Final:compile
[INFO] |  |  \- io.netty:netty-handler:jar:4.2.13.Final:compile
```

