### PR TITLE
#1604 Track LLM and embedding cost per individual call

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/EmbeddingInvocationEvent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/EmbeddingInvocationEvent.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.event
+
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.EmbeddingInvocation
+
+/**
+ * Emitted once per embedding call.
+ *
+ * @property invocation per-call invocation record (model, usage, timestamp, cost)
+ * @property interactionId unique identifier of the embedding request
+ */
+class EmbeddingInvocationEvent(
+    agentProcess: AgentProcess,
+    val invocation: EmbeddingInvocation,
+    val interactionId: String,
+) : AbstractAgentProcessEvent(agentProcess) {
+
+    override fun toString(): String =
+        "EmbeddingInvocationEvent(model=${invocation.embeddingMetadata.name}, " +
+                "interactionId=$interactionId, usage=${invocation.usage}, cost=${invocation.cost()})"
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/EmbeddingInvocationEvent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/EmbeddingInvocationEvent.kt
@@ -31,6 +31,5 @@ class EmbeddingInvocationEvent(
 ) : AbstractAgentProcessEvent(agentProcess) {
 
     override fun toString(): String =
-        "EmbeddingInvocationEvent(model=${invocation.embeddingMetadata.name}, " +
-                "interactionId=$interactionId, usage=${invocation.usage}, cost=${invocation.cost()})"
+        """EmbeddingInvocationEvent(model=${invocation.embeddingMetadata.name}, interactionId=$interactionId, usage=${invocation.usage}, cost=${invocation.cost()})"""
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/LlmInvocationEvent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/LlmInvocationEvent.kt
@@ -38,6 +38,5 @@ class LlmInvocationEvent(
 ) : AbstractAgentProcessEvent(agentProcess) {
 
     override fun toString(): String =
-        "LlmInvocationEvent(model=${invocation.llmMetadata.name}, " +
-                "interactionId=$interactionId, usage=${invocation.usage}, cost=${invocation.cost()})"
+        """LlmInvocationEvent(model=${invocation.llmMetadata.name}, interactionId=$interactionId, usage=${invocation.usage}, cost=${invocation.cost()})"""
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/LlmInvocationEvent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/LlmInvocationEvent.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.event
+
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.LlmInvocation
+
+/**
+ * Emitted once per individual LLM invocation (per-call, not per-loop).
+ *
+ * Survives CONCURRENT mode and validation/binding retries — each effective LLM call
+ * produces exactly one event. Listener exceptions are isolated by the underlying
+ * `notifyAfterLlmCall` try/catch, so a misbehaving listener cannot break the tool loop.
+ *
+ * In CONCURRENT mode, this event may be emitted from multiple threads simultaneously.
+ * Stateful listeners (cost aggregation, rate caps, etc.) MUST use thread-safe structures.
+ *
+ * @property invocation per-call invocation record (model, usage, timestamp, cost)
+ * @property interactionId unique identifier of the parent LlmInteraction
+ */
+class LlmInvocationEvent(
+    agentProcess: AgentProcess,
+    val invocation: LlmInvocation,
+    val interactionId: String,
+) : AbstractAgentProcessEvent(agentProcess) {
+
+    override fun toString(): String =
+        "LlmInvocationEvent(model=${invocation.llmMetadata.name}, " +
+                "interactionId=$interactionId, usage=${invocation.usage}, cost=${invocation.cost()})"
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
@@ -16,10 +16,13 @@
 package com.embabel.agent.spi.support
 
 import com.embabel.agent.api.common.Asyncer
+import com.embabel.agent.api.event.LlmInvocationEvent
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.event.ToolLoopStartEvent
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolCallContext
+import com.embabel.agent.api.tool.callback.AfterLlmCallContext
+import com.embabel.agent.api.tool.callback.ToolLoopInspector
 import com.embabel.agent.api.tool.config.ToolLoopConfiguration
 import com.embabel.agent.core.LlmInvocation
 import com.embabel.agent.core.ReplanRequestedException
@@ -157,7 +160,7 @@ open class ToolLoopLlmOperations(
             injectionStrategy = injectionStrategy,
             maxIterations = interaction.maxToolIterations,
             toolDecorator = injectedToolDecorator,
-            toolLoopInspectors = interaction.toolLoopInspectors,
+            toolLoopInspectors = resolveToolLoopInspectors(interaction, llm, llmRequestEvent),
             toolLoopTransformers = interaction.toolLoopTransformers,
             toolCallInspectors = interaction.toolCallInspectors,
             toolCallContext = effectiveContext,
@@ -181,7 +184,7 @@ open class ToolLoopLlmOperations(
             outputParser = outputParser,
         )
 
-        handleToolLoopCompletion(toolLoopStartEvent, result, llmRequestEvent, llm)
+        handleToolLoopCompletion(toolLoopStartEvent, result, llmRequestEvent)
 
         // Guardrails: Post-validation of assistant response
         // For the tool loop path, validate the final result based on its type
@@ -249,7 +252,7 @@ open class ToolLoopLlmOperations(
             injectionStrategy = injectionStrategy,
             maxIterations = interaction.maxToolIterations,
             toolDecorator = injectedToolDecorator,
-            toolLoopInspectors = interaction.toolLoopInspectors,
+            toolLoopInspectors = resolveToolLoopInspectors(interaction, llm, llmRequestEvent),
             toolLoopTransformers = interaction.toolLoopTransformers,
             toolCallInspectors = interaction.toolCallInspectors,
             toolCallContext = effectiveContext,
@@ -276,18 +279,7 @@ open class ToolLoopLlmOperations(
         validateUserInput(userMessages, interaction, llmRequestEvent.agentProcess.blackboard)
 
         val tools = interaction.tools
-
-        // Publish ToolLoopStartEvent before the tool loop
-        val toolLoopStartEvent = ToolLoopStartEvent(
-            agentProcess = llmRequestEvent.agentProcess,
-            action = llmRequestEvent.action,
-            toolNames = tools.map { it.definition.name },
-            maxIterations = interaction.maxToolIterations,
-            interactionId = interaction.id.value,
-            outputClass = outputClass,
-        ).also { startEvent ->
-            llmRequestEvent.agentProcess.processContext.onProcessEvent(startEvent)
-        }
+        val toolLoopStartEvent = publishToolLoopStartEvent(llmRequestEvent, tools, interaction, outputClass)
 
         val result = toolLoop.execute(
             initialMessages = initialMessages,
@@ -295,25 +287,7 @@ open class ToolLoopLlmOperations(
             outputParser = outputParser,
         )
 
-        // Publish ToolLoopCompletedEvent after the tool loop
-        llmRequestEvent.agentProcess.processContext.onProcessEvent(
-            toolLoopStartEvent.completedEvent(
-                totalIterations = result.totalIterations,
-                replanRequested = result.replanRequested,
-            )
-        )
-
-        result.totalUsage?.let { usage ->
-            recordUsage(llm, usage, llmRequestEvent)
-        }
-
-        // If replan was requested, re-throw the exception to propagate to action executor
-        if (result.replanRequested) {
-            throw ReplanRequestedException(
-                reason = result.replanReason ?: "Tool requested replan",
-                blackboardUpdater = result.blackboardUpdater,
-            )
-        }
+        handleToolLoopCompletion(toolLoopStartEvent, result, llmRequestEvent)
 
         // ToolLoopResult.result is non-nullable by design - if tool loop completes, it has a result
         val maybeReturn = result.result
@@ -384,7 +358,7 @@ open class ToolLoopLlmOperations(
             injectionStrategy = injectionStrategy,
             maxIterations = interaction.maxToolIterations,
             toolDecorator = injectedToolDecorator,
-            toolLoopInspectors = interaction.toolLoopInspectors,
+            toolLoopInspectors = resolveToolLoopInspectors(interaction, llm, llmRequestEvent),
             toolLoopTransformers = interaction.toolLoopTransformers,
             toolCallInspectors = interaction.toolCallInspectors,
             toolCallContext = effectiveContext,
@@ -408,7 +382,7 @@ open class ToolLoopLlmOperations(
             outputParser = outputParser,
         )
 
-        handleToolLoopCompletion(toolLoopStartEvent, result, llmRequestEvent, llm)
+        handleToolLoopCompletion(toolLoopStartEvent, result, llmRequestEvent)
 
         val thinkingResponse = result.result
 
@@ -488,7 +462,7 @@ open class ToolLoopLlmOperations(
                 injectionStrategy = injectionStrategy,
                 maxIterations = interaction.maxToolIterations,
                 toolDecorator = injectedToolDecorator,
-                toolLoopInspectors = interaction.toolLoopInspectors,
+                toolLoopInspectors = resolveToolLoopInspectors(interaction, llm, llmRequestEvent),
                 toolLoopTransformers = interaction.toolLoopTransformers,
                 toolCallInspectors = interaction.toolCallInspectors,
                 toolCallContext = effectiveContext,
@@ -523,7 +497,7 @@ open class ToolLoopLlmOperations(
                 outputParser = outputParser,
             )
 
-            handleToolLoopCompletion(toolLoopStartEvent, result, llmRequestEvent, llm)
+            handleToolLoopCompletion(toolLoopStartEvent, result, llmRequestEvent)
 
             val thinkingResult = result.result
 
@@ -783,6 +757,55 @@ open class ToolLoopLlmOperations(
         }
 
     /**
+     * Create a per-call billing inspector that records each LLM invocation and emits an
+     * [LlmInvocationEvent].
+     *
+     * The inspector captures `llm` and `llmRequestEvent` via closure, so each tool-loop
+     * instance gets its own inspector — per-call by construction (survives CONCURRENT
+     * mode and validation/binding retries).
+     *
+     * Listener exceptions are isolated by `notifyAfterLlmCall`'s try/catch in the
+     * underlying tool loop, so a misbehaving listener cannot break the loop.
+     */
+    private fun createBillingInspector(
+        llm: LlmService<*>,
+        llmRequestEvent: LlmRequestEvent<*>,
+    ): ToolLoopInspector = object : ToolLoopInspector {
+        override fun afterLlmCall(context: AfterLlmCallContext) {
+            val usage = context.usage ?: return
+            val invocation = LlmInvocation(
+                llmMetadata = llm,
+                usage = usage,
+                agentName = llmRequestEvent.agentProcess.agent.name,
+                timestamp = Instant.now(),
+                runningTime = Duration.ZERO,
+            )
+            llmRequestEvent.agentProcess.recordLlmInvocation(invocation)
+            llmRequestEvent.agentProcess.processContext.onProcessEvent(
+                LlmInvocationEvent(
+                    agentProcess = llmRequestEvent.agentProcess,
+                    invocation = invocation,
+                    interactionId = llmRequestEvent.interaction.id.value,
+                )
+            )
+        }
+    }
+
+    /**
+     * Build the effective inspector list for a tool loop: the user-provided
+     * [LlmInteraction.toolLoopInspectors] plus the per-call billing inspector
+     * when an [LlmRequestEvent] is present (i.e. the call is agent-bound).
+     */
+    private fun resolveToolLoopInspectors(
+        interaction: LlmInteraction,
+        llm: LlmService<*>,
+        llmRequestEvent: LlmRequestEvent<*>?,
+    ): List<ToolLoopInspector> =
+        interaction.toolLoopInspectors + listOfNotNull(
+            llmRequestEvent?.let { createBillingInspector(llm, it) }
+        )
+
+    /**
      * Publish ToolLoopStartEvent and return it for later completion tracking.
      */
     private fun <O> publishToolLoopStartEvent(
@@ -804,14 +827,16 @@ open class ToolLoopLlmOperations(
     }
 
     /**
-     * Handle tool loop completion: publish completed event, record usage, check for replan.
+     * Handle tool loop completion: publish completed event, check for replan.
      * Throws ReplanRequestedException if replan was requested.
+     *
+     * Per-call usage recording happens in the billing inspector
+     * ([createBillingInspector]) — no aggregate post-loop recording is needed here.
      */
     private fun <O> handleToolLoopCompletion(
         toolLoopStartEvent: ToolLoopStartEvent?,
         result: com.embabel.agent.spi.loop.ToolLoopResult<O>,
         llmRequestEvent: LlmRequestEvent<*>?,
-        llm: LlmService<*>,
     ) {
         // Publish ToolLoopCompletedEvent after the tool loop
         toolLoopStartEvent?.let { startEvent ->
@@ -821,10 +846,6 @@ open class ToolLoopLlmOperations(
                     replanRequested = result.replanRequested,
                 )
             )
-        }
-
-        result.totalUsage?.let { usage ->
-            recordUsage(llm, usage, llmRequestEvent)
         }
 
         // If replan was requested, re-throw the exception to propagate to action executor

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/embedding/EmbeddingOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/embedding/EmbeddingOperations.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.spi.support.embedding
 import com.embabel.agent.api.event.AgentProcessEmbeddingEvent
 import com.embabel.agent.api.event.EmbeddingEvent
 import com.embabel.agent.api.event.EmbeddingEventListener
+import com.embabel.agent.api.event.EmbeddingInvocationEvent
 import com.embabel.agent.api.event.EmbeddingRequestEvent
 import com.embabel.agent.spi.support.springai.EmbeddingModelCallEvent
 import com.embabel.agent.core.AgentProcess
@@ -97,15 +98,23 @@ internal class EmbeddingOperations(
 
         emit(requestEvent.responseEvent(usage, runningTime), agentProcess)
 
-        agentProcess?.recordEmbeddingInvocation(
-            EmbeddingInvocation(
+        agentProcess?.let { ap ->
+            val invocation = EmbeddingInvocation(
                 embeddingMetadata = delegate,
                 usage = usage,
-                agentName = agentProcess.agent.name,
+                agentName = ap.agent.name,
                 timestamp = requestEvent.timestamp,
                 runningTime = runningTime,
             )
-        )
+            ap.recordEmbeddingInvocation(invocation)
+            ap.processContext.onProcessEvent(
+                EmbeddingInvocationEvent(
+                    agentProcess = ap,
+                    invocation = invocation,
+                    interactionId = interactionId,
+                )
+            )
+        }
 
         return callResult.embeddings
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/event/EmbeddingInvocationEventTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/event/EmbeddingInvocationEventTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.event
+
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.EmbeddingInvocation
+import com.embabel.agent.core.Usage
+import com.embabel.common.ai.model.EmbeddingServiceMetadata
+import com.embabel.common.ai.model.PricingModel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.Duration
+import java.time.Instant
+
+class EmbeddingInvocationEventTest {
+
+    private val metadata = EmbeddingServiceMetadata(
+        name = "embed-test",
+        provider = "test-provider",
+        pricingModel = PricingModel.usdPer1MTokens(0.02, 0.0),
+    )
+
+    private fun makeInvocation(promptTokens: Int = 1_000_000) = EmbeddingInvocation(
+        embeddingMetadata = metadata,
+        usage = Usage(promptTokens, 0, null),
+        agentName = "test-agent",
+        timestamp = Instant.now(),
+        runningTime = Duration.ZERO,
+    )
+
+    @Test
+    fun `exposes invocation, interactionId and agentProcess`() {
+        val agentProcess = mock(AgentProcess::class.java)
+        `when`(agentProcess.id).thenReturn("process-1")
+        val invocation = makeInvocation()
+
+        val event = EmbeddingInvocationEvent(agentProcess, invocation, "embed-interaction-7")
+
+        assertSame(agentProcess, event.agentProcess)
+        assertSame(invocation, event.invocation)
+        assertEquals("embed-interaction-7", event.interactionId)
+        assertEquals("process-1", event.processId)
+    }
+
+    @Test
+    fun `toString surfaces model, interactionId, usage and cost`() {
+        val agentProcess = mock(AgentProcess::class.java)
+        `when`(agentProcess.id).thenReturn("p")
+        val invocation = makeInvocation()
+
+        val s = EmbeddingInvocationEvent(agentProcess, invocation, "i-1").toString()
+
+        assertTrue(s.contains("embed-test"), "expected model name in toString: $s")
+        assertTrue(s.contains("i-1"), "expected interactionId in toString: $s")
+        assertTrue(s.contains("usage="), "expected usage in toString: $s")
+        assertTrue(s.contains("cost="), "expected cost in toString: $s")
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/event/LlmInvocationEventTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/event/LlmInvocationEventTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.event
+
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.LlmInvocation
+import com.embabel.agent.core.Usage
+import com.embabel.common.ai.model.LlmMetadata
+import com.embabel.common.ai.model.PricingModel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import java.time.Duration
+import java.time.Instant
+
+class LlmInvocationEventTest {
+
+    private val metadata = LlmMetadata(
+        name = "gpt-test",
+        provider = "test-provider",
+        pricingModel = PricingModel.usdPer1MTokens(1.0, 2.0),
+    )
+
+    private fun makeInvocation(
+        promptTokens: Int = 100,
+        completionTokens: Int = 50,
+    ) = LlmInvocation(
+        llmMetadata = metadata,
+        usage = Usage(promptTokens, completionTokens, null),
+        agentName = "test-agent",
+        timestamp = Instant.now(),
+        runningTime = Duration.ZERO,
+    )
+
+    @Test
+    fun `exposes invocation, interactionId and agentProcess`() {
+        val agentProcess = mock(AgentProcess::class.java)
+        `when`(agentProcess.id).thenReturn("process-1")
+        val invocation = makeInvocation()
+
+        val event = LlmInvocationEvent(agentProcess, invocation, "interaction-42")
+
+        assertSame(agentProcess, event.agentProcess)
+        assertSame(invocation, event.invocation)
+        assertEquals("interaction-42", event.interactionId)
+        assertEquals("process-1", event.processId)
+    }
+
+    @Test
+    fun `toString surfaces model, interactionId, usage and cost for diagnostics`() {
+        val agentProcess = mock(AgentProcess::class.java)
+        `when`(agentProcess.id).thenReturn("p")
+        val invocation = makeInvocation(promptTokens = 1_000_000, completionTokens = 0)
+
+        val s = LlmInvocationEvent(agentProcess, invocation, "i-1").toString()
+
+        assertTrue(s.contains("gpt-test"), "expected model name in toString: $s")
+        assertTrue(s.contains("i-1"), "expected interactionId in toString: $s")
+        assertTrue(s.contains("usage="), "expected usage in toString: $s")
+        assertTrue(s.contains("cost="), "expected cost in toString: $s")
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.api.common.InteractionId
 import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.common.ToolsStats
 import com.embabel.agent.api.event.AgenticEventListener
+import com.embabel.agent.api.event.LlmInvocationEvent
 import com.embabel.agent.core.Agent
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcess
@@ -100,7 +101,9 @@ class ChatClientLlmTransformerTest {
                     eventListener = ese,
                 )
                 assertEquals(person, result)
-                assertEquals(5, ese.processEvents.size)
+                // LlmRequestEvent, ToolLoopStartEvent, LlmInvocationEvent (per-call billing),
+                // ToolLoopCompletedEvent, LlmResponseEvent, ChatModelCallEvent
+                assertEquals(6, ese.processEvents.size)
             }
 
             @Test
@@ -109,6 +112,27 @@ class ChatClientLlmTransformerTest {
                 val result = runWithPromptReturning(jacksonObjectMapper().writeValueAsString(person))
                 assertEquals(person, result)
                 assertTrue(llmInvocationHistory.invocations.isNotEmpty())
+            }
+
+            @Test
+            fun `emits LlmInvocationEvent per LLM call with the matching interactionId`() {
+                val ese = EventSavingAgenticEventListener()
+                val person = SpiPerson("John")
+                runWithPromptReturning(
+                    llmReturn = jacksonObjectMapper().writeValueAsString(person),
+                    eventListener = ese,
+                )
+
+                val billingEvents = ese.processEvents.filterIsInstance<LlmInvocationEvent>()
+                assertEquals(1, billingEvents.size, "Expected exactly one billing event per LLM call")
+                val event = billingEvents.single()
+                assertEquals("test", event.interactionId)
+                // The event must wrap the same invocation that was recorded on the agent process.
+                assertEquals(
+                    llmInvocationHistory.invocations.last(),
+                    event.invocation,
+                    "LlmInvocationEvent.invocation should match the recorded LlmInvocation",
+                )
             }
 
         }
@@ -232,8 +256,9 @@ class ChatClientLlmTransformerTest {
                     outputClass = SpiPerson::class.java,
                 )
                 assertEquals(Result.success(person), result.result)
-                // Embabel tool loop emits: LlmRequestEvent, ToolLoopStartEvent, ToolLoopCompletedEvent, LlmMaybeResponseEvent + ChatModelCallEvent
-                assertEquals(5, ese.processEvents.size)
+                // Embabel tool loop emits: LlmRequestEvent, ToolLoopStartEvent, LlmInvocationEvent (per-call billing),
+                // ToolLoopCompletedEvent, LlmMaybeResponseEvent + ChatModelCallEvent
+                assertEquals(6, ese.processEvents.size)
             }
 
             @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/EmbeddingOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/EmbeddingOperationsTest.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.spi.support
 import com.embabel.agent.api.event.AgentProcessEmbeddingEvent
 import com.embabel.agent.api.event.EmbeddingEvent
 import com.embabel.agent.api.event.EmbeddingEventListener
+import com.embabel.agent.api.event.EmbeddingInvocationEvent
 import com.embabel.agent.api.event.EmbeddingRequestEvent
 import com.embabel.agent.api.event.EmbeddingResponseEvent
 import com.embabel.agent.spi.support.embedding.EmbeddingOperations
@@ -397,5 +398,44 @@ class EmbeddingOperationsTest {
         assertEquals(3, wrappers.size, "Wrapper events must fire even when the listener throws")
         // And the invocation was still recorded.
         assertEquals(1, process.embeddingInvocations.size)
+    }
+
+    @Test
+    fun `embed emits EmbeddingInvocationEvent with the recorded invocation when an agent is active`() {
+        val service = springAiServiceWith(StubModelWithUsage(tokens = 250))
+        val ops = EmbeddingOperations(service)
+
+        process.withCurrent { ops.embed("hello") }
+
+        val billingEvents = listener.processEvents.filterIsInstance<EmbeddingInvocationEvent>()
+        assertEquals(1, billingEvents.size)
+        val event = billingEvents.single()
+        assertSame(process.embeddingInvocations.single(), event.invocation)
+        assertEquals(250, event.invocation.usage.promptTokens)
+    }
+
+    @Test
+    fun `embed without an active agent does not emit EmbeddingInvocationEvent`() {
+        val service = springAiServiceWith(StubModelWithUsage(tokens = 100))
+        val ops = EmbeddingOperations(service)
+
+        ops.embed("hello")
+
+        assertTrue(listener.processEvents.none { it is EmbeddingInvocationEvent })
+    }
+
+    @Test
+    fun `EmbeddingInvocationEvent interactionId matches the EmbeddingRequestEvent id`() {
+        val service = springAiServiceWith(StubModelWithUsage(tokens = 50))
+        val ops = EmbeddingOperations(service, listener = embeddingListener)
+
+        process.withCurrent { ops.embed("hello") }
+
+        val request = capturedEvents.filterIsInstance<EmbeddingRequestEvent>().single()
+        val billingEvent = listener.processEvents.filterIsInstance<EmbeddingInvocationEvent>().single()
+        assertEquals(
+            request.id, billingEvent.interactionId,
+            "EmbeddingInvocationEvent.interactionId must match the request's id (same correlation)",
+        )
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperationsTest.kt
@@ -16,11 +16,13 @@
 package com.embabel.agent.spi.support
 
 import com.embabel.agent.api.common.InteractionId
+import com.embabel.agent.api.event.LlmInvocationEvent
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.Blackboard
 import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.core.ReplanRequestedException
 import com.embabel.agent.core.Usage
 import com.embabel.agent.core.support.LlmInteraction
@@ -92,8 +94,10 @@ class ToolLoopLlmOperationsTest {
         }
         every { mockProcessContext.onProcessEvent(any()) } answers { eventListener.onProcessEvent(firstArg()) }
         every { mockProcessContext.agentProcess } returns mockAgentProcess
+        every { mockProcessContext.processOptions } returns ProcessOptions()
         every { mockAgentProcess.agent } returns SimpleTestAgent
         every { mockAgentProcess.processContext } returns mockProcessContext
+        every { mockAgentProcess.blackboard } returns mockk(relaxed = true)
 
         mockModelProvider = mockk<ModelProvider>()
     }
@@ -1082,6 +1086,443 @@ class ToolLoopLlmOperationsTest {
         }
     }
 
+    /**
+     * Tests that the per-call billing inspector emits one LlmInvocationEvent per LLM call
+     * (not one aggregate per tool-loop) and records one LlmInvocation per call on the
+     * agent process. Covers the 4 doTransform* sites where the inspector is registered.
+     */
+    @Nested
+    inner class BillingInspectorTests {
+
+        private val interactionIdValue = "test-interaction"
+
+        private fun mockLlmRequestEvent(): LlmRequestEvent<String> {
+            val event = mockk<LlmRequestEvent<String>>(relaxed = true)
+            every { event.agentProcess } returns mockAgentProcess
+            every { event.interaction } returns createInteraction()
+            return event
+        }
+
+
+        @Test
+        fun `doTransform with N tool iterations emits N LlmInvocationEvents (per-call, not aggregate)`() {
+            val tool = TestTool("t", "t") { Tool.Result.text("ok") }
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(
+                    LlmMessageResponse(
+                        AssistantMessageWithToolCalls(" ", listOf(ToolCall("c1", "t", "{}"))),
+                        textContent = "",
+                        usage = Usage(10, 5, null),
+                    ),
+                    LlmMessageResponse(
+                        AssistantMessageWithToolCalls(" ", listOf(ToolCall("c2", "t", "{}"))),
+                        textContent = "",
+                        usage = Usage(20, 10, null),
+                    ),
+                    LlmMessageResponse(
+                        AssistantMessage("done"),
+                        textContent = "done",
+                        usage = Usage(30, 15, null),
+                    ),
+                )
+            )
+            val operations = createTestableOperations(messageSender)
+
+            operations.testDoTransformWithEvent(
+                messages = listOf(UserMessage("go")),
+                interaction = createInteraction(tools = listOf(tool)),
+                outputClass = String::class.java,
+                llmRequestEvent = mockLlmRequestEvent(),
+            )
+
+            // 3 LLM calls → 3 events, 3 recorded invocations (no aggregate post-loop)
+            val billingEvents = eventListener.processEvents.filterIsInstance<LlmInvocationEvent>()
+            assertEquals(3, billingEvents.size, "Expected one event per LLM call")
+            assertEquals(3, mutableLlmInvocationHistory.invocations.size,
+                "Expected one recordLlmInvocation per call (no aggregate)")
+
+            // All events share the parent interactionId
+            assertTrue(billingEvents.all { it.interactionId == interactionIdValue })
+
+            // Each event's invocation usage matches the LLM call's usage (per-call, not summed)
+            val perCallPromptTokens = billingEvents.map { it.invocation.usage.promptTokens }
+            assertEquals(listOf(10, 20, 30), perCallPromptTokens)
+        }
+
+        @Test
+        fun `doTransformIfPossible emits LlmInvocationEvent per call`() {
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(
+                    LlmMessageResponse(
+                        AssistantMessage("""{"success": "ok"}"""),
+                        textContent = """{"success": "ok"}""",
+                        usage = Usage(42, 0, null),
+                    )
+                )
+            )
+            val operations = createTestableOperations(
+                messageSender = messageSender,
+                maybeReturnConverter = createMaybeReturnConverter(String::class.java),
+            )
+
+            operations.testDoTransformIfPossibleWithEvent(
+                messages = listOf(UserMessage("go")),
+                interaction = createInteraction(),
+                outputClass = String::class.java,
+                llmRequestEvent = mockLlmRequestEvent(),
+            )
+
+            val billingEvents = eventListener.processEvents.filterIsInstance<LlmInvocationEvent>()
+            assertEquals(1, billingEvents.size)
+            assertEquals(interactionIdValue, billingEvents.single().interactionId)
+            assertEquals(42, billingEvents.single().invocation.usage.promptTokens)
+            assertEquals(1, mutableLlmInvocationHistory.invocations.size)
+        }
+
+        @Test
+        fun `doTransformWithThinking emits LlmInvocationEvent per call`() {
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(
+                    LlmMessageResponse(
+                        AssistantMessage("hello"),
+                        textContent = "hello",
+                        usage = Usage(7, 3, null),
+                    )
+                )
+            )
+            val operations = createTestableOperations(messageSender)
+
+            operations.testDoTransformWithThinkingWithEvent(
+                messages = listOf(UserMessage("go")),
+                interaction = createInteraction(),
+                outputClass = String::class.java,
+                llmRequestEvent = mockLlmRequestEvent(),
+            )
+
+            val billingEvents = eventListener.processEvents.filterIsInstance<LlmInvocationEvent>()
+            assertEquals(1, billingEvents.size)
+            assertEquals(7, billingEvents.single().invocation.usage.promptTokens)
+            assertEquals(1, mutableLlmInvocationHistory.invocations.size)
+        }
+
+        @Test
+        fun `doTransformWithThinkingIfPossible emits LlmInvocationEvent per call`() {
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(
+                    LlmMessageResponse(
+                        AssistantMessage("""{"success": "ok"}"""),
+                        textContent = """{"success": "ok"}""",
+                        usage = Usage(11, 4, null),
+                    )
+                )
+            )
+            val operations = createTestableOperations(
+                messageSender = messageSender,
+                maybeReturnConverter = createMaybeReturnConverter(String::class.java),
+            )
+
+            operations.testDoTransformWithThinkingIfPossibleWithEvent(
+                messages = listOf(UserMessage("go")),
+                interaction = createInteraction(),
+                outputClass = String::class.java,
+                llmRequestEvent = mockLlmRequestEvent(),
+            )
+
+            val billingEvents = eventListener.processEvents.filterIsInstance<LlmInvocationEvent>()
+            assertEquals(1, billingEvents.size)
+            assertEquals(11, billingEvents.single().invocation.usage.promptTokens)
+            assertEquals(1, mutableLlmInvocationHistory.invocations.size)
+        }
+
+        /**
+         * Integration-style test: a real listener subscribes to LlmInvocationEvent and
+         * accumulates cost. Verifies the end-to-end use case from #1604 — an organization
+         * tracking total cost across multiple LLM calls.
+         */
+        @Test
+        fun `cost-tracking listener accumulates per-call cost across a multi-iteration loop`() {
+            // 3 LLM calls with different token usage. Pricing: $1 per 1M input + $2 per 1M output.
+            // Per-call costs (USD):
+            //   call 1: 1_000_000 in × $1/1M + 500_000 out × $2/1M = $1 + $1   = $2
+            //   call 2: 2_000_000 in × $1/1M + 500_000 out × $2/1M = $2 + $1   = $3
+            //   call 3: 3_000_000 in × $1/1M +   0       × $2/1M = $3         = $3
+            // Expected total: $8
+            val tool = TestTool("t", "t") { Tool.Result.text("ok") }
+
+            // Override the LLM with one that has a pricing model.
+            val fakeChatModel = FakeChatModel("unused")
+            val pricedLlm = SpringAiLlmService(
+                name = "priced-test",
+                provider = "test",
+                chatModel = fakeChatModel,
+                optionsConverter = DefaultOptionsConverter,
+                pricingModel = com.embabel.common.ai.model.PricingModel.usdPer1MTokens(1.0, 2.0),
+            )
+            every { mockModelProvider.getLlm(any()) } returns pricedLlm
+
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(
+                    LlmMessageResponse(
+                        AssistantMessageWithToolCalls(" ", listOf(ToolCall("c1", "t", "{}"))),
+                        textContent = "",
+                        usage = Usage(1_000_000, 500_000, null),
+                    ),
+                    LlmMessageResponse(
+                        AssistantMessageWithToolCalls(" ", listOf(ToolCall("c2", "t", "{}"))),
+                        textContent = "",
+                        usage = Usage(2_000_000, 500_000, null),
+                    ),
+                    LlmMessageResponse(
+                        AssistantMessage("done"),
+                        textContent = "done",
+                        usage = Usage(3_000_000, 0, null),
+                    ),
+                )
+            )
+            val operations = TestableToolLoopLlmOperations(
+                modelProvider = mockModelProvider,
+                toolDecorator = DefaultToolDecorator(),
+                objectMapper = objectMapper,
+                messageSender = messageSender,
+                outputConverter = null,
+            )
+
+            // The listener under test — what an organization-level cost tracker would look like.
+            val totalCost = java.util.concurrent.atomic.DoubleAdder()
+            val callCount = java.util.concurrent.atomic.AtomicInteger(0)
+            val costListener = object : com.embabel.agent.api.event.AgenticEventListener {
+                override fun onProcessEvent(event: com.embabel.agent.api.event.AgentProcessEvent) {
+                    if (event is LlmInvocationEvent) {
+                        totalCost.add(event.invocation.cost())
+                        callCount.incrementAndGet()
+                    }
+                }
+            }
+            // Plug the listener into the existing process-event pipeline.
+            every { mockProcessContext.onProcessEvent(any()) } answers {
+                eventListener.onProcessEvent(firstArg())
+                costListener.onProcessEvent(firstArg())
+            }
+
+            operations.testDoTransformWithEvent(
+                messages = listOf(UserMessage("go")),
+                interaction = createInteraction(tools = listOf(tool)),
+                outputClass = String::class.java,
+                llmRequestEvent = mockLlmRequestEvent(),
+            )
+
+            assertEquals(3, callCount.get(), "Listener should receive one event per LLM call")
+            assertEquals(8.0, totalCost.sum(), 1e-9, "Listener should accumulate cost from each per-call event")
+
+            // And the same total reachable from the agent process aggregate (sanity check).
+            val aggregateCost = mutableLlmInvocationHistory.invocations.sumOf { it.cost() }
+            assertEquals(8.0, aggregateCost, 1e-9, "Process-level cost() must match the listener's sum")
+        }
+
+        /**
+         * The PR claim is: in CONCURRENT mode, N parallel LLM calls produce N distinct
+         * events — each one carrying its own interactionId, with no cross-thread bleed.
+         *
+         * Each thread runs its own doTransform with a unique interactionId. A shared,
+         * thread-safe listener accumulates events. We verify:
+         *  - N events fired (no loss, no duplication)
+         *  - All N interactionIds reach the listener distinctly (no captured state shared
+         *    across the per-call billing inspectors)
+         *  - Total cost matches the sum of per-call costs (no double-count, no skipped call)
+         *  - One recordLlmInvocation per call survives concurrency
+         *  - No exception leaks out of any thread
+         */
+        @Test
+        fun `concurrent doTransform calls each emit a distinct LlmInvocationEvent`() {
+            // Priced LLM so cost() is non-zero and easy to sum: $1 per 1M input tokens.
+            val pricedLlm = SpringAiLlmService(
+                name = "priced-test",
+                provider = "test",
+                chatModel = FakeChatModel("unused"),
+                optionsConverter = DefaultOptionsConverter,
+                pricingModel = com.embabel.common.ai.model.PricingModel.usdPer1MTokens(1.0, 0.0),
+            )
+            every { mockModelProvider.getLlm(any()) } returns pricedLlm
+
+            // Replace the @BeforeEach stubs that mutate non-thread-safe fixture collections
+            // (eventListener._processEvents, mutableLlmInvocationHistory.invocations).
+            // For this test we route into thread-safe collectors only.
+            val callCount = java.util.concurrent.atomic.AtomicInteger()
+            val recordedInvocations = java.util.concurrent.atomic.AtomicInteger()
+            val seenInteractionIds = java.util.concurrent.ConcurrentHashMap.newKeySet<String>()
+            val totalCost = java.util.concurrent.atomic.DoubleAdder()
+            every { mockProcessContext.onProcessEvent(any()) } answers {
+                val ev = firstArg<com.embabel.agent.api.event.AgentProcessEvent>()
+                if (ev is LlmInvocationEvent) {
+                    callCount.incrementAndGet()
+                    seenInteractionIds.add(ev.interactionId)
+                    totalCost.add(ev.invocation.cost())
+                }
+            }
+            every { mockAgentProcess.recordLlmInvocation(any()) } answers {
+                recordedInvocations.incrementAndGet()
+            }
+
+            val threadCount = 16
+            val executor = java.util.concurrent.Executors.newFixedThreadPool(threadCount)
+            val startGate = java.util.concurrent.CountDownLatch(1)
+            val finished = java.util.concurrent.CountDownLatch(threadCount)
+            val errors = java.util.concurrent.CopyOnWriteArrayList<Throwable>()
+
+            try {
+                repeat(threadCount) { i ->
+                    executor.submit {
+                        try {
+                            startGate.await()
+
+                            // Fresh sender per thread — TestLlmMessageSender's callIndex is
+                            // a non-atomic Int and would race if shared.
+                            val sender = TestLlmMessageSender(
+                                responses = listOf(
+                                    LlmMessageResponse(
+                                        AssistantMessage("done $i"),
+                                        textContent = "done $i",
+                                        usage = Usage(1_000_000, 0, null), // exactly $1 per call
+                                    )
+                                )
+                            )
+                            val operations = TestableToolLoopLlmOperations(
+                                modelProvider = mockModelProvider,
+                                toolDecorator = DefaultToolDecorator(),
+                                objectMapper = objectMapper,
+                                messageSender = sender,
+                                outputConverter = null,
+                            )
+
+                            // Unique interactionId per thread — this is the value the
+                            // billing inspector captures via closure. The test fails if
+                            // any of those captures bleed across threads.
+                            val perThreadInteractionId = "interaction-$i"
+                            val interaction = LlmInteraction(
+                                id = InteractionId(perThreadInteractionId),
+                                tools = emptyList(),
+                                llm = LlmOptions(),
+                            )
+                            val event = mockk<LlmRequestEvent<String>>(relaxed = true)
+                            every { event.agentProcess } returns mockAgentProcess
+                            every { event.interaction } returns interaction
+
+                            operations.testDoTransformWithEvent(
+                                messages = listOf(UserMessage("go")),
+                                interaction = interaction,
+                                outputClass = String::class.java,
+                                llmRequestEvent = event,
+                            )
+                        } catch (t: Throwable) {
+                            errors.add(t)
+                        } finally {
+                            finished.countDown()
+                        }
+                    }
+                }
+
+                startGate.countDown() // release all threads simultaneously
+                assertTrue(
+                    finished.await(30, java.util.concurrent.TimeUnit.SECONDS),
+                    "Concurrent doTransform calls timed out"
+                )
+            } finally {
+                executor.shutdownNow()
+            }
+
+            assertTrue(errors.isEmpty(), "Concurrent execution raised exceptions: $errors")
+            assertEquals(
+                threadCount, callCount.get(),
+                "Each parallel LLM call must produce exactly one LlmInvocationEvent"
+            )
+            assertEquals(
+                (0 until threadCount).map { "interaction-$it" }.toSet(),
+                seenInteractionIds.toSet(),
+                "Each event must carry its caller's interactionId — no cross-thread bleed in the inspector closure"
+            )
+            assertEquals(
+                threadCount.toDouble(), totalCost.sum(), 1e-9,
+                "Each event must contribute its own cost — no double-counting, no missed call"
+            )
+            assertEquals(
+                threadCount, recordedInvocations.get(),
+                "Each parallel LLM call must record one invocation on the agent process"
+            )
+        }
+
+        /**
+         * The PR's KDoc on [LlmInvocationEvent] claims:
+         *   "Listener exceptions are isolated by the underlying notifyAfterLlmCall
+         *    try/catch, so a misbehaving listener cannot break the tool loop."
+         *
+         * Existing low-level coverage in `ToolLoopCallbackSupportTest` proves the
+         * try/catch isolates ANY inspector failure. This test exercises the
+         * specific PR chain end-to-end: a user listener subscribed to
+         * LlmInvocationEvent throws on every call → the billing inspector's
+         * onProcessEvent therefore throws → the loop must still terminate
+         * normally and keep emitting on subsequent iterations.
+         */
+        @Test
+        fun `tool loop survives a listener that throws on every LlmInvocationEvent`() {
+            val tool = TestTool("t", "t") { Tool.Result.text("ok") }
+            val messageSender = TestLlmMessageSender(
+                responses = listOf(
+                    LlmMessageResponse(
+                        AssistantMessageWithToolCalls(" ", listOf(ToolCall("c1", "t", "{}"))),
+                        textContent = "",
+                        usage = Usage(10, 5, null),
+                    ),
+                    LlmMessageResponse(
+                        AssistantMessageWithToolCalls(" ", listOf(ToolCall("c2", "t", "{}"))),
+                        textContent = "",
+                        usage = Usage(20, 10, null),
+                    ),
+                    LlmMessageResponse(
+                        AssistantMessage("done"),
+                        textContent = "done",
+                        usage = Usage(30, 15, null),
+                    ),
+                )
+            )
+            val operations = createTestableOperations(messageSender)
+
+            // Model a misbehaving cost listener: every LlmInvocationEvent dispatch throws.
+            // Other event types pass through normally.
+            val attemptedDispatches = java.util.concurrent.atomic.AtomicInteger()
+            every { mockProcessContext.onProcessEvent(any()) } answers {
+                val ev = firstArg<com.embabel.agent.api.event.AgentProcessEvent>()
+                if (ev is LlmInvocationEvent) {
+                    attemptedDispatches.incrementAndGet()
+                    throw RuntimeException("simulated misbehaving cost listener")
+                }
+                eventListener.onProcessEvent(ev)
+            }
+
+            // The loop must complete despite the listener throwing on every iteration.
+            val result = operations.testDoTransformWithEvent(
+                messages = listOf(UserMessage("go")),
+                interaction = createInteraction(tools = listOf(tool)),
+                outputClass = String::class.java,
+                llmRequestEvent = mockLlmRequestEvent(),
+            )
+
+            assertEquals(
+                "done", result,
+                "doTransform must complete even when the listener throws on every LLM call"
+            )
+            assertEquals(
+                3, attemptedDispatches.get(),
+                "Inspector must keep emitting on every LLM call, despite the listener throwing each time"
+            )
+            // recordLlmInvocation runs BEFORE onProcessEvent in the inspector,
+            // so per-call recording is unaffected by the listener failure.
+            assertEquals(
+                3, mutableLlmInvocationHistory.invocations.size,
+                "Per-call recording must succeed for every LLM call, untouched by the listener failure"
+            )
+        }
+    }
+
     // Helper methods
 
     private fun createInteraction(
@@ -1245,6 +1686,37 @@ internal open class TestableToolLoopLlmOperations(
             llmRequestEvent = null,
         )
     }
+
+    // ===== Variants that pass a real LlmRequestEvent so the billing inspector fires =====
+
+    fun <O> testDoTransformWithEvent(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>,
+    ): O = doTransform(messages, interaction, outputClass, llmRequestEvent)
+
+    fun <O> testDoTransformIfPossibleWithEvent(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>,
+    ): Result<O> = doTransformIfPossible(messages, interaction, outputClass, llmRequestEvent)
+
+    fun <O> testDoTransformWithThinkingWithEvent(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>,
+    ): ThinkingResponse<O> = doTransformWithThinking(messages, interaction, outputClass, llmRequestEvent)
+
+    fun <O> testDoTransformWithThinkingIfPossibleWithEvent(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>,
+    ): Result<ThinkingResponse<O>> =
+        doTransformWithThinkingIfPossible(messages, interaction, outputClass, llmRequestEvent)
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiCostTrackingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiCostTrackingIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai;
+
+import com.embabel.agent.api.common.Ai;
+import com.embabel.agent.api.common.PromptRunner;
+import com.embabel.agent.api.event.AgentProcessEvent;
+import com.embabel.agent.api.event.AgenticEventListener;
+import com.embabel.agent.api.event.LlmInvocationEvent;
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.concurrent.atomic.LongAdder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end integration test for the per-call billing event flow.
+ *
+ * <p>Boots the full Spring context with OpenAI, invokes a real LLM, and
+ * verifies that the {@link CostListener} bean — registered as a regular
+ * {@link AgenticEventListener} — receives one {@link LlmInvocationEvent}
+ * per LLM call, each carrying non-zero token usage and a matching
+ * {@code interactionId}. Aggregating {@code event.invocation.cost()} gives a
+ * total greater than zero (real pricing model) — this is the use case
+ * described in issue #1604 (organisation-level cost tracking).
+ */
+@SpringBootTest(
+        properties = {
+                "embabel.models.cheapest=gpt-4.1-mini",
+                "embabel.models.best=gpt-4.1-mini",
+                "embabel.models.default-llm=gpt-4.1-mini",
+                "embabel.agent.platform.llm-operations.prompts.defaultTimeout=240s",
+                "spring.main.allow-bean-definition-overriding=true",
+        }
+)
+@ActiveProfiles("cost-tracking-it")
+@ConfigurationPropertiesScan(basePackages = "com.embabel.agent")
+@ComponentScan(basePackages = "com.embabel.agent")
+@Import({AgentOpenAiAutoConfiguration.class, LLMOpenAiCostTrackingIT.CostListenerConfig.class})
+class LLMOpenAiCostTrackingIT {
+
+    private static final Logger logger = LoggerFactory.getLogger(LLMOpenAiCostTrackingIT.class);
+
+    @Autowired
+    private Ai ai;
+
+    @Autowired
+    private CostListener costListener;
+
+    @Test
+    void llm_call_emits_one_LlmInvocationEvent_with_real_usage_and_cost() {
+        costListener.reset();
+
+        PromptRunner runner = ai.withLlm("gpt-4.1-mini");
+
+        WeatherFact result = runner.createObject(
+                "What is a typical July high temperature in Paris in Celsius? "
+                        + "Return only the city and temperature.",
+                WeatherFact.class
+        );
+
+        assertNotNull(result, "Agent must return a non-null result");
+        assertNotNull(result.getCity(), "Result must have a city");
+
+        // The whole point: at least one LlmInvocationEvent must have fired
+        List<LlmInvocationEvent> events = costListener.events();
+        assertFalse(events.isEmpty(),
+                "CostListener must receive at least one LlmInvocationEvent for the real LLM call");
+        logger.info("Received {} LlmInvocationEvent(s)", events.size());
+
+        // Each event carries real usage data
+        for (LlmInvocationEvent ev : events) {
+            Integer pt = ev.getInvocation().getUsage().getPromptTokens();
+            Integer ct = ev.getInvocation().getUsage().getCompletionTokens();
+            assertNotNull(pt, "promptTokens must be present");
+            assertNotNull(ct, "completionTokens must be present");
+            assertTrue(pt > 0, "promptTokens must be > 0 for a real call");
+            assertTrue(ct > 0, "completionTokens must be > 0 for a real call");
+            assertNotNull(ev.getInteractionId(), "interactionId must be set");
+            assertNotNull(ev.getAgentProcess(), "agentProcess must be present");
+            assertNotNull(ev.getInvocation().getLlmMetadata().getName(),
+                    "model name must be reported");
+        }
+
+        // Aggregating cost across all events gives the per-request bill
+        double totalCost = costListener.totalCostUsd();
+        long totalCalls = costListener.totalCalls();
+        long totalPrompt = costListener.totalPromptTokens();
+        long totalCompletion = costListener.totalCompletionTokens();
+
+        logger.info("Total: calls={}, prompt={}, completion={}, cost=${}",
+                totalCalls, totalPrompt, totalCompletion, totalCost);
+
+        assertEquals(events.size(), totalCalls,
+                "Aggregated call count must equal number of events");
+        assertTrue(totalPrompt > 0, "Total prompt tokens must be > 0");
+        assertTrue(totalCompletion > 0, "Total completion tokens must be > 0");
+        assertTrue(totalCost > 0.0,
+                "Total cost must be > 0 (gpt-4.1-mini has a non-null pricing model)");
+    }
+
+    /** Spring config that exposes a {@link CostListener} bean — auto-discovered by embabel. */
+    @Configuration
+    static class CostListenerConfig {
+        @Bean
+        CostListener costListener() {
+            return new CostListener();
+        }
+    }
+
+    /**
+     * Reference implementation of the use case from #1604: an organisation-level
+     * cost tracker subscribing to {@link LlmInvocationEvent} and aggregating
+     * tokens / cost across calls. Thread-safe (CONCURRENT mode would emit
+     * events from multiple threads).
+     */
+    static class CostListener implements AgenticEventListener {
+
+        private final List<LlmInvocationEvent> received = new CopyOnWriteArrayList<>();
+        private final LongAdder promptTokens = new LongAdder();
+        private final LongAdder completionTokens = new LongAdder();
+        private final DoubleAdder costUsd = new DoubleAdder();
+        private final AtomicInteger callCount = new AtomicInteger();
+
+        @Override
+        public void onProcessEvent(@NotNull AgentProcessEvent event) {
+            if (event instanceof LlmInvocationEvent llm) {
+                received.add(llm);
+                Integer pt = llm.getInvocation().getUsage().getPromptTokens();
+                Integer ct = llm.getInvocation().getUsage().getCompletionTokens();
+                promptTokens.add(pt != null ? pt : 0);
+                completionTokens.add(ct != null ? ct : 0);
+                costUsd.add(llm.getInvocation().cost());
+                callCount.incrementAndGet();
+            }
+        }
+
+        List<LlmInvocationEvent> events() {
+            return List.copyOf(received);
+        }
+
+        long totalCalls() {
+            return callCount.get();
+        }
+
+        long totalPromptTokens() {
+            return promptTokens.sum();
+        }
+
+        long totalCompletionTokens() {
+            return completionTokens.sum();
+        }
+
+        double totalCostUsd() {
+            return costUsd.sum();
+        }
+
+        void reset() {
+            received.clear();
+            promptTokens.reset();
+            completionTokens.reset();
+            costUsd.reset();
+            callCount.set(0);
+        }
+    }
+
+    /** Output type for the LLM call. */
+    public static class WeatherFact {
+        private String city;
+        private Integer celsius;
+
+        public WeatherFact() {}
+
+        public String getCity() { return city; }
+        public void setCity(String city) { this.city = city; }
+
+        public Integer getCelsius() { return celsius; }
+        public void setCelsius(Integer celsius) { this.celsius = celsius; }
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/cost-tracking/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/cost-tracking/page.adoc
@@ -1,0 +1,97 @@
+[[reference.cost-tracking]]
+=== Tracking LLM Cost and Usage
+
+Embabel emits an event for every LLM and embedding call your agent makes.
+Subscribe to those events to know, in real time, how much each call cost,
+which model handled it, and which agent process it belongs to.
+
+==== The events
+
+Two events are available:
+
+- `LlmInvocationEvent` — emitted once per LLM call.
+- `EmbeddingInvocationEvent` — emitted once per embedding call.
+
+Each event exposes:
+
+- `invocation.llmMetadata` (or `embeddingMetadata`) — model name and provider
+- `invocation.usage` — token counts
+- `invocation.cost()` — computed cost for that call
+- `interactionId` — identifier of the originating interaction
+- `agentProcess` — the agent process that triggered the call (use `agentProcess.id` to group, `agentProcess.agent.name` to label)
+
+==== Subscribing to cost events
+
+Implement `AgenticEventListener` and react to the events you care about.
+The listener is registered like any other Embabel event listener.
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+public class OrganizationCostTracker implements AgenticEventListener {
+
+    private final ConcurrentMap<String, DoubleAdder> costPerAgent = new ConcurrentHashMap<>();
+
+    @Override
+    public void onProcessEvent(AgentProcessEvent event) {
+        if (event instanceof LlmInvocationEvent llm) {
+            costPerAgent
+                .computeIfAbsent(llm.getAgentProcess().getAgent().getName(), k -> new DoubleAdder())
+                .add(llm.getInvocation().cost());
+        }
+    }
+}
+----
+
+Kotlin::
++
+[source,kotlin]
+----
+class OrganizationCostTracker : AgenticEventListener {
+
+    private val costPerAgent = ConcurrentHashMap<String, DoubleAdder>()
+
+    override fun onProcessEvent(event: AgentProcessEvent) {
+        if (event is LlmInvocationEvent) {
+            costPerAgent
+                .computeIfAbsent(event.agentProcess.agent.name) { DoubleAdder() }
+                .add(event.invocation.cost())
+        }
+    }
+}
+----
+====
+
+The same pattern works for `EmbeddingInvocationEvent`.
+
+TIP: Use a thread-safe data structure (as above) for any state your listener accumulates. Several agent processes may emit events at the same time.
+
+==== Blocking spending: the Budget Guardrail pattern
+
+Cost events fire *after* the call completes, so they cannot stop the call that just ran.
+What they can do is stop the *next* one.
+
+The pattern combines two pieces you already know:
+
+1. **A listener that counts.** Subscribe to `LlmInvocationEvent` and accumulate cost or tokens against the key you care about — agent process id, tenant, end user.
+2. **A guardrail that blocks.** A `UserInputGuardRail` reads the counter before the next LLM call. If the budget is exceeded, the guardrail returns a `CRITICAL` validation error and the call never happens.
+
+[source,text]
+----
+                       LLM call ───► LlmInvocationEvent ─┐
+                                                          ▼
+                                            counter (per agent / tenant / user)
+                                                          │
+   next call ──► UserInputGuardRail reads counter ────────┘
+                                │
+                       over budget? ──► CRITICAL ──► call blocked
+----
+
+The counter lives in your listener; the decision lives in your guardrail.
+Embabel wires both into the agent process for you.
+See <<reference.guardrails>> for how to register a `UserInputGuardRail` and how `CRITICAL` validation errors stop execution.
+
+NOTE: For a hard cap on the agent process itself (e.g. "stop this run after $1 of total spend"), see `EarlyTerminationPolicy` in <<reference.agent-process>>. Use it standalone, or alongside the Budget Guardrail as a safety net.

--- a/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
@@ -41,6 +41,8 @@ include::thinking/page.adoc[]
 
 include::interceptors/page.adoc[]
 
+include::cost-tracking/page.adoc[]
+
 include::guardrails/page.adoc[]
 
 include::termination/page.adoc[]


### PR DESCRIPTION
This PR closes the observability part of #1604. The goal is to track cost per individual LLM call.

Today, usage is recorded once per tool-loop as a single aggregate. This breaks down in `CONCURRENT` mode . The ticket needs `LlmMetadata`, `Usage`, `interactionId` and `agentProcess.id` available for each call.

The PR adds two new events: `LlmInvocationEvent` and `EmbeddingInvocationEvent`. Each fires once per call, with the four required fields. Listeners can aggregate cost as they need.

The implementation reuses an existing extension point. A `ToolLoopInspector` is created inline at each `toolLoopFactory.create(...)` site in `ToolLoopLlmOperations`. It captures `llm` and `llmRequestEvent` via closure. `DefaultToolLoop` fires it through its `afterLlmCall` hook. The tool-loop core is untouched.

Small side refactor: `doTransformIfPossible` was inlining start/completed event logic. It now uses the shared `publishToolLoopStartEvent` and `handleToolLoopCompletion` helpers, like the three other `doTransform*` methods. This addresses the "seems one call is missing" review comment of @igordayen 

The post-loop `recordUsage(...)` was removed from `handleToolLoopCompletion`. Keeping it would double-count on top of the per-call inspector.

`EmbeddingOperations` emits `EmbeddingInvocationEvent` after each recorded invocation, same pattern.

---

## Behavior change

`agentProcess.llmInvocations` now contains **N entries per loop** (one per call) instead of one aggregate. Sums (`cost()`, `usage()`) are unchanged. Tests asserting `size == 1` on loop scenarios were updated. No production caller depends on the aggregate semantics.

---

## Sample listener

```kotlin
class OrganizationCostTracker : AgenticEventListener {
    private val costPerAgent = ConcurrentHashMap<String, DoubleAdder>()

    override fun onProcessEvent(event: AgentProcessEvent) {
        if (event is LlmInvocationEvent) {
            costPerAgent
                .computeIfAbsent(event.agentProcess.agent.name) { DoubleAdder() }
                .add(event.invocation.cost())
        }
    }
}
```

> In `CONCURRENT` mode the event fires from multiple threads. Stateful listeners must be thread-safe.

---

## Not in this PR

**Pre-call enforcement** #1597 (blocking when a usage limit is hit) is out of scope.but this feature solve it.

**Streaming** is deferred. Stefan confirmed it isn't needed for v0.5.

**Observability module** - a full update will be handled in a dedicated PR to account for the changes introduced here and handle in the same time issue #1561 and #1588

---

## Test plan

  - `LlmInvocationEventTest` / `EmbeddingInvocationEventTest` - event shape and fields
  - `ChatClientLlmTransformerTest` - per-call count + matching `interactionId`
  - `EmbeddingOperationsTest` - emission with/without active agent
  - `ToolLoopLlmOperationsTest.BillingInspectorTests` - per-call emission across the 4 `doTransform*` paths, listener-cost aggregation, concurrency (16 parallel calls produce 16 distinct events with no cross-thread `interactionId` bleed), and listener-exception isolation (loop survives a listener that throws on every `LlmInvocationEvent`)
  - `LLMOpenAiCostTrackingIT` - end-to-end IT with a real OpenAI call
  - Full `embabel-agent-api` suite green: 3530 tests, 0 failures