### PR TITLE
adds missing Gemini 3.1 and 3.5 models

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
@@ -25,10 +25,14 @@ class GoogleGenAiModels {
 
     companion object {
 
+        // Gemini 3.5 Family (Latest Generation - Stable)
+        const val GEMINI_3_5_FLASH = "gemini-3.5-flash"
+
         // Gemini 3.1 Family (Preview - Latest Generation)
         const val GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview"
-        const val GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
         const val GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = "gemini-3.1-pro-preview-customtools"
+        const val GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
+        const val GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite"
         const val GEMINI_3_1_FLASH_LITE_PREVIEW = "gemini-3.1-flash-lite-preview"
 
         // Gemini 2.5 Family (Stable - Current Generation)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
@@ -30,8 +30,8 @@ class GoogleGenAiModels {
 
         // Gemini 3.1 Family (Preview - Latest Generation)
         const val GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview"
-        const val GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = "gemini-3.1-pro-preview-customtools"
         const val GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview"
+        const val GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = "gemini-3.1-pro-preview-customtools"
         const val GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite"
         const val GEMINI_3_1_FLASH_LITE_PREVIEW = "gemini-3.1-flash-lite-preview"
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
@@ -22,7 +22,22 @@ models:
       usd_per1m_output_tokens: 9.00
 
   # ========================================
-  # GEMINI 3 FAMILY (Stable & Preview Generations)
+  # GEMINI 3.1 FAMILY (Latest Generation - Stable)
+  # ========================================
+
+  # Gemini 3.1 Flash Lite - Production lightweight and cost-effective model
+  - name: "gemini_3_1_flash_lite"
+    model_id: "gemini-3.1-flash-lite"
+    display_name: "Gemini 3.1 Flash Lite"
+    knowledge_cutoff_date: "2025-01-01"
+    max_output_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 1.50
+
+  # ========================================
+  # GEMINI 3 FAMILY (Preview - Latest Generation)
   # ========================================
 
   # Gemini 3.1 Pro Preview - Most advanced reasoning model
@@ -57,17 +72,6 @@ models:
     pricing_model:
       usd_per1m_input_tokens: 0.50
       usd_per1m_output_tokens: 3.00
-
-  # Gemini 3.1 Flash Lite - Production lightweight and cost-effective model
-  - name: "gemini_3_1_flash_lite"
-    model_id: "gemini-3.1-flash-lite"
-    display_name: "Gemini 3.1 Flash Lite"
-    knowledge_cutoff_date: "2025-01-01"
-    max_output_tokens: 65536
-    temperature: 0.7
-    pricing_model:
-      usd_per1m_input_tokens: 0.25
-      usd_per1m_output_tokens: 1.50
 
   # Gemini 3.1 Flash Lite Preview - Lightweight and cost-effective latest generation model
   - name: "gemini_3_1_flash_lite_preview"

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
@@ -25,18 +25,7 @@ models:
   # GEMINI 3 FAMILY (Stable & Preview Generations)
   # ========================================
 
-  # Gemini 3.1 Pro - Production advanced reasoning model
-  - name: "gemini_3_1_pro"
-    model_id: "gemini-3.1-pro"
-    display_name: "Gemini 3.1 Pro"
-    knowledge_cutoff_date: "2025-01-01"
-    max_output_tokens: 65536
-    temperature: 0.7
-    pricing_model:
-      usd_per1m_input_tokens: 2.00
-      usd_per1m_output_tokens: 12.00
-
-  # Gemini 3.1 Pro Preview - Most advanced reasoning model
+  # Gemini 3.1 Pro Preview - Most advanced reasoning model (Preview)
   - name: "gemini_3_1_pro_preview"
     model_id: "gemini-3.1-pro-preview"
     display_name: "Gemini 3.1 Pro Preview"

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
@@ -2,13 +2,39 @@
 # google-genai-models.yml
 # ============================================
 # Google GenAI (Gemini) models configuration
-# Updated with latest Gemini models as of November 2025
+# Updated with latest Gemini models as of June 2026
 # Using native Spring AI Google GenAI support
 
 models:
   # ========================================
-  # GEMINI 3 FAMILY (Preview - Latest Generation)
+  # GEMINI 3.5 FAMILY (Latest Generation - Stable)
   # ========================================
+
+  # Gemini 3.5 Flash - Frontier-level reasoning at Flash tier speed & cost
+  - name: "gemini_3_5_flash"
+    model_id: "gemini-3.5-flash"
+    display_name: "Gemini 3.5 Flash"
+    knowledge_cutoff_date: "2025-01-01"
+    max_output_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 1.50
+      usd_per1m_output_tokens: 9.00
+
+  # ========================================
+  # GEMINI 3 FAMILY (Stable & Preview Generations)
+  # ========================================
+
+  # Gemini 3.1 Pro - Production advanced reasoning model
+  - name: "gemini_3_1_pro"
+    model_id: "gemini-3.1-pro"
+    display_name: "Gemini 3.1 Pro"
+    knowledge_cutoff_date: "2025-01-01"
+    max_output_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 2.00
+      usd_per1m_output_tokens: 12.00
 
   # Gemini 3.1 Pro Preview - Most advanced reasoning model
   - name: "gemini_3_1_pro_preview"
@@ -43,7 +69,18 @@ models:
       usd_per1m_input_tokens: 0.50
       usd_per1m_output_tokens: 3.00
 
-  # Gemini 3.1 Flash Lite Preview - Lightweight and cost-effective latest generation model
+  # Gemini 3.1 Flash Lite - Production lightweight and cost-effective model
+  - name: "gemini_3_1_flash_lite"
+    model_id: "gemini-3.1-flash-lite"
+    display_name: "Gemini 3.1 Flash Lite"
+    knowledge_cutoff_date: "2025-01-01"
+    max_output_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 1.50
+
+  # Gemini 3.1 Flash Lite Preview - Lightweight preview generation model
   - name: "gemini_3_1_flash_lite_preview"
     model_id: "gemini-3.1-flash-lite-preview"
     display_name: "Gemini 3.1 Flash Lite Preview"
@@ -131,4 +168,3 @@ embedding_models:
     dimensions: 3072
     pricing_model:
       usd_per1m_tokens: 0.15
-

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
@@ -25,7 +25,7 @@ models:
   # GEMINI 3 FAMILY (Stable & Preview Generations)
   # ========================================
 
-  # Gemini 3.1 Pro Preview - Most advanced reasoning model (Preview)
+  # Gemini 3.1 Pro Preview - Most advanced reasoning model
   - name: "gemini_3_1_pro_preview"
     model_id: "gemini-3.1-pro-preview"
     display_name: "Gemini 3.1 Pro Preview"
@@ -69,7 +69,7 @@ models:
       usd_per1m_input_tokens: 0.25
       usd_per1m_output_tokens: 1.50
 
-  # Gemini 3.1 Flash Lite Preview - Lightweight preview generation model
+  # Gemini 3.1 Flash Lite Preview - Lightweight and cost-effective latest generation model
   - name: "gemini_3_1_flash_lite_preview"
     model_id: "gemini-3.1-flash-lite-preview"
     display_name: "Gemini 3.1 Flash Lite Preview"
@@ -157,3 +157,4 @@ embedding_models:
     dimensions: 3072
     pricing_model:
       usd_per1m_tokens: 0.15
+

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiChatIntegrationIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiChatIntegrationIT.kt
@@ -70,9 +70,11 @@ class GoogleGenAiChatIntegrationIT(
     @Test
     fun `registers all google genai model beans`() {
         val expectedBeans = listOf(
+            "gemini_3_5_flash",
             "gemini_3_1_pro_preview",
             "gemini_3_1_pro_preview_customtools",
             "gemini_3_flash_preview",
+            "gemini_3_1_flash_lite",
             "gemini_3_1_flash_lite_preview",
             "gemini_25_pro",
             "gemini_25_flash",
@@ -114,9 +116,11 @@ class GoogleGenAiChatIntegrationIT(
     companion object {
         @JvmStatic
         fun allGoogleGenAiModelIds(): List<String> = listOf(
+            GoogleGenAiModels.GEMINI_3_5_FLASH,
             GoogleGenAiModels.GEMINI_3_1_PRO_PREVIEW,
             GoogleGenAiModels.GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS,
             GoogleGenAiModels.GEMINI_3_FLASH_PREVIEW,
+            GoogleGenAiModels.GEMINI_3_1_FLASH_LITE,
             GoogleGenAiModels.GEMINI_3_1_FLASH_LITE_PREVIEW,
             GoogleGenAiModels.GEMINI_2_5_PRO,
             GoogleGenAiModels.GEMINI_2_5_FLASH,

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
@@ -388,15 +388,10 @@ class GoogleGenAiModelLoaderTest {
         assertEquals(11, result.models.size, "Should load exactly 11 Google GenAI models")
 
         val expectedModels = listOf(
-            "gemini_3_5_flash",
-            "gemini_3_1_pro_preview",
-            "gemini_3_1_pro_preview_customtools",
-            "gemini_3_flash_preview",
-            "gemini_3_1_flash_lite",
-            "gemini_3_1_flash_lite_preview",
-            "gemini_25_pro",
-            "gemini_25_flash",
-            "gemini_25_flash_lite",
+            "gemini_3_1_pro_preview", "gemini_3_1_pro_preview_customtools",
+            "gemini_3_flash_preview", "gemini_3_1_flash_lite_preview", "gemini_25_pro", "gemini_25_flash",
+            "gemini_25_flash_lite", "gemini_20_flash", "gemini_20_flash_lite",
+            "gemini_3_5_flash", "gemini_3_1_flash_lite"
         )
 
         expectedModels.forEach { expectedName ->

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
@@ -385,7 +385,7 @@ class GoogleGenAiModelLoaderTest {
         val result = loader.loadAutoConfigMetadata()
 
         // Assert
-        assertEquals(9, result.models.size, "Should load exactly 9 Google GenAI models")
+        assertEquals(12, result.models.size, "Should load exactly 9 Google GenAI models")
 
         val expectedModels = listOf(
             "gemini_3_1_pro_preview", "gemini_3_1_pro_preview_customtools",

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
@@ -376,7 +376,7 @@ class GoogleGenAiModelLoaderTest {
     }
 
     @Test
-    fun `should load all 9 expected Google GenAI models`() {
+    fun `should load all 11 expected Google GenAI models`() {
 
         // Arrange
         val loader = GoogleGenAiModelLoader()
@@ -385,12 +385,18 @@ class GoogleGenAiModelLoaderTest {
         val result = loader.loadAutoConfigMetadata()
 
         // Assert
-        assertEquals(12, result.models.size, "Should load exactly 9 Google GenAI models")
+        assertEquals(11, result.models.size, "Should load exactly 11 Google GenAI models")
 
         val expectedModels = listOf(
-            "gemini_3_1_pro_preview", "gemini_3_1_pro_preview_customtools",
-            "gemini_3_flash_preview", "gemini_3_1_flash_lite_preview", "gemini_25_pro", "gemini_25_flash",
-            "gemini_25_flash_lite", "gemini_20_flash", "gemini_20_flash_lite"
+            "gemini_3_5_flash",
+            "gemini_3_1_pro_preview",
+            "gemini_3_1_pro_preview_customtools",
+            "gemini_3_flash_preview",
+            "gemini_3_1_flash_lite",
+            "gemini_3_1_flash_lite_preview",
+            "gemini_25_pro",
+            "gemini_25_flash",
+            "gemini_25_flash_lite",
         )
 
         expectedModels.forEach { expectedName ->
@@ -461,6 +467,36 @@ class GoogleGenAiModelLoaderTest {
         assertNotNull(gemini31FlashLitePreview, "Gemini 3.1 Flash Lite preview should be loaded")
         assertEquals("gemini_3_1_flash_lite_preview", gemini31FlashLitePreview?.name)
         assertEquals("gemini-3.1-flash-lite-preview", gemini31FlashLitePreview?.modelId)
+    }
+
+    @Test
+    fun `should load Gemini 35 Flash model`() {
+        // Arrange
+        val loader = GoogleGenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify Gemini 3.5 Flash is present
+        val gemini35Flash = result.models.find { it.modelId == "gemini-3.5-flash" }
+        assertNotNull(gemini35Flash, "Gemini 3.5 Flash should be loaded")
+        assertEquals("gemini_3_5_flash", gemini35Flash?.name)
+        assertEquals("gemini-3.5-flash", gemini35Flash?.modelId)
+    }
+
+    @Test
+    fun `should load Gemini 31 Flash Lite model`() {
+        // Arrange
+        val loader = GoogleGenAiModelLoader()
+
+        // Act
+        val result = loader.loadAutoConfigMetadata()
+
+        // Assert - verify Gemini 3.1 Flash Lite is present
+        val gemini31FlashLite = result.models.find { it.modelId == "gemini-3.1-flash-lite" }
+        assertNotNull(gemini31FlashLite, "Gemini 3.1 Flash Lite should be loaded")
+        assertEquals("gemini_3_1_flash_lite", gemini31FlashLite?.name)
+        assertEquals("gemini-3.1-flash-lite", gemini31FlashLite?.modelId)
     }
 
     @Test

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -615,14 +615,17 @@ dependencies {
 
 Available LLM models include:
 
+* `gemini-3.5-flash` - Frontier-level reasoning at Flash tier speed & cost (Latest Generation - Stable)
 * `gemini-3.1-pro-preview` - Latest Gemini 3.1 Pro preview with advanced reasoning
 * `gemini-3.1-pro-preview-customtools` - Gemini 3.1 Pro optimized for custom tool usage
-* `gemini-3.1-flash-lite-preview` - Lightweight and cost-effective latest generation model
-* `gemini-2.5-pro` - High-performance model with thinking support
-* `gemini-2.5-flash` - Best price-performance model
-* `gemini-2.5-flash-lite` - Cost-effective high-throughput model
-* `gemini-2.0-flash` - Fast and efficient
-* `gemini-2.0-flash-lite` - Lightweight version
+* `gemini-3-flash-preview` - Fast model with thinking capabilities
+* `gemini-3.1-flash-lite` - Production lightweight and cost-effective model (Latest Generation - Stable)
+* `gemini-3.1-flash-lite-preview` - Lightweight and cost-effective latest generation preview model
+* `gemini-2.5-pro` - High-performance model with thinking support (Current Generation - Stable)
+* `gemini-2.5-flash` - Best price-performance model (Current Generation - Stable)
+* `gemini-2.5-flash-lite` - Cost-effective high-throughput model (Current Generation - Stable)
+* `gemini-2.0-flash` - Fast and efficient (Previous Generation)
+* `gemini-2.0-flash-lite` - Lightweight version (Previous Generation)
 
 Available embedding models include:
 
@@ -634,11 +637,12 @@ Example configuration in `application.yml`:
 ----
 embabel:
   models:
-    default-llm: gemini-2.5-flash  # <1>
+    default-llm: gemini-3.5-flash  # <1>
     default-embedding-model: gemini-embedding-001  # <2>
     llms:
-      fast: gemini-2.5-flash
-      best: gemini-2.5-pro
+      fast: gemini-3.5-flash
+      cost-effective: gemini-3.1-flash-lite
+      best: gemini-3.1-pro
       reasoning: gemini-3.1-pro-preview
     embedding-services:
       default: gemini-embedding-001

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -636,12 +636,11 @@ Example configuration in `application.yml`:
 ----
 embabel:
   models:
-    default-llm: gemini-3.5-flash  # <1>
+    default-llm: gemini-2.5-flash  # <1>
     default-embedding-model: gemini-embedding-001  # <2>
     llms:
-      fast: gemini-3.5-flash
-      cost-effective: gemini-3.1-flash-lite
-      best: gemini-3.1-pro
+      fast: gemini-2.5-flash
+      best: gemini-2.5-pro
       reasoning: gemini-3.1-pro-preview
     embedding-services:
       default: gemini-embedding-001

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -615,17 +615,16 @@ dependencies {
 
 Available LLM models include:
 
-* `gemini-3.5-flash` - Frontier-level reasoning at Flash tier speed & cost (Latest Generation - Stable)
+* `gemini-3.5-flash` - Frontier-level reasoning at Flash tier speed & cost
+* `gemini-3.1-flash-lite` - Production lightweight and cost-effective model
 * `gemini-3.1-pro-preview` - Latest Gemini 3.1 Pro preview with advanced reasoning
 * `gemini-3.1-pro-preview-customtools` - Gemini 3.1 Pro optimized for custom tool usage
-* `gemini-3-flash-preview` - Fast model with thinking capabilities
-* `gemini-3.1-flash-lite` - Production lightweight and cost-effective model (Latest Generation - Stable)
-* `gemini-3.1-flash-lite-preview` - Lightweight and cost-effective latest generation preview model
-* `gemini-2.5-pro` - High-performance model with thinking support (Current Generation - Stable)
-* `gemini-2.5-flash` - Best price-performance model (Current Generation - Stable)
-* `gemini-2.5-flash-lite` - Cost-effective high-throughput model (Current Generation - Stable)
-* `gemini-2.0-flash` - Fast and efficient (Previous Generation)
-* `gemini-2.0-flash-lite` - Lightweight version (Previous Generation)
+* `gemini-3.1-flash-lite-preview` - Lightweight and cost-effective latest generation model
+* `gemini-2.5-pro` - High-performance model with thinking support
+* `gemini-2.5-flash` - Best price-performance model
+* `gemini-2.5-flash-lite` - Cost-effective high-throughput model
+* `gemini-2.0-flash` - Fast and efficient
+* `gemini-2.0-flash-lite` - Lightweight version
 
 Available embedding models include:
 


### PR DESCRIPTION
Adds 3 additional models according to the Google documentation https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/google-models
