### PR TITLE
OllamaOptionsConverter now forwards LlmOptions regarding thinking.

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
@@ -319,11 +319,11 @@ class OllamaModelsConfig(
     }
 }
 
-private const val OLLAMA_THINK_LEVEL_LOW_THRESHOLD = 2000
-
-private const val OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD = 4000
-
 object OllamaOptionsConverter : OptionsConverter<OllamaChatOptions> {
+    private const val OLLAMA_THINK_LEVEL_LOW_THRESHOLD = 2000
+
+    private const val OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD = 4000
+
     override fun convertOptions(options: LlmOptions): OllamaChatOptions =
         OllamaChatOptions.builder()
             .temperature(options.temperature)

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
@@ -31,6 +31,7 @@ import org.springframework.ai.ollama.OllamaEmbeddingModel
 import org.springframework.ai.ollama.api.OllamaApi
 import org.springframework.ai.ollama.api.OllamaChatOptions
 import org.springframework.ai.ollama.api.OllamaEmbeddingOptions
+import org.springframework.ai.ollama.api.ThinkOption
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -318,6 +319,10 @@ class OllamaModelsConfig(
     }
 }
 
+private const val OLLAMA_THINK_LEVEL_LOW_THRESHOLD = 2000
+
+private const val OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD = 4000
+
 object OllamaOptionsConverter : OptionsConverter<OllamaChatOptions> {
     override fun convertOptions(options: LlmOptions): OllamaChatOptions =
         OllamaChatOptions.builder()
@@ -326,5 +331,16 @@ object OllamaOptionsConverter : OptionsConverter<OllamaChatOptions> {
             .presencePenalty(options.presencePenalty)
             .frequencyPenalty(options.frequencyPenalty)
             .topK(options.topK)
+            .thinkOption(toThinkOption(options.thinking))
             .build()
+
+    private fun toThinkOption(thinkingConfig: Thinking?): ThinkOption {
+        val budget = thinkingConfig?.tokenBudget ?: return ThinkOption.ThinkBoolean.DISABLED
+
+        return when {
+            budget < OLLAMA_THINK_LEVEL_LOW_THRESHOLD -> ThinkOption.ThinkLevel.LOW
+            budget < OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD -> ThinkOption.ThinkLevel.MEDIUM
+            else -> ThinkOption.ThinkLevel.HIGH
+        }
+    }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ollama/OllamaOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ollama/OllamaOptionsConverterTest.kt
@@ -16,8 +16,44 @@
 package com.embabel.agent.config.models.ollama
 
 import com.embabel.agent.test.models.OptionsConverterTestSupport
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.Thinking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
 import org.springframework.ai.ollama.api.OllamaChatOptions
+import org.springframework.ai.ollama.api.ThinkOption
 
 class OllamaOptionsConverterTest : OptionsConverterTestSupport<OllamaChatOptions>(
     optionsConverter = OllamaOptionsConverter
-)
+) {
+
+    @Test
+    fun `should set thinking to disabled when not provided`() {
+        val options = optionsConverter.convertOptions(LlmOptions())
+        assertEquals(ThinkOption.ThinkBoolean.DISABLED, options.thinkOption)
+    }
+
+    @Test
+    fun `should set thinking to low when budget is under 2000`() {
+        val options = optionsConverter.convertOptions(
+            LlmOptions().withThinking(Thinking.withTokenBudget(1000))
+        )
+        assertEquals(ThinkOption.ThinkLevel.LOW, options.thinkOption)
+    }
+
+    @Test
+    fun `should set thinking to medium when budget is between 2000 and 4000`() {
+        val options = optionsConverter.convertOptions(
+            LlmOptions().withThinking(Thinking.withTokenBudget(3000))
+        )
+        assertEquals(ThinkOption.ThinkLevel.MEDIUM, options.thinkOption)
+    }
+
+    @Test
+    fun `should set thinking to high when budget is 4000 or more`() {
+        val options = optionsConverter.convertOptions(
+            LlmOptions().withThinking(Thinking.withTokenBudget(5000))
+        )
+        assertEquals(ThinkOption.ThinkLevel.HIGH, options.thinkOption)
+    }
+}


### PR DESCRIPTION
`OllamaOptionsConverter` now forwards LlmOptions regarding thinking. Thinking is disabled by default.

Embabel `tokenBudget` is translated into Ollama `ThinkLevel` using thresholds:

```
private const val OLLAMA_THINK_LEVEL_LOW_THRESHOLD = 2000

private const val OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD = 4000

..........


        when {
            budget < OLLAMA_THINK_LEVEL_LOW_THRESHOLD -> ThinkOption.ThinkLevel.LOW
            budget < OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD -> ThinkOption.ThinkLevel.MEDIUM
            else -> ThinkOption.ThinkLevel.HIGH
        }
```

Closes #1683