### PR TITLE
Prepend help info to the default shell's prompt

### DIFF
--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/DefaultPromptProvider.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/DefaultPromptProvider.kt
@@ -24,7 +24,7 @@ import org.springframework.shell.jline.PromptProvider
  */
 internal class DefaultPromptProvider : PromptProvider {
     override fun getPrompt() = AttributedString(
-        "Type help for available commands.\nembabel> ",
+        "Type 'help' for available commands.\nembabel> ",
         AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW)
     )
 }

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/DefaultPromptProvider.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/DefaultPromptProvider.kt
@@ -24,7 +24,7 @@ import org.springframework.shell.jline.PromptProvider
  */
 internal class DefaultPromptProvider : PromptProvider {
     override fun getPrompt() = AttributedString(
-        "Type /help for available commands.\nembabel> ",
+        "Type help for available commands.\nembabel> ",
         AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW)
     )
 }

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/DefaultPromptProvider.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/DefaultPromptProvider.kt
@@ -24,7 +24,7 @@ import org.springframework.shell.jline.PromptProvider
  */
 internal class DefaultPromptProvider : PromptProvider {
     override fun getPrompt() = AttributedString(
-        "embabel> ",
+        "Type /help for available commands.\nembabel> ",
         AttributedStyle.DEFAULT.foreground(AttributedStyle.YELLOW)
     )
 }

--- a/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/DefaultPromptProviderTest.kt
+++ b/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/DefaultPromptProviderTest.kt
@@ -65,7 +65,7 @@ class DefaultPromptProviderTest {
         val prompt = provider.getPrompt()
 
         // Assert
-        assertEquals("embabel> ", prompt.toString())
+        assertEquals("Type /help for available commands.\nembabel> ", prompt.toString())
     }
 
     @Test

--- a/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/DefaultPromptProviderTest.kt
+++ b/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/DefaultPromptProviderTest.kt
@@ -65,7 +65,7 @@ class DefaultPromptProviderTest {
         val prompt = provider.getPrompt()
 
         // Assert
-        assertEquals("Type /help for available commands.\nembabel> ", prompt.toString())
+        assertEquals("Type help for available commands.\nembabel> ", prompt.toString())
     }
 
     @Test

--- a/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/DefaultPromptProviderTest.kt
+++ b/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/DefaultPromptProviderTest.kt
@@ -65,7 +65,7 @@ class DefaultPromptProviderTest {
         val prompt = provider.getPrompt()
 
         // Assert
-        assertEquals("Type help for available commands.\nembabel> ", prompt.toString())
+        assertEquals("Type 'help' for available commands.\nembabel> ", prompt.toString())
     }
 
     @Test


### PR DESCRIPTION

Adding a reminder to the default shell prompt so that it will be an easy starting point for new users of embabel project 

`
22:50:14.916 [main] INFO  EmbabeldemoApplication - Started EmbabeldemoApplication in 1.223 seconds (process running for 1.344)
Type 'help' for available commands.
embabel> `
