### PR TITLE
Prepare 0.4.0

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>0.1.13</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.13-SNAPSHOT</version>
+        <version>0.1.13</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,7 +16,7 @@
 
     <properties>
         <argLine/>
-        <embabel-common.version>0.1.12-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.12</embabel-common.version>
         <netty.version>4.2.13.Final</netty.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>


### PR DESCRIPTION
This pull request updates project dependencies from snapshot versions to their corresponding release versions. These changes ensure that the project now references stable, released artifacts rather than potentially unstable development snapshots.

Dependency version updates:

* Updated the parent version in `pom.xml` from `0.1.13-SNAPSHOT` to the released `0.1.13`.
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.12-SNAPSHOT` to the released `0.1.12`.
* Updated the parent version in `embabel-agent-dependencies/pom.xml` from `0.1.13-SNAPSHOT` to the released `0.1.13`.