### PR TITLE
Don't depend on Spring AI being on classpath to handle tool annotations

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/toolUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/toolUtils.kt
@@ -17,15 +17,26 @@ package com.embabel.agent.core.support
 
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolObject
-import com.embabel.agent.core.Usage
-import com.embabel.agent.spi.support.springai.toEmbabelTool
-import com.embabel.agent.spi.support.springai.toSpringToolCallback
-import org.springframework.ai.support.ToolCallbacks
-import org.springframework.ai.tool.ToolCallback
+
+/**
+ * SPI for extracting framework-specific tools (e.g. Spring AI) from an arbitrary
+ * object. Implementations are discovered reflectively so that this package has
+ * no compile-time dependency on the underlying framework.
+ */
+internal interface ExternalToolExtractor {
+    fun extract(obj: Any): List<Tool>
+}
+
+private val externalToolExtractor: ExternalToolExtractor? = try {
+    Class.forName("org.springframework.ai.tool.ToolCallback")
+    val cls = Class.forName("com.embabel.agent.spi.support.springai.SpringAiToolExtractor")
+    cls.getField("INSTANCE").get(null) as ExternalToolExtractor
+} catch (_: ClassNotFoundException) {
+    null
+}
 
 /**
  * Extract native Tools from ToolObject instances.
- * Preferred over safelyGetToolCallbacks as it returns framework-agnostic Tools.
  */
 fun safelyGetTools(instances: Collection<ToolObject>): List<Tool> =
     instances.flatMap { safelyGetToolsFrom(it) }
@@ -34,35 +45,19 @@ fun safelyGetTools(instances: Collection<ToolObject>): List<Tool> =
 
 /**
  * Extract native Tools from a single ToolObject.
- * Handles Embabel @LlmTool annotations, Spring AI @Tool annotations,
- * and direct Tool/ToolCallback instances.
+ * Handles Embabel @LlmTool annotations and direct Tool instances.
+ * If a Spring AI extractor is on the classpath, also handles Spring AI
+ * @Tool annotations and ToolCallback instances.
  */
 fun safelyGetToolsFrom(toolObject: ToolObject): List<Tool> {
     val tools = mutableListOf<Tool>()
     toolObject.objects.forEach { obj ->
-        // Handle Tool instances directly
         if (obj is Tool) {
             tools.add(obj)
             return@forEach
         }
-
-        // Handle ToolCallback instances by wrapping them
-        if (obj is ToolCallback) {
-            tools.add(obj.toEmbabelTool())
-            return@forEach
-        }
-
-        // Scan for Embabel @LlmTool annotations
-        val embabelTools = Tool.safelyFromInstance(obj)
-        tools.addAll(embabelTools)
-
-        // Scan for Spring AI @Tool annotations and wrap them
-        try {
-            val springCallbacks = ToolCallbacks.from(obj).toList()
-            tools.addAll(springCallbacks.map { it.toEmbabelTool() })
-        } catch (_: IllegalStateException) {
-            // Ignore - no @Tool annotations found
-        }
+        tools.addAll(Tool.safelyFromInstance(obj))
+        externalToolExtractor?.let { tools.addAll(it.extract(obj)) }
     }
     return tools
         .filter { toolObject.filter(it.definition.name) }
@@ -77,20 +72,6 @@ fun safelyGetToolsFrom(toolObject: ToolObject): List<Tool> {
         .distinctBy { it.definition.name }
         .sortedBy { it.definition.name }
 }
-
-/**
- * Extract tools and convert to Spring AI ToolCallbacks.
- * Internal use only - external code should use [safelyGetTools] and convert at the Spring AI boundary.
- */
-internal fun safelyGetToolCallbacks(instances: Collection<ToolObject>): List<ToolCallback> =
-    safelyGetTools(instances).map { it.toSpringToolCallback() }
-
-/**
- * Extract tools from a single ToolObject and convert to Spring AI ToolCallbacks.
- * Internal use only - external code should use [safelyGetToolsFrom].
- */
-internal fun safelyGetToolCallbacksFrom(toolObject: ToolObject): List<ToolCallback> =
-    safelyGetToolsFrom(toolObject).map { it.toSpringToolCallback() }
 
 /**
  * Allows renaming a Tool while preserving its behavior.
@@ -109,12 +90,4 @@ internal class RenamedTool(
     override val metadata: Tool.Metadata = delegate.metadata
 
     override fun call(input: String): Tool.Result = delegate.call(input)
-}
-
-fun org.springframework.ai.chat.metadata.Usage.toEmbabelUsage(): Usage {
-    return Usage(
-        promptTokens = this.promptTokens,
-        completionTokens = this.completionTokens,
-        nativeUsage = this.nativeUsage,
-    )
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -24,7 +24,6 @@ import com.embabel.agent.core.internal.streaming.StreamingLlmOperations
 import com.embabel.agent.spi.support.springai.streaming.StreamingChatClientOperations
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.support.LlmInteraction
-import com.embabel.agent.core.support.toEmbabelUsage
 import com.embabel.agent.spi.AutoLlmSelectionCriteriaResolver
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.ToolDecorator

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmMessageSender.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmMessageSender.kt
@@ -16,7 +16,6 @@
 package com.embabel.agent.spi.support.springai
 
 import com.embabel.agent.api.tool.Tool
-import com.embabel.agent.core.support.toEmbabelUsage
 import com.embabel.agent.spi.loop.LlmMessageResponse
 import com.embabel.agent.spi.loop.LlmMessageSender
 import com.embabel.chat.Message

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiToolExtractor.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiToolExtractor.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.springai
+
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.core.support.ExternalToolExtractor
+import org.springframework.ai.support.ToolCallbacks
+import org.springframework.ai.tool.ToolCallback
+
+/**
+ * Discovered reflectively by core toolUtils when Spring AI is on the classpath.
+ * Must be referenced only via its FQCN from core to preserve the classpath check.
+ */
+internal object SpringAiToolExtractor : ExternalToolExtractor {
+
+    override fun extract(obj: Any): List<Tool> {
+        if (obj is ToolCallback) {
+            return listOf(obj.toEmbabelTool())
+        }
+        return try {
+            ToolCallbacks.from(obj).map { it.toEmbabelTool() }
+        } catch (_: IllegalStateException) {
+            emptyList()
+        }
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/springAiUtils.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/springAiUtils.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.springai
+
+import com.embabel.agent.api.tool.ToolObject
+import com.embabel.agent.core.Usage
+import com.embabel.agent.core.support.safelyGetTools
+import com.embabel.agent.core.support.safelyGetToolsFrom
+import org.springframework.ai.tool.ToolCallback
+
+/**
+ * Extract tools and convert to Spring AI ToolCallbacks.
+ * Internal use only - external code should use [safelyGetTools] and convert at the Spring AI boundary.
+ */
+internal fun safelyGetToolCallbacks(instances: Collection<ToolObject>): List<ToolCallback> =
+    safelyGetTools(instances).map { it.toSpringToolCallback() }
+
+/**
+ * Extract tools from a single ToolObject and convert to Spring AI ToolCallbacks.
+ * Internal use only - external code should use [safelyGetToolsFrom].
+ */
+internal fun safelyGetToolCallbacksFrom(toolObject: ToolObject): List<ToolCallback> =
+    safelyGetToolsFrom(toolObject).map { it.toSpringToolCallback() }
+
+fun org.springframework.ai.chat.metadata.Usage.toEmbabelUsage(): Usage {
+    return Usage(
+        promptTokens = this.promptTokens,
+        completionTokens = this.completionTokens,
+        nativeUsage = this.nativeUsage,
+    )
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ToolUtilsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/ToolUtilsTest.kt
@@ -21,12 +21,8 @@ import com.embabel.common.util.StringTransformer
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.springframework.ai.chat.metadata.DefaultUsage
 
-/**
- * Tests for utility functions and classes in springAiUtils.kt.
- */
-class SpringAiUtilsTest {
+class ToolUtilsTest {
 
     @Nested
     inner class RenamedToolTest {
@@ -176,14 +172,13 @@ class SpringAiUtilsTest {
             val tool = createMockTool("same-name") { Tool.Result.text("{}") }
             val toolObject = ToolObject(
                 objects = listOf(tool),
-                namingStrategy = StringTransformer { it }, // Identity transform
+                namingStrategy = StringTransformer { it },
             )
 
             val tools = safelyGetToolsFrom(toolObject)
 
             assertEquals(1, tools.size)
             assertEquals("same-name", tools[0].definition.name)
-            // Should be the original tool, not wrapped in RenamedTool
             assertFalse(tools[0] is RenamedTool)
         }
 
@@ -223,29 +218,6 @@ class SpringAiUtilsTest {
 
             assertEquals("alpha", tools[0].definition.name)
             assertEquals("zulu", tools[1].definition.name)
-        }
-    }
-
-    @Nested
-    inner class ToEmbabelUsageTest {
-
-        @Test
-        fun `converts Spring AI Usage to Embabel Usage`() {
-            val springUsage = DefaultUsage(100, 50)
-
-            val embabelUsage = springUsage.toEmbabelUsage()
-
-            assertEquals(100, embabelUsage.promptTokens)
-            assertEquals(50, embabelUsage.completionTokens)
-        }
-
-        @Test
-        fun `preserves total tokens calculation`() {
-            val springUsage = DefaultUsage(200, 100)
-
-            val embabelUsage = springUsage.toEmbabelUsage()
-
-            assertEquals(300, embabelUsage.totalTokens)
         }
     }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SafelyGetToolCallbacksTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SafelyGetToolCallbacksTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.core.support
+package com.embabel.agent.spi.support.springai
 
 import com.embabel.agent.api.annotation.LlmTool
 import com.embabel.agent.api.annotation.support.FunnyTool
@@ -26,11 +26,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.ai.tool.ToolCallback
 import kotlin.test.assertEquals
 
-class SpringAiUtilsKtTest {
+class SafelyGetToolCallbacksTest {
 
-    /**
-     * Test class using Embabel's @Tool.Method annotation
-     */
     class EmbabelToolMethodExample {
         @LlmTool(description = "Adds two numbers")
         fun add(
@@ -45,9 +42,6 @@ class SpringAiUtilsKtTest {
         ): Int = a * b
     }
 
-    /**
-     * Test class using both Spring AI @Tool and Embabel @Tool.Method
-     */
     class MixedToolExample {
         @org.springframework.ai.tool.annotation.Tool(description = "Spring tool")
         fun springTool(): String = "spring"
@@ -253,5 +247,4 @@ class SpringAiUtilsKtTest {
         assertEquals(1, result.size)
         assertEquals("add", result[0].toolDefinition.name())
     }
-
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiUsageTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiUsageTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.springai
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.metadata.DefaultUsage
+
+class SpringAiUsageTest {
+
+    @Test
+    fun `converts Spring AI Usage to Embabel Usage`() {
+        val springUsage = DefaultUsage(100, 50)
+
+        val embabelUsage = springUsage.toEmbabelUsage()
+
+        assertEquals(100, embabelUsage.promptTokens)
+        assertEquals(50, embabelUsage.completionTokens)
+    }
+
+    @Test
+    fun `preserves total tokens calculation`() {
+        val springUsage = DefaultUsage(200, 100)
+
+        val embabelUsage = springUsage.toEmbabelUsage()
+
+        assertEquals(300, embabelUsage.totalTokens)
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/LlmInvocationHistoryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/LlmInvocationHistoryTest.kt
@@ -18,7 +18,7 @@ package com.embabel.agent.support
 import com.embabel.agent.api.common.ToolsStats
 import com.embabel.agent.core.LlmInvocation
 import com.embabel.agent.core.LlmInvocationHistory
-import com.embabel.agent.core.support.toEmbabelUsage
+import com.embabel.agent.spi.support.springai.toEmbabelUsage
 import com.embabel.agent.spi.LlmService
 import com.embabel.common.ai.model.PricingModel
 import io.mockk.every


### PR DESCRIPTION
This PR removes the hard dependency on Spring AI `ToolCallback` in tool resolution. Spring AI is now only used if it's found on the classpath.