### PR TITLE
Reject @AchievesGoal on void action methods

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -418,6 +418,14 @@ class AgentMetadataReader(
     ): AgentCoreGoal? {
         val actionAnnotation = method.getAnnotation(Action::class.java)
         val goalAnnotation = method.getAnnotation(AchievesGoal::class.java) ?: return null
+        if (method.returnType == Void.TYPE) {
+            logger.error(
+                "@AchievesGoal cannot be applied to void-returning @Action method {}.{}.",
+                stateClass.name,
+                method.name,
+            )
+            return null
+        }
         val inputBinding = IoBinding(
             name = actionAnnotation.outputBinding,
             type = method.returnType.name,
@@ -679,6 +687,14 @@ class AgentMetadataReader(
     ): AgentCoreGoal? {
         val actionAnnotation = method.getAnnotation(Action::class.java)
         val goalAnnotation = method.getAnnotation(AchievesGoal::class.java) ?: return null
+        if (method.returnType == Void.TYPE) {
+            logger.error(
+                "@AchievesGoal cannot be applied to void-returning @Action method {}.{}.",
+                instance.javaClass.name,
+                method.name,
+            )
+            return null
+        }
         val inputBinding = IoBinding(
             name = actionAnnotation.outputBinding,
             type = method.returnType.name,

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/annotation/support/VoidAchievesGoalJavaTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/annotation/support/VoidAchievesGoalJavaTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.annotation.support;
+
+import com.embabel.agent.api.annotation.AchievesGoal;
+import com.embabel.agent.api.annotation.Action;
+import com.embabel.agent.api.annotation.Agent;
+import com.embabel.agent.api.common.PlannerType;
+import com.embabel.agent.api.dsl.Frog;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VoidAchievesGoalJavaTest {
+
+    @Test
+    void voidActionWithAchievesGoalIsRejected() {
+        var reader = new AgentMetadataReader();
+        var metadata = reader.createAgentMetadata(new VoidGoalAgent());
+
+        assertNotNull(metadata, "Agent metadata should still be created — must not block startup");
+        assertTrue(
+                metadata.getGoals().stream().noneMatch(g -> g.getName().endsWith(".consumeFrog")),
+                "No goal should be created for an @AchievesGoal method returning void: "
+                        + metadata.getGoals());
+    }
+
+    @Test
+    void infoStringDoesNotThrowForVoidGoal() {
+        var reader = new AgentMetadataReader();
+        var metadata = reader.createAgentMetadata(new VoidGoalAgent());
+        assertNotNull(metadata);
+        var agent = (com.embabel.agent.core.Agent) metadata;
+
+        assertDoesNotThrow(agent::getPlanningSystem);
+        assertDoesNotThrow(() -> agent.infoString(true, 0));
+    }
+}
+
+@Agent(description = "void goal agent", planner = PlannerType.UTILITY)
+class VoidGoalAgent {
+
+    @Action
+    public Frog makeFrog() {
+        return new Frog("Kermit");
+    }
+
+    @AchievesGoal(description = "Consume a frog")
+    @Action
+    public void consumeFrog(Frog frog) {
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/TriggerAnnotationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/TriggerAnnotationTest.kt
@@ -118,13 +118,14 @@ class NullReturningTriggerAgent {
     fun processRequest(
         request: IncomingRequest,
         context: RequestContext
-    ): Unit {
+    ): Void? {
         invocationCount++
-        // Returns Unit (void) - ActionVoidResult added to blackboard
+        // Returns null - ActionVoidResult added to blackboard
         // lastResult becomes ActionVoidResult, not IncomingRequest
         // trigger precondition lastResult:IncomingRequest becomes FALSE
         // action does not rerun
         println("processRequest invoked: count=$invocationCount")
+        return null
     }
 }
 


### PR DESCRIPTION
An @Action method annotated with @AchievesGoal must have a non-void return type, because the goal's output type is derived from the method's return type. Previously, a void return resulted ibn a ClassNotFoundException.

This PR detects this combination in AgentMetadataReader, logs a corresponding error, and skip goal creation. Agent startup is not affected.

TriggerAnnotationTest was updated so that it still works, despite using void returning type.

Closes: gh-1086