### PR TITLE
#1467 - Removed explicitely setting the ArchUnit version 1.3.0. Now it will be picked up from the embabel-build-dependencies that now sets the ArchUnit version to 1.4.0

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -21,7 +21,6 @@
     </scm>
 
     <properties>
-        <archunit.version>1.3.0</archunit.version>
         <spotbugs-annotations.version>4.9.8</spotbugs-annotations.version>
         <!-- Exclude test utilities from SonarQube analysis -->
         <sonar.coverage.exclusions>**/test/integration/**</sonar.coverage.exclusions>


### PR DESCRIPTION

This pull request is gated by https://github.com/embabel/embabel-build/pull/78