### PR TITLE
docs: fix typo in documentation site domain (emababel -> embabel)

### DIFF
--- a/embabel-agent-docs/README.md
+++ b/embabel-agent-docs/README.md
@@ -64,7 +64,7 @@ Reference
 
 ### In this grouping:
 
-* Each group is a separate page on the site, eg hub.emababel.org/intro and hub.embabel.org/reference
+* Each group is a separate page on the site, eg hub.embabel.org/intro and hub.embabel.org/reference
 * Links inside these separate pages are fragments.
 
 We need a way to for links to work in this format, without breaking anything in normal asciidoc. Therefore:


### PR DESCRIPTION
## Description

Fixes a typo in `embabel-agent-docs/README.md` where the documentation site domain was incorrectly spelled as `hub.emababel.org` instead of `hub.embabel.org`.

### Problem

On line 67, the same line contained two different spellings of the domain:
- `hub.emababel.org/intro` (incorrect — extra 'a')
- `hub.embabel.org/reference` (correct)

This inconsistency could confuse developers configuring the documentation site.

### Fix

Corrected `emababel` to `embabel` to match the project's actual domain.

### Checklist

- [x] I have read the [coding style guide](embabel-agent-api/.embabel/coding-style.md)
- [x] This change only affects documentation
- [x] Commit is signed off per DCO requirements