### PR TITLE
Recognize @Nullable annotation when resolving action parameters

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/ActionMethodArgumentResolver.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/ActionMethodArgumentResolver.kt
@@ -188,13 +188,7 @@ class BlackboardArgumentResolver : ActionMethodArgumentResolver {
         kotlinParameter: KParameter?,
     ): Set<IoBinding> {
         if (kotlinParameter != null) {
-            if (kotlinParameter.type.isMarkedNullable) {
-                return emptySet()
-            }
-            val nullableAnnotation = kotlinParameter.annotations.find {
-                it.annotationClass.simpleName == "Nullable"
-            }
-            if (nullableAnnotation != null) {
+            if (isNullable(kotlinParameter)) {
                 return emptySet()
             }
 
@@ -210,6 +204,9 @@ class BlackboardArgumentResolver : ActionMethodArgumentResolver {
                 (kotlinParameter.type.classifier as KClass<*>).java
             )
         } else {
+            if (isNullable(javaParameter)) {
+                return emptySet()
+            }
             val annotation = javaParameter.getAnnotation(RequireNameMatch::class.java)
             val parameterName = if (javaParameter.isNamePresent) javaParameter.name else null
             val name =
@@ -225,6 +222,16 @@ class BlackboardArgumentResolver : ActionMethodArgumentResolver {
             )
         }
     }
+
+    private fun isNullable(parameter: KParameter): Boolean =
+        parameter.type.isMarkedNullable || parameter.annotations.any {
+            it.annotationClass.simpleName == "Nullable"
+        }
+
+    private fun isNullable(parameter: Parameter) : Boolean =
+        parameter.annotations.any {
+            it.annotationClass.simpleName == "Nullable"
+        }
 
     override fun resolveArgument(
         javaParameter: Parameter,
@@ -243,7 +250,7 @@ class BlackboardArgumentResolver : ActionMethodArgumentResolver {
                     dataDictionary = operationContext.processContext.agentProcess.agent,
                 )
                 if (arg == null) {
-                    val isNullable = kotlinParameter.isOptional || kotlinParameter.type.isMarkedNullable
+                    val isNullable = kotlinParameter.isOptional || isNullable(kotlinParameter)
                     if (!isNullable) {
                         error("Operation ${operationContext.operation.name}: Internal error. No value found in blackboard for non-nullable parameter ${kotlinParameter.name}:${classifier.java.name}")
                     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/ActionMethodArgumentResolverTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/ActionMethodArgumentResolverTest.kt
@@ -17,8 +17,10 @@ package com.embabel.agent.api.annotation.support
 
 import com.embabel.agent.api.common.Ai
 import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.api.dsl.SnakeMeal
 import com.embabel.agent.core.IoBinding
 import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.test.unit.FakeOperationContext
 import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
@@ -27,6 +29,7 @@ import kotlin.reflect.jvm.kotlinFunction
 import kotlin.test.DefaultAsserter.assertSame
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ActionMethodArgumentResolverTest {
@@ -117,6 +120,18 @@ class ActionMethodArgumentResolverTest {
             expected = expected,
             actual = arg
         )
+    }
+
+    @Test
+    fun `blackboard resolveArgument returns null for Kotlin parameter with Nullable annotation when blackboard has no value`() {
+        val argumentResolver = BlackboardArgumentResolver()
+        val javaMethod = OneTransformerActionWithNullableParameterJavaSpring::class.java
+            .getDeclaredMethod("toPerson", UserInput::class.java, SnakeMeal::class.java)
+        val javaParameter = javaMethod.parameters[1]
+        val kotlinParameter = javaMethod.kotlinFunction!!.valueParameters[1]
+
+        val arg = argumentResolver.resolveArgument(javaParameter, kotlinParameter, operationContext)
+        assertNull(arg)
     }
 
 


### PR DESCRIPTION
This PR ensures that the same nullable-logic is used in BlackboardArgumentResolver::resolveInputBinding and BlackboardArgumentResolver::resolveArgument.
In other words, check KParameter::isMarkedNullable as well as "Nullable" annotations.

Closes: gh-1650