### PR TITLE
Do not support agents with multiple distinct goal types

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -16,9 +16,6 @@
 package com.embabel.agent.api.annotation.support
 
 import com.embabel.agent.api.annotation.*
-import com.embabel.agent.api.annotation.Action
-import com.embabel.agent.api.annotation.Agent
-import com.embabel.agent.api.annotation.Condition
 import com.embabel.agent.api.common.OperationContext
 import com.embabel.agent.api.common.PlannerType
 import com.embabel.agent.api.common.StuckHandler
@@ -226,9 +223,9 @@ class AgentMetadataReader(
         }
 
         val agent = if (agenticInfo.agentAnnotation != null) {
+            val goalActions = actionMethods.filter { it.isAnnotationPresent(AchievesGoal::class.java) }
             if (plannerType == PlannerType.SUPERVISOR) {
                 // Find the goal action (the action with @AchievesGoal)
-                val goalActions = actionMethods.filter { it.isAnnotationPresent(AchievesGoal::class.java) }
                 if (goalActions.isEmpty()) {
                     logger.warn(
                         "SUPERVISOR planner requires at least one @AchievesGoal action on {}",
@@ -259,6 +256,15 @@ class AgentMetadataReader(
                     conditions = conditions,
                 )
             } else {
+                val distinctGoalTypes = goalActions.map { it.returnType }.toSet()
+                if (distinctGoalTypes.size > 1) {
+                    logger.warn(
+                        "Agent {} has {} @AchievesGoal actions, while one is supported",
+                        targetType.name,
+                        goalActions.size,
+                    )
+                    return null
+                }
                 CoreAgent(
                     name = agenticInfo.agentName(),
                     provider = agenticInfo.agentAnnotation.provider.ifBlank {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderMetadataTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderMetadataTest.kt
@@ -97,6 +97,15 @@ class AgentMetadataReaderMetadataTest {
         }
 
         @Test
+        fun `agent with AchievesGoal actions returning distinct types is rejected`() {
+            val reader = AgentMetadataReader()
+            assertNull(
+                reader.createAgentMetadata(AgentWithMultipleAchievesGoalActions()),
+                "@Agent with @AchievesGoal actions returning different types must be rejected (issue #797)",
+            )
+        }
+
+        @Test
         fun `OperationContext constructor injection throws IllegalStateException`() {
             val reader = AgentMetadataReader()
             val placeholder = com.embabel.agent.test.integration.IntegrationTestUtils

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
@@ -822,6 +822,19 @@ class AgentWithNonReadOnlyAction {
     }
 }
 
+@Agent(description = "agent with multiple AchievesGoal actions")
+class AgentWithMultipleAchievesGoalActions {
+
+    @AchievesGoal(description = "First result")
+    @Action
+    fun firstAction(userInput: UserInput): PersonWithReverseTool = PersonWithReverseTool(userInput.content)
+
+    @AchievesGoal(description = "Second result")
+    @Action
+    fun secondAction(person: PersonWithReverseTool): Frog = Frog(person.name)
+
+}
+
 @Agent(description = "agent with duplicate action names via overloaded methods")
 class AgentWithDuplicateActionNames {
 


### PR DESCRIPTION
This PR ensures that agents with multiple @AchievesGoal types are not supported, unless they use the same return type.

Closes: gh-797