### PR TITLE
Add OCI Generative AI starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,10 +720,31 @@ The Embabel Agent Framework supports local models from:
 
 #### OCI Generative AI
 
-Add `embabel-agent-starter-oci-genai` to use OCI Generative AI chat and embedding models. Configure
-`embabel.agent.platform.models.ocigenai.compartment-id` and, if needed, set
+Add `embabel-agent-starter-oci-genai` to use OCI Generative AI chat and embedding models.
+
+```xml
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-oci-genai</artifactId>
+</dependency>
+```
+
+Configure `embabel.agent.platform.models.ocigenai.compartment-id` and, if needed, set
 `embabel.agent.platform.models.ocigenai.authentication-type` to `FILE`, `INSTANCE_PRINCIPAL`, `RESOURCE_PRINCIPAL`,
-`WORKLOAD_IDENTITY`, `SESSION_TOKEN` or `SIMPLE`.
+`WORKLOAD_IDENTITY`, `SESSION_TOKEN` or `SIMPLE`. When the standard OpenAI provider is not on the classpath, the OCI
+starter supplies OCI defaults for Embabel's default LLM and embedding model:
+
+```properties
+embabel.models.default-llm=cohere.command-a-03-2025
+embabel.models.default-embedding-model=cohere.embed-v4.0
+```
+
+Override those values in application configuration if you want another OCI model. Use OCI model ids such as
+`cohere.command-a-03-2025` or `meta.llama-3.3-70b-instruct` for Embabel model selection.
+The Spring bean names registered by the starter are Java-friendly aliases such as `cohere_command_a` and
+`llama_33_70b`.
+If your application exposes Spring Boot Actuator `env` or `configprops` values, keep those endpoints secured and ensure
+OCI credential fields such as `pass-phrase`, `session-token` and `private-key` are sanitized.
 
 #### Custom LLMs
 

--- a/README.md
+++ b/README.md
@@ -612,6 +612,9 @@ Optional:
 
 - `ANTHROPIC_API_KEY`: For the Anthropic API. Necessary for the coding agent.
 - `MINIMAX_API_KEY`: For the [MiniMax](https://www.minimax.io) API. Supports MiniMax-M2.7 and MiniMax-M2.7-highspeed models.
+- OCI Generative AI uses OCI SDK authentication providers. Add `embabel-agent-starter-oci-genai` and set
+  `embabel.agent.platform.models.ocigenai.compartment-id`; OCI config file, instance principal, resource principal,
+  workload identity, session token and simple key authentication are supported.
 
 > We strongly recommend providing both an OpenAI and Anthropic key, as some examples require both. And it's important to
 > try to find the best LLM for a given task, rather than automatically choose a familiar provider.
@@ -714,6 +717,13 @@ The Embabel Agent Framework supports local models from:
   queried. All local models will be available.
 - LMStudio: This uses the openAI compatible client. Just include LMStudio as a dependency and make sure your LMStudio
   server is running.
+
+#### OCI Generative AI
+
+Add `embabel-agent-starter-oci-genai` to use OCI Generative AI chat and embedding models. Configure
+`embabel.agent.platform.models.ocigenai.compartment-id` and, if needed, set
+`embabel.agent.platform.models.ocigenai.authentication-type` to `FILE`, `INSTANCE_PRINCIPAL`, `RESOURCE_PRINCIPAL`,
+`WORKLOAD_IDENTITY`, `SESSION_TOKEN` or `SIMPLE`.
 
 #### Custom LLMs
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/OciGenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/OciGenAiModels.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.models
+
+/**
+ * Constants for OCI Generative AI model identifiers.
+ */
+class OciGenAiModels {
+
+    companion object {
+
+        const val GOOGLE_GEMINI_2_5_PRO = "google.gemini-2.5-pro"
+        const val GOOGLE_GEMINI_2_5_FLASH = "google.gemini-2.5-flash"
+
+        const val OPENAI_GPT_OSS_120B = "openai.gpt-oss-120b"
+
+        const val XAI_GROK_4_3 = "xai.grok-4.3"
+
+        const val COHERE_COMMAND_A_REASONING = "cohere.command-a-reasoning"
+        const val COHERE_COMMAND_A_VISION = "cohere.command-a-vision"
+        const val COHERE_COMMAND_A = "cohere.command-a-03-2025"
+
+        const val META_LLAMA_4_MAVERICK = "meta.llama-4-maverick-17b-128e-instruct-fp8"
+        const val META_LLAMA_4_SCOUT = "meta.llama-4-scout-17b-16e-instruct"
+        const val META_LLAMA_3_3_70B = "meta.llama-3.3-70b-instruct"
+
+        const val COHERE_EMBED_V4 = "cohere.embed-v4.0"
+
+        const val PROVIDER = "OCIGenAI"
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-autoconfigure</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>embabel-agent-oci-genai-autoconfigure</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Autoconfiguration Models OCI GenAI</name>
+    <description>OCI Generative AI Models for Embabel Agent API</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-generativeaiinference</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common-httpclient-jersey3</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-addons-oke-workload-identity</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/ocigenai/AgentOciGenAiAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/ocigenai/AgentOciGenAiAutoConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.ocigenai;
+
+import com.embabel.agent.config.models.ocigenai.OciGenAiClientConfig;
+import com.embabel.agent.config.models.ocigenai.OciGenAiModelsConfig;
+import com.oracle.bmc.generativeaiinference.GenerativeAiInference;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Autoconfiguration for OCI Generative AI models in the Embabel Agent system.
+ */
+@AutoConfiguration
+@ConditionalOnClass(GenerativeAiInference.class)
+@AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
+@Import({OciGenAiClientConfig.class, OciGenAiModelsConfig.class})
+public class AgentOciGenAiAutoConfiguration {
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/ocigenai/OciGenAiEnvironmentPostProcessor.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/ocigenai/OciGenAiEnvironmentPostProcessor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.ocigenai;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.util.ClassUtils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@ApiStatus.Internal
+public class OciGenAiEnvironmentPostProcessor implements EnvironmentPostProcessor, Ordered {
+
+    static final String DEFAULT_LLM_PROPERTY = "embabel.models.default-llm";
+    static final String DEFAULT_EMBEDDING_PROPERTY = "embabel.models.default-embedding-model";
+    static final String OCI_DEFAULT_LLM = "cohere.command-a-03-2025";
+    static final String OCI_DEFAULT_EMBEDDING = "cohere.embed-v4.0";
+    private static final String PROPERTY_SOURCE_NAME = "ociGenAiDefaultModels";
+    private static final String OPENAI_AUTO_CONFIGURATION =
+            "com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+        if (isOpenAiProviderPresent()) {
+            return;
+        }
+
+        Map<String, Object> defaults = new LinkedHashMap<>();
+        if (!environment.containsProperty(DEFAULT_LLM_PROPERTY)) {
+            defaults.put(DEFAULT_LLM_PROPERTY, OCI_DEFAULT_LLM);
+        }
+        if (!environment.containsProperty(DEFAULT_EMBEDDING_PROPERTY)) {
+            defaults.put(DEFAULT_EMBEDDING_PROPERTY, OCI_DEFAULT_EMBEDDING);
+        }
+        if (!defaults.isEmpty()) {
+            environment.getPropertySources().addLast(new MapPropertySource(PROPERTY_SOURCE_NAME, defaults));
+        }
+    }
+
+    boolean isOpenAiProviderPresent() {
+        return ClassUtils.isPresent(OPENAI_AUTO_CONFIGURATION, getClass().getClassLoader());
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatModel.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.config.models.ocigenai
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.oracle.bmc.generativeaiinference.GenerativeAiInference
+import com.oracle.bmc.generativeaiinference.model.BaseChatResponse
 import com.oracle.bmc.generativeaiinference.model.BaseChatRequest
 import com.oracle.bmc.generativeaiinference.model.ChatDetails
 import com.oracle.bmc.generativeaiinference.model.ChatResult
@@ -28,7 +29,6 @@ import com.oracle.bmc.generativeaiinference.model.CohereChatResponse
 import com.oracle.bmc.generativeaiinference.model.CohereChatResponseV2
 import com.oracle.bmc.generativeaiinference.model.CohereMessage
 import com.oracle.bmc.generativeaiinference.model.CohereMessageV2
-import com.oracle.bmc.generativeaiinference.model.CohereSystemMessage
 import com.oracle.bmc.generativeaiinference.model.CohereSystemMessageV2
 import com.oracle.bmc.generativeaiinference.model.CohereTextContentV2
 import com.oracle.bmc.generativeaiinference.model.CohereToolMessageV2
@@ -44,10 +44,12 @@ import com.oracle.bmc.generativeaiinference.model.OnDemandServingMode
 import com.oracle.bmc.generativeaiinference.model.ServingMode
 import com.oracle.bmc.generativeaiinference.model.TextContent
 import com.oracle.bmc.generativeaiinference.model.ToolChoiceAuto
-import com.oracle.bmc.generativeaiinference.model.ToolDefinition
+import com.oracle.bmc.generativeaiinference.model.Usage
 import com.oracle.bmc.generativeaiinference.requests.ChatRequest
+import com.oracle.bmc.generativeaiinference.responses.ChatResponse as OciChatResponse
 import com.oracle.bmc.generativeaiinference.model.CohereToolCallV2 as OciCohereToolCallV2
 import com.oracle.bmc.generativeaiinference.model.Function as CohereFunction
+import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.messages.MessageType
 import org.springframework.ai.chat.messages.ToolResponseMessage
 import org.springframework.ai.chat.metadata.ChatGenerationMetadata
@@ -70,6 +72,9 @@ import com.oracle.bmc.generativeaiinference.model.UserMessage as OciUserMessage
 
 /**
  * Spring AI [ChatModel] backed by OCI Generative AI Inference.
+ *
+ * OCI streaming uses SSE response handling that is separate from the synchronous
+ * chat response path, so this model currently sends non-streaming requests.
  */
 class OciGenAiChatModel(
     private val client: GenerativeAiInference,
@@ -77,6 +82,7 @@ class OciGenAiChatModel(
     private val retryTemplate: RetryTemplate,
     private val objectMapper: ObjectMapper = ObjectMapper(),
 ) : ChatModel {
+    private val logger = LoggerFactory.getLogger(OciGenAiChatModel::class.java)
 
     override fun call(prompt: Prompt): ChatResponse {
         val options = defaultOptions.merge(prompt.options)
@@ -90,7 +96,7 @@ class OciGenAiChatModel(
             )
             .build()
 
-        val response = retryTemplate.execute<com.oracle.bmc.generativeaiinference.responses.ChatResponse, RuntimeException> {
+        val response = retryTemplate.execute<OciChatResponse, RuntimeException> {
             client.chat(request)
         }
         return toSpringChatResponse(response.chatResult, options)
@@ -98,8 +104,8 @@ class OciGenAiChatModel(
 
     override fun getDefaultOptions(): ChatOptions = defaultOptions.copy()
 
-    private fun chatRequest(prompt: Prompt, options: OciGenAiChatOptions): BaseChatRequest =
-        when (options.getApiFormat()) {
+    internal fun chatRequest(prompt: Prompt, options: OciGenAiChatOptions): BaseChatRequest =
+        when (options.apiFormat) {
             OciGenAiApiFormat.GENERIC -> genericChatRequest(prompt, options)
             OciGenAiApiFormat.COHERE_V2 -> cohereChatRequestV2(prompt, options)
             OciGenAiApiFormat.COHERE -> cohereChatRequest(prompt, options)
@@ -168,17 +174,20 @@ class OciGenAiChatModel(
 
     private fun cohereChatRequest(prompt: Prompt, options: OciGenAiChatOptions): CohereChatRequest {
         val messages = prompt.instructions
-        val lastUserMessage = messages.lastOrNull { it.messageType == MessageType.USER }?.text
-            ?: messages.lastOrNull()?.text
-            ?: ""
+        val lastUserIndex = messages.indexOfLast { it.messageType == MessageType.USER }
+        val lastRequestMessageIndex = if (lastUserIndex >= 0) lastUserIndex else messages.lastIndex
+        val lastUserMessage = messages.getOrNull(lastRequestMessageIndex)?.text ?: ""
         val preamble = messages
             .filter { it.messageType == MessageType.SYSTEM }
             .joinToString("\n") { it.text }
             .ifBlank { null }
-        val history = messages
-            .dropLastWhile { it.text != lastUserMessage }
-            .dropLast(1)
-            .mapNotNull(::toCohereHistoryMessage)
+        val history = if (lastRequestMessageIndex > 0) {
+            messages.subList(0, lastRequestMessageIndex)
+                .filter { it.messageType != MessageType.SYSTEM }
+                .mapNotNull(::toCohereHistoryMessage)
+        } else {
+            emptyList()
+        }
 
         return CohereChatRequest.builder()
             .message(lastUserMessage)
@@ -195,7 +204,7 @@ class OciGenAiChatModel(
             .build()
     }
 
-    private fun toGenericMessages(message: SpringMessage): List<OciMessage> =
+    internal fun toGenericMessages(message: SpringMessage): List<OciMessage> =
         when (message.messageType) {
             MessageType.SYSTEM -> listOf(OciSystemMessage.builder().content(textContent(message.text)).build())
             MessageType.USER -> listOf(OciUserMessage.builder().content(textContent(message.text)).build())
@@ -214,6 +223,7 @@ class OciGenAiChatModel(
                     .arguments(it.arguments())
                     .build()
             }
+            ?: emptyList()
         return OciAssistantMessage.builder()
             .content(textContent(message.text ?: ""))
             .toolCalls(toolCalls)
@@ -231,7 +241,7 @@ class OciGenAiChatModel(
         }
     }
 
-    private fun toCohereV2Messages(message: SpringMessage): List<CohereMessageV2> =
+    internal fun toCohereV2Messages(message: SpringMessage): List<CohereMessageV2> =
         when (message.messageType) {
             MessageType.SYSTEM -> listOf(
                 CohereSystemMessageV2.builder().content(cohereV2TextContent(message.text)).build()
@@ -256,6 +266,7 @@ class OciGenAiChatModel(
                     .function(parseToolArguments(it.arguments()))
                     .build()
             }
+            ?: emptyList()
         return CohereAssistantMessageV2.builder()
             .content(cohereV2TextContent(message.text ?: ""))
             .toolCalls(toolCalls)
@@ -275,7 +286,6 @@ class OciGenAiChatModel(
 
     private fun toCohereHistoryMessage(message: SpringMessage): CohereMessage? =
         when (message.messageType) {
-            MessageType.SYSTEM -> CohereSystemMessage.builder().message(message.text).build()
             MessageType.USER -> CohereUserMessage.builder().message(message.text).build()
             MessageType.ASSISTANT -> CohereChatBotMessage.builder().message(message.text ?: "").build()
             else -> null
@@ -289,42 +299,36 @@ class OciGenAiChatModel(
 
     private fun parseToolSchema(inputSchema: String): Any =
         runCatching { objectMapper.readValue(inputSchema, Any::class.java) }
-            .getOrElse { emptyMap<String, Any>() }
+            .getOrElse { e ->
+                logger.warn("Failed to parse OCI GenAI tool schema; using empty parameters: {}", e.message)
+                emptyMap<String, Any>()
+            }
 
     private fun parseToolArguments(arguments: String): Any =
         runCatching { objectMapper.readValue(arguments, Any::class.java) }
-            .getOrElse { arguments }
+            .getOrElse { e ->
+                logger.warn("Failed to parse OCI GenAI tool arguments; using raw arguments: {}", e.message)
+                arguments
+            }
 
     private fun servingMode(options: OciGenAiChatOptions): ServingMode =
-        when (options.getServingMode()) {
+        when (options.servingMode) {
             OciGenAiServingMode.ON_DEMAND -> OnDemandServingMode.builder()
                 .modelId(requireNotNull(options.getModel()) { "OCI GenAI model is required for on-demand serving" })
                 .build()
 
             OciGenAiServingMode.DEDICATED -> DedicatedServingMode.builder()
-                .endpointId(requireNotNull(options.getEndpointId()) { "OCI GenAI endpointId is required for dedicated serving" })
+                .endpointId(requireNotNull(options.endpointId) { "OCI GenAI endpointId is required for dedicated serving" })
                 .build()
         }
 
     private fun requireCompartmentId(options: OciGenAiChatOptions): String =
-        requireNotNull(options.getCompartmentId()) {
+        requireNotNull(options.compartmentId) {
             "OCI GenAI compartmentId is required: set embabel.agent.platform.models.ocigenai.compartment-id"
         }
 
     private fun toSpringChatResponse(chatResult: ChatResult, options: OciGenAiChatOptions): ChatResponse {
-        val response = chatResult.chatResponse
-        val generation = when (response) {
-            is GenericChatResponse -> toGenericGeneration(response)
-            is CohereChatResponseV2 -> toCohereV2Generation(response)
-            is CohereChatResponse -> toCohereGeneration(response)
-            else -> Generation(SpringAssistantMessage(""))
-        }
-        val usage = when (response) {
-            is GenericChatResponse -> response.usage
-            is CohereChatResponseV2 -> response.usage
-            is CohereChatResponse -> response.usage
-            else -> null
-        }
+        val (generation, usage) = generationAndUsage(chatResult.chatResponse)
         val metadata = ChatResponseMetadata.builder()
             .model(chatResult.modelId ?: options.getModel())
             .usage(
@@ -335,6 +339,14 @@ class OciGenAiChatModel(
             .build()
         return ChatResponse(listOf(generation), metadata)
     }
+
+    private fun generationAndUsage(response: BaseChatResponse?): GenerationAndUsage =
+        when (response) {
+            is GenericChatResponse -> GenerationAndUsage(toGenericGeneration(response), response.usage)
+            is CohereChatResponseV2 -> GenerationAndUsage(toCohereV2Generation(response), response.usage)
+            is CohereChatResponse -> GenerationAndUsage(toCohereGeneration(response), response.usage)
+            else -> GenerationAndUsage(Generation(SpringAssistantMessage("")), null)
+        }
 
     private fun toGenericGeneration(response: GenericChatResponse): Generation {
         val choice = response.choices.firstOrNull()
@@ -399,4 +411,9 @@ class OciGenAiChatModel(
             .build()
         return Generation(SpringAssistantMessage(response.text ?: ""), generationMetadata)
     }
+
+    private data class GenerationAndUsage(
+        val generation: Generation,
+        val usage: Usage?,
+    )
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatModel.kt
@@ -1,0 +1,402 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.oracle.bmc.generativeaiinference.GenerativeAiInference
+import com.oracle.bmc.generativeaiinference.model.BaseChatRequest
+import com.oracle.bmc.generativeaiinference.model.ChatDetails
+import com.oracle.bmc.generativeaiinference.model.ChatResult
+import com.oracle.bmc.generativeaiinference.model.CohereAssistantMessageV2
+import com.oracle.bmc.generativeaiinference.model.CohereChatBotMessage
+import com.oracle.bmc.generativeaiinference.model.CohereChatRequest
+import com.oracle.bmc.generativeaiinference.model.CohereChatRequestV2
+import com.oracle.bmc.generativeaiinference.model.CohereChatResponse
+import com.oracle.bmc.generativeaiinference.model.CohereChatResponseV2
+import com.oracle.bmc.generativeaiinference.model.CohereMessage
+import com.oracle.bmc.generativeaiinference.model.CohereMessageV2
+import com.oracle.bmc.generativeaiinference.model.CohereSystemMessage
+import com.oracle.bmc.generativeaiinference.model.CohereSystemMessageV2
+import com.oracle.bmc.generativeaiinference.model.CohereTextContentV2
+import com.oracle.bmc.generativeaiinference.model.CohereToolMessageV2
+import com.oracle.bmc.generativeaiinference.model.CohereToolV2
+import com.oracle.bmc.generativeaiinference.model.CohereUserMessage
+import com.oracle.bmc.generativeaiinference.model.CohereUserMessageV2
+import com.oracle.bmc.generativeaiinference.model.DedicatedServingMode
+import com.oracle.bmc.generativeaiinference.model.FunctionCall
+import com.oracle.bmc.generativeaiinference.model.FunctionDefinition
+import com.oracle.bmc.generativeaiinference.model.GenericChatRequest
+import com.oracle.bmc.generativeaiinference.model.GenericChatResponse
+import com.oracle.bmc.generativeaiinference.model.OnDemandServingMode
+import com.oracle.bmc.generativeaiinference.model.ServingMode
+import com.oracle.bmc.generativeaiinference.model.TextContent
+import com.oracle.bmc.generativeaiinference.model.ToolChoiceAuto
+import com.oracle.bmc.generativeaiinference.model.ToolDefinition
+import com.oracle.bmc.generativeaiinference.requests.ChatRequest
+import com.oracle.bmc.generativeaiinference.model.CohereToolCallV2 as OciCohereToolCallV2
+import com.oracle.bmc.generativeaiinference.model.Function as CohereFunction
+import org.springframework.ai.chat.messages.MessageType
+import org.springframework.ai.chat.messages.ToolResponseMessage
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata
+import org.springframework.ai.chat.metadata.ChatResponseMetadata
+import org.springframework.ai.chat.metadata.DefaultUsage
+import org.springframework.ai.chat.model.ChatModel
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.model.Generation
+import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.model.tool.ToolCallingChatOptions
+import org.springframework.retry.support.RetryTemplate
+import org.springframework.ai.chat.messages.AssistantMessage as SpringAssistantMessage
+import org.springframework.ai.chat.messages.Message as SpringMessage
+import com.oracle.bmc.generativeaiinference.model.AssistantMessage as OciAssistantMessage
+import com.oracle.bmc.generativeaiinference.model.Message as OciMessage
+import com.oracle.bmc.generativeaiinference.model.SystemMessage as OciSystemMessage
+import com.oracle.bmc.generativeaiinference.model.ToolMessage as OciToolMessage
+import com.oracle.bmc.generativeaiinference.model.UserMessage as OciUserMessage
+
+/**
+ * Spring AI [ChatModel] backed by OCI Generative AI Inference.
+ */
+class OciGenAiChatModel(
+    private val client: GenerativeAiInference,
+    private val defaultOptions: OciGenAiChatOptions,
+    private val retryTemplate: RetryTemplate,
+    private val objectMapper: ObjectMapper = ObjectMapper(),
+) : ChatModel {
+
+    override fun call(prompt: Prompt): ChatResponse {
+        val options = defaultOptions.merge(prompt.options)
+        val request = ChatRequest.builder()
+            .chatDetails(
+                ChatDetails.builder()
+                    .compartmentId(requireCompartmentId(options))
+                    .servingMode(servingMode(options))
+                    .chatRequest(chatRequest(prompt, options))
+                    .build()
+            )
+            .build()
+
+        val response = retryTemplate.execute<com.oracle.bmc.generativeaiinference.responses.ChatResponse, RuntimeException> {
+            client.chat(request)
+        }
+        return toSpringChatResponse(response.chatResult, options)
+    }
+
+    override fun getDefaultOptions(): ChatOptions = defaultOptions.copy()
+
+    private fun chatRequest(prompt: Prompt, options: OciGenAiChatOptions): BaseChatRequest =
+        when (options.getApiFormat()) {
+            OciGenAiApiFormat.GENERIC -> genericChatRequest(prompt, options)
+            OciGenAiApiFormat.COHERE_V2 -> cohereChatRequestV2(prompt, options)
+            OciGenAiApiFormat.COHERE -> cohereChatRequest(prompt, options)
+        }
+
+    private fun genericChatRequest(prompt: Prompt, options: OciGenAiChatOptions): GenericChatRequest {
+        val tools = options.toolCallbacks.map { toolCallback ->
+            val definition = toolCallback.toolDefinition
+            FunctionDefinition.builder()
+                .name(definition.name())
+                .description(definition.description())
+                .parameters(parseToolSchema(definition.inputSchema()))
+                .build()
+        }
+
+        val builder = GenericChatRequest.builder()
+            .messages(prompt.instructions.flatMap(::toGenericMessages))
+            .isStream(false)
+            .maxTokens(options.maxTokens)
+            .temperature(options.temperature)
+            .topP(options.topP)
+            .topK(options.topK)
+            .frequencyPenalty(options.frequencyPenalty)
+            .presencePenalty(options.presencePenalty)
+            .stop(options.stopSequences)
+
+        if (tools.isNotEmpty()) {
+            builder.tools(tools)
+                .toolChoice(ToolChoiceAuto.builder().build())
+                .isParallelToolCalls(false)
+        }
+        return builder.build()
+    }
+
+    private fun cohereChatRequestV2(prompt: Prompt, options: OciGenAiChatOptions): CohereChatRequestV2 {
+        val tools = options.toolCallbacks.map { toolCallback ->
+            val definition = toolCallback.toolDefinition
+            CohereToolV2.builder()
+                .type(CohereToolV2.Type.Function)
+                .function(
+                    CohereFunction.builder()
+                        .name(definition.name())
+                        .description(definition.description())
+                        .parameters(parseToolSchema(definition.inputSchema()))
+                        .build()
+                )
+                .build()
+        }
+
+        val builder = CohereChatRequestV2.builder()
+            .messages(prompt.instructions.flatMap(::toCohereV2Messages))
+            .isStream(false)
+            .maxTokens(options.maxTokens)
+            .temperature(options.temperature)
+            .topP(options.topP)
+            .topK(options.topK)
+            .frequencyPenalty(options.frequencyPenalty)
+            .presencePenalty(options.presencePenalty)
+            .stopSequences(options.stopSequences)
+
+        if (tools.isNotEmpty()) {
+            builder.tools(tools)
+        }
+        return builder.build()
+    }
+
+    private fun cohereChatRequest(prompt: Prompt, options: OciGenAiChatOptions): CohereChatRequest {
+        val messages = prompt.instructions
+        val lastUserMessage = messages.lastOrNull { it.messageType == MessageType.USER }?.text
+            ?: messages.lastOrNull()?.text
+            ?: ""
+        val preamble = messages
+            .filter { it.messageType == MessageType.SYSTEM }
+            .joinToString("\n") { it.text }
+            .ifBlank { null }
+        val history = messages
+            .dropLastWhile { it.text != lastUserMessage }
+            .dropLast(1)
+            .mapNotNull(::toCohereHistoryMessage)
+
+        return CohereChatRequest.builder()
+            .message(lastUserMessage)
+            .chatHistory(history)
+            .preambleOverride(preamble)
+            .isStream(false)
+            .maxTokens(options.maxTokens)
+            .temperature(options.temperature)
+            .topP(options.topP)
+            .topK(options.topK)
+            .frequencyPenalty(options.frequencyPenalty)
+            .presencePenalty(options.presencePenalty)
+            .stopSequences(options.stopSequences)
+            .build()
+    }
+
+    private fun toGenericMessages(message: SpringMessage): List<OciMessage> =
+        when (message.messageType) {
+            MessageType.SYSTEM -> listOf(OciSystemMessage.builder().content(textContent(message.text)).build())
+            MessageType.USER -> listOf(OciUserMessage.builder().content(textContent(message.text)).build())
+            MessageType.ASSISTANT -> listOf(toGenericAssistantMessage(message))
+            MessageType.TOOL -> toGenericToolMessages(message)
+            else -> listOf(OciUserMessage.builder().content(textContent(message.text)).build())
+        }
+
+    private fun toGenericAssistantMessage(message: SpringMessage): OciAssistantMessage {
+        val assistant = message as? SpringAssistantMessage
+        val toolCalls = assistant?.toolCalls
+            ?.map {
+                FunctionCall.builder()
+                    .id(it.id())
+                    .name(it.name())
+                    .arguments(it.arguments())
+                    .build()
+            }
+        return OciAssistantMessage.builder()
+            .content(textContent(message.text ?: ""))
+            .toolCalls(toolCalls)
+            .build()
+    }
+
+    private fun toGenericToolMessages(message: SpringMessage): List<OciMessage> {
+        val toolResponseMessage = message as? ToolResponseMessage
+            ?: return listOf(OciUserMessage.builder().content(textContent(message.text ?: "")).build())
+        return toolResponseMessage.responses.map { response ->
+            OciToolMessage.builder()
+                .toolCallId(response.id())
+                .content(textContent(response.responseData()))
+                .build()
+        }
+    }
+
+    private fun toCohereV2Messages(message: SpringMessage): List<CohereMessageV2> =
+        when (message.messageType) {
+            MessageType.SYSTEM -> listOf(
+                CohereSystemMessageV2.builder().content(cohereV2TextContent(message.text)).build()
+            )
+
+            MessageType.USER -> listOf(
+                CohereUserMessageV2.builder().content(cohereV2TextContent(message.text)).build()
+            )
+
+            MessageType.ASSISTANT -> listOf(toCohereV2AssistantMessage(message))
+            MessageType.TOOL -> toCohereV2ToolMessages(message)
+            else -> listOf(CohereUserMessageV2.builder().content(cohereV2TextContent(message.text)).build())
+        }
+
+    private fun toCohereV2AssistantMessage(message: SpringMessage): CohereAssistantMessageV2 {
+        val assistant = message as? SpringAssistantMessage
+        val toolCalls = assistant?.toolCalls
+            ?.map {
+                OciCohereToolCallV2.builder()
+                    .id(it.id())
+                    .type(OciCohereToolCallV2.Type.Function)
+                    .function(parseToolArguments(it.arguments()))
+                    .build()
+            }
+        return CohereAssistantMessageV2.builder()
+            .content(cohereV2TextContent(message.text ?: ""))
+            .toolCalls(toolCalls)
+            .build()
+    }
+
+    private fun toCohereV2ToolMessages(message: SpringMessage): List<CohereMessageV2> {
+        val toolResponseMessage = message as? ToolResponseMessage
+            ?: return listOf(CohereUserMessageV2.builder().content(cohereV2TextContent(message.text ?: "")).build())
+        return toolResponseMessage.responses.map { response ->
+            CohereToolMessageV2.builder()
+                .toolCallId(response.id())
+                .content(cohereV2TextContent(response.responseData()))
+                .build()
+        }
+    }
+
+    private fun toCohereHistoryMessage(message: SpringMessage): CohereMessage? =
+        when (message.messageType) {
+            MessageType.SYSTEM -> CohereSystemMessage.builder().message(message.text).build()
+            MessageType.USER -> CohereUserMessage.builder().message(message.text).build()
+            MessageType.ASSISTANT -> CohereChatBotMessage.builder().message(message.text ?: "").build()
+            else -> null
+        }
+
+    private fun textContent(text: String): List<TextContent> =
+        listOf(TextContent.builder().text(text).build())
+
+    private fun cohereV2TextContent(text: String): List<CohereTextContentV2> =
+        listOf(CohereTextContentV2.builder().text(text).build())
+
+    private fun parseToolSchema(inputSchema: String): Any =
+        runCatching { objectMapper.readValue(inputSchema, Any::class.java) }
+            .getOrElse { emptyMap<String, Any>() }
+
+    private fun parseToolArguments(arguments: String): Any =
+        runCatching { objectMapper.readValue(arguments, Any::class.java) }
+            .getOrElse { arguments }
+
+    private fun servingMode(options: OciGenAiChatOptions): ServingMode =
+        when (options.getServingMode()) {
+            OciGenAiServingMode.ON_DEMAND -> OnDemandServingMode.builder()
+                .modelId(requireNotNull(options.getModel()) { "OCI GenAI model is required for on-demand serving" })
+                .build()
+
+            OciGenAiServingMode.DEDICATED -> DedicatedServingMode.builder()
+                .endpointId(requireNotNull(options.getEndpointId()) { "OCI GenAI endpointId is required for dedicated serving" })
+                .build()
+        }
+
+    private fun requireCompartmentId(options: OciGenAiChatOptions): String =
+        requireNotNull(options.getCompartmentId()) {
+            "OCI GenAI compartmentId is required: set embabel.agent.platform.models.ocigenai.compartment-id"
+        }
+
+    private fun toSpringChatResponse(chatResult: ChatResult, options: OciGenAiChatOptions): ChatResponse {
+        val response = chatResult.chatResponse
+        val generation = when (response) {
+            is GenericChatResponse -> toGenericGeneration(response)
+            is CohereChatResponseV2 -> toCohereV2Generation(response)
+            is CohereChatResponse -> toCohereGeneration(response)
+            else -> Generation(SpringAssistantMessage(""))
+        }
+        val usage = when (response) {
+            is GenericChatResponse -> response.usage
+            is CohereChatResponseV2 -> response.usage
+            is CohereChatResponse -> response.usage
+            else -> null
+        }
+        val metadata = ChatResponseMetadata.builder()
+            .model(chatResult.modelId ?: options.getModel())
+            .usage(
+                usage?.let {
+                    DefaultUsage(it.promptTokens, it.completionTokens, it.totalTokens, it)
+                }
+            )
+            .build()
+        return ChatResponse(listOf(generation), metadata)
+    }
+
+    private fun toGenericGeneration(response: GenericChatResponse): Generation {
+        val choice = response.choices.firstOrNull()
+        val message = choice?.message
+        val text = message?.content.orEmpty()
+            .filterIsInstance<TextContent>()
+            .joinToString("") { it.text ?: "" }
+        val toolCalls = (message as? OciAssistantMessage)?.toolCalls.orEmpty()
+            .filterIsInstance<FunctionCall>()
+            .map { SpringAssistantMessage.ToolCall(it.id, "function", it.name, it.arguments) }
+        val assistant = SpringAssistantMessage.builder()
+            .content(text)
+            .toolCalls(toolCalls)
+            .build()
+        val generationMetadata = ChatGenerationMetadata.builder()
+            .finishReason(choice?.finishReason)
+            .build()
+        return Generation(assistant, generationMetadata)
+    }
+
+    private fun toCohereV2Generation(response: CohereChatResponseV2): Generation {
+        val message = response.message
+        val text = message?.content.orEmpty()
+            .filterIsInstance<CohereTextContentV2>()
+            .joinToString("") { it.text ?: "" }
+        val toolCalls = message?.toolCalls.orEmpty()
+            .map {
+                SpringAssistantMessage.ToolCall(
+                    it.id,
+                    "function",
+                    cohereV2ToolName(it.function),
+                    cohereV2ToolArguments(it.function),
+                )
+            }
+        val assistant = SpringAssistantMessage.builder()
+            .content(text)
+            .toolCalls(toolCalls)
+            .build()
+        val generationMetadata = ChatGenerationMetadata.builder()
+            .finishReason(response.finishReason?.value)
+            .build()
+        return Generation(assistant, generationMetadata)
+    }
+
+    private fun cohereV2ToolName(function: Any?): String =
+        when (function) {
+            is CohereFunction -> function.name
+            is Map<*, *> -> function["name"]?.toString() ?: ""
+            else -> ""
+        }
+
+    private fun cohereV2ToolArguments(function: Any?): String =
+        when (function) {
+            is CohereFunction -> objectMapper.writeValueAsString(function.parameters ?: emptyMap<String, Any>())
+            is Map<*, *> -> objectMapper.writeValueAsString(function["parameters"] ?: function["arguments"] ?: emptyMap<String, Any>())
+            else -> "{}"
+        }
+
+    private fun toCohereGeneration(response: CohereChatResponse): Generation {
+        val generationMetadata = ChatGenerationMetadata.builder()
+            .finishReason(response.finishReason?.value)
+            .build()
+        return Generation(SpringAssistantMessage(response.text ?: ""), generationMetadata)
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatOptions.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatOptions.kt
@@ -22,12 +22,12 @@ import org.springframework.ai.tool.ToolCallback
 /**
  * Spring AI chat options for OCI Generative AI.
  */
-class OciGenAiChatOptions(
+class OciGenAiChatOptions internal constructor(
     private var model: String? = null,
-    private var compartmentId: String? = null,
-    private var servingMode: OciGenAiServingMode = OciGenAiServingMode.ON_DEMAND,
-    private var endpointId: String? = null,
-    private var apiFormat: OciGenAiApiFormat = OciGenAiApiFormat.GENERIC,
+    var compartmentId: String? = null,
+    initialServingMode: OciGenAiServingMode? = null,
+    var endpointId: String? = null,
+    initialApiFormat: OciGenAiApiFormat? = null,
     private var maxTokens: Int? = null,
     private var temperature: Double? = null,
     private var topP: Double? = null,
@@ -41,34 +41,25 @@ class OciGenAiChatOptions(
     private var internalToolExecutionEnabled: Boolean? = null,
 ) : ToolCallingChatOptions {
 
+    private var servingModeExplicit: Boolean = initialServingMode != null
+    private var apiFormatExplicit: Boolean = initialApiFormat != null
+
+    var servingMode: OciGenAiServingMode = initialServingMode ?: OciGenAiServingMode.ON_DEMAND
+        set(value) {
+            field = value
+            servingModeExplicit = true
+        }
+
+    var apiFormat: OciGenAiApiFormat = initialApiFormat ?: OciGenAiApiFormat.GENERIC
+        set(value) {
+            field = value
+            apiFormatExplicit = true
+        }
+
     override fun getModel(): String? = model
 
     fun setModel(model: String?) {
         this.model = model
-    }
-
-    fun getCompartmentId(): String? = compartmentId
-
-    fun setCompartmentId(compartmentId: String?) {
-        this.compartmentId = compartmentId
-    }
-
-    fun getServingMode(): OciGenAiServingMode = servingMode
-
-    fun setServingMode(servingMode: OciGenAiServingMode) {
-        this.servingMode = servingMode
-    }
-
-    fun getEndpointId(): String? = endpointId
-
-    fun setEndpointId(endpointId: String?) {
-        this.endpointId = endpointId
-    }
-
-    fun getApiFormat(): OciGenAiApiFormat = apiFormat
-
-    fun setApiFormat(apiFormat: OciGenAiApiFormat) {
-        this.apiFormat = apiFormat
     }
 
     override fun getFrequencyPenalty(): Double? = frequencyPenalty
@@ -155,10 +146,14 @@ class OciGenAiChatOptions(
             setMergedToolCallbacks(merged, runtimeOptions)
         }
         if (runtimeOptions is OciGenAiChatOptions) {
-            runtimeOptions.getCompartmentId()?.let { merged.setCompartmentId(it) }
-            merged.setServingMode(runtimeOptions.getServingMode())
-            runtimeOptions.getEndpointId()?.let { merged.setEndpointId(it) }
-            merged.setApiFormat(runtimeOptions.getApiFormat())
+            runtimeOptions.compartmentId?.let { merged.compartmentId = it }
+            if (runtimeOptions.servingModeExplicit) {
+                merged.servingMode = runtimeOptions.servingMode
+            }
+            runtimeOptions.endpointId?.let { merged.endpointId = it }
+            if (runtimeOptions.apiFormatExplicit) {
+                merged.apiFormat = runtimeOptions.apiFormat
+            }
         }
         return merged
     }
@@ -174,7 +169,7 @@ class OciGenAiChatOptions(
             merged.toolNames = runtimeOptions.toolNames
         }
         if (runtimeOptions.toolContext.isNotEmpty()) {
-            merged.toolContext = toolContext + runtimeOptions.toolContext
+            merged.toolContext = merged.toolContext + runtimeOptions.toolContext
         }
         runtimeOptions.internalToolExecutionEnabled?.let { merged.internalToolExecutionEnabled = it }
     }
@@ -184,9 +179,9 @@ class OciGenAiChatOptions(
         OciGenAiChatOptions(
             model = model,
             compartmentId = compartmentId,
-            servingMode = servingMode,
+            initialServingMode = if (servingModeExplicit) servingMode else null,
             endpointId = endpointId,
-            apiFormat = apiFormat,
+            initialApiFormat = if (apiFormatExplicit) apiFormat else null,
             maxTokens = maxTokens,
             temperature = temperature,
             topP = topP,
@@ -209,13 +204,13 @@ class OciGenAiChatOptions(
 
         fun model(model: String?) = apply { options.setModel(model) }
 
-        fun compartmentId(compartmentId: String?) = apply { options.setCompartmentId(compartmentId) }
+        fun compartmentId(compartmentId: String?) = apply { options.compartmentId = compartmentId }
 
-        fun servingMode(servingMode: OciGenAiServingMode) = apply { options.setServingMode(servingMode) }
+        fun servingMode(servingMode: OciGenAiServingMode) = apply { options.servingMode = servingMode }
 
-        fun endpointId(endpointId: String?) = apply { options.setEndpointId(endpointId) }
+        fun endpointId(endpointId: String?) = apply { options.endpointId = endpointId }
 
-        fun apiFormat(apiFormat: OciGenAiApiFormat) = apply { options.setApiFormat(apiFormat) }
+        fun apiFormat(apiFormat: OciGenAiApiFormat) = apply { options.apiFormat = apiFormat }
 
         fun maxTokens(maxTokens: Int?) = apply { options.setMaxTokens(maxTokens) }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatOptions.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatOptions.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.model.tool.ToolCallingChatOptions
+import org.springframework.ai.tool.ToolCallback
+
+/**
+ * Spring AI chat options for OCI Generative AI.
+ */
+class OciGenAiChatOptions(
+    private var model: String? = null,
+    private var compartmentId: String? = null,
+    private var servingMode: OciGenAiServingMode = OciGenAiServingMode.ON_DEMAND,
+    private var endpointId: String? = null,
+    private var apiFormat: OciGenAiApiFormat = OciGenAiApiFormat.GENERIC,
+    private var maxTokens: Int? = null,
+    private var temperature: Double? = null,
+    private var topP: Double? = null,
+    private var topK: Int? = null,
+    private var frequencyPenalty: Double? = null,
+    private var presencePenalty: Double? = null,
+    private var stopSequences: List<String>? = null,
+    private var toolCallbacks: List<ToolCallback> = emptyList(),
+    private var toolNames: Set<String> = emptySet(),
+    private var toolContext: Map<String, Any> = emptyMap(),
+    private var internalToolExecutionEnabled: Boolean? = null,
+) : ToolCallingChatOptions {
+
+    override fun getModel(): String? = model
+
+    fun setModel(model: String?) {
+        this.model = model
+    }
+
+    fun getCompartmentId(): String? = compartmentId
+
+    fun setCompartmentId(compartmentId: String?) {
+        this.compartmentId = compartmentId
+    }
+
+    fun getServingMode(): OciGenAiServingMode = servingMode
+
+    fun setServingMode(servingMode: OciGenAiServingMode) {
+        this.servingMode = servingMode
+    }
+
+    fun getEndpointId(): String? = endpointId
+
+    fun setEndpointId(endpointId: String?) {
+        this.endpointId = endpointId
+    }
+
+    fun getApiFormat(): OciGenAiApiFormat = apiFormat
+
+    fun setApiFormat(apiFormat: OciGenAiApiFormat) {
+        this.apiFormat = apiFormat
+    }
+
+    override fun getFrequencyPenalty(): Double? = frequencyPenalty
+
+    fun setFrequencyPenalty(frequencyPenalty: Double?) {
+        this.frequencyPenalty = frequencyPenalty
+    }
+
+    override fun getMaxTokens(): Int? = maxTokens
+
+    fun setMaxTokens(maxTokens: Int?) {
+        this.maxTokens = maxTokens
+    }
+
+    override fun getPresencePenalty(): Double? = presencePenalty
+
+    fun setPresencePenalty(presencePenalty: Double?) {
+        this.presencePenalty = presencePenalty
+    }
+
+    override fun getStopSequences(): List<String>? = stopSequences
+
+    fun setStopSequences(stopSequences: List<String>?) {
+        this.stopSequences = stopSequences
+    }
+
+    override fun getTemperature(): Double? = temperature
+
+    fun setTemperature(temperature: Double?) {
+        this.temperature = temperature
+    }
+
+    override fun getTopK(): Int? = topK
+
+    fun setTopK(topK: Int?) {
+        this.topK = topK
+    }
+
+    override fun getTopP(): Double? = topP
+
+    fun setTopP(topP: Double?) {
+        this.topP = topP
+    }
+
+    override fun getToolCallbacks(): List<ToolCallback> = toolCallbacks
+
+    override fun setToolCallbacks(toolCallbacks: MutableList<ToolCallback>) {
+        this.toolCallbacks = toolCallbacks
+    }
+
+    override fun getToolNames(): Set<String> = toolNames
+
+    override fun setToolNames(toolNames: MutableSet<String>) {
+        this.toolNames = toolNames
+    }
+
+    override fun getInternalToolExecutionEnabled(): Boolean? = internalToolExecutionEnabled
+
+    override fun setInternalToolExecutionEnabled(internalToolExecutionEnabled: Boolean?) {
+        this.internalToolExecutionEnabled = internalToolExecutionEnabled
+    }
+
+    override fun getToolContext(): Map<String, Any> = toolContext
+
+    override fun setToolContext(toolContext: MutableMap<String, Any>) {
+        this.toolContext = toolContext
+    }
+
+    fun merge(runtimeOptions: ChatOptions?): OciGenAiChatOptions {
+        val merged = copy<OciGenAiChatOptions>()
+        if (runtimeOptions == null) {
+            return merged
+        }
+        runtimeOptions.model?.let { merged.setModel(it) }
+        runtimeOptions.frequencyPenalty?.let { merged.setFrequencyPenalty(it) }
+        runtimeOptions.maxTokens?.let { merged.setMaxTokens(it) }
+        runtimeOptions.presencePenalty?.let { merged.setPresencePenalty(it) }
+        runtimeOptions.stopSequences?.let { merged.setStopSequences(it) }
+        runtimeOptions.temperature?.let { merged.setTemperature(it) }
+        runtimeOptions.topK?.let { merged.setTopK(it) }
+        runtimeOptions.topP?.let { merged.setTopP(it) }
+
+        if (runtimeOptions is ToolCallingChatOptions) {
+            setMergedToolCallbacks(merged, runtimeOptions)
+        }
+        if (runtimeOptions is OciGenAiChatOptions) {
+            runtimeOptions.getCompartmentId()?.let { merged.setCompartmentId(it) }
+            merged.setServingMode(runtimeOptions.getServingMode())
+            runtimeOptions.getEndpointId()?.let { merged.setEndpointId(it) }
+            merged.setApiFormat(runtimeOptions.getApiFormat())
+        }
+        return merged
+    }
+
+    private fun setMergedToolCallbacks(
+        merged: OciGenAiChatOptions,
+        runtimeOptions: ToolCallingChatOptions,
+    ) {
+        if (runtimeOptions.toolCallbacks.isNotEmpty()) {
+            merged.toolCallbacks = runtimeOptions.toolCallbacks
+        }
+        if (runtimeOptions.toolNames.isNotEmpty()) {
+            merged.toolNames = runtimeOptions.toolNames
+        }
+        if (runtimeOptions.toolContext.isNotEmpty()) {
+            merged.toolContext = toolContext + runtimeOptions.toolContext
+        }
+        runtimeOptions.internalToolExecutionEnabled?.let { merged.internalToolExecutionEnabled = it }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ChatOptions> copy(): T =
+        OciGenAiChatOptions(
+            model = model,
+            compartmentId = compartmentId,
+            servingMode = servingMode,
+            endpointId = endpointId,
+            apiFormat = apiFormat,
+            maxTokens = maxTokens,
+            temperature = temperature,
+            topP = topP,
+            topK = topK,
+            frequencyPenalty = frequencyPenalty,
+            presencePenalty = presencePenalty,
+            stopSequences = stopSequences,
+            toolCallbacks = toolCallbacks,
+            toolNames = toolNames,
+            toolContext = toolContext,
+            internalToolExecutionEnabled = internalToolExecutionEnabled,
+        ) as T
+
+    companion object {
+        fun builder() = Builder()
+    }
+
+    class Builder {
+        private val options = OciGenAiChatOptions()
+
+        fun model(model: String?) = apply { options.setModel(model) }
+
+        fun compartmentId(compartmentId: String?) = apply { options.setCompartmentId(compartmentId) }
+
+        fun servingMode(servingMode: OciGenAiServingMode) = apply { options.setServingMode(servingMode) }
+
+        fun endpointId(endpointId: String?) = apply { options.setEndpointId(endpointId) }
+
+        fun apiFormat(apiFormat: OciGenAiApiFormat) = apply { options.setApiFormat(apiFormat) }
+
+        fun maxTokens(maxTokens: Int?) = apply { options.setMaxTokens(maxTokens) }
+
+        fun temperature(temperature: Double?) = apply { options.setTemperature(temperature) }
+
+        fun topP(topP: Double?) = apply { options.setTopP(topP) }
+
+        fun topK(topK: Int?) = apply { options.setTopK(topK) }
+
+        fun frequencyPenalty(frequencyPenalty: Double?) = apply { options.setFrequencyPenalty(frequencyPenalty) }
+
+        fun presencePenalty(presencePenalty: Double?) = apply { options.setPresencePenalty(presencePenalty) }
+
+        fun stopSequences(stopSequences: List<String>?) = apply { options.setStopSequences(stopSequences) }
+
+        fun toolCallbacks(toolCallbacks: List<ToolCallback>?) = apply {
+            options.setToolCallbacks(toolCallbacks?.toMutableList() ?: mutableListOf())
+        }
+
+        fun internalToolExecutionEnabled(internalToolExecutionEnabled: Boolean?) =
+            apply { options.setInternalToolExecutionEnabled(internalToolExecutionEnabled) }
+
+        fun build(): OciGenAiChatOptions = options.copy()
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiEmbeddingModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiEmbeddingModel.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+import com.oracle.bmc.generativeaiinference.GenerativeAiInference
+import com.oracle.bmc.generativeaiinference.model.DedicatedServingMode
+import com.oracle.bmc.generativeaiinference.model.EmbedTextDetails
+import com.oracle.bmc.generativeaiinference.model.OnDemandServingMode
+import com.oracle.bmc.generativeaiinference.model.ServingMode
+import com.oracle.bmc.generativeaiinference.requests.EmbedTextRequest
+import org.springframework.ai.document.Document
+import org.springframework.ai.embedding.Embedding
+import org.springframework.ai.embedding.EmbeddingModel
+import org.springframework.ai.embedding.EmbeddingRequest
+import org.springframework.ai.embedding.EmbeddingResponse
+import org.springframework.ai.embedding.EmbeddingResponseMetadata
+import org.springframework.ai.embedding.EmbeddingResultMetadata
+import org.springframework.ai.chat.metadata.DefaultUsage
+import org.springframework.ai.chat.metadata.EmptyUsage
+import org.springframework.retry.support.RetryTemplate
+
+class OciGenAiEmbeddingModel(
+    private val client: GenerativeAiInference,
+    private val options: OciGenAiEmbeddingOptions,
+    private val retryTemplate: RetryTemplate,
+) : EmbeddingModel {
+
+    override fun call(request: EmbeddingRequest): EmbeddingResponse {
+        val dimensions = request.options?.dimensions ?: options.dimensions
+        val details = EmbedTextDetails.builder()
+            .inputs(request.instructions)
+            .servingMode(servingMode(options))
+            .compartmentId(options.compartmentId)
+            .outputDimensions(dimensions)
+            .truncate(options.truncate.toOci())
+            .inputType(options.inputType?.toOci())
+            .build()
+        val response = retryTemplate.execute<com.oracle.bmc.generativeaiinference.responses.EmbedTextResponse, RuntimeException> {
+            client.embedText(EmbedTextRequest.builder().embedTextDetails(details).build())
+        }
+        val result = response.embedTextResult
+        val embeddings = result.embeddings.orEmpty().mapIndexed { index, values ->
+            Embedding(values.map { it ?: 0.0f }.toFloatArray(), index, EmbeddingResultMetadata.EMPTY)
+        }
+        val usage = result.usage?.let { DefaultUsage(it.promptTokens, it.completionTokens, it.totalTokens, it) }
+        return EmbeddingResponse(
+            embeddings,
+            EmbeddingResponseMetadata(result.modelId ?: options.model, usage ?: EmptyUsage()),
+        )
+    }
+
+    override fun embed(document: Document): FloatArray =
+        embed(getEmbeddingContent(document))
+
+    private fun servingMode(options: OciGenAiEmbeddingOptions): ServingMode =
+        when (options.servingMode) {
+            OciGenAiServingMode.ON_DEMAND -> OnDemandServingMode.builder()
+                .modelId(options.model)
+                .build()
+
+            OciGenAiServingMode.DEDICATED -> DedicatedServingMode.builder()
+                .endpointId(requireNotNull(options.endpointId) { "OCI GenAI embedding endpointId is required for dedicated serving" })
+                .build()
+        }
+}
+
+data class OciGenAiEmbeddingOptions(
+    val model: String,
+    val compartmentId: String,
+    val servingMode: OciGenAiServingMode = OciGenAiServingMode.ON_DEMAND,
+    val endpointId: String? = null,
+    val dimensions: Int? = null,
+    val truncate: OciGenAiEmbeddingTruncate = OciGenAiEmbeddingTruncate.NONE,
+    val inputType: OciGenAiEmbeddingInputType? = null,
+)
+
+private fun OciGenAiEmbeddingTruncate.toOci(): EmbedTextDetails.Truncate =
+    when (this) {
+        OciGenAiEmbeddingTruncate.NONE -> EmbedTextDetails.Truncate.None
+        OciGenAiEmbeddingTruncate.START -> EmbedTextDetails.Truncate.Start
+        OciGenAiEmbeddingTruncate.END -> EmbedTextDetails.Truncate.End
+    }
+
+private fun OciGenAiEmbeddingInputType.toOci(): EmbedTextDetails.InputType =
+    when (this) {
+        OciGenAiEmbeddingInputType.SEARCH_DOCUMENT -> EmbedTextDetails.InputType.SearchDocument
+        OciGenAiEmbeddingInputType.SEARCH_QUERY -> EmbedTextDetails.InputType.SearchQuery
+        OciGenAiEmbeddingInputType.CLASSIFICATION -> EmbedTextDetails.InputType.Classification
+        OciGenAiEmbeddingInputType.CLUSTERING -> EmbedTextDetails.InputType.Clustering
+    }

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiEmbeddingModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiEmbeddingModel.kt
@@ -21,6 +21,7 @@ import com.oracle.bmc.generativeaiinference.model.EmbedTextDetails
 import com.oracle.bmc.generativeaiinference.model.OnDemandServingMode
 import com.oracle.bmc.generativeaiinference.model.ServingMode
 import com.oracle.bmc.generativeaiinference.requests.EmbedTextRequest
+import com.oracle.bmc.generativeaiinference.responses.EmbedTextResponse as OciEmbedTextResponse
 import org.springframework.ai.document.Document
 import org.springframework.ai.embedding.Embedding
 import org.springframework.ai.embedding.EmbeddingModel
@@ -48,7 +49,7 @@ class OciGenAiEmbeddingModel(
             .truncate(options.truncate.toOci())
             .inputType(options.inputType?.toOci())
             .build()
-        val response = retryTemplate.execute<com.oracle.bmc.generativeaiinference.responses.EmbedTextResponse, RuntimeException> {
+        val response = retryTemplate.execute<OciEmbedTextResponse, RuntimeException> {
             client.embedText(EmbedTextRequest.builder().embedTextDetails(details).build())
         }
         val result = response.embedTextResult

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelLoader.kt
@@ -35,7 +35,7 @@ data class OciGenAiModelDefinition(
     override val knowledgeCutoffDate: LocalDate? = null,
     override val pricingModel: PerTokenPricingModel? = null,
     val apiFormat: OciGenAiApiFormat = OciGenAiApiFormat.GENERIC,
-    val maxTokens: Int? = 4096,
+    val maxTokens: Int? = null,
     val temperature: Double? = 0.7,
     val topP: Double? = null,
     val topK: Int? = null,
@@ -98,28 +98,4 @@ class OciGenAiModelLoader(
     companion object {
         private const val DEFAULT_CONFIG_PATH = "classpath:models/oci-genai-models.yml"
     }
-}
-
-enum class OciGenAiApiFormat {
-    GENERIC,
-    COHERE_V2,
-    COHERE,
-}
-
-enum class OciGenAiServingMode {
-    ON_DEMAND,
-    DEDICATED,
-}
-
-enum class OciGenAiEmbeddingTruncate {
-    NONE,
-    START,
-    END,
-}
-
-enum class OciGenAiEmbeddingInputType {
-    SEARCH_DOCUMENT,
-    SEARCH_QUERY,
-    CLASSIFICATION,
-    CLUSTERING,
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelLoader.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+import com.embabel.common.ai.autoconfig.AbstractYamlModelLoader
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadata
+import com.embabel.common.ai.autoconfig.LlmAutoConfigProvider
+import com.embabel.common.ai.model.PerTokenPricingModel
+import org.springframework.core.io.DefaultResourceLoader
+import org.springframework.core.io.ResourceLoader
+import java.time.LocalDate
+
+data class OciGenAiModelDefinitions(
+    override val models: List<OciGenAiModelDefinition> = emptyList(),
+    val embeddingModels: List<OciGenAiEmbeddingModelDefinition> = emptyList(),
+) : LlmAutoConfigProvider<OciGenAiModelDefinition>
+
+data class OciGenAiModelDefinition(
+    override val name: String,
+    override val modelId: String,
+    override val displayName: String? = null,
+    override val knowledgeCutoffDate: LocalDate? = null,
+    override val pricingModel: PerTokenPricingModel? = null,
+    val apiFormat: OciGenAiApiFormat = OciGenAiApiFormat.GENERIC,
+    val maxTokens: Int? = 4096,
+    val temperature: Double? = 0.7,
+    val topP: Double? = null,
+    val topK: Int? = null,
+) : LlmAutoConfigMetadata
+
+data class OciGenAiEmbeddingModelDefinition(
+    val name: String,
+    val modelId: String,
+    val displayName: String? = null,
+    val dimensions: Int? = null,
+    val truncate: OciGenAiEmbeddingTruncate = OciGenAiEmbeddingTruncate.NONE,
+    val inputType: OciGenAiEmbeddingInputType? = null,
+    val pricingModel: OciGenAiEmbeddingPricingModel? = null,
+)
+
+data class OciGenAiEmbeddingPricingModel(
+    val usdPer1mTokens: Double,
+)
+
+class OciGenAiModelLoader(
+    resourceLoader: ResourceLoader = DefaultResourceLoader(),
+    configPath: String = DEFAULT_CONFIG_PATH,
+) : AbstractYamlModelLoader<OciGenAiModelDefinitions>(resourceLoader, configPath) {
+
+    override fun getProviderClass() = OciGenAiModelDefinitions::class
+
+    override fun createEmptyProvider() = OciGenAiModelDefinitions()
+
+    override fun getProviderName() = "OCI GenAI"
+
+    override fun validateModels(provider: OciGenAiModelDefinitions) {
+        provider.models.forEach { model ->
+            validateCommonFields(model)
+            model.maxTokens?.let {
+                require(it > 0) { "Max tokens must be positive for model ${model.name}" }
+            }
+            model.temperature?.let {
+                require(it in 0.0..2.0) { "Temperature must be between 0 and 2 for model ${model.name}" }
+            }
+            model.topP?.let {
+                require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }
+            }
+            model.topK?.let {
+                require(it > 0) { "Top K must be positive for model ${model.name}" }
+            }
+        }
+
+        provider.embeddingModels.forEach { model ->
+            require(model.name.isNotBlank()) { "Embedding model name cannot be blank" }
+            require(model.modelId.isNotBlank()) { "Embedding model ID cannot be blank" }
+            model.dimensions?.let {
+                require(it > 0) { "Dimensions must be positive for embedding model ${model.name}" }
+            }
+            model.pricingModel?.let {
+                require(it.usdPer1mTokens >= 0.0) { "Pricing must be non-negative for embedding model ${model.name}" }
+            }
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_CONFIG_PATH = "classpath:models/oci-genai-models.yml"
+    }
+}
+
+enum class OciGenAiApiFormat {
+    GENERIC,
+    COHERE_V2,
+    COHERE,
+}
+
+enum class OciGenAiServingMode {
+    ON_DEMAND,
+    DEDICATED,
+}
+
+enum class OciGenAiEmbeddingTruncate {
+    NONE,
+    START,
+    END,
+}
+
+enum class OciGenAiEmbeddingInputType {
+    SEARCH_DOCUMENT,
+    SEARCH_QUERY,
+    CLASSIFICATION,
+    CLUSTERING,
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelsConfig.kt
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+import com.embabel.agent.api.models.OciGenAiModels
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.common.RetryProperties
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadataLoader
+import com.embabel.common.ai.autoconfig.ProviderInitialization
+import com.embabel.common.ai.autoconfig.RegisteredModel
+import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.OptionsConverter
+import com.embabel.common.ai.model.PerTokenPricingModel
+import com.embabel.common.ai.model.PricingModel
+import com.embabel.common.ai.model.SpringAiEmbeddingService
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.oracle.bmc.Region
+import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
+import com.oracle.bmc.auth.ConfigFileAuthenticationDetailsProvider
+import com.oracle.bmc.auth.InstancePrincipalsAuthenticationDetailsProvider
+import com.oracle.bmc.auth.ResourcePrincipalAuthenticationDetailsProvider
+import com.oracle.bmc.auth.SessionTokenAuthenticationDetailsProvider
+import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider
+import com.oracle.bmc.auth.okeworkloadidentity.OkeWorkloadIdentityAuthenticationDetailsProvider
+import com.oracle.bmc.generativeaiinference.GenerativeAiInference
+import com.oracle.bmc.generativeaiinference.GenerativeAiInferenceClient
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import java.nio.file.Paths
+
+@ConfigurationProperties(prefix = "embabel.agent.platform.models.ocigenai")
+class OciGenAiProperties : RetryProperties {
+
+    var authenticationType: AuthenticationType = AuthenticationType.FILE
+    var configFile: String? = null
+    var profile: String? = null
+    var federationEndpoint: String? = null
+    var tenantId: String? = null
+    var userId: String? = null
+    var fingerprint: String? = null
+    var privateKey: String? = null
+    var privateKeyFile: String? = null
+    var passPhrase: String? = null
+    var sessionToken: String? = null
+    var sessionTokenFile: String? = null
+    var workloadIdentityTokenPath: String? = null
+    var region: String? = null
+    var endpoint: String? = null
+    var compartmentId: String? = null
+    var servingMode: OciGenAiServingMode = OciGenAiServingMode.ON_DEMAND
+    var endpointId: String? = null
+
+    override var maxAttempts: Int = 10
+    override var backoffMillis: Long = 5_000L
+    override var backoffMultiplier: Double = 5.0
+    override var backoffMaxInterval: Long = 180_000L
+
+    enum class AuthenticationType {
+        FILE,
+        INSTANCE_PRINCIPAL,
+        RESOURCE_PRINCIPAL,
+        WORKLOAD_IDENTITY,
+        SIMPLE,
+        SESSION_TOKEN,
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(OciGenAiProperties::class)
+class OciGenAiClientConfig(
+    private val properties: OciGenAiProperties,
+) {
+
+    @Bean
+    @ConditionalOnMissingBean(AbstractAuthenticationDetailsProvider::class)
+    fun ociGenAiAuthenticationProvider(): AbstractAuthenticationDetailsProvider =
+        when (properties.authenticationType) {
+            OciGenAiProperties.AuthenticationType.FILE -> ConfigFileAuthenticationDetailsProvider(
+                expandHome(properties.configFile ?: DEFAULT_OCI_CONFIG_FILE),
+                properties.profile ?: DEFAULT_OCI_PROFILE,
+            )
+
+            OciGenAiProperties.AuthenticationType.INSTANCE_PRINCIPAL ->
+                InstancePrincipalsAuthenticationDetailsProvider.builder()
+                    .apply { properties.federationEndpoint?.let { federationEndpoint(it) } }
+                    .build()
+
+            OciGenAiProperties.AuthenticationType.RESOURCE_PRINCIPAL ->
+                ResourcePrincipalAuthenticationDetailsProvider.builder()
+                    .apply { properties.federationEndpoint?.let { resourcePrincipalSessionTokenEndpoint(it) } }
+                    .build()
+
+            OciGenAiProperties.AuthenticationType.WORKLOAD_IDENTITY ->
+                OkeWorkloadIdentityAuthenticationDetailsProvider.builder()
+                    .apply {
+                        properties.tenantId?.let { tenancyId(it) }
+                        properties.region?.let { region(Region.fromRegionId(it)) }
+                        properties.workloadIdentityTokenPath?.let { tokenPath(it) }
+                    }
+                    .build()
+
+            OciGenAiProperties.AuthenticationType.SIMPLE ->
+                SimpleAuthenticationDetailsProvider.builder()
+                    .tenantId(requireProperty(properties.tenantId, "tenant-id"))
+                    .userId(requireProperty(properties.userId, "user-id"))
+                    .fingerprint(requireProperty(properties.fingerprint, "fingerprint"))
+                    .privateKeySupplier {
+                        properties.privateKeyFile?.let { Files.newInputStream(Paths.get(expandHome(it))) }
+                            ?: ByteArrayInputStream(requireProperty(properties.privateKey, "private-key").toByteArray())
+                    }
+                    .apply {
+                        properties.passPhrase?.let { passPhrase(it) }
+                        properties.region?.let { region(Region.fromRegionId(it)) }
+                    }
+                    .build()
+
+            OciGenAiProperties.AuthenticationType.SESSION_TOKEN ->
+                if (properties.configFile != null) {
+                    SessionTokenAuthenticationDetailsProvider(
+                        expandHome(properties.configFile!!),
+                        properties.profile ?: DEFAULT_OCI_PROFILE,
+                    )
+                } else {
+                    SessionTokenAuthenticationDetailsProvider.builder()
+                        .tenantId(requireProperty(properties.tenantId, "tenant-id"))
+                        .userId(requireProperty(properties.userId, "user-id"))
+                        .fingerprint(requireProperty(properties.fingerprint, "fingerprint"))
+                        .apply {
+                            properties.privateKeyFile?.let { privateKeyFilePath(expandHome(it)) }
+                            properties.passPhrase?.let { passPhrase(it) }
+                            properties.sessionToken?.let { sessionToken(it) }
+                            properties.sessionTokenFile?.let { sessionTokenFilePath(expandHome(it)) }
+                            properties.region?.let { region(it) }
+                        }
+                        .build()
+                }
+        }
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun ociGenAiInferenceClient(
+        authenticationDetailsProvider: AbstractAuthenticationDetailsProvider,
+    ): GenerativeAiInference {
+        val client = GenerativeAiInferenceClient.builder().build(authenticationDetailsProvider)
+        properties.endpoint?.let { client.setEndpoint(it) }
+        if (properties.endpoint == null) {
+            properties.region?.let { client.setRegion(it) }
+        }
+        return client
+    }
+
+    private fun requireProperty(value: String?, name: String): String =
+        require(!value.isNullOrBlank()) {
+            "OCI GenAI $name is required for ${properties.authenticationType} authentication"
+        }.let { value!! }
+
+    private fun expandHome(path: String): String =
+        if (path.startsWith("~/")) {
+            Paths.get(System.getProperty("user.home"), path.removePrefix("~/")).toString()
+        } else {
+            path
+        }
+
+    companion object {
+        private const val DEFAULT_OCI_CONFIG_FILE = "~/.oci/config"
+        private const val DEFAULT_OCI_PROFILE = "DEFAULT"
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(OciGenAiProperties::class)
+class OciGenAiModelsConfig(
+    private val properties: OciGenAiProperties,
+    private val client: ObjectProvider<GenerativeAiInference>,
+    private val configurableBeanFactory: ConfigurableBeanFactory,
+    private val objectMapper: ObjectProvider<ObjectMapper>,
+    private val modelLoader: LlmAutoConfigMetadataLoader<OciGenAiModelDefinitions> = OciGenAiModelLoader(),
+) {
+    private val logger = LoggerFactory.getLogger(OciGenAiModelsConfig::class.java)
+
+    init {
+        logger.info("OCI GenAI models are available: {}", properties)
+    }
+
+    @Bean
+    fun ociGenAiModelsInitializer(): ProviderInitialization {
+        val definitions = modelLoader.loadAutoConfigMetadata()
+
+        val registeredLlms = buildList {
+            definitions.models.forEach { modelDef ->
+                val llm = createOciGenAiLlm(modelDef)
+                configurableBeanFactory.registerSingleton(modelDef.name, llm)
+                add(RegisteredModel(beanName = modelDef.name, modelId = modelDef.modelId))
+                logger.info("Registered OCI GenAI model bean: {} -> {}", modelDef.name, modelDef.modelId)
+            }
+        }
+
+        val registeredEmbeddings = buildList {
+            definitions.embeddingModels.forEach { embeddingDef ->
+                val embeddingService = createOciGenAiEmbedding(embeddingDef)
+                configurableBeanFactory.registerSingleton(embeddingDef.name, embeddingService)
+                add(RegisteredModel(beanName = embeddingDef.name, modelId = embeddingDef.modelId))
+                logger.info(
+                    "Registered OCI GenAI embedding model bean: {} -> {}",
+                    embeddingDef.name,
+                    embeddingDef.modelId,
+                )
+            }
+        }
+
+        return ProviderInitialization(
+            provider = OciGenAiModels.PROVIDER,
+            registeredLlms = registeredLlms,
+            registeredEmbeddings = registeredEmbeddings,
+        ).also { logger.info(it.summary()) }
+    }
+
+    private fun createOciGenAiLlm(modelDef: OciGenAiModelDefinition): LlmService<*> {
+        val chatModel = OciGenAiChatModel(
+            client = client.getObject(),
+            defaultOptions = createDefaultOptions(modelDef),
+            retryTemplate = properties.retryTemplate("oci-genai-${modelDef.modelId}"),
+            objectMapper = objectMapper.getIfAvailable { ObjectMapper() },
+        )
+        return SpringAiLlmService(
+            name = modelDef.modelId,
+            chatModel = chatModel,
+            provider = OciGenAiModels.PROVIDER,
+            optionsConverter = OciGenAiOptionsConverter,
+            knowledgeCutoffDate = modelDef.knowledgeCutoffDate,
+            pricingModel = modelDef.pricingModel?.let {
+                PerTokenPricingModel(
+                    usdPer1mInputTokens = it.usdPer1mInputTokens,
+                    usdPer1mOutputTokens = it.usdPer1mOutputTokens,
+                )
+            },
+        )
+    }
+
+    private fun createDefaultOptions(modelDef: OciGenAiModelDefinition): OciGenAiChatOptions =
+        OciGenAiChatOptions.builder()
+            .model(modelDef.modelId)
+            .compartmentId(properties.compartmentId)
+            .servingMode(properties.servingMode)
+            .endpointId(properties.endpointId)
+            .apiFormat(modelDef.apiFormat)
+            .maxTokens(modelDef.maxTokens)
+            .temperature(modelDef.temperature)
+            .topP(modelDef.topP)
+            .topK(modelDef.topK)
+            .build()
+
+    private fun createOciGenAiEmbedding(embeddingDef: OciGenAiEmbeddingModelDefinition): EmbeddingService {
+        val embeddingModel = OciGenAiEmbeddingModel(
+            client = client.getObject(),
+            options = OciGenAiEmbeddingOptions(
+                model = embeddingDef.modelId,
+                compartmentId = requireNotNull(properties.compartmentId) {
+                    "OCI GenAI compartment-id is required to configure embedding model ${embeddingDef.name}"
+                },
+                servingMode = properties.servingMode,
+                endpointId = properties.endpointId,
+                dimensions = embeddingDef.dimensions,
+                truncate = embeddingDef.truncate,
+                inputType = embeddingDef.inputType,
+            ),
+            retryTemplate = properties.retryTemplate("oci-genai-embedding-${embeddingDef.modelId}"),
+        )
+        val pricing = embeddingDef.pricingModel?.let {
+            PricingModel.usdPer1MTokens(it.usdPer1mTokens, 0.0)
+        }
+        return SpringAiEmbeddingService(
+            name = embeddingDef.modelId,
+            model = embeddingModel,
+            provider = OciGenAiModels.PROVIDER,
+            configuredDimensions = embeddingDef.dimensions,
+            pricingModel = pricing,
+        )
+    }
+}
+
+object OciGenAiOptionsConverter : OptionsConverter<OciGenAiChatOptions> {
+
+    override fun convertOptions(options: LlmOptions): OciGenAiChatOptions =
+        OciGenAiChatOptions.builder()
+            .temperature(options.temperature)
+            .topP(options.topP)
+            .topK(options.topK)
+            .maxTokens(options.maxTokens)
+            .frequencyPenalty(options.frequencyPenalty)
+            .presencePenalty(options.presencePenalty)
+            .internalToolExecutionEnabled(false)
+            .build()
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelsConfig.kt
@@ -28,6 +28,7 @@ import com.embabel.common.ai.model.OptionsConverter
 import com.embabel.common.ai.model.PerTokenPricingModel
 import com.embabel.common.ai.model.PricingModel
 import com.embabel.common.ai.model.SpringAiEmbeddingService
+import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.oracle.bmc.Region
 import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider
@@ -78,6 +79,32 @@ class OciGenAiProperties : RetryProperties {
     override var backoffMultiplier: Double = 5.0
     override var backoffMaxInterval: Long = 180_000L
 
+    override fun toString(): String =
+        "OciGenAiProperties(" +
+            "authenticationType=$authenticationType, " +
+            "configFile=$configFile, " +
+            "profile=$profile, " +
+            "federationEndpoint=$federationEndpoint, " +
+            "tenantId=$tenantId, " +
+            "userId=$userId, " +
+            "fingerprint=${fingerprint.masked()}, " +
+            "privateKey=${privateKey.masked()}, " +
+            "privateKeyFile=$privateKeyFile, " +
+            "passPhrase=${passPhrase.masked()}, " +
+            "sessionToken=${sessionToken.masked()}, " +
+            "sessionTokenFile=$sessionTokenFile, " +
+            "workloadIdentityTokenPath=$workloadIdentityTokenPath, " +
+            "region=$region, " +
+            "endpoint=$endpoint, " +
+            "compartmentId=$compartmentId, " +
+            "servingMode=$servingMode, " +
+            "endpointId=$endpointId, " +
+            "maxAttempts=$maxAttempts, " +
+            "backoffMillis=$backoffMillis, " +
+            "backoffMultiplier=$backoffMultiplier, " +
+            "backoffMaxInterval=$backoffMaxInterval" +
+            ")"
+
     enum class AuthenticationType {
         FILE,
         INSTANCE_PRINCIPAL,
@@ -90,6 +117,7 @@ class OciGenAiProperties : RetryProperties {
 
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(OciGenAiProperties::class)
+@ExcludeFromJacocoGeneratedReport(reason = "OCI GenAI client configuration can't be unit tested")
 class OciGenAiClientConfig(
     private val properties: OciGenAiProperties,
 ) {
@@ -138,12 +166,12 @@ class OciGenAiClientConfig(
                     .build()
 
             OciGenAiProperties.AuthenticationType.SESSION_TOKEN ->
-                if (properties.configFile != null) {
+                properties.configFile?.let { configFile ->
                     SessionTokenAuthenticationDetailsProvider(
-                        expandHome(properties.configFile!!),
+                        expandHome(configFile),
                         properties.profile ?: DEFAULT_OCI_PROFILE,
                     )
-                } else {
+                } ?: run {
                     SessionTokenAuthenticationDetailsProvider.builder()
                         .tenantId(requireProperty(properties.tenantId, "tenant-id"))
                         .userId(requireProperty(properties.userId, "user-id"))
@@ -173,9 +201,9 @@ class OciGenAiClientConfig(
     }
 
     private fun requireProperty(value: String?, name: String): String =
-        require(!value.isNullOrBlank()) {
+        requireNotNull(value?.takeIf { it.isNotBlank() }) {
             "OCI GenAI $name is required for ${properties.authenticationType} authentication"
-        }.let { value!! }
+        }
 
     private fun expandHome(path: String): String =
         if (path.startsWith("~/")) {
@@ -190,8 +218,16 @@ class OciGenAiClientConfig(
     }
 }
 
+private fun String?.masked(): String =
+    if (this.isNullOrBlank()) {
+        "null"
+    } else {
+        "<masked>"
+    }
+
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(OciGenAiProperties::class)
+@ExcludeFromJacocoGeneratedReport(reason = "OCI GenAI model configuration can't be unit tested")
 class OciGenAiModelsConfig(
     private val properties: OciGenAiProperties,
     private val client: ObjectProvider<GenerativeAiInference>,
@@ -211,23 +247,39 @@ class OciGenAiModelsConfig(
 
         val registeredLlms = buildList {
             definitions.models.forEach { modelDef ->
-                val llm = createOciGenAiLlm(modelDef)
-                configurableBeanFactory.registerSingleton(modelDef.name, llm)
-                add(RegisteredModel(beanName = modelDef.name, modelId = modelDef.modelId))
-                logger.info("Registered OCI GenAI model bean: {} -> {}", modelDef.name, modelDef.modelId)
+                try {
+                    val llm = createOciGenAiLlm(modelDef)
+                    configurableBeanFactory.registerSingleton(modelDef.name, llm)
+                    add(RegisteredModel(beanName = modelDef.name, modelId = modelDef.modelId))
+                    logger.info("Registered OCI GenAI model bean: {} -> {}", modelDef.name, modelDef.modelId)
+                } catch (e: Exception) {
+                    logger.error(
+                        "Failed to create OCI GenAI model: {} ({})",
+                        modelDef.name, modelDef.modelId, e
+                    )
+                    throw e
+                }
             }
         }
 
         val registeredEmbeddings = buildList {
             definitions.embeddingModels.forEach { embeddingDef ->
-                val embeddingService = createOciGenAiEmbedding(embeddingDef)
-                configurableBeanFactory.registerSingleton(embeddingDef.name, embeddingService)
-                add(RegisteredModel(beanName = embeddingDef.name, modelId = embeddingDef.modelId))
-                logger.info(
-                    "Registered OCI GenAI embedding model bean: {} -> {}",
-                    embeddingDef.name,
-                    embeddingDef.modelId,
-                )
+                try {
+                    val embeddingService = createOciGenAiEmbedding(embeddingDef)
+                    configurableBeanFactory.registerSingleton(embeddingDef.name, embeddingService)
+                    add(RegisteredModel(beanName = embeddingDef.name, modelId = embeddingDef.modelId))
+                    logger.info(
+                        "Registered OCI GenAI embedding model bean: {} -> {}",
+                        embeddingDef.name,
+                        embeddingDef.modelId,
+                    )
+                } catch (e: Exception) {
+                    logger.error(
+                        "Failed to create OCI GenAI embedding model: {} ({})",
+                        embeddingDef.name, embeddingDef.modelId, e
+                    )
+                    throw e
+                }
             }
         }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiTypes.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiTypes.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+enum class OciGenAiApiFormat {
+    GENERIC,
+    COHERE_V2,
+    COHERE,
+}
+
+enum class OciGenAiServingMode {
+    ON_DEMAND,
+    DEDICATED,
+}
+
+enum class OciGenAiEmbeddingTruncate {
+    NONE,
+    START,
+    END,
+}
+
+enum class OciGenAiEmbeddingInputType {
+    SEARCH_DOCUMENT,
+    SEARCH_QUERY,
+    CLASSIFICATION,
+    CLUSTERING,
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+  com.embabel.agent.autoconfigure.models.ocigenai.OciGenAiEnvironmentPostProcessor

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2024-2026 Embabel Pty Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.embabel.agent.autoconfigure.models.ocigenai.AgentOciGenAiAutoConfiguration

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/resources/models/oci-genai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/resources/models/oci-genai-models.yml
@@ -1,0 +1,88 @@
+# ============================================
+# oci-genai-models.yml
+# ============================================
+# OCI Generative AI models configuration.
+# Model identifiers are from Oracle OCI Generative AI documentation as of May 2026.
+
+models:
+  # Google Gemini family.
+  - name: "gemini_2_5_pro"
+    model_id: "google.gemini-2.5-pro"
+    display_name: "Google Gemini 2.5 Pro"
+    api_format: "GENERIC"
+    max_tokens: 8192
+    temperature: 0.7
+
+  - name: "gemini_2_5_flash"
+    model_id: "google.gemini-2.5-flash"
+    display_name: "Google Gemini 2.5 Flash"
+    api_format: "GENERIC"
+    max_tokens: 8192
+    temperature: 0.7
+
+  # OpenAI GPT-OSS family.
+  - name: "gpt_oss_120b"
+    model_id: "openai.gpt-oss-120b"
+    display_name: "OpenAI GPT-OSS 120B"
+    api_format: "GENERIC"
+    max_tokens: 8192
+    temperature: 0.7
+
+  # xAI Grok family.
+  - name: "grok_4_3"
+    model_id: "xai.grok-4.3"
+    display_name: "xAI Grok 4.3"
+    api_format: "GENERIC"
+    max_tokens: 8192
+    temperature: 0.7
+
+  # Cohere Command A family. These models use OCI's Cohere Chat API v2.
+  - name: "cohere_command_a_reasoning"
+    model_id: "cohere.command-a-reasoning"
+    display_name: "Cohere Command A Reasoning"
+    api_format: "COHERE_V2"
+    max_tokens: 8192
+    temperature: 0.7
+
+  - name: "cohere_command_a_vision"
+    model_id: "cohere.command-a-vision"
+    display_name: "Cohere Command A Vision"
+    api_format: "COHERE_V2"
+    max_tokens: 8192
+    temperature: 0.7
+
+  - name: "cohere_command_a"
+    model_id: "cohere.command-a-03-2025"
+    display_name: "Cohere Command A"
+    api_format: "COHERE_V2"
+    max_tokens: 8192
+    temperature: 0.7
+
+  # Meta Llama family. These use OCI's GENERIC chat format and support tools.
+  - name: "llama_4_maverick"
+    model_id: "meta.llama-4-maverick-17b-128e-instruct-fp8"
+    display_name: "Meta Llama 4 Maverick"
+    api_format: "GENERIC"
+    max_tokens: 8192
+    temperature: 0.7
+
+  - name: "llama_4_scout"
+    model_id: "meta.llama-4-scout-17b-16e-instruct"
+    display_name: "Meta Llama 4 Scout"
+    api_format: "GENERIC"
+    max_tokens: 8192
+    temperature: 0.7
+
+  - name: "llama_33_70b"
+    model_id: "meta.llama-3.3-70b-instruct"
+    display_name: "Meta Llama 3.3 70B Instruct"
+    api_format: "GENERIC"
+    max_tokens: 8192
+    temperature: 0.7
+
+embedding_models:
+  - name: "cohere_embed_v4"
+    model_id: "cohere.embed-v4.0"
+    display_name: "Cohere Embed 4"
+    dimensions: 1536
+    truncate: "END"

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/ocigenai/AgentOciGenAiAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/ocigenai/AgentOciGenAiAutoConfigurationTest.java
@@ -17,6 +17,7 @@ package com.embabel.agent.autoconfigure.models.ocigenai;
 
 import com.embabel.common.ai.autoconfig.ProviderInitialization;
 import com.embabel.common.ai.model.EmbeddingService;
+import com.oracle.bmc.auth.AbstractAuthenticationDetailsProvider;
 import com.oracle.bmc.generativeaiinference.GenerativeAiInference;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -49,6 +50,11 @@ class AgentOciGenAiAutoConfigurationTest {
 
     @Configuration(proxyBeanMethods = false)
     static class FakeOciClientConfiguration {
+        @Bean
+        AbstractAuthenticationDetailsProvider ociAuthenticationDetailsProvider() {
+            return mock(AbstractAuthenticationDetailsProvider.class);
+        }
+
         @Bean
         GenerativeAiInference generativeAiInference() {
             return mock(GenerativeAiInference.class);

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/ocigenai/AgentOciGenAiAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/ocigenai/AgentOciGenAiAutoConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.ocigenai;
+
+import com.embabel.common.ai.autoconfig.ProviderInitialization;
+import com.embabel.common.ai.model.EmbeddingService;
+import com.oracle.bmc.generativeaiinference.GenerativeAiInference;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class AgentOciGenAiAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AgentOciGenAiAutoConfiguration.class))
+            .withUserConfiguration(FakeOciClientConfiguration.class)
+            .withPropertyValues("embabel.agent.platform.models.ocigenai.compartment-id=ocid1.compartment.oc1..test");
+
+    @Test
+    void registersProviderInitializationFromBundledMetadata() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(ProviderInitialization.class);
+            assertThat(context.getBean(ProviderInitialization.class).getProvider()).isEqualTo("OCIGenAI");
+            assertThat(context.getBean(ProviderInitialization.class).getRegisteredLlms()).isNotEmpty();
+            assertThat(context.getBean(ProviderInitialization.class).getRegisteredEmbeddings()).isNotEmpty();
+            assertThat(context).hasBean("llama_4_maverick");
+            assertThat(context).hasBean("cohere_embed_v4");
+            assertThat(context.getBean("cohere_embed_v4")).isInstanceOf(EmbeddingService.class);
+        });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class FakeOciClientConfiguration {
+        @Bean
+        GenerativeAiInference generativeAiInference() {
+            return mock(GenerativeAiInference.class);
+        }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/ocigenai/OciGenAiEnvironmentPostProcessorTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/ocigenai/OciGenAiEnvironmentPostProcessorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.ocigenai;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OciGenAiEnvironmentPostProcessorTest {
+
+    @Nested
+    class Defaults {
+
+        @Test
+        void suppliesOciDefaultsWhenNoUserDefaultsAreConfigured() {
+            var environment = new StandardEnvironment();
+            var processor = new TestOciGenAiEnvironmentPostProcessor(false);
+
+            processor.postProcessEnvironment(environment, new SpringApplication());
+
+            assertThat(environment.getProperty(OciGenAiEnvironmentPostProcessor.DEFAULT_LLM_PROPERTY))
+                    .isEqualTo(OciGenAiEnvironmentPostProcessor.OCI_DEFAULT_LLM);
+            assertThat(environment.getProperty(OciGenAiEnvironmentPostProcessor.DEFAULT_EMBEDDING_PROPERTY))
+                    .isEqualTo(OciGenAiEnvironmentPostProcessor.OCI_DEFAULT_EMBEDDING);
+        }
+
+        @Test
+        void ociDefaultsOverrideFrameworkDefaultsAddedLater() {
+            var environment = new StandardEnvironment();
+            var processor = new TestOciGenAiEnvironmentPostProcessor(false);
+
+            processor.postProcessEnvironment(environment, new SpringApplication());
+            environment.getPropertySources().addLast(
+                    new MapPropertySource(
+                            "frameworkDefaults",
+                            Map.of(
+                                    OciGenAiEnvironmentPostProcessor.DEFAULT_LLM_PROPERTY, "gpt-4.1-mini",
+                                    OciGenAiEnvironmentPostProcessor.DEFAULT_EMBEDDING_PROPERTY, "text-embedding-3-small"
+                            )
+                    )
+            );
+
+            assertThat(environment.getProperty(OciGenAiEnvironmentPostProcessor.DEFAULT_LLM_PROPERTY))
+                    .isEqualTo(OciGenAiEnvironmentPostProcessor.OCI_DEFAULT_LLM);
+            assertThat(environment.getProperty(OciGenAiEnvironmentPostProcessor.DEFAULT_EMBEDDING_PROPERTY))
+                    .isEqualTo(OciGenAiEnvironmentPostProcessor.OCI_DEFAULT_EMBEDDING);
+        }
+
+        @Test
+        void preservesUserConfiguredDefaults() {
+            var environment = new StandardEnvironment();
+            environment.getPropertySources().addFirst(
+                    new MapPropertySource(
+                            "testDefaults",
+                            Map.of(
+                                    OciGenAiEnvironmentPostProcessor.DEFAULT_LLM_PROPERTY, "user-llm",
+                                    OciGenAiEnvironmentPostProcessor.DEFAULT_EMBEDDING_PROPERTY, "user-embedding"
+                            )
+                    )
+            );
+            var processor = new TestOciGenAiEnvironmentPostProcessor(false);
+
+            processor.postProcessEnvironment(environment, new SpringApplication());
+
+            assertThat(environment.getProperty(OciGenAiEnvironmentPostProcessor.DEFAULT_LLM_PROPERTY))
+                    .isEqualTo("user-llm");
+            assertThat(environment.getProperty(OciGenAiEnvironmentPostProcessor.DEFAULT_EMBEDDING_PROPERTY))
+                    .isEqualTo("user-embedding");
+        }
+    }
+
+    @Nested
+    class OpenAiProvider {
+
+        @Test
+        void doesNotOverrideOpenAiDefaultWhenOpenAiProviderIsPresent() {
+            var environment = new StandardEnvironment();
+            var processor = new TestOciGenAiEnvironmentPostProcessor(true);
+
+            processor.postProcessEnvironment(environment, new SpringApplication());
+
+            assertThat(environment.getProperty(OciGenAiEnvironmentPostProcessor.DEFAULT_LLM_PROPERTY)).isNull();
+            assertThat(environment.getProperty(OciGenAiEnvironmentPostProcessor.DEFAULT_EMBEDDING_PROPERTY)).isNull();
+        }
+    }
+
+    @Nested
+    class Ordering {
+
+        @Test
+        void runsAfterBootConfigDataEnvironmentPostProcessor() {
+            var processor = new OciGenAiEnvironmentPostProcessor();
+
+            assertThat(processor.getOrder()).isEqualTo(Ordered.LOWEST_PRECEDENCE);
+        }
+    }
+
+    private static final class TestOciGenAiEnvironmentPostProcessor extends OciGenAiEnvironmentPostProcessor {
+
+        private final boolean openAiProviderPresent;
+
+        private TestOciGenAiEnvironmentPostProcessor(boolean openAiProviderPresent) {
+            this.openAiProviderPresent = openAiProviderPresent;
+        }
+
+        @Override
+        boolean isOpenAiProviderPresent() {
+            return openAiProviderPresent;
+        }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatModelTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatModelTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+import com.oracle.bmc.generativeaiinference.GenerativeAiInference
+import com.oracle.bmc.generativeaiinference.model.AssistantMessage
+import com.oracle.bmc.generativeaiinference.model.CohereAssistantMessageV2
+import com.oracle.bmc.generativeaiinference.model.CohereChatBotMessage
+import com.oracle.bmc.generativeaiinference.model.CohereChatRequest
+import com.oracle.bmc.generativeaiinference.model.CohereSystemMessage
+import com.oracle.bmc.generativeaiinference.model.CohereUserMessage
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.messages.Message
+import org.springframework.ai.chat.messages.MessageType
+import org.springframework.ai.chat.messages.SystemMessage
+import org.springframework.ai.chat.messages.UserMessage
+import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.retry.support.RetryTemplate
+import org.springframework.ai.chat.messages.AssistantMessage as SpringAssistantMessage
+
+class OciGenAiChatModelTest {
+
+    @Nested
+    inner class AssistantMessages {
+
+        @Test
+        fun `generic assistant conversion uses empty tool calls when message has no Spring tool calls`() {
+            val assistantMessage = chatModel().toGenericMessages(NonSpringAssistantMessage("hello")).single()
+
+            assertTrue(assistantMessage is AssistantMessage)
+            val toolCalls = (assistantMessage as AssistantMessage).toolCalls
+            assertNotNull(toolCalls)
+            assertTrue(toolCalls.isEmpty())
+        }
+
+        @Test
+        fun `cohere v2 assistant conversion uses empty tool calls when message has no Spring tool calls`() {
+            val assistantMessage = chatModel().toCohereV2Messages(NonSpringAssistantMessage("hello")).single()
+
+            assertTrue(assistantMessage is CohereAssistantMessageV2)
+            val toolCalls = (assistantMessage as CohereAssistantMessageV2).toolCalls
+            assertNotNull(toolCalls)
+            assertTrue(toolCalls.isEmpty())
+        }
+    }
+
+    @Nested
+    inner class LegacyCohereRequests {
+
+        @Test
+        fun `legacy cohere request history uses last user message position`() {
+            val options = options(OciGenAiApiFormat.COHERE)
+            val request = chatModel().chatRequest(
+                Prompt(
+                    listOf(
+                        UserMessage("first"),
+                        SpringAssistantMessage("same"),
+                        UserMessage("same"),
+                        SpringAssistantMessage("same"),
+                    )
+                ),
+                options,
+            ) as CohereChatRequest
+
+            assertEquals("same", request.message)
+            assertEquals(2, request.chatHistory.size)
+            assertTrue(request.chatHistory[0] is CohereUserMessage)
+            assertEquals("first", (request.chatHistory[0] as CohereUserMessage).message)
+            assertTrue(request.chatHistory[1] is CohereChatBotMessage)
+            assertEquals("same", (request.chatHistory[1] as CohereChatBotMessage).message)
+        }
+
+        @Test
+        fun `legacy cohere request keeps system messages only in preamble`() {
+            val options = options(OciGenAiApiFormat.COHERE)
+            val request = chatModel().chatRequest(
+                Prompt(
+                    listOf(
+                        SystemMessage("You are concise."),
+                        UserMessage("first"),
+                        SpringAssistantMessage("answer"),
+                        UserMessage("second"),
+                    )
+                ),
+                options,
+            ) as CohereChatRequest
+
+            assertEquals("You are concise.", request.preambleOverride)
+            assertEquals("second", request.message)
+            assertEquals(2, request.chatHistory.size)
+            assertTrue(request.chatHistory.none { it is CohereSystemMessage })
+            assertTrue(request.chatHistory[0] is CohereUserMessage)
+            assertEquals("first", (request.chatHistory[0] as CohereUserMessage).message)
+            assertTrue(request.chatHistory[1] is CohereChatBotMessage)
+            assertEquals("answer", (request.chatHistory[1] as CohereChatBotMessage).message)
+        }
+    }
+
+    private fun chatModel() = OciGenAiChatModel(
+        client = mockk<GenerativeAiInference>(),
+        defaultOptions = options(OciGenAiApiFormat.GENERIC),
+        retryTemplate = RetryTemplate(),
+    )
+
+    private fun options(apiFormat: OciGenAiApiFormat) =
+        OciGenAiChatOptions.builder()
+            .model("test-model")
+            .compartmentId("ocid1.compartment.oc1..test")
+            .apiFormat(apiFormat)
+            .build()
+
+    private class NonSpringAssistantMessage(
+        private val content: String,
+    ) : Message {
+
+        override fun getMessageType(): MessageType = MessageType.ASSISTANT
+
+        override fun getText(): String = content
+
+        override fun getMetadata(): Map<String, Any> = emptyMap()
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiModelLoaderTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.core.io.DefaultResourceLoader
+import java.io.File
+import java.nio.file.Files
+
+class OciGenAiModelLoaderTest {
+
+    @Test
+    fun `should load valid model definitions from default YAML file`() {
+        val result = OciGenAiModelLoader().loadAutoConfigMetadata()
+
+        assertTrue(result.models.isNotEmpty(), "Should load at least one LLM model")
+        assertTrue(result.embeddingModels.isNotEmpty(), "Should load at least one embedding model")
+        assertTrue(result.models.any { it.apiFormat == OciGenAiApiFormat.GENERIC }, "Should include generic chat models")
+        assertTrue(result.models.any { it.apiFormat == OciGenAiApiFormat.COHERE_V2 }, "Should include Cohere chat models")
+
+        val firstModel = result.models.first()
+        assertNotNull(firstModel.name)
+        assertTrue(firstModel.modelId.isNotBlank())
+
+        val firstEmbedding = result.embeddingModels.first()
+        assertTrue(firstEmbedding.name.isNotBlank())
+        assertTrue(firstEmbedding.modelId.isNotBlank())
+    }
+
+    @Test
+    fun `should validate all loaded model defaults`() {
+        val result = OciGenAiModelLoader().loadAutoConfigMetadata()
+
+        result.models.forEach { model ->
+            model.maxTokens?.let { assertTrue(it > 0, "Max tokens should be positive for ${model.name}") }
+            model.temperature?.let { assertTrue(it in 0.0..2.0, "Temperature should be valid for ${model.name}") }
+            model.topP?.let { assertTrue(it in 0.0..1.0, "Top P should be valid for ${model.name}") }
+            model.topK?.let { assertTrue(it > 0, "Top K should be positive for ${model.name}") }
+        }
+
+        result.embeddingModels.forEach { model ->
+            model.dimensions?.let { assertTrue(it > 0, "Dimensions should be positive for ${model.name}") }
+        }
+    }
+
+    @Test
+    fun `should return empty definitions when file does not exist`() {
+        val result = OciGenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "classpath:does-not-exist.yml",
+        ).loadAutoConfigMetadata()
+
+        assertTrue(result.models.isEmpty())
+        assertTrue(result.embeddingModels.isEmpty())
+    }
+
+    @Test
+    fun `should reject invalid temperature`() {
+        val tempFile = createTempYamlFile(
+            """
+            models:
+              - name: invalid-temperature
+                model_id: meta.test
+                temperature: 3.0
+            """.trimIndent()
+        )
+
+        val result = OciGenAiModelLoader(
+            resourceLoader = DefaultResourceLoader(),
+            configPath = "file:${tempFile.absolutePath}",
+        ).loadAutoConfigMetadata()
+
+        assertTrue(result.models.isEmpty())
+    }
+
+    @Test
+    fun `should parse embedding enum values`() {
+        val result = OciGenAiModelLoader().loadAutoConfigMetadata()
+        val embedV4 = result.embeddingModels.first { it.name == "cohere_embed_v4" }
+
+        assertEquals(OciGenAiEmbeddingTruncate.END, embedV4.truncate)
+    }
+
+    private fun createTempYamlFile(content: String): File {
+        val tempFile = Files.createTempFile("oci-genai-models", ".yml").toFile()
+        tempFile.writeText(content)
+        tempFile.deleteOnExit()
+        return tempFile
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiOptionsConverterTest.kt
@@ -47,7 +47,71 @@ class OciGenAiOptionsConverterTest : OptionsConverterTestSupport<OciGenAiChatOpt
         val options = OciGenAiOptionsConverter.convertOptions(LlmOptions())
 
         assertNull(options.model)
-        assertNull(options.getCompartmentId())
+        assertNull(options.compartmentId)
         assertFalse(options.internalToolExecutionEnabled ?: true)
+    }
+
+    @Test
+    fun `converted LlmOptions preserve provider-specific defaults when merged`() {
+        val defaults = OciGenAiChatOptions.builder()
+            .model("cohere.command-a-03-2025")
+            .compartmentId("ocid1.compartment.oc1..test")
+            .servingMode(OciGenAiServingMode.DEDICATED)
+            .endpointId("ocid1.generativeaiendpoint.oc1..test")
+            .apiFormat(OciGenAiApiFormat.COHERE_V2)
+            .temperature(0.7)
+            .build()
+        val runtimeOptions = OciGenAiOptionsConverter.convertOptions(
+            LlmOptions().withTemperature(0.2)
+        )
+
+        val merged = defaults.merge(runtimeOptions)
+
+        assertEquals("cohere.command-a-03-2025", merged.model)
+        assertEquals("ocid1.compartment.oc1..test", merged.compartmentId)
+        assertEquals(OciGenAiServingMode.DEDICATED, merged.servingMode)
+        assertEquals("ocid1.generativeaiendpoint.oc1..test", merged.endpointId)
+        assertEquals(OciGenAiApiFormat.COHERE_V2, merged.apiFormat)
+        assertEquals(0.2, merged.temperature)
+    }
+
+    @Test
+    fun `explicit OCI runtime options override provider-specific defaults`() {
+        val defaults = OciGenAiChatOptions.builder()
+            .servingMode(OciGenAiServingMode.DEDICATED)
+            .endpointId("ocid1.generativeaiendpoint.oc1..default")
+            .apiFormat(OciGenAiApiFormat.COHERE_V2)
+            .build()
+        val runtimeOptions = OciGenAiChatOptions.builder()
+            .servingMode(OciGenAiServingMode.ON_DEMAND)
+            .apiFormat(OciGenAiApiFormat.GENERIC)
+            .build()
+
+        val merged = defaults.merge(runtimeOptions)
+
+        assertEquals(OciGenAiServingMode.ON_DEMAND, merged.servingMode)
+        assertEquals(OciGenAiApiFormat.GENERIC, merged.apiFormat)
+    }
+
+    @Test
+    fun `copy preserves explicit serving mode and api format tracking`() {
+        val defaults = OciGenAiChatOptions.builder()
+            .servingMode(OciGenAiServingMode.DEDICATED)
+            .endpointId("ocid1.generativeaiendpoint.oc1..default")
+            .apiFormat(OciGenAiApiFormat.COHERE_V2)
+            .build()
+
+        val explicitCopy = defaults.copy<OciGenAiChatOptions>()
+        val unconfiguredCopy = OciGenAiChatOptions.builder()
+            .build()
+            .copy<OciGenAiChatOptions>()
+
+        val preservedDefaults = explicitCopy.merge(OciGenAiOptionsConverter.convertOptions(LlmOptions()))
+        val preservedAfterUnconfiguredMerge = defaults.merge(unconfiguredCopy)
+
+        assertEquals(OciGenAiServingMode.DEDICATED, preservedDefaults.servingMode)
+        assertEquals(OciGenAiApiFormat.COHERE_V2, preservedDefaults.apiFormat)
+        assertEquals(OciGenAiServingMode.DEDICATED, preservedAfterUnconfiguredMerge.servingMode)
+        assertEquals(OciGenAiApiFormat.COHERE_V2, preservedAfterUnconfiguredMerge.apiFormat)
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiOptionsConverterTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.ocigenai
+
+import com.embabel.agent.test.models.OptionsConverterTestSupport
+import com.embabel.common.ai.model.LlmOptions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class OciGenAiOptionsConverterTest : OptionsConverterTestSupport<OciGenAiChatOptions>(
+    optionsConverter = OciGenAiOptionsConverter,
+) {
+
+    @Test
+    fun `should set standard chat options`() {
+        val options = OciGenAiOptionsConverter.convertOptions(
+            LlmOptions()
+                .withTemperature(0.2)
+                .withTopP(0.9)
+                .withTopK(50)
+                .withMaxTokens(123)
+        )
+
+        assertEquals(0.2, options.temperature)
+        assertEquals(0.9, options.topP)
+        assertEquals(50, options.topK)
+        assertEquals(123, options.maxTokens)
+    }
+
+    @Test
+    fun `should not override provider defaults`() {
+        val options = OciGenAiOptionsConverter.convertOptions(LlmOptions())
+
+        assertNull(options.model)
+        assertNull(options.getCompartmentId())
+        assertFalse(options.internalToolExecutionEnabled ?: true)
+    }
+}

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -37,6 +37,7 @@
         <module>models/embabel-agent-deepseek-autoconfigure</module>
         <module>models/embabel-agent-gemini-autoconfigure</module>
         <module>models/embabel-agent-google-genai-autoconfigure</module>
+        <module>models/embabel-agent-oci-genai-autoconfigure</module>
         <module>models/embabel-agent-minimax-autoconfigure</module>
         <module>models/embabel-agent-mistral-ai-autoconfigure</module>
         <module>models/embabel-agent-onnx-autoconfigure</module>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -17,6 +17,7 @@
 
     <properties>
         <bouncycastle.version>1.84</bouncycastle.version>
+        <oci-sdk.version>3.86.1</oci-sdk.version>
     </properties>
 
     <scm>
@@ -180,6 +181,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-oci-genai-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-minimax-autoconfigure</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -312,6 +319,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-oci-genai</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-minimax</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -413,6 +426,14 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bc-jdk18on-bom</artifactId>
                 <version>${bouncycastle.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.oracle.oci.sdk</groupId>
+                <artifactId>oci-java-sdk-bom</artifactId>
+                <version>${oci-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -660,6 +660,65 @@ embabel:
 <3> Google GenAI specific configuration
 <4> API key can be set here or via environment variable `GOOGLE_API_KEY`
 
+===== OCI Generative AI
+
+To use OCI Generative AI with your agent, add the `embabel-agent-starter-oci-genai` starter.
+
+Add this to your build system as follows:
+[tabs]
+====
+Maven (pom.xml)::
++
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-oci-genai</artifactId>
+    <version>${embabel-agent.version}</version>
+</dependency>
+----
+Gradle Kotlin DSL (build.gradle.kts)::
++
+[source,kotlin]
+----
+dependencies {
+    implementation("com.embabel.agent:embabel-agent-starter-oci-genai:${embabel-agent.version}")
+}
+----
+
+Gradle Groovy DSL (build.gradle)::
++
+[source,groovy]
+----
+dependencies {
+    implementation 'com.embabel.agent:embabel-agent-starter-oci-genai:${embabel-agent.version}'
+}
+----
+====
+
+The starter defaults to OCI config file authentication with `~/.oci/config` and profile `DEFAULT`.
+At minimum, configure the compartment OCID and region.
+When the standard OpenAI provider is not on the classpath, the OCI starter supplies OCI defaults for Embabel's default LLM and embedding model, so an OCI-only application does not need to override `embabel.models.default-llm` just to start.
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        ocigenai:
+          compartment-id: ocid1.compartment.oc1...
+          region: us-chicago-1
+          # authentication-type: FILE
+  models:
+    # Optional: choose a different OCI model id
+    # default-llm: meta.llama-3.3-70b-instruct
+    # default-embedding-model: cohere.embed-v4.0
+----
+
+Other supported authentication types are `INSTANCE_PRINCIPAL`, `RESOURCE_PRINCIPAL`, `WORKLOAD_IDENTITY`, `SESSION_TOKEN` and `SIMPLE`.
+See the configuration reference for the full OCI property list.
+
 ===== Mistral AI
 
 * Required:

--- a/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
@@ -236,6 +236,12 @@ The following are modules intended for direct use (versus supporting infrastruct
 | Quick start with AI Studio
 | Incubating
 
+| `embabel-agent-starter-oci-genai`
+| This repo
+| OCI Generative AI starter
+| Quick start with OCI GenAI
+| Incubating
+
 | `embabel-agent-starter-lmstudio`
 | This repo
 | LM Studio starter

--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
@@ -500,6 +500,144 @@ embedding_models:
       usd_per1m_tokens: 0.15
 ----
 
+====== OCI Generative AI
+
+OCI Generative AI models are configured through the `embabel-agent-starter-oci-genai` starter dependency.
+The starter registers OCI chat and embedding models from bundled metadata and uses the OCI Java SDK authentication providers.
+
+When the standard OpenAI provider is not on the classpath, the OCI starter supplies OCI defaults for Embabel's default
+LLM and embedding model:
+
+[source,properties]
+----
+embabel.models.default-llm=cohere.command-a-03-2025
+embabel.models.default-embedding-model=cohere.embed-v4.0
+----
+
+Override those values in application configuration if you want another OCI model.
+Use OCI model ids for Embabel model selection.
+The starter's Spring bean names are Java-friendly aliases, for example `cohere_command_a` for `cohere.command-a-03-2025`
+and `llama_33_70b` for `meta.llama-3.3-70b-instruct`.
+
+[cols="3,2,1,4",options="header"]
+|===
+|Property |Type |Default |Description
+
+|`embabel.agent.platform.models.ocigenai.authentication-type`
+|Enum
+|`FILE`
+|Authentication provider to use. Supported values are `FILE`, `INSTANCE_PRINCIPAL`, `RESOURCE_PRINCIPAL`, `WORKLOAD_IDENTITY`, `SESSION_TOKEN` and `SIMPLE`.
+
+|`embabel.agent.platform.models.ocigenai.config-file`
+|String
+|`~/.oci/config`
+|OCI config file path for `FILE` authentication, or optional config file path for `SESSION_TOKEN` authentication.
+
+|`embabel.agent.platform.models.ocigenai.profile`
+|String
+|`DEFAULT`
+|OCI config profile name.
+
+|`embabel.agent.platform.models.ocigenai.region`
+|String
+|_(none)_
+|OCI region id, such as `us-chicago-1`. Used when an explicit endpoint is not set.
+
+|`embabel.agent.platform.models.ocigenai.endpoint`
+|String
+|_(none)_
+|Explicit OCI Generative AI inference endpoint URL. Overrides region-based endpoint selection.
+
+|`embabel.agent.platform.models.ocigenai.compartment-id`
+|String
+|_(none)_
+|OCI compartment OCID used for chat and embedding requests. Required.
+
+|`embabel.agent.platform.models.ocigenai.serving-mode`
+|Enum
+|`ON_DEMAND`
+|OCI serving mode. Supported values are `ON_DEMAND` and `DEDICATED`.
+
+|`embabel.agent.platform.models.ocigenai.endpoint-id`
+|String
+|_(none)_
+|Dedicated serving endpoint OCID. Required when `serving-mode` is `DEDICATED`.
+
+|`embabel.agent.platform.models.ocigenai.tenant-id`
+|String
+|_(none)_
+|Tenancy OCID for `SIMPLE`, `SESSION_TOKEN`, or workload identity configuration as required by the selected OCI authentication provider.
+
+|`embabel.agent.platform.models.ocigenai.user-id`
+|String
+|_(none)_
+|User OCID for `SIMPLE` or builder-based `SESSION_TOKEN` authentication.
+
+|`embabel.agent.platform.models.ocigenai.fingerprint`
+|String
+|_(none)_
+|API key fingerprint for `SIMPLE` or builder-based `SESSION_TOKEN` authentication.
+
+|`embabel.agent.platform.models.ocigenai.private-key`
+|String
+|_(none)_
+|PEM private key content for `SIMPLE` authentication. Prefer `private-key-file` where possible.
+
+|`embabel.agent.platform.models.ocigenai.private-key-file`
+|String
+|_(none)_
+|Path to a PEM private key file for `SIMPLE` or builder-based `SESSION_TOKEN` authentication.
+
+|`embabel.agent.platform.models.ocigenai.pass-phrase`
+|String
+|_(none)_
+|Private key pass phrase, if the configured private key is encrypted.
+
+|`embabel.agent.platform.models.ocigenai.session-token`
+|String
+|_(none)_
+|Session token value for builder-based `SESSION_TOKEN` authentication.
+
+|`embabel.agent.platform.models.ocigenai.session-token-file`
+|String
+|_(none)_
+|Path to a session token file for builder-based `SESSION_TOKEN` authentication.
+
+|`embabel.agent.platform.models.ocigenai.workload-identity-token-path`
+|String
+|_(none)_
+|Workload identity token path for `WORKLOAD_IDENTITY` authentication.
+
+|`embabel.agent.platform.models.ocigenai.federation-endpoint`
+|String
+|_(none)_
+|Optional federation endpoint for principal-based authentication.
+
+|`embabel.agent.platform.models.ocigenai.max-attempts`
+|Int
+|`10`
+|Maximum retry attempts for OCI GenAI requests.
+
+|`embabel.agent.platform.models.ocigenai.backoff-millis`
+|Long
+|`5000`
+|Initial retry backoff in milliseconds.
+
+|`embabel.agent.platform.models.ocigenai.backoff-multiplier`
+|Double
+|`5.0`
+|Retry backoff multiplier.
+
+|`embabel.agent.platform.models.ocigenai.backoff-max-interval`
+|Long
+|`180000`
+|Maximum retry backoff interval in milliseconds.
+
+|===
+
+If your application exposes Spring Boot Actuator `env` or `configprops` values, secure those endpoints and sanitize OCI
+credential property names such as `pass-phrase`, `session-token` and `private-key`.
+
 ===== HTTP Client Configuration
 
 From `NettyClientFactoryProperties` - configuration for the HTTP client used by model providers (OpenAI, Anthropic, etc.) when making API calls.
@@ -800,4 +938,3 @@ From `DockerProperties` - configuration for Docker local models (OpenAI-compatib
 |Maximum backoff interval in milliseconds
 
 |===
-

--- a/embabel-agent-rag/embabel-agent-rag-core/pom.xml
+++ b/embabel-agent-rag/embabel-agent-rag-core/pom.xml
@@ -32,4 +32,52 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <configuration>
+                    <myIncremental>false</myIncremental>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <myIncremental>false</myIncremental>
+                            <sourceDirs>
+                                <source>src/main/java</source>
+                                <source>src/main/kotlin</source>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <myIncremental>false</myIncremental>
+                            <sourceDirs>
+                                <source>src/test/java</source>
+                                <source>src/test/kotlin</source>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
+
 </project>

--- a/embabel-agent-starters/embabel-agent-starter-oci-genai/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-oci-genai/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>embabel-agent-starter-oci-genai</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent OCI GenAI Starter</name>
+    <description>Embabel Agent OCI Generative AI Starter</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-oci-genai-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -36,6 +36,7 @@
         <module>embabel-agent-starter-deepseek</module>
         <module>embabel-agent-starter-gemini</module>
         <module>embabel-agent-starter-google-genai</module>
+        <module>embabel-agent-starter-oci-genai</module>
         <module>embabel-agent-starter-minimax</module>
         <module>embabel-agent-starter-mistral-ai</module>
         <module>embabel-agent-starter-a2a</module>


### PR DESCRIPTION
## Summary

Adds first-class OCI Generative AI support to Embabel through a new optional starter and autoconfiguration module.

This PR includes:

- `embabel-agent-starter-oci-genai`
- OCI GenAI chat and embedding model integration
- model constants for the Embabel API
- YAML-backed default OCI model definitions
- support for on-demand and dedicated serving modes
- support for common OCI authentication modes, including config file, simple credentials, instance principal, resource principal, session token, and workload identity
- documentation for installation and configuration
- unit coverage for autoconfiguration, model loading, chat option conversion, and OCI message conversion behavior

## Justification

OCI GenAI is an important provider for enterprise JVM applications running on or integrating with Oracle Cloud. Adding an official starter lets Embabel users adopt OCI-hosted chat and embedding models without writing custom provider wiring, while keeping the integration isolated behind the same optional starter pattern used by the existing model providers.

This is especially useful for deployments that need OCI-native authentication, tenancy-aware configuration, data residency alignment, private endpoint support, or consistency with existing Oracle Cloud infrastructure. The implementation follows the existing Embabel provider model: users opt in by adding the starter, configure provider-specific properties, and can then select OCI GenAI models through the normal Embabel model abstraction.

The addition should not affect existing users because it is contained in new starter/autoconfigure modules and only activates when the OCI GenAI starter is present.

NOTE: Full `mvn -U -B clean test verify` was attempted but failed earlier in the reactor in `embabel-agent-shell` with a JUnit discovery/classpath error unrelated to the OCI GenAI changes. Targeted clean test runs for the affected OCI GenAI modules and their dependencies passed successfully.

NOTE: In line with the stated dogfooding position, AI was used in preparation of this contribution.