### PR TITLE
Improve LlmDataBindingProperties logging message

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionQos.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionQos.kt
@@ -16,7 +16,6 @@
 package com.embabel.agent.core
 
 import com.embabel.agent.spi.common.RetryProperties
-
 /**
  * Quality of service requirements for an action
  */
@@ -25,5 +24,6 @@ data class ActionQos(
     override val backoffMillis: Long = 10000,
     override val backoffMultiplier: Double = 5.0,
     override val backoffMaxInterval: Long = 60000,
+    override val propertyPrefix: String = "",
     val idempotent: Boolean = false,
 ) : RetryProperties

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
@@ -88,7 +88,7 @@ interface RetryProperties : RetryTemplateProvider {
                     callback: RetryCallback<T, E>,
                     throwable: Throwable?,
                 ) {
-                    if( throwable != null) {
+                    throwable?.let {
                         loggerFor<RetryProperties>().warn(
                             "Maximum attempts of {} have reached. The maximum attempt can be configured using property {}.max-attempts",
                             maxAttempts,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
@@ -86,7 +86,7 @@ interface RetryProperties : RetryTemplateProvider {
                 override fun <T, E : Throwable> close(
                     context: RetryContext,
                     callback: RetryCallback<T, E>,
-                    throwable: Throwable,
+                    throwable: Throwable?,
                 ) {
                     if( throwable != null) {
                         loggerFor<RetryProperties>().warn(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.spi.common
 
 import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.spi.support.LlmDataBindingProperties.Companion.PREFIX
 import com.embabel.agent.spi.support.LlmDataBindingProperties.Companion.isRateLimitError
 import com.embabel.agent.spi.support.springai.SpringAiRetryPolicy
 import com.embabel.common.util.loggerFor
@@ -28,6 +29,7 @@ import java.time.Duration
 
 interface RetryTemplateProvider {
     val maxAttempts: Int
+    val prefix: String
     fun retryTemplate(name: String): RetryTemplate
 }
 
@@ -77,6 +79,19 @@ interface RetryProperties : RetryTemplateProvider {
                         "Operation $name: Retry error. Retry count: ${context.retryCount}",
                         throwable,
                     )
+                }
+                override fun <T, E : Throwable> close(
+                    context: RetryContext,
+                    callback: RetryCallback<T, E>,
+                    throwable: Throwable,
+                ) {
+                    if( throwable != null) {
+                        loggerFor<RetryProperties>().warn(
+                            "Maximum attempts of {} have reached. The maximum attempt can be configured using property {}.max-attempts",
+                            maxAttempts,
+                            prefix
+                        )
+                    }
                 }
             })
             .build()

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
@@ -16,7 +16,6 @@
 package com.embabel.agent.spi.common
 
 import com.embabel.agent.api.tool.ToolControlFlowSignal
-import com.embabel.agent.spi.support.LlmDataBindingProperties.Companion.PREFIX
 import com.embabel.agent.spi.support.LlmDataBindingProperties.Companion.isRateLimitError
 import com.embabel.agent.spi.support.springai.SpringAiRetryPolicy
 import com.embabel.common.util.loggerFor
@@ -29,7 +28,11 @@ import java.time.Duration
 
 interface RetryTemplateProvider {
     val maxAttempts: Int
-    val prefix: String
+
+    /**
+     * Prefix when field values are assigned via configuration.
+     */
+    val propertyPrefix: String
     fun retryTemplate(name: String): RetryTemplate
 }
 
@@ -89,7 +92,7 @@ interface RetryProperties : RetryTemplateProvider {
                         loggerFor<RetryProperties>().warn(
                             "Maximum attempts of {} have reached. The maximum attempt can be configured using property {}.max-attempts",
                             maxAttempts,
-                            prefix
+                            propertyPrefix
                         )
                     }
                 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -87,7 +87,7 @@ class LlmDataBindingProperties(
                     callback: RetryCallback<T, E>,
                     throwable: Throwable?,
                 ) {
-                    if( throwable != null) {
+                    throwable?.let {
                         logger.warn(
                             "Maximum attempts of {} have reached. The maximum attempt can be configured using property {}.max-attempts",
                             maxAttempts,
@@ -108,12 +108,13 @@ class LlmDataBindingProperties(
             "429",
         )
 
+        const val PREFIX  = "embabel.agent.platform.llm-operations.data-binding"
+
         fun isRateLimitError(t: Throwable): Boolean {
             val message = t.message?.lowercase() ?: return false
             return RATE_LIMIT_PATTERNS.any { pattern ->
                 message.contains(pattern)
             }
         }
-        const val PREFIX  = "embabel.agent.platform.llm-operations.data-binding"
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.api.tool.ToolControlFlowSignal
 import com.embabel.agent.api.validation.guardrails.GuardRailViolationException
 import com.embabel.agent.core.ReplanRequestedException
 import com.embabel.agent.spi.common.RetryTemplateProvider
+import com.embabel.agent.spi.support.LlmDataBindingProperties.Companion.PREFIX
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.retry.RetryCallback
@@ -35,15 +36,15 @@ import java.time.Duration
  * @param sendValidationInfo Should we send validation info to the LLM in every request,
  * even before a validation error occurs?
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.llm-operations.data-binding")
+@ConfigurationProperties(prefix = PREFIX)
 class LlmDataBindingProperties(
     override val maxAttempts: Int = 10,
     val fixedBackoffMillis: Long = 30L,
     val sendValidationInfo: Boolean = true,
+    override val prefix: String = PREFIX,
 ) : RetryTemplateProvider {
 
     private val logger = LoggerFactory.getLogger(LlmDataBindingProperties::class.java)
-    private val maxAttemptsConfigPropertyMessage = "The maximum attempt can be configured using embabel.agent.platform.llm-operations.data-binding.max-attempts"
 
     override fun retryTemplate(name: String): RetryTemplate {
         return RetryTemplate.builder()
@@ -69,8 +70,7 @@ class LlmDataBindingProperties(
                             "LLM invocation {} RATE LIMITED: Retry attempt {} of {}.{}",
                             name,
                             context.retryCount,
-                            maxAttempts,
-                            maxAttemptsConfigPropertyMessage
+                            maxAttempts
                         )
                     } else {
                         logger.warn(
@@ -78,8 +78,7 @@ class LlmDataBindingProperties(
                             name,
                             context.retryCount,
                             maxAttempts,
-                            throwable.message ?: "Unknown error",
-                            maxAttemptsConfigPropertyMessage
+                            throwable.message ?: "Unknown error"
                         )
                     }
                 }
@@ -102,5 +101,6 @@ class LlmDataBindingProperties(
                 message.contains(pattern)
             }
         }
+        const val PREFIX  = "embabel.agent.platform.llm-operations.data-binding"
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -41,7 +41,7 @@ class LlmDataBindingProperties(
     override val maxAttempts: Int = 10,
     val fixedBackoffMillis: Long = 30L,
     val sendValidationInfo: Boolean = true,
-    override val prefix: String = PREFIX,
+    override val propertyPrefix: String = PREFIX,
 ) : RetryTemplateProvider {
 
     private val logger = LoggerFactory.getLogger(LlmDataBindingProperties::class.java)
@@ -79,6 +79,19 @@ class LlmDataBindingProperties(
                             context.retryCount,
                             maxAttempts,
                             throwable.message ?: "Unknown error"
+                        )
+                    }
+                }
+                override fun <T: Any, E : Throwable> close(
+                    context: RetryContext,
+                    callback: RetryCallback<T, E>,
+                    throwable: Throwable,
+                ) {
+                    if( throwable != null) {
+                        logger.warn(
+                            "Maximum attempts of {} have reached. The maximum attempt can be configured using property {}.max-attempts",
+                            maxAttempts,
+                            propertyPrefix
                         )
                     }
                 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -85,7 +85,7 @@ class LlmDataBindingProperties(
                 override fun <T: Any, E : Throwable> close(
                     context: RetryContext,
                     callback: RetryCallback<T, E>,
-                    throwable: Throwable,
+                    throwable: Throwable?,
                 ) {
                     if( throwable != null) {
                         logger.warn(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -43,6 +43,7 @@ class LlmDataBindingProperties(
 ) : RetryTemplateProvider {
 
     private val logger = LoggerFactory.getLogger(LlmDataBindingProperties::class.java)
+    private val maxAttemptsConfigPropertyMessage = "The maximum attempt can be configured using embabel.agent.platform.llm-operations.data-binding.max-attempts"
 
     override fun retryTemplate(name: String): RetryTemplate {
         return RetryTemplate.builder()
@@ -65,18 +66,20 @@ class LlmDataBindingProperties(
                     }
                     if (isRateLimitError(throwable)) {
                         logger.info(
-                            "LLM invocation {} RATE LIMITED: Retry attempt {} of {}",
+                            "LLM invocation {} RATE LIMITED: Retry attempt {} of {}.{}",
                             name,
                             context.retryCount,
                             maxAttempts,
+                            maxAttemptsConfigPropertyMessage
                         )
                     } else {
                         logger.warn(
-                            "LLM invocation {}: Retry attempt {} of {} due to: {}",
+                            "LLM invocation {}: Retry attempt {} of {} due to: {}. {}",
                             name,
                             context.retryCount,
                             maxAttempts,
-                            throwable.message ?: "Unknown error"
+                            throwable.message ?: "Unknown error",
+                            maxAttemptsConfigPropertyMessage
                         )
                     }
                 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmRanker.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmRanker.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.api.common.ranking.Rankings
 import com.embabel.agent.core.internal.LlmOperations
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.spi.common.RetryProperties
+import com.embabel.agent.spi.support.RankingProperties.Companion.PREFIX
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.ModelSelectionCriteria
 import com.embabel.common.ai.model.ModelSelectionCriteria.Companion.byName
@@ -40,14 +41,19 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * @param backoffMultiplier multiplier for backoff time
  * @param backoffMaxInterval maximum backoff time in milliseconds
  */
-@ConfigurationProperties("embabel.agent.platform.ranking")
+@ConfigurationProperties(PREFIX)
 data class RankingProperties(
     val llm: String? = null,
     override val maxAttempts: Int = 5,
     override val backoffMillis: Long = 100L,
     override val backoffMultiplier: Double = 5.0,
     override val backoffMaxInterval: Long = 180000L,
-) : RetryProperties
+    override val propertyPrefix: String = PREFIX,
+) : RetryProperties {
+    companion object {
+        const val PREFIX: String  = "embabel.agent.platform.ranking"
+    }
+}
 
 /**
  * Use an LLM to rank things

--- a/embabel-agent-api/src/test/java/com/embabel/agent/spi/support/RankingPropertiesTest.kt
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/spi/support/RankingPropertiesTest.kt
@@ -1,0 +1,32 @@
+package com.embabel.agent.spi.support
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+import kotlin.test.assertTrue
+
+@ExtendWith(OutputCaptureExtension::class)
+class RankingPropertiesTest {
+    @Test
+    fun `should log how to configure maximum attempt`(output: CapturedOutput) {
+        val properties = RankingProperties(maxAttempts = 1)
+        val retryTemplate = properties.retryTemplate("test")
+        var attemptCount = 0
+        assertThrows<RuntimeException> {
+            retryTemplate.execute<Unit, RuntimeException> {
+                attemptCount++
+                throw RuntimeException("Dummy error")
+            }
+        }
+        // Should only attempt once
+        assertEquals(1, attemptCount)
+        // Checking default values.
+        assertEquals(100, properties.backoffMillis)
+        assertEquals(5.0, properties.backoffMultiplier)
+        assertEquals(180000, properties.backoffMaxInterval)
+        assertTrue(output.out.contains("Maximum attempts of 1 have reached. The maximum attempt can be configured using property embabel.agent.platform.ranking.max-attempts"))
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/LlmDataBindingPropertiesTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/LlmDataBindingPropertiesTest.kt
@@ -23,7 +23,12 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+import kotlin.test.assertTrue
 
+@ExtendWith(OutputCaptureExtension::class)
 class LlmDataBindingPropertiesTest {
 
     @Nested
@@ -94,6 +99,22 @@ class LlmDataBindingPropertiesTest {
             verify { mockBlackboard["intent"] = "support" }
             verify { mockBlackboard["confidence"] = 0.95 }
             verify { mockBlackboard["target"] = "handleSupport" }
+        }
+
+        @Test
+        fun `should log how to configure maximum attempt`(output: CapturedOutput) {
+            val properties = LlmDataBindingProperties(maxAttempts = 1)
+            val retryTemplate = properties.retryTemplate("test")
+            var attemptCount = 0
+            assertThrows<RuntimeException> {
+                retryTemplate.execute<Unit, RuntimeException> {
+                    attemptCount++
+                    throw RuntimeException("Dummy error")
+                }
+            }
+            // Should only attempt once
+            assertEquals(1, attemptCount)
+            assertTrue(output.out.contains("Maximum attempts of 1 have reached. The maximum attempt can be configured using property embabel.agent.platform.llm-operations.data-binding.max-attempts"))
         }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.anthropic
 
 import com.embabel.agent.api.models.AnthropicModels
+import com.embabel.agent.config.models.anthropic.AnthropicProperties.Companion.PREFIX
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
@@ -52,7 +53,7 @@ import org.springframework.web.client.RestClient
  * "embabel.agent.platform.models.anthropic" and control retry behavior
  * when calling Anthropic APIs.
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.anthropic")
+@ConfigurationProperties(prefix = PREFIX)
 class AnthropicProperties : RetryProperties {
     /**
      * Base URL for Anthropic API requests.
@@ -83,6 +84,11 @@ class AnthropicProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.anthropic"
+    }
 }
 
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModelsConfig.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.config.models.bedrock
 
+import com.embabel.agent.config.models.bedrock.BedrockProperties.Companion.PREFIX
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
@@ -60,7 +61,7 @@ import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient
  * Configuration properties for Bedrock models.
  * These properties control retry behavior when calling AWS Bedrock APIs.
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.bedrock")
+@ConfigurationProperties(prefix = PREFIX)
 class BedrockProperties : RetryProperties {
     /**
      * Maximum number of attempts.
@@ -81,6 +82,11 @@ class BedrockProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.bedrock"
+    }
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.deepseek
 
 import com.embabel.agent.api.models.DeepSeekModels
+import com.embabel.agent.config.models.deepseek.DeepSeekProperties.Companion.PREFIX
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.common.ai.model.OptionsConverter
@@ -43,7 +44,7 @@ import java.time.LocalDate
  * "embabel.agent.platform.models.deepseek" and control retry behavior
  * when calling Deepseek APIs.
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.deepseek")
+@ConfigurationProperties(prefix = PREFIX)
 class DeepSeekProperties : RetryProperties {
     /**
      * Base URL for DeepSeek API requests.
@@ -59,6 +60,8 @@ class DeepSeekProperties : RetryProperties {
      *  Maximum number of attempts.
      */
     override var maxAttempts: Int = 4
+    override val prefix: String = PREFIX
+
 
     /**
      * Initial backoff interval (in milliseconds).
@@ -74,6 +77,10 @@ class DeepSeekProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 60000L
+
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.deepseek"
+    }
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
@@ -60,8 +60,6 @@ class DeepSeekProperties : RetryProperties {
      *  Maximum number of attempts.
      */
     override var maxAttempts: Int = 4
-    override val prefix: String = PREFIX
-
 
     /**
      * Initial backoff interval (in milliseconds).
@@ -78,6 +76,7 @@ class DeepSeekProperties : RetryProperties {
      */
     override var backoffMaxInterval: Long = 60000L
 
+    override val propertyPrefix: String = PREFIX
     companion object {
         const val PREFIX  = "embabel.agent.platform.models.deepseek"
     }

--- a/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/docker/DockerLocalModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dockermodels-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/docker/DockerLocalModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.docker
 
 import com.embabel.agent.api.models.DockerLocalModels.Companion.PROVIDER
+import com.embabel.agent.config.models.docker.DockerRetryProperties.Companion.PREFIX
 import com.embabel.agent.openai.OpenAiChatOptionsConverter
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
@@ -45,7 +46,7 @@ import org.springframework.web.client.body
 import org.springframework.web.reactive.function.client.WebClient
 
 
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.docker")
+@ConfigurationProperties(prefix = PREFIX)
 class DockerRetryProperties : RetryProperties {
 
     /**
@@ -67,6 +68,11 @@ class DockerRetryProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.docker"
+    }
 }
 
 @ConfigurationProperties(prefix = "embabel.agent.models.docker")

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/gemini/GeminiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/gemini/GeminiModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.gemini
 
 import com.embabel.agent.api.models.GeminiModels
+import com.embabel.agent.config.models.gemini.GeminiProperties.Companion.PREFIX
 import com.embabel.agent.openai.OpenAiChatOptionsConverter
 import com.embabel.agent.openai.OpenAiCompatibleModelFactory
 import com.embabel.agent.spi.LlmService
@@ -44,7 +45,7 @@ import org.springframework.web.reactive.function.client.WebClient
  * "embabel.agent.platform.models.gemini" and control retry behavior
  * when calling Google Gemini APIs.
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.gemini")
+@ConfigurationProperties(prefix = PREFIX)
 class GeminiProperties : RetryProperties {
     /**
      * Base URL for Gemini API requests.
@@ -75,6 +76,11 @@ class GeminiProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.gemini"
+    }
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.googlegenai
 
 import com.embabel.agent.api.models.GoogleGenAiModels
+import com.embabel.agent.config.models.googlegenai.GoogleGenAiProperties.Companion.PREFIX
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.JsonWrappingToolResponseContentAdapter
@@ -60,7 +61,7 @@ import org.springframework.context.annotation.Configuration
  *
  * If both are configured, Vertex AI (project/location) takes precedence.
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.googlegenai")
+@ConfigurationProperties(prefix = PREFIX)
 class GoogleGenAiProperties : RetryProperties {
 
     /**
@@ -100,6 +101,11 @@ class GoogleGenAiProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.googlegenai"
+    }
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-lmstudio-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/lmstudio/LmStudioModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.lmstudio
 
 import com.embabel.agent.api.models.LmStudioModels
+import com.embabel.agent.config.models.lmstudio.LmStudioProperties.Companion.PREFIX
 import com.embabel.agent.openai.OpenAiCompatibleModelFactory
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.common.ai.autoconfig.ProviderInitialization
@@ -38,7 +39,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.RestClient
 import org.springframework.web.reactive.function.client.WebClient
 
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.lmstudio")
+@ConfigurationProperties(prefix = PREFIX)
 class LmStudioProperties : RetryProperties {
 
     /**
@@ -70,6 +71,11 @@ class LmStudioProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.lmstudio"
+    }
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/minimax/MiniMaxModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/minimax/MiniMaxModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.minimax
 
 import com.embabel.agent.api.models.MiniMaxModels
+import com.embabel.agent.config.models.minimax.MiniMaxProperties.Companion.PREFIX
 import com.embabel.agent.openai.OpenAiCompatibleModelFactory
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.common.RetryProperties
@@ -43,7 +44,7 @@ import java.time.LocalDate
  * "embabel.agent.platform.models.minimax" and control retry behavior
  * when calling MiniMax APIs.
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.minimax")
+@ConfigurationProperties(prefix = PREFIX)
 class MiniMaxProperties : RetryProperties {
     /**
      * Base URL for MiniMax API requests.
@@ -74,6 +75,11 @@ class MiniMaxProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 60000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.minimax"
+    }
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.mistralai
 
 import com.embabel.agent.api.models.MistralAiModels
+import com.embabel.agent.config.models.mistralai.MistralAiProperties.Companion.PREFIX
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
@@ -45,7 +46,7 @@ import org.springframework.web.reactive.function.client.WebClient
  * Configuration properties for Mistral AI models.
  * These properties control retry behavior when calling Mistral AI APIs.
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.mistralai")
+@ConfigurationProperties(prefix = PREFIX)
 class MistralAiProperties : RetryProperties {
     /**
      * Base URL for Mistral AI API requests.
@@ -76,6 +77,11 @@ class MistralAiProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180_000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.mistralai"
+    }
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.ocigenai
 
 import com.embabel.agent.api.models.OciGenAiModels
+import com.embabel.agent.config.models.ocigenai.OciGenAiProperties.Companion.PREFIX
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
@@ -52,7 +53,7 @@ import java.io.ByteArrayInputStream
 import java.nio.file.Files
 import java.nio.file.Paths
 
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.ocigenai")
+@ConfigurationProperties(prefix = PREFIX)
 class OciGenAiProperties : RetryProperties {
 
     var authenticationType: AuthenticationType = AuthenticationType.FILE
@@ -78,6 +79,11 @@ class OciGenAiProperties : RetryProperties {
     override var backoffMillis: Long = 5_000L
     override var backoffMultiplier: Double = 5.0
     override var backoffMaxInterval: Long = 180_000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.ocigenai"
+    }
 
     override fun toString(): String =
         "OciGenAiProperties(" +

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.config.models.openai
 
 import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.config.models.openai.OpenAiProperties.Companion.PREFIX
 import com.embabel.agent.openai.Gpt5ChatOptionsConverter
 import com.embabel.agent.openai.OpenAiCompatibleModelFactory
 import com.embabel.agent.openai.StandardOpenAiOptionsConverter
@@ -47,7 +48,7 @@ import org.springframework.web.reactive.function.client.WebClient
  * These properties can be set in application.properties/yaml using the
  * prefix embabel.agent.platform.models.openai.
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.openai")
+@ConfigurationProperties(prefix = PREFIX)
 class OpenAiProperties : RetryProperties {
     /**
      * Base URL for OpenAI API requests.
@@ -88,6 +89,11 @@ class OpenAiProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.openai"
+    }
 }
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-custom-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/custom/OpenAiCustomModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-custom-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/custom/OpenAiCustomModelsConfig.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.config.models.openai.custom
 
+import com.embabel.agent.config.models.openai.custom.OpenAiCustomProperties.Companion.PREFIX
 import com.embabel.agent.openai.OpenAiCompatibleModelFactory
 import com.embabel.agent.openai.StandardOpenAiOptionsConverter
 import com.embabel.agent.spi.LlmService
@@ -41,7 +42,7 @@ import org.springframework.web.reactive.function.client.WebClient
  * These properties can be set in application.properties/yaml using the
  * prefix embabel.agent.platform.models.openai.custom
  */
-@ConfigurationProperties(prefix = "embabel.agent.platform.models.openai.custom")
+@ConfigurationProperties(prefix = PREFIX)
 class OpenAiCustomProperties : RetryProperties {
     /**
      * Base URL for OpenAI Custom API requests.
@@ -89,6 +90,11 @@ class OpenAiCustomProperties : RetryProperties {
      * Maximum backoff interval (in milliseconds).
      */
     override var backoffMaxInterval: Long = 180000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.openai.custom"
+    }
 }
 
 /**


### PR DESCRIPTION
**Context**
  While running a sample locally as an experiment, I have observed the  `Retry attempt .. ` [message](https://github.com/embabel/embabel-agent/blob/main/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt#L74) in the log and had to look in the code base to find out the configuration property to modify it.
  
  IMHO, it will   be better if we log the corresponding property also on the same message so that people can easily configure it.
  
  **Test**
   - Tested locally with a sample. Please see the log with this changes
   
   ```Retry attempt 1 of 2 due to: Invalid LLM return when expecting com.demo.ai.embabeldemo.BlogDraft: Root cause=com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 3, column: 14] (through reference chain: com.demo.ai.embabeldemo.BlogDraft["content"]). The maximum attempt can be configured using embabel.agent.platform.llm-operations.data-binding.max-attempts```
 
 **Caveat**
 The log still prints the `.properties` syntax  but not the _yaml_  but I hope they will figure out the yaml formating from that.