### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ Required:
 Optional:
 
 - `ANTHROPIC_API_KEY`: For the Anthropic API. Necessary for the coding agent.
-- `MINIMAX_API_KEY`: For the [MiniMax](https://www.minimax.io) API. Supports MiniMax-M2.7 and MiniMax-M2.7-highspeed models.
+- `MINIMAX_API_KEY`: For the [MiniMax](https://www.minimax.io) API. Supports MiniMax-M3, MiniMax-M2.7 and MiniMax-M2.7-highspeed models.
 
 > We strongly recommend providing both an OpenAI and Anthropic key, as some examples require both. And it's important to
 > try to find the best LLM for a given task, rather than automatically choose a familiar provider.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/MiniMaxModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/MiniMaxModels.kt
@@ -26,6 +26,7 @@ class MiniMaxModels {
 
     companion object {
 
+        const val MINIMAX_M3 = "MiniMax-M3"
         const val MINIMAX_M2_7 = "MiniMax-M2.7"
         const val MINIMAX_M2_7_HIGHSPEED = "MiniMax-M2.7-highspeed"
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/minimax/MiniMaxModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/minimax/MiniMaxModelsConfig.kt
@@ -78,7 +78,7 @@ class MiniMaxProperties : RetryProperties {
 
 /**
  * Configuration class for MiniMax models.
- * This class provides beans for MiniMax models (M2.7, M2.7-highspeed)
+ * This class provides beans for MiniMax models (M3, M2.7, M2.7-highspeed)
  * via the OpenAI-compatible API provided by MiniMax.
  *
  * MiniMax models require temperature values in the range (0.0, 1.0].
@@ -119,6 +119,21 @@ class MiniMaxModelsConfig(
 
     init {
         logger.info("MiniMax models are available: {}", properties)
+    }
+
+    @Bean
+    fun miniMaxM3(): LlmService<*> {
+        return openAiCompatibleLlm(
+            model = MiniMaxModels.MINIMAX_M3,
+            provider = MiniMaxModels.PROVIDER,
+            knowledgeCutoffDate = LocalDate.of(2025, 6, 1),
+            optionsConverter = MiniMaxOptionsConverter,
+            pricingModel = PerTokenPricingModel(
+                usdPer1mInputTokens = 0.60,
+                usdPer1mOutputTokens = 2.40,
+            ),
+            retryTemplate = properties.retryTemplate(MiniMaxModels.MINIMAX_M3),
+        )
     }
 
     @Bean

--- a/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/minimax/AgentMiniMaxAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/minimax/AgentMiniMaxAutoConfigurationTest.java
@@ -35,15 +35,17 @@ class AgentMiniMaxAutoConfigurationTest {
            .withPropertyValues("embabel.agent.platform.models.minimax.api-key=test-key");
 
    /**
-    * Confirms that both MiniMax model beans are registered and backed by the generic LLM service abstraction exposed to the rest of the platform.
+    * Confirms that all MiniMax model beans are registered and backed by the generic LLM service abstraction exposed to the rest of the platform.
     */
    @Test
    void registersMiniMaxModelBeans() {
       // Act
       contextRunner.run(context -> {
          // Assert
+         assertThat(context).hasBean("miniMaxM3");
          assertThat(context).hasBean("miniMaxM27");
          assertThat(context).hasBean("miniMaxM27Highspeed");
+         assertThat(context.getBean("miniMaxM3")).isInstanceOf(LlmService.class);
          assertThat(context.getBean("miniMaxM27")).isInstanceOf(LlmService.class);
          assertThat(context.getBean("miniMaxM27Highspeed")).isInstanceOf(LlmService.class);
       });

--- a/embabel-agent-docs/src/main/asciidoc/reference/minimax/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/minimax/page.adoc
@@ -84,7 +84,7 @@ Use the property for local development and the environment variable in productio
 |===
 
 `MiniMax-M3` is the latest flagship model — the best default choice and significantly cheaper than `MiniMax-M2.7`.
-`MiniMax-M2.7` is the previous flagship, retained for backward compatibility and projects that need its 1M-token context window.
+`MiniMax-M2.7` is the previous flagship, retained for backward compatibility and projects that need its 192K context context window.
 `MiniMax-M2.7-highspeed` trades some quality for significantly lower latency and cost — a good choice for intermediate steps in a multi-action agent flow.
 
 TIP: Embabel's per-step LLM selection makes MiniMax models particularly well-suited to mixed strategies: use `MiniMax-M2.7-highspeed` for extraction and classification steps, and reserve `MiniMax-M3` (or a premium model) only for the final reasoning step.

--- a/embabel-agent-docs/src/main/asciidoc/reference/minimax/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/minimax/page.adoc
@@ -71,20 +71,20 @@ Use the property for local development and the environment variable in productio
 
 |`MiniMax-M2.7`
 |`MiniMax-M2.7`
-|1M tokens
+|192K tokens
 |$1.10
 |$4.40
 
 |`MiniMax-M2.7-highspeed`
 |`MiniMax-M2.7-highspeed`
-|1M tokens
+|192K tokens
 |$0.55
 |$2.20
 
 |===
 
 `MiniMax-M3` is the latest flagship model — the best default choice and significantly cheaper than `MiniMax-M2.7`.
-`MiniMax-M2.7` is the previous flagship, retained for backward compatibility and projects that need its 192K context context window.
+`MiniMax-M2.7` is the previous flagship, retained for backward compatibility and projects that need its 192K context window.
 `MiniMax-M2.7-highspeed` trades some quality for significantly lower latency and cost — a good choice for intermediate steps in a multi-action agent flow.
 
 TIP: Embabel's per-step LLM selection makes MiniMax models particularly well-suited to mixed strategies: use `MiniMax-M2.7-highspeed` for extraction and classification steps, and reserve `MiniMax-M3` (or a premium model) only for the final reasoning step.

--- a/embabel-agent-docs/src/main/asciidoc/reference/minimax/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/minimax/page.adoc
@@ -63,6 +63,12 @@ Use the property for local development and the environment variable in productio
 |===
 |Model Name |Model ID |Context Window |Input (per 1M tokens) |Output (per 1M tokens)
 
+|`MiniMax-M3`
+|`MiniMax-M3`
+|512K tokens
+|$0.60
+|$2.40
+
 |`MiniMax-M2.7`
 |`MiniMax-M2.7`
 |1M tokens
@@ -77,10 +83,11 @@ Use the property for local development and the environment variable in productio
 
 |===
 
-`MiniMax-M2.7` is the flagship model, optimized for quality.
+`MiniMax-M3` is the latest flagship model — the best default choice and significantly cheaper than `MiniMax-M2.7`.
+`MiniMax-M2.7` is the previous flagship, retained for backward compatibility and projects that need its 1M-token context window.
 `MiniMax-M2.7-highspeed` trades some quality for significantly lower latency and cost — a good choice for intermediate steps in a multi-action agent flow.
 
-TIP: Embabel's per-step LLM selection makes MiniMax models particularly well-suited to mixed strategies: use `MiniMax-M2.7-highspeed` for extraction and classification steps, and reserve `MiniMax-M2.7` (or a premium model) only for the final reasoning step.
+TIP: Embabel's per-step LLM selection makes MiniMax models particularly well-suited to mixed strategies: use `MiniMax-M2.7-highspeed` for extraction and classification steps, and reserve `MiniMax-M3` (or a premium model) only for the final reasoning step.
 
 ==== Using MiniMax Models
 
@@ -93,7 +100,7 @@ Kotlin::
 [source,kotlin]
 ----
 // Declarative
-@LlmCall(llm = "MiniMax-M2.7")
+@LlmCall(llm = "MiniMax-M3")
 fun summarize(article: Article): Summary
 
 // Programmatic
@@ -106,7 +113,7 @@ Java::
 [source,java]
 ----
 // Declarative
-@LlmCall(llm = "MiniMax-M2.7")
+@LlmCall(llm = "MiniMax-M3")
 Summary summarize(Article article);
 
 // Programmatic
@@ -123,7 +130,7 @@ embabel:
   models:
     llms:
       cheapest: MiniMax-M2.7-highspeed
-      best: MiniMax-M2.7
+      best: MiniMax-M3
 ----
 
 Then reference by role with the `#` prefix:


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to use `MiniMax-M3` as the default model.

`MiniMax-M3` is the latest flagship model: 512K context window, up to 128K output, image input support on both OpenAI- and Anthropic-compatible APIs, and significantly cheaper than M2.7. M3 is added first in the constants and bean registration, marked as the recommended default in docs, and used in all reference examples. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are kept for backward compatibility and projects that need their 1M-token context window.

## Changes

- `MiniMaxModels.MINIMAX_M3 = "MiniMax-M3"` constant added at the top of the companion object.
- New `miniMaxM3()` bean in `MiniMaxModelsConfig`, registered before the existing M2.7 beans, with M3 pricing (`$0.60` / `$2.40` per 1M input/output tokens).
- `MiniMaxModelsConfig` class kdoc updated to list models as `(M3, M2.7, M2.7-highspeed)`.
- `AgentMiniMaxAutoConfigurationTest` asserts all three model beans (`miniMaxM3`, `miniMaxM27`, `miniMaxM27Highspeed`) are registered as `LlmService` instances.
- `README.md` updated: `MINIMAX_API_KEY` now lists `MiniMax-M3, MiniMax-M2.7 and MiniMax-M2.7-highspeed`.
- `embabel-agent-docs/.../minimax/page.adoc` updated:
  - Available Models table now shows M3 (512K, $0.60/$2.40) first, followed by M2.7 and M2.7-highspeed.
  - Description text: M3 is the latest flagship and the best default choice; M2.7 is documented as the previous flagship retained for backward compatibility / 1M context.
  - `@LlmCall` and role-map examples now use `MiniMax-M3` as the default flagship; `MiniMax-M2.7-highspeed` still appears as the cheapest role.

No changes to `MINIMAX_API_KEY`, base URL, TTS, retry config, or option-conversion logic — purely a model-list addition with M3 promoted to default.

## Why

`MiniMax-M3` is the current flagship MiniMax model and is cheaper than M2.7 while supporting image input. Promoting it to default keeps the integration aligned with the upstream provider.

## Testing

`mvn -o test -Dtest=AgentMiniMaxAutoConfigurationTest` and `mvn -o test -Dtest=MiniMaxOptionsConverterTest` both pass locally (Java 21).