### PR TITLE
Introduce Gobal Guardrails configuration

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/validation/guardrails/GuardRailInstantiationException.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/validation/guardrails/GuardRailInstantiationException.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.validation.guardrails
+
+/**
+ * Exception thrown when a guardrail fails to instantiate during application startup.
+ *
+ * This exception is thrown only when `embabel.agent.guardrails.fail-on-error=true`.
+ * It indicates a configuration error such as:
+ * - Invalid class name
+ * - Class does not implement the required guardrail interface
+ * - Constructor instantiation failure
+ */
+class GuardRailInstantiationException(
+    message: String,
+    cause: Throwable? = null
+) : RuntimeException(message, cause)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistry.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistry.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.spi.support.guardrails
 
 import com.embabel.agent.api.validation.guardrails.AssistantMessageGuardRail
+import com.embabel.agent.api.validation.guardrails.GuardRailInstantiationException
 import com.embabel.agent.api.validation.guardrails.UserInputGuardRail
 import com.embabel.common.util.loggerFor
 import jakarta.annotation.PostConstruct
@@ -49,7 +50,10 @@ class GlobalGuardRailsRegistry(
     private val userInputClassNames: String,
 
     @Value("\${embabel.agent.guardrails.assistant-message:}")
-    private val assistantMessageClassNames: String
+    private val assistantMessageClassNames: String,
+
+    @Value("\${embabel.agent.guardrails.fail-on-error:false}")
+    private val failOnError: Boolean
 ) {
     private val logger = loggerFor<GlobalGuardRailsRegistry>()
 
@@ -100,22 +104,29 @@ class GlobalGuardRailsRegistry(
 
                 // Check if class implements the required interface
                 if (!ClassUtils.isAssignable(T::class.java, clazz)) {
-                    logger.error("Class '{}' does not implement {}",
-                        trimmedClassName, T::class.java.simpleName)
+                    val errorMsg = "Class '$trimmedClassName' does not implement ${T::class.java.simpleName}"
+                    logger.error(errorMsg)
+                    if (failOnError) {
+                        throw GuardRailInstantiationException(errorMsg)
+                    }
                     return@mapNotNull null
                 }
 
                 val instance = BeanUtils.instantiateClass(clazz) as T
 
-                logger.info("Instantiated guardrail: {} from class: {}",
-                    (instance as? UserInputGuardRail)?.name ?:
-                    (instance as? AssistantMessageGuardRail)?.name,
-                    trimmedClassName)
+                logger.info("Instantiated guardrail: {}",
+                    clazz.simpleName ?: trimmedClassName)
 
                 instance
             } catch (e: Exception) {
-                logger.error("Failed to instantiate guardrail from class '{}': {}",
-                    className.trim(), e.message, e)
+                if (e is GuardRailInstantiationException) {
+                    throw e
+                }
+                val errorMsg = "Failed to instantiate guardrail from class '${className.trim()}': ${e.message}"
+                logger.error(errorMsg, e)
+                if (failOnError) {
+                    throw GuardRailInstantiationException(errorMsg, e)
+                }
                 null
             }
         }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistry.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistry.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.guardrails
+
+import com.embabel.agent.api.validation.guardrails.AssistantMessageGuardRail
+import com.embabel.agent.api.validation.guardrails.UserInputGuardRail
+import com.embabel.common.util.loggerFor
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.BeanUtils
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.util.ClassUtils
+
+/**
+ * Registry for globally configured guardrails loaded from application properties.
+ *
+ * Guardrails are instantiated from comma-separated class names specified in:
+ * - embabel.agent.guardrails.user-input
+ * - embabel.agent.guardrails.assistant-message
+ *
+ * Global guardrails are created once as singletons and reused across all LLM operations.
+ *
+ * This registry can be accessed in two ways:
+ * - As an injected Spring bean: `constructor(private val registry: GlobalGuardRailsRegistry)`
+ * - Statically via companion object: `GlobalGuardRailsRegistry.get()`
+ *
+ * Example configuration:
+ * ```
+ * embabel.agent.guardrails.user-input=com.example.ProfanityFilter,com.example.LengthValidator
+ * embabel.agent.guardrails.assistant-message=com.example.OutputValidator
+ * ```
+ */
+@Component
+class GlobalGuardRailsRegistry(
+    @Value("\${embabel.agent.guardrails.user-input:}")
+    private val userInputClassNames: String,
+
+    @Value("\${embabel.agent.guardrails.assistant-message:}")
+    private val assistantMessageClassNames: String
+) {
+    private val logger = loggerFor<GlobalGuardRailsRegistry>()
+
+    companion object {
+        private lateinit var instance: GlobalGuardRailsRegistry
+        private lateinit var userInputGuardRails: List<UserInputGuardRail>
+        private lateinit var assistantMessageGuardRails: List<AssistantMessageGuardRail>
+
+        /**
+         * Get the singleton instance of the registry.
+         * Returns null if the registry has not been initialized by Spring.
+         */
+        fun get(): GlobalGuardRailsRegistry? = if (::instance.isInitialized) instance else null
+
+        /**
+         * Get the list of global user input guardrails.
+         * Returns empty list if not yet initialized.
+         */
+        fun getUserInputGuardRails(): List<UserInputGuardRail> =
+            if (::userInputGuardRails.isInitialized) userInputGuardRails else emptyList()
+
+        /**
+         * Get the list of global assistant message guardrails.
+         * Returns empty list if not yet initialized.
+         */
+        fun getAssistantMessageGuardRails(): List<AssistantMessageGuardRail> =
+            if (::assistantMessageGuardRails.isInitialized) assistantMessageGuardRails else emptyList()
+    }
+
+    @PostConstruct
+    fun init() {
+        userInputGuardRails = instantiateGuardRails<UserInputGuardRail>(userInputClassNames)
+        assistantMessageGuardRails = instantiateGuardRails<AssistantMessageGuardRail>(assistantMessageClassNames)
+
+        instance = this
+
+        logger.info("GlobalGuardRailsRegistry initialized with {} user-input guardrails, {} assistant-message guardrails",
+            userInputGuardRails.size, assistantMessageGuardRails.size)
+    }
+
+    private inline fun <reified T> instantiateGuardRails(commaSeparated: String): List<T> {
+        if (commaSeparated.isBlank()) return emptyList()
+
+        return commaSeparated.split(",").mapNotNull { className ->
+            try {
+                val trimmedClassName = className.trim()
+                val clazz = ClassUtils.forName(trimmedClassName, ClassUtils.getDefaultClassLoader())
+
+                // Check if class implements the required interface
+                if (!ClassUtils.isAssignable(T::class.java, clazz)) {
+                    logger.error("Class '{}' does not implement {}",
+                        trimmedClassName, T::class.java.simpleName)
+                    return@mapNotNull null
+                }
+
+                val instance = BeanUtils.instantiateClass(clazz) as T
+
+                logger.info("Instantiated guardrail: {} from class: {}",
+                    (instance as? UserInputGuardRail)?.name ?:
+                    (instance as? AssistantMessageGuardRail)?.name,
+                    trimmedClassName)
+
+                instance
+            } catch (e: Exception) {
+                logger.error("Failed to instantiate guardrail from class '{}': {}",
+                    className.trim(), e.message, e)
+                null
+            }
+        }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/guardrails/llmOperationGuardRails.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/guardrails/llmOperationGuardRails.kt
@@ -33,19 +33,25 @@ private val logger = loggerFor<Any>()
 
 /**
  * Internal helper for user input validation that handles common guardrail logic.
+ * Merges global guardrails from registry with interaction-specific guardrails.
  */
 private fun validateUserInputInternal(
     interaction: LlmInteraction,
     blackboard: Blackboard?,
     validator: (UserInputGuardRail, Blackboard) -> ValidationResult
 ) {
-    val userInputGuards = interaction.guardRails
+    val interactionGuards = interaction.guardRails
         .filterIsInstance<UserInputGuardRail>()
 
-    if (userInputGuards.isEmpty()) return
+    val globalGuards = GlobalGuardRailsRegistry.getUserInputGuardRails()
+
+    // Merge global and interaction-specific guardrails, removing duplicates by name
+    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it.name }
+
+    if (effectiveGuards.isEmpty()) return
 
     val effectiveBlackboard = blackboard ?: InMemoryBlackboard()
-    userInputGuards.forEach { guard ->
+    effectiveGuards.forEach { guard ->
         val result = validator(guard, effectiveBlackboard)
         handleValidationResult(guard.name, result)
     }
@@ -78,60 +84,75 @@ internal fun validateUserInput(
 }
 
 /**
- * Validates String assistant response using configured guardrails from interaction options.
+ * Validates String assistant response using configured guardrails from interaction options and global registry.
  */
 internal fun validateAssistantResponse(
     response: String,
     interaction: LlmInteraction,
     blackboard: Blackboard?
 ) {
-    val assistantGuards = interaction.guardRails
+    val interactionGuards = interaction.guardRails
         .filterIsInstance<AssistantMessageGuardRail>()
 
-    if (assistantGuards.isEmpty()) return
+    val globalGuards = GlobalGuardRailsRegistry.getAssistantMessageGuardRails()
+
+    // Merge global and interaction-specific guardrails, removing duplicates by name
+    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it.name }
+
+    if (effectiveGuards.isEmpty()) return
 
     val effectiveBlackboard = blackboard ?: InMemoryBlackboard()
-    assistantGuards.forEach { guard ->
+    effectiveGuards.forEach { guard ->
         val result = guard.validate(response, effectiveBlackboard)
         handleValidationResult(guard.name, result)
     }
 }
 
 /**
- * Validates AssistantMessage response using configured guardrails from interaction options.
+ * Validates AssistantMessage response using configured guardrails from interaction options and global registry.
  */
 internal fun validateAssistantResponse(
     response: AssistantMessage,
     interaction: LlmInteraction,
     blackboard: Blackboard?
 ) {
-    val assistantGuards = interaction.guardRails
+    val interactionGuards = interaction.guardRails
         .filterIsInstance<AssistantMessageGuardRail>()
 
-    if (assistantGuards.isEmpty()) return
+    val globalGuards = GlobalGuardRailsRegistry.getAssistantMessageGuardRails()
+
+    // Merge global and interaction-specific guardrails, removing duplicates by name
+    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it.name }
+
+    if (effectiveGuards.isEmpty()) return
 
     val effectiveBlackboard = blackboard ?: InMemoryBlackboard()
-    assistantGuards.forEach { guard ->
+    effectiveGuards.forEach { guard ->
         val result = guard.validate(response, effectiveBlackboard)
         handleValidationResult(guard.name, result)
     }
 }
 
 /**
- * Validates ThinkingResponse using configured guardrails from interaction options.
+ * Validates ThinkingResponse using configured guardrails from interaction options and global registry.
  */
 internal fun validateAssistantResponse(
     response: ThinkingResponse<*>,
     interaction: LlmInteraction,
     blackboard: Blackboard?
 ) {
-    val assistantGuards = interaction.guardRails
+    val interactionGuards = interaction.guardRails
         .filterIsInstance<AssistantMessageGuardRail>()
 
-    if (assistantGuards.isEmpty()) return
+    val globalGuards = GlobalGuardRailsRegistry.getAssistantMessageGuardRails()
+
+    // Merge global and interaction-specific guardrails, removing duplicates by name
+    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it.name }
+
+    if (effectiveGuards.isEmpty()) return
 
     val effectiveBlackboard = blackboard ?: InMemoryBlackboard()
-    assistantGuards.forEach { guard ->
+    effectiveGuards.forEach { guard ->
         val result = guard.validate(response, effectiveBlackboard)
         handleValidationResult(guard.name, result)
     }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/guardrails/llmOperationGuardRails.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/guardrails/llmOperationGuardRails.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.spi.support.guardrails
 
 import com.embabel.agent.core.Blackboard
 import com.embabel.agent.api.validation.guardrails.AssistantMessageGuardRail
+import com.embabel.agent.api.validation.guardrails.GuardRail
 import com.embabel.agent.api.validation.guardrails.GuardRailViolationException
 import com.embabel.agent.api.validation.guardrails.UserInputGuardRail
 import com.embabel.agent.core.support.LlmInteraction
@@ -45,15 +46,15 @@ private fun validateUserInputInternal(
 
     val globalGuards = GlobalGuardRailsRegistry.getUserInputGuardRails()
 
-    // Merge global and interaction-specific guardrails, removing duplicates by name
-    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it.name }
+    // Merge global and interaction-specific guardrails, removing duplicates by class
+    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it::class }
 
     if (effectiveGuards.isEmpty()) return
 
     val effectiveBlackboard = blackboard ?: InMemoryBlackboard()
     effectiveGuards.forEach { guard ->
         val result = validator(guard, effectiveBlackboard)
-        handleValidationResult(guard.name, result)
+        handleValidationResult(guard, result)
     }
 }
 
@@ -84,28 +85,40 @@ internal fun validateUserInput(
 }
 
 /**
- * Validates String assistant response using configured guardrails from interaction options and global registry.
+ * Internal helper for assistant response validation that handles common guardrail logic.
+ * Merges global guardrails from registry with interaction-specific guardrails.
  */
-internal fun validateAssistantResponse(
-    response: String,
+private fun validateAssistantInternal(
     interaction: LlmInteraction,
-    blackboard: Blackboard?
+    blackboard: Blackboard?,
+    validator: (AssistantMessageGuardRail, Blackboard) -> ValidationResult
 ) {
     val interactionGuards = interaction.guardRails
         .filterIsInstance<AssistantMessageGuardRail>()
 
     val globalGuards = GlobalGuardRailsRegistry.getAssistantMessageGuardRails()
 
-    // Merge global and interaction-specific guardrails, removing duplicates by name
-    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it.name }
+    // Merge global and interaction-specific guardrails, removing duplicates by class
+    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it::class }
 
     if (effectiveGuards.isEmpty()) return
 
     val effectiveBlackboard = blackboard ?: InMemoryBlackboard()
     effectiveGuards.forEach { guard ->
-        val result = guard.validate(response, effectiveBlackboard)
-        handleValidationResult(guard.name, result)
+        val result = validator(guard, effectiveBlackboard)
+        handleValidationResult(guard, result)
     }
+}
+
+/**
+ * Validates String assistant response using configured guardrails from interaction options and global registry.
+ */
+internal fun validateAssistantResponse(
+    response: String,
+    interaction: LlmInteraction,
+    blackboard: Blackboard?
+) = validateAssistantInternal(interaction, blackboard) { guard, bb ->
+    guard.validate(response, bb)
 }
 
 /**
@@ -115,22 +128,8 @@ internal fun validateAssistantResponse(
     response: AssistantMessage,
     interaction: LlmInteraction,
     blackboard: Blackboard?
-) {
-    val interactionGuards = interaction.guardRails
-        .filterIsInstance<AssistantMessageGuardRail>()
-
-    val globalGuards = GlobalGuardRailsRegistry.getAssistantMessageGuardRails()
-
-    // Merge global and interaction-specific guardrails, removing duplicates by name
-    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it.name }
-
-    if (effectiveGuards.isEmpty()) return
-
-    val effectiveBlackboard = blackboard ?: InMemoryBlackboard()
-    effectiveGuards.forEach { guard ->
-        val result = guard.validate(response, effectiveBlackboard)
-        handleValidationResult(guard.name, result)
-    }
+) = validateAssistantInternal(interaction, blackboard) { guard, bb ->
+    guard.validate(response, bb)
 }
 
 /**
@@ -140,28 +139,18 @@ internal fun validateAssistantResponse(
     response: ThinkingResponse<*>,
     interaction: LlmInteraction,
     blackboard: Blackboard?
-) {
-    val interactionGuards = interaction.guardRails
-        .filterIsInstance<AssistantMessageGuardRail>()
-
-    val globalGuards = GlobalGuardRailsRegistry.getAssistantMessageGuardRails()
-
-    // Merge global and interaction-specific guardrails, removing duplicates by name
-    val effectiveGuards = (globalGuards + interactionGuards).distinctBy { it.name }
-
-    if (effectiveGuards.isEmpty()) return
-
-    val effectiveBlackboard = blackboard ?: InMemoryBlackboard()
-    effectiveGuards.forEach { guard ->
-        val result = guard.validate(response, effectiveBlackboard)
-        handleValidationResult(guard.name, result)
-    }
+) = validateAssistantInternal(interaction, blackboard) { guard, bb ->
+    guard.validate(response, bb)
 }
 
 /**
  * Handles validation results and throws exceptions for critical violations.
  */
-private fun handleValidationResult(guardName: String, result: ValidationResult) {
+private fun handleValidationResult(guard: GuardRail, result: ValidationResult) {
+    val guardName = guard.name
+    val guardClassName = guard::class.simpleName
+    val guardIdentifier = guardClassName?.let { "$guardName ($it)" } ?: guardName
+
     val severityPriority = mapOf(
         ValidationSeverity.INFO to 1,
         ValidationSeverity.WARNING to 2,
@@ -174,16 +163,16 @@ private fun handleValidationResult(guardName: String, result: ValidationResult) 
     when (highestSeverity) {
         ValidationSeverity.INFO -> {
             if (result.errors.isNotEmpty()) {
-                logger.info("GuardRail '{}' info: {}", guardName,
+                logger.info("GuardRail '{}' info: {}", guardIdentifier,
                     result.errors.joinToString("; ") { it.message })
             }
         }
         ValidationSeverity.WARNING -> {
-            logger.warn("GuardRail '{}' warning: {}", guardName,
+            logger.warn("GuardRail '{}' warning: {}", guardIdentifier,
                 result.errors.joinToString("; ") { it.message })
         }
         ValidationSeverity.ERROR -> {
-            logger.error("GuardRail '{}' error: {}", guardName,
+            logger.error("GuardRail '{}' error: {}", guardIdentifier,
                 result.errors.joinToString("; ") { it.message })
         }
         ValidationSeverity.CRITICAL -> {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistryFailOnErrorTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistryFailOnErrorTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.guardrails
+
+import com.embabel.agent.api.validation.guardrails.GuardRailInstantiationException
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Tests for fail-on-error behavior in GlobalGuardRailsRegistry.
+ * Tests the configuration property: embabel.agent.guardrails.fail-on-error
+ */
+class GlobalGuardRailsRegistryFailOnErrorTest {
+
+    @Test
+    fun `should throw exception when failOnError is true and class does not exist`() {
+        val registry = GlobalGuardRailsRegistry(
+            userInputClassNames = "com.example.NonExistentClass",
+            assistantMessageClassNames = "",
+            failOnError = true
+        )
+
+        val exception = assertThrows<GuardRailInstantiationException> {
+            registry.init()
+        }
+
+        assertTrue(exception.message?.contains("NonExistentClass") == true,
+            "Exception message should contain class name")
+    }
+
+    @Test
+    fun `should throw exception when failOnError is true and class does not implement interface`() {
+        val registry = GlobalGuardRailsRegistry(
+            userInputClassNames = "java.lang.String",
+            assistantMessageClassNames = "",
+            failOnError = true
+        )
+
+        val exception = assertThrows<GuardRailInstantiationException> {
+            registry.init()
+        }
+
+        assertTrue(exception.message?.contains("does not implement") == true,
+            "Exception message should indicate interface mismatch")
+    }
+
+    @Test
+    fun `should not throw exception when failOnError is false and class does not exist`() {
+        val registry = GlobalGuardRailsRegistry(
+            userInputClassNames = "com.example.NonExistentClass",
+            assistantMessageClassNames = "",
+            failOnError = false
+        )
+
+        assertDoesNotThrow {
+            registry.init()
+        }
+
+        // Should have empty list since class failed to load
+        assertTrue(GlobalGuardRailsRegistry.getUserInputGuardRails().isEmpty())
+    }
+
+    @Test
+    fun `should not throw exception when failOnError is false and class does not implement interface`() {
+        val registry = GlobalGuardRailsRegistry(
+            userInputClassNames = "java.lang.String",
+            assistantMessageClassNames = "",
+            failOnError = false
+        )
+
+        assertDoesNotThrow {
+            registry.init()
+        }
+
+        // Should have empty list since class failed validation
+        assertTrue(GlobalGuardRailsRegistry.getUserInputGuardRails().isEmpty())
+    }
+
+    @Test
+    fun `should load valid guardrails even when failOnError is true`() {
+        val registry = GlobalGuardRailsRegistry(
+            userInputClassNames = "com.embabel.agent.spi.support.guardrails.GlobalUserGuardRail",
+            assistantMessageClassNames = "",
+            failOnError = true
+        )
+
+        assertDoesNotThrow {
+            registry.init()
+        }
+
+        assertEquals(1, GlobalGuardRailsRegistry.getUserInputGuardRails().size)
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistryIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistryIntegrationTest.kt
@@ -134,18 +134,17 @@ class GlobalGuardRailsRegistryIntegrationTest {
         }
 
         @Test
-        fun `should remove duplicate guardrails by name`() {
-            val duplicateGuard = DuplicateNameGuardRail()
+        fun `should remove duplicate guardrails by class`() {
+            val globalGuard = GlobalGuardRailsRegistry.getUserInputGuardRails().first() as GlobalUserGuardRail
             val interaction = LlmInteraction(
                 id = InteractionId("test"),
-                guardRails = listOf(duplicateGuard)
+                guardRails = listOf(globalGuard)  // Same instance/class as global
             )
 
             validateUserInput("test input", interaction, InMemoryBlackboard())
 
-            val globalGuard = GlobalGuardRailsRegistry.getUserInputGuardRails().first() as GlobalUserGuardRail
-            assertEquals(1, globalGuard.invocationCount, "Global guardrail should be invoked")
-            assertEquals(0, duplicateGuard.invocationCount, "Duplicate should be filtered out")
+            // Should only be invoked once even though it's in both global and interaction lists
+            assertEquals(1, globalGuard.invocationCount, "Same class should only be invoked once")
         }
 
         @Test
@@ -237,20 +236,6 @@ class InteractionUserGuardRail : UserInputGuardRail {
 
     override val name: String = "InteractionUserGuardRail"
     override val description: String = "Interaction user guardrail"
-    override fun validate(input: String, blackboard: Blackboard): ValidationResult {
-        invocationCount++
-        return ValidationResult(true, emptyList())
-    }
-}
-
-/**
- * Test guardrail with duplicate name to test deduplication.
- */
-class DuplicateNameGuardRail : UserInputGuardRail {
-    var invocationCount = 0
-
-    override val name: String = "GlobalUserGuardRail" // Same name as GlobalUserGuardRail
-    override val description: String = "Duplicate name guardrail"
     override fun validate(input: String, blackboard: Blackboard): ValidationResult {
         invocationCount++
         return ValidationResult(true, emptyList())

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistryIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/guardrails/GlobalGuardRailsRegistryIntegrationTest.kt
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.guardrails
+
+import com.embabel.agent.api.common.InteractionId
+import com.embabel.agent.api.validation.guardrails.AssistantMessageGuardRail
+import com.embabel.agent.api.validation.guardrails.GuardRailViolationException
+import com.embabel.agent.api.validation.guardrails.UserInputGuardRail
+import com.embabel.agent.core.Blackboard
+import com.embabel.agent.core.support.InMemoryBlackboard
+import com.embabel.agent.core.support.LlmInteraction
+import com.embabel.common.core.thinking.ThinkingResponse
+import com.embabel.common.core.validation.ValidationError
+import com.embabel.common.core.validation.ValidationResult
+import com.embabel.common.core.validation.ValidationSeverity
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * Spring Boot integration test for GlobalGuardRailsRegistry.
+ * Verifies Spring integration and guardrail merging with properties.
+ */
+@SpringBootTest(classes = [GlobalGuardRailsRegistryIntegrationTest.TestConfiguration::class])
+@ActiveProfiles("guardrails")
+@TestPropertySource(
+    properties = [
+        "embabel.agent.guardrails.user-input=com.embabel.agent.spi.support.guardrails.GlobalUserGuardRail",
+        "embabel.agent.guardrails.assistant-message=com.embabel.agent.spi.support.guardrails.GlobalAssistantGuardRail"
+    ]
+)
+class GlobalGuardRailsRegistryIntegrationTest {
+
+    @Autowired
+    private lateinit var registry: GlobalGuardRailsRegistry
+
+    @BeforeEach
+    fun resetInvocationCounts() {
+        // Reset singleton guardrail invocation counts before each test
+        val globalUserGuard = GlobalGuardRailsRegistry.getUserInputGuardRails().firstOrNull() as? GlobalUserGuardRail
+        globalUserGuard?.invocationCount = 0
+        val globalAssistantGuard = GlobalGuardRailsRegistry.getAssistantMessageGuardRails().firstOrNull() as? GlobalAssistantGuardRail
+        globalAssistantGuard?.invocationCount = 0
+    }
+
+    @Nested
+    inner class RegistrySpringIntegrationTests {
+
+        @Test
+        fun `should autowire registry bean`() {
+            assertNotNull(registry)
+        }
+
+        @Test
+        fun `should load user input guardrails from properties`() {
+            val guards = GlobalGuardRailsRegistry.getUserInputGuardRails()
+
+            assertEquals(1, guards.size)
+            assertEquals("GlobalUserGuardRail", guards.first().name)
+        }
+
+        @Test
+        fun `should load assistant message guardrails from properties`() {
+            val guards = GlobalGuardRailsRegistry.getAssistantMessageGuardRails()
+
+            assertEquals(1, guards.size)
+            assertEquals("GlobalAssistantGuardRail", guards.first().name)
+        }
+
+        @Test
+        fun `should access registry via singleton pattern`() {
+            val instance = GlobalGuardRailsRegistry.get()
+
+            assertNotNull(instance)
+            assertSame(registry, instance)
+        }
+
+        @Test
+        fun `should return same guardrail instances across multiple accesses`() {
+            val guards1 = GlobalGuardRailsRegistry.getUserInputGuardRails()
+            val guards2 = GlobalGuardRailsRegistry.getUserInputGuardRails()
+
+            assertSame(guards1, guards2)
+        }
+    }
+
+    @Nested
+    inner class GuardRailMergingIntegrationTests {
+
+        @Test
+        fun `should merge global and interaction-specific guardrails`() {
+            val interactionGuard = InteractionUserGuardRail()
+            val interaction = LlmInteraction(
+                id = InteractionId("test"),
+                guardRails = listOf(interactionGuard)
+            )
+
+            validateUserInput("test input", interaction, InMemoryBlackboard())
+
+            val globalGuard = GlobalGuardRailsRegistry.getUserInputGuardRails().first() as GlobalUserGuardRail
+            assertEquals(1, globalGuard.invocationCount, "Global guardrail should be invoked")
+            assertEquals(1, interactionGuard.invocationCount, "Interaction guardrail should be invoked")
+        }
+
+        @Test
+        fun `should use only global guardrails when no interaction guardrails`() {
+            val interaction = LlmInteraction(
+                id = InteractionId("test"),
+                guardRails = emptyList()
+            )
+
+            validateUserInput("test input", interaction, InMemoryBlackboard())
+
+            val globalGuard = GlobalGuardRailsRegistry.getUserInputGuardRails().first() as GlobalUserGuardRail
+            assertEquals(1, globalGuard.invocationCount)
+        }
+
+        @Test
+        fun `should remove duplicate guardrails by name`() {
+            val duplicateGuard = DuplicateNameGuardRail()
+            val interaction = LlmInteraction(
+                id = InteractionId("test"),
+                guardRails = listOf(duplicateGuard)
+            )
+
+            validateUserInput("test input", interaction, InMemoryBlackboard())
+
+            val globalGuard = GlobalGuardRailsRegistry.getUserInputGuardRails().first() as GlobalUserGuardRail
+            assertEquals(1, globalGuard.invocationCount, "Global guardrail should be invoked")
+            assertEquals(0, duplicateGuard.invocationCount, "Duplicate should be filtered out")
+        }
+
+        @Test
+        fun `should throw exception for critical violations`() {
+            val criticalGuard = CriticalUserGuardRail()
+            val interaction = LlmInteraction(
+                id = InteractionId("test"),
+                guardRails = listOf(criticalGuard)
+            )
+
+            assertThrows(GuardRailViolationException::class.java) {
+                validateUserInput("test input", interaction, InMemoryBlackboard())
+            }
+        }
+
+        @Test
+        fun `should merge assistant message guardrails`() {
+            val interaction = LlmInteraction(
+                id = InteractionId("test"),
+                guardRails = emptyList()
+            )
+
+            validateAssistantResponse("test response", interaction, InMemoryBlackboard())
+
+            val globalGuard =
+                GlobalGuardRailsRegistry.getAssistantMessageGuardRails().first() as GlobalAssistantGuardRail
+            assertEquals(1, globalGuard.invocationCount)
+        }
+
+        @Test
+        fun `should work without blackboard`() {
+            val interaction = LlmInteraction(
+                id = InteractionId("test"),
+                guardRails = emptyList()
+            )
+
+            assertDoesNotThrow {
+                validateUserInput("test input", interaction, null)
+            }
+
+            val globalGuard = GlobalGuardRailsRegistry.getUserInputGuardRails().first() as GlobalUserGuardRail
+            assertEquals(1, globalGuard.invocationCount)
+        }
+    }
+
+    @org.springframework.context.annotation.Configuration
+    @org.springframework.context.annotation.ComponentScan(basePackages = ["com.embabel.agent.spi.support.guardrails"])
+    class TestConfiguration
+}
+
+/**
+ * Global test guardrail for user input.
+ */
+class GlobalUserGuardRail : UserInputGuardRail {
+    var invocationCount = 0
+
+    override val name: String = "GlobalUserGuardRail"
+    override val description: String = "Global user guardrail"
+    override fun validate(input: String, blackboard: Blackboard): ValidationResult {
+        invocationCount++
+        return ValidationResult(true, emptyList())
+    }
+}
+
+/**
+ * Global test guardrail for assistant messages.
+ */
+class GlobalAssistantGuardRail : AssistantMessageGuardRail {
+    var invocationCount = 0
+
+    override val name: String = "GlobalAssistantGuardRail"
+    override val description: String = "Global assistant guardrail"
+    override fun validate(input: String, blackboard: Blackboard): ValidationResult {
+        invocationCount++
+        return ValidationResult(true, emptyList())
+    }
+
+    override fun validate(response: ThinkingResponse<*>, blackboard: Blackboard): ValidationResult {
+        invocationCount++
+        return ValidationResult(true, emptyList())
+    }
+}
+
+/**
+ * Test guardrail for interaction-specific usage.
+ */
+class InteractionUserGuardRail : UserInputGuardRail {
+    var invocationCount = 0
+
+    override val name: String = "InteractionUserGuardRail"
+    override val description: String = "Interaction user guardrail"
+    override fun validate(input: String, blackboard: Blackboard): ValidationResult {
+        invocationCount++
+        return ValidationResult(true, emptyList())
+    }
+}
+
+/**
+ * Test guardrail with duplicate name to test deduplication.
+ */
+class DuplicateNameGuardRail : UserInputGuardRail {
+    var invocationCount = 0
+
+    override val name: String = "GlobalUserGuardRail" // Same name as GlobalUserGuardRail
+    override val description: String = "Duplicate name guardrail"
+    override fun validate(input: String, blackboard: Blackboard): ValidationResult {
+        invocationCount++
+        return ValidationResult(true, emptyList())
+    }
+}
+
+/**
+ * Test guardrail that returns critical validation error.
+ */
+class CriticalUserGuardRail : UserInputGuardRail {
+    override val name: String = "CriticalUserGuardRail"
+    override val description: String = "Critical severity guardrail"
+    override fun validate(input: String, blackboard: Blackboard): ValidationResult {
+        return ValidationResult(
+            false,
+            listOf(ValidationError("critical-error", "Critical violation", ValidationSeverity.CRITICAL))
+        )
+    }
+}


### PR DESCRIPTION
##Oveview

See issue #1597 

Introduced Global Guard Rails Registry - dual-purpose Bean, which can be accessed as a singleton or through injection.

Updated guard rails SPI accordingly.

Note:
- guardrails got listed in agent-application.properties (see example in test)
- used POJOs for guardrails instantiation, not beans (YAGNI). if requied can be considered as well, or just use references to singletons inside POJO

