### PR TITLE
StreamingJacksonOutputConverter.getFormat() respects disabled thinking

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperations.kt
@@ -351,7 +351,8 @@ internal class StreamingChatClientOperations(
         val streamingConverter = StreamingJacksonOutputConverter(
             clazz = outputClass,
             objectMapper = chatClientLlmOperations.objectMapper,
-            fieldFilter = interaction.fieldFilter
+            fieldFilter = interaction.fieldFilter,
+            thinkingEnabled = interaction.llm.thinking?.enabled ?: false,
         )
 
         // Build prompt using helper methods, including streaming format instructions

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/streaming/StreamingLlmOperationsImpl.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/streaming/StreamingLlmOperationsImpl.kt
@@ -30,7 +30,6 @@ import com.embabel.agent.spi.support.buildConsolidatedPromptMessages
 import com.embabel.agent.spi.support.buildPromptContributionsString
 import com.embabel.agent.spi.support.guardrails.validateUserInput
 import com.embabel.chat.Message
-import com.embabel.chat.SystemMessage
 import com.embabel.chat.UserMessage
 import com.embabel.common.ai.converters.streaming.StreamingJacksonOutputConverter
 import com.embabel.common.core.streaming.StreamingEvent
@@ -201,7 +200,8 @@ internal class StreamingLlmOperationsImpl(
         val streamingConverter = StreamingJacksonOutputConverter(
             clazz = outputClass,
             objectMapper = objectMapper,
-            fieldFilter = interaction.fieldFilter
+            fieldFilter = interaction.fieldFilter,
+            thinkingEnabled = interaction.llm.thinking?.enabled ?: false,
         )
 
         // Build prompt contributions with streaming format instructions

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/streaming/StreamingJacksonOutputConverter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/streaming/StreamingJacksonOutputConverter.kt
@@ -44,17 +44,25 @@ import java.util.function.Predicate
  */
 class StreamingJacksonOutputConverter<T> : FilteringJacksonOutputConverter<T> {
 
+    private val thinkingEnabled: Boolean
+
     constructor(
         clazz: Class<T>,
         objectMapper: ObjectMapper,
         fieldFilter: Predicate<Field> = Predicate { true },
-    ) : super(clazz, objectMapper, fieldFilter)
+        thinkingEnabled: Boolean = true,
+    ) : super(clazz, objectMapper, fieldFilter) {
+        this.thinkingEnabled = thinkingEnabled
+    }
 
     constructor(
         typeReference: ParameterizedTypeReference<T>,
         objectMapper: ObjectMapper,
         fieldFilter: Predicate<Field> = Predicate { true },
-    ) : super(typeReference, objectMapper, fieldFilter)
+        thinkingEnabled: Boolean = true,
+    ) : super(typeReference, objectMapper, fieldFilter) {
+        this.thinkingEnabled = thinkingEnabled
+    }
 
     /**
      * Convert streaming JSONL text to a Flux of typed objects.
@@ -105,28 +113,39 @@ class StreamingJacksonOutputConverter<T> : FilteringJacksonOutputConverter<T> {
      * Override format to request JSONL instead of single JSON.
      * Inherits schema injection from parent but modifies instructions for streaming.
      */
-    override fun getFormat(): String =
-        """|
+    override fun getFormat(): String {
+        val thinkingInstructions = if (thinkingEnabled) {
+            """|
+               |You may include reasoning content using thinking blocks.
+               |Use EXACTLY the <think> tag format - do not use variations like <thinking>, <thought>, or <analysis>.
+               |<think>your reasoning here
+               |another line of thinking</think>
+               |
+               |Thinking blocks are separate from JSON objects and can appear before, between, or after JSON lines as needed for your analysis.
+               |""".trimMargin()
+        } else ""
+
+        val exampleFormat = if (thinkingEnabled) {
+            """|
+               |Example format:
+               |<think>analyzing the requirements</think>
+               |{"field": "precise_value"}
+               |<think>considering next item</think>
+               |{"field": "another_precise_value"}
+               |""".trimMargin()
+        } else ""
+
+        return """|
            |Your response should be in JSONL (JSON Lines) format.
            |Each line must contain exactly one JSON object that strictly adheres to the provided schema.
            |Do not include any explanations in the JSON objects themselves.
            |Do not include markdown code blocks or wrap responses in arrays.
            |Ensure RFC7464 compliant JSON Lines, one valid JSON object per line.
-           |
-           |You may include reasoning content using thinking blocks.
-           |Use EXACTLY the <think> tag format - do not use variations like <thinking>, <thought>, or <analysis>.
-           |<think>your reasoning here
-           |another line of thinking</think>
-           |
-           |Thinking blocks are separate from JSON objects and can appear before, between, or after JSON lines as needed for your analysis.
+           |$thinkingInstructions
            |
            |Here is the JSON Schema instance each JSON object must adhere to:
            |```${jsonSchema}```
-           |
-           |Example format:
-           |<think>analyzing the requirements</think>
-           |{"field": "precise_value"}
-           |<think>considering next item</think>
-           |{"field": "another_precise_value"}
+           |$exampleFormat
            |""".trimMargin()
+    }
 }

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/streaming/StreamingJacksonOutputConverterTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/streaming/StreamingJacksonOutputConverterTest.kt
@@ -323,6 +323,64 @@ class StreamingJacksonOutputConverterTest {
     }
 
     @Test
+    fun `getFormat should omit thinking instructions when thinkingEnabled is false`() {
+        // Given
+        val converter = StreamingJacksonOutputConverter(
+            clazz = SimpleItem::class.java,
+            objectMapper = objectMapper,
+            thinkingEnabled = false
+        )
+
+        // When
+        val format = converter.getFormat()
+
+        // Then
+        assertFalse(format.contains("<think>"))
+        assertFalse(format.contains("reasoning content"))
+        assertFalse(format.contains("analyzing the requirements"))
+    }
+
+    @Test
+    fun `streaming converter should still work with JSONL when thinkingEnabled is false`() {
+        // Given
+        val converter = StreamingJacksonOutputConverter(
+            clazz = SimpleItem::class.java,
+            objectMapper = objectMapper,
+            thinkingEnabled = false
+        )
+        val validJsonl = """
+            {"name": "test1"}
+            {"name": "test2"}
+        """.trimIndent()
+
+        // When
+        val result = converter.convertStream(validJsonl)
+
+        // Then
+        val items = result.collectList().block()
+        assertNotNull(items)
+        assertEquals(2, items!!.size)
+        assertEquals("test1", items[0].name)
+    }
+
+    @Test
+    fun `streaming converter should still include JSONL instructions when thinkingEnabled is false`() {
+        // Given
+        val converter = StreamingJacksonOutputConverter(
+            clazz = SimpleItem::class.java,
+            objectMapper = objectMapper,
+            thinkingEnabled = false
+        )
+
+        // When
+        val format = converter.getFormat()
+
+        // Then
+        assertTrue(format.contains("JSONL (JSON Lines) format"))
+        assertTrue(format.contains("one valid JSON object per line"))
+    }
+
+    @Test
     fun `streaming converter should handle filtering with actual streaming for multiple objects`() {
         // Given - converter that only allows name and age
         val converter = StreamingJacksonOutputConverter(


### PR DESCRIPTION
`StreamingJacksonOutputConverter.getFormat()` now includes formatting instructions for thinking blocks only if thinking is enabled through `LlmOptions`. This prevents thinkging instructions to sneak through to the AI-model even when thinking is disabled.

Closes #1685