### PR TITLE
Allow unescaped CTRL characters

### DIFF
--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
@@ -60,6 +60,8 @@ open class JacksonOutputConverter<T> protected constructor(
      * - ALLOW_SINGLE_QUOTES: `{'a': 'b'}` is valid
      * - ALLOW_UNQUOTED_FIELD_NAMES: `{a: "b"}` is valid
      * - ALLOW_JAVA_COMMENTS: `{"a": 1 /* comment */}` is valid
+     * - ALLOW_UNESCAPED_CONTROL_CHARS: """{"name":"Hello
+     * World"}""" is valid.
      */
     private val lenientMapper: ObjectMapper by lazy {
         objectMapper.copy().apply {
@@ -69,6 +71,7 @@ open class JacksonOutputConverter<T> protected constructor(
             enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES.mappedFeature())
             enable(JsonReadFeature.ALLOW_JAVA_COMMENTS.mappedFeature())
             enable(JsonReadFeature.ALLOW_YAML_COMMENTS.mappedFeature())
+            enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS.mappedFeature())
         }
     }
 

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
@@ -356,6 +356,20 @@ class JacksonOutputConverterTest {
             assertEquals("test", result?.name)
             assertEquals(42, result?.value)
         }
+        @Test
+        fun `handles unquoted CTRL characters`() {
+            val converter = JacksonOutputConverter(SimpleObject::class.java, objectMapper)
+            // Value with unquoted newline character.
+            val name = """Hello
+World"""
+            val messyJson = """{"name":"$name", "value": 42}"""
+
+            val result = converter.convert(messyJson)
+
+            assertNotNull(result)
+            assertEquals(name, result?.name)
+            assertEquals(42, result?.value)
+        }
     }
 
     @Nested

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.common.ai.converters
 
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
@@ -371,7 +372,7 @@ World"""
             val mapper = ObjectMapper().registerModule(
                 KotlinModule.Builder().build()
             )
-            val exception = assertThrows<com.fasterxml.jackson.databind.JsonMappingException> {
+            val exception = assertThrows<JsonMappingException> {
                 mapper.readValue(messyJson, SimpleObject::class.java)
             }
 

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
@@ -15,13 +15,16 @@
  */
 package com.embabel.common.ai.converters
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -356,14 +359,27 @@ class JacksonOutputConverterTest {
             assertEquals("test", result?.name)
             assertEquals(42, result?.value)
         }
+
         @Test
         fun `handles unquoted CTRL characters`() {
-            val converter = JacksonOutputConverter(SimpleObject::class.java, objectMapper)
             // Value with unquoted newline character.
             val name = """Hello
 World"""
             val messyJson = """{"name":"$name", "value": 42}"""
 
+            // Parse the malformed json string without the lenient mapper.
+            val mapper = ObjectMapper().registerModule(
+                KotlinModule.Builder().build()
+            )
+            val exception = assertThrows<com.fasterxml.jackson.databind.JsonMappingException> {
+                mapper.readValue(messyJson, SimpleObject::class.java)
+            }
+
+            // Verify that the assertion is thrown as expected.
+            assert(exception.message?.contains("Illegal unquoted character ((CTRL-CHAR, code 10))") == true)
+
+            // Parse the malformed json string with the lenient mapper.
+            val converter = JacksonOutputConverter(SimpleObject::class.java, objectMapper)
             val result = converter.convert(messyJson)
 
             assertNotNull(result)


### PR DESCRIPTION
**Context** - 
Observed below issue when parsing an LLM output
`ExceptionWrappingConverter - Error com.fasterxml.jackson.databind.JsonMappingException: Illegal unquoted character ((CTRL-CHAR, code 10)): `

** Solution***
 -   Use lenient parsing with ALLOW_UNESCAPED_CONTROL_CHARS
 
 ** Testing **
   - Verified with a unit test which was failing with the same error without the changes. 