### PR TITLE
Spring AI 2.0.0 GA Migration

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmMessageSender.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmMessageSender.kt
@@ -198,18 +198,20 @@ internal class SpringAiLlmMessageSender(
         // If chatOptions already implements ToolCallingChatOptions (e.g., AnthropicChatOptions,
         // OpenAiChatOptions, etc.), use its copy() method to preserve all provider-specific settings
         if (chatOptions is ToolCallingChatOptions) {
-            // Spring AI 2.0: toolCallbacks / internalToolExecutionEnabled are read-only on
-            // ToolCallingChatOptions, so use mutate() to derive a new instance. This preserves
-            // the provider-specific subtype (e.g. Anthropic cache settings) while attaching our
-            // tool callbacks and disabling Spring AI's automatic tool execution.
+            // Spring AI 2.0 GA: toolCallbacks are read-only on ToolCallingChatOptions, so use
+            // mutate() to derive a new instance, preserving the provider-specific subtype (e.g.
+            // Anthropic cache settings) while attaching our tool callbacks. The per-request
+            // internalToolExecutionEnabled flag was removed in 2.0.0; disabling Spring AI's
+            // automatic tool execution is now configured on the ChatModel (ToolCallingManager /
+            // ToolExecutionEligibilityPredicate) so embabel's DefaultToolLoop stays in control.
             return chatOptions.mutate()
                 .toolCallbacks(toolCallbacks)
-                .internalToolExecutionEnabled(false)
                 .build()
         }
 
-        // Fallback: Create generic ToolCallingChatOptions
-        // IMPORTANT: Disable internal tool execution - we handle tools ourselves in DefaultToolLoop
+        // Fallback: Create generic ToolCallingChatOptions.
+        // We handle tools ourselves in DefaultToolLoop. Spring AI 2.0 GA removed the per-request
+        // internalToolExecutionEnabled flag; internal execution is disabled on the ChatModel.
         return ToolCallingChatOptions.builder()
             .model(chatOptions.model)
             .temperature(chatOptions.temperature)
@@ -220,7 +222,6 @@ internal class SpringAiLlmMessageSender(
             .presencePenalty(chatOptions.presencePenalty)
             .stopSequences(chatOptions.stopSequences)
             .toolCallbacks(toolCallbacks)
-            .internalToolExecutionEnabled(false)
             .build()
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiToolExtractor.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiToolExtractor.kt
@@ -32,6 +32,11 @@ internal object SpringAiToolExtractor : ExternalToolExtractor {
         }
         return try {
             ToolCallbacks.from(obj).map { it.toEmbabelTool() }
+        } catch (_: IllegalArgumentException) {
+            // Spring AI 2.0's ToolCallbacks.from throws IllegalArgumentException when the object has
+            // no @Tool-annotated methods (Spring AI 1.x/M8 threw IllegalStateException). Either way,
+            // "no tools on this object" is a normal result for agents, so return an empty list.
+            emptyList()
         } catch (_: IllegalStateException) {
             emptyList()
         }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -88,15 +88,15 @@ class FakeChatModel(
     private var index = 0
 
     val promptsPassed = mutableListOf<Prompt>()
-    val optionsPassed = mutableListOf<ToolCallingChatOptions>()
+    val optionsPassed = mutableListOf<ChatOptions>()
 
     override fun getDefaultOptions(): ChatOptions = options
 
     override fun call(prompt: Prompt): ChatResponse {
         promptsPassed.add(prompt)
-        val options = prompt.options as? ToolCallingChatOptions
-            ?: throw IllegalArgumentException("Expected ToolCallingChatOptions")
-        optionsPassed.add(options)
+        // Spring AI 2.0's ChatClient merge does not preserve the ToolCallingChatOptions subtype;
+        // a real ChatModel receives a plain ChatOptions here (tools flow via the ToolCallingAdvisor).
+        optionsPassed.add(prompt.options)
         return ChatResponse(
             listOf(
                 Generation(AssistantMessage(responses[index])).also {
@@ -302,7 +302,7 @@ class ChatClientLlmOperationsTest {
             )
             assertEquals(duke, result)
             assertEquals(1, fakeChatModel.promptsPassed.size)
-            val tools = fakeChatModel.optionsPassed[0].toolCallbacks
+            val tools = (fakeChatModel.optionsPassed[0] as? ToolCallingChatOptions)?.toolCallbacks.orEmpty()
             assertEquals(0, tools.size)
         }
 
@@ -610,8 +610,6 @@ class ChatClientLlmOperationsTest {
             override fun call(prompt: Prompt): ChatResponse {
                 callCount.incrementAndGet()
                 Thread.sleep(delayMillis)
-                val options = prompt.options as? ToolCallingChatOptions
-                    ?: throw IllegalArgumentException("Expected ToolCallingChatOptions")
                 return ChatResponse(listOf(Generation(AssistantMessage(response))))
             }
         }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
@@ -50,7 +50,7 @@ import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.model.Generation
-import org.springframework.ai.chat.prompt.DefaultChatOptions
+import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.Prompt
 
 class MutableLlmInvocationHistory : LlmInvocationHistory {
@@ -193,7 +193,7 @@ class ChatClientLlmTransformerTest {
 
             val mockModelProvider = mockk<ModelProvider>()
             val mockChatModel = mockk<ChatModel>()
-            every { mockChatModel.defaultOptions } returns DefaultChatOptions()
+            every { mockChatModel.defaultOptions } returns ChatOptions.builder().build()
             val promptSlot = slot<Prompt>()
             every { mockChatModel.call(capture(promptSlot)) } returns ChatResponse(
                 listOf(
@@ -381,7 +381,7 @@ class ChatClientLlmTransformerTest {
 
             val mockModelProvider = mockk<ModelProvider>()
             val mockChatModel = mockk<ChatModel>()
-            every { mockChatModel.defaultOptions } returns DefaultChatOptions()
+            every { mockChatModel.defaultOptions } returns ChatOptions.builder().build()
             val promptSlot = slot<Prompt>()
             every { mockChatModel.call(capture(promptSlot)) } returns ChatResponse(
                 listOf(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsGuardRailTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsGuardRailTest.kt
@@ -83,15 +83,15 @@ class StreamingGuardRailTestFakeChatModel(
     private var index = 0
 
     val promptsPassed = mutableListOf<Prompt>()
-    val optionsPassed = mutableListOf<ToolCallingChatOptions>()
+    val optionsPassed = mutableListOf<ChatOptions>()
 
     override fun getDefaultOptions(): ChatOptions = options
 
     override fun call(prompt: Prompt): ChatResponse {
         promptsPassed.add(prompt)
-        val options = prompt.options as? ToolCallingChatOptions
-            ?: throw IllegalArgumentException("Expected ToolCallingChatOptions")
-        optionsPassed.add(options)
+        // Spring AI 2.0's ChatClient merge does not preserve the ToolCallingChatOptions subtype;
+        // a real ChatModel receives a plain ChatOptions here (tools flow via the ToolCallingAdvisor).
+        optionsPassed.add(prompt.options)
         return ChatResponse(
             listOf(
                 Generation(SpringAssistantMessage(responses[index])).also {
@@ -104,9 +104,9 @@ class StreamingGuardRailTestFakeChatModel(
 
     override fun stream(prompt: Prompt): Flux<ChatResponse> {
         promptsPassed.add(prompt)
-        val options = prompt.options as? ToolCallingChatOptions
-            ?: throw IllegalArgumentException("Expected ToolCallingChatOptions")
-        optionsPassed.add(options)
+        // Spring AI 2.0's ChatClient merge does not preserve the ToolCallingChatOptions subtype;
+        // a real ChatModel receives a plain ChatOptions here (tools flow via the ToolCallingAdvisor).
+        optionsPassed.add(prompt.options)
 
         // Create streaming chunks from response
         val response = responses[index]

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/pom.xml
@@ -36,6 +36,16 @@
            <artifactId>spring-ai-anthropic</artifactId>
         </dependency>
 
+        <!--
+          Spring AI 2.0's spring-ai-anthropic depends only on anthropic-java-core, not the OkHttp
+          client. AnthropicModelFactory uses AnthropicOkHttpClient directly, so declare the client
+          artifact explicitly. Version is managed by the embabel-build BOM (anthropic-java.version).
+        -->
+        <dependency>
+            <groupId>com.anthropic</groupId>
+            <artifactId>anthropic-java-client-okhttp</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test-internal</artifactId>

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/UsageExtensionsTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/UsageExtensionsTest.kt
@@ -46,6 +46,8 @@ private fun anthropicUsage(
         .outputTokens(outputTokens)
         .cacheCreationInputTokens(cacheCreationInputTokens)
         .cacheReadInputTokens(cacheReadInputTokens)
+        // anthropic-java 2.40.1 made outputTokensDetails a required builder field; set it explicitly (empty).
+        .outputTokensDetails(Optional.empty())
         .cacheCreation(Optional.empty())
         .inferenceGeo(Optional.empty())
         .serverToolUse(Optional.empty())

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModelsConfig.kt
@@ -27,6 +27,7 @@ import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import io.micrometer.observation.ObservationRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.ai.bedrock.cohere.BedrockCohereEmbeddingModel
+import org.springframework.ai.bedrock.cohere.BedrockCohereEmbeddingOptions
 import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi
 import org.springframework.ai.bedrock.converse.BedrockChatOptions
 import org.springframework.ai.bedrock.converse.BedrockProxyChatModel
@@ -38,10 +39,8 @@ import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionCo
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionProperties
 import org.springframework.ai.model.bedrock.cohere.autoconfigure.BedrockCohereEmbeddingProperties
 import org.springframework.ai.model.bedrock.titan.autoconfigure.BedrockTitanEmbeddingProperties
-import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate
 import org.springframework.ai.model.tool.ToolCallingChatOptions
 import org.springframework.ai.model.tool.ToolCallingManager
-import org.springframework.ai.model.tool.ToolExecutionEligibilityPredicate
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -256,7 +255,10 @@ class BedrockModelsConfig(
                     tools.jackson.databind.json.JsonMapper.builder().build(),
                     connectionProperties.timeout
                 ),
-                bedrockCohereEmbeddingProperties.options
+                BedrockCohereEmbeddingOptions.builder()
+                    .inputType(bedrockCohereEmbeddingProperties.options.inputType)
+                    .truncate(bedrockCohereEmbeddingProperties.options.truncate)
+                    .build()
             ),
             provider = PROVIDER,
         )
@@ -313,8 +315,6 @@ class EmbabelBedrockProxyChatModelBuilder internal constructor() {
     private var region: Region? = Region.US_EAST_1
     private var timeout: java.time.Duration? = java.time.Duration.ofMinutes(10)
     private var toolCallingManager: ToolCallingManager? = null
-    private var toolExecutionEligibilityPredicate: ToolExecutionEligibilityPredicate =
-        DefaultToolExecutionEligibilityPredicate()
     private var defaultOptions = BedrockChatOptions.builder().build()
     private var observationRegistry = ObservationRegistry.NOOP
     private var customObservationConvention: ChatModelObservationConvention? = null
@@ -324,12 +324,6 @@ class EmbabelBedrockProxyChatModelBuilder internal constructor() {
 
     fun toolCallingManager(toolCallingManager: ToolCallingManager?): EmbabelBedrockProxyChatModelBuilder {
         this.toolCallingManager = toolCallingManager
-        return this
-    }
-
-    fun toolExecutionEligibilityPredicate(toolExecutionEligibilityPredicate: ToolExecutionEligibilityPredicate):
-            EmbabelBedrockProxyChatModelBuilder {
-        this.toolExecutionEligibilityPredicate = toolExecutionEligibilityPredicate
         return this
     }
 
@@ -402,8 +396,7 @@ class EmbabelBedrockProxyChatModelBuilder internal constructor() {
             bedrockRuntimeAsyncClient,
             defaultOptions,
             observationRegistry,
-            toolCallingManager ?: defaultToolCallingManager,
-            toolExecutionEligibilityPredicate
+            toolCallingManager ?: defaultToolCallingManager
         ).apply {
             if (customObservationConvention != null) {
                 setObservationConvention(customObservationConvention)

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/bedrock/EmbabelBedrockProxyChatModelBuilderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/bedrock/EmbabelBedrockProxyChatModelBuilderTest.kt
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.ai.bedrock.converse.BedrockChatOptions
 import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention
-import org.springframework.ai.model.tool.DefaultToolExecutionEligibilityPredicate
 import org.springframework.ai.model.tool.ToolCallingManager
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
@@ -62,7 +61,6 @@ class EmbabelBedrockProxyChatModelBuilderTest {
 
         val chatModel = EmbabelBedrockProxyChatModelBuilder()
             .toolCallingManager(toolCallingManager)
-            .toolExecutionEligibilityPredicate(DefaultToolExecutionEligibilityPredicate())
             .customObservationConvention(observationConvention)
             .credentialsProvider(credentialsProvider)
             .region(region)

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekModelsConfig.kt
@@ -152,7 +152,7 @@ class DeepSeekModelsConfig(
                     .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
                     .build()
             )
-            .defaultOptions(
+            .options(
                 DeepSeekChatOptions.builder()
                     .model(name)
                     .build()

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelsConfig.kt
@@ -38,7 +38,7 @@ import io.micrometer.observation.ObservationRegistry
 import org.slf4j.LoggerFactory
 import org.springframework.ai.google.genai.GoogleGenAiChatModel
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions
-import org.springframework.ai.google.genai.GoogleGenAiEmbeddingConnectionDetails
+import org.springframework.ai.google.genai.embedding.GoogleGenAiEmbeddingConnectionDetails
 import org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingModel
 import org.springframework.ai.google.genai.text.GoogleGenAiTextEmbeddingOptions
 import org.springframework.ai.model.tool.ToolCallingManager

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelsConfig.kt
@@ -150,7 +150,7 @@ class MistralAiModelsConfig(
     private fun createMistralAiLlm(modelDef: MistralAiModelDefinition): LlmService<*> {
         val mistralChatModel = MistralAiChatModel
             .builder()
-            .defaultOptions(createDefaultOptions(modelDef))
+            .options(createDefaultOptions(modelDef))
             .mistralAiApi(createMistralAiApi())
             .toolCallingManager(
                 ToolCallingManager.builder()

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatOptions.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiChatOptions.kt
@@ -110,13 +110,15 @@ class OciGenAiChatOptions internal constructor(
         this.toolCallbacks = toolCallbacks
     }
 
-    override fun getToolNames(): Set<String> = toolNames
+    // toolNames removed from Spring AI 2.0 ToolCallingChatOptions; kept as an OCI-internal property.
+    fun getToolNames(): Set<String> = toolNames
 
     fun setToolNames(toolNames: Set<String>) {
         this.toolNames = toolNames
     }
 
-    override fun getInternalToolExecutionEnabled(): Boolean? = internalToolExecutionEnabled
+    // internalToolExecutionEnabled removed from Spring AI 2.0 ToolCallingChatOptions; kept as an OCI-internal property.
+    fun getInternalToolExecutionEnabled(): Boolean? = internalToolExecutionEnabled
 
     fun setInternalToolExecutionEnabled(internalToolExecutionEnabled: Boolean?) {
         this.internalToolExecutionEnabled = internalToolExecutionEnabled
@@ -161,6 +163,10 @@ class OciGenAiChatOptions internal constructor(
             if (runtimeOptions.apiFormatExplicit) {
                 merged.apiFormat = runtimeOptions.apiFormat
             }
+            if (runtimeOptions.toolNames.isNotEmpty()) {
+                merged.toolNames = runtimeOptions.toolNames
+            }
+            runtimeOptions.internalToolExecutionEnabled?.let { merged.internalToolExecutionEnabled = it }
         }
         return merged
     }
@@ -172,17 +178,16 @@ class OciGenAiChatOptions internal constructor(
         if (runtimeOptions.toolCallbacks.isNotEmpty()) {
             merged.toolCallbacks = runtimeOptions.toolCallbacks
         }
-        if (runtimeOptions.toolNames.isNotEmpty()) {
-            merged.toolNames = runtimeOptions.toolNames
-        }
         if (runtimeOptions.toolContext.isNotEmpty()) {
             merged.toolContext = merged.toolContext + runtimeOptions.toolContext
         }
-        runtimeOptions.internalToolExecutionEnabled?.let { merged.internalToolExecutionEnabled = it }
+        // toolNames / internalToolExecutionEnabled were removed from Spring AI 2.0 ToolCallingChatOptions;
+        // they are OCI-internal now and merged in merge() when both sides are OciGenAiChatOptions.
     }
 
+    // ChatOptions.copy() was removed in Spring AI 2.0; kept as an OCI-internal deep-copy helper.
     @Suppress("UNCHECKED_CAST")
-    override fun <T : ChatOptions> copy(): T =
+    fun <T : ChatOptions> copy(): T =
         OciGenAiChatOptions(
             model = model,
             compartmentId = compartmentId,
@@ -254,13 +259,15 @@ class OciGenAiChatOptions internal constructor(
         override fun toolCallbacks(vararg toolCallbacks: ToolCallback): Builder =
             apply { options.setToolCallbacks(toolCallbacks.toList()) }
 
-        override fun toolNames(toolNames: Set<String>): Builder =
+        // toolNames / internalToolExecutionEnabled removed from Spring AI 2.0 ToolCallingChatOptions.Builder;
+        // kept as OCI-internal builder methods.
+        fun toolNames(toolNames: Set<String>): Builder =
             apply { options.setToolNames(toolNames) }
 
-        override fun toolNames(vararg toolNames: String): Builder =
+        fun toolNames(vararg toolNames: String): Builder =
             apply { options.setToolNames(toolNames.toSet()) }
 
-        override fun internalToolExecutionEnabled(internalToolExecutionEnabled: Boolean?): Builder =
+        fun internalToolExecutionEnabled(internalToolExecutionEnabled: Boolean?): Builder =
             apply { options.setInternalToolExecutionEnabled(internalToolExecutionEnabled) }
 
         override fun toolContext(toolContext: Map<String, Any>): Builder =

--- a/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-oci-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ocigenai/OciGenAiOptionsConverterTest.kt
@@ -48,7 +48,7 @@ class OciGenAiOptionsConverterTest : OptionsConverterTestSupport<OciGenAiChatOpt
 
         assertNull(options.model)
         assertNull(options.compartmentId)
-        assertFalse(options.internalToolExecutionEnabled ?: true)
+        assertFalse(options.getInternalToolExecutionEnabled() ?: true)
     }
 
     @Test

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
@@ -161,7 +161,7 @@ class OllamaModelsConfig(
                     )
                     .build()
             )
-            .defaultOptions(
+            .options(
                 OllamaChatOptions.builder()
                     .model(uniqueModelName)
                     .build()
@@ -206,7 +206,7 @@ class OllamaModelsConfig(
                     )
                     .build()
             )
-            .defaultOptions(
+            .options(
                 OllamaEmbeddingOptions.builder()
                     .model(uniqueModelName)
                     .build()

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
@@ -28,7 +28,7 @@ import com.github.victools.jsonschema.module.jackson.JacksonOption
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.ai.converter.StructuredOutputConverter
-import org.springframework.ai.util.LoggingMarkers
+import org.slf4j.MarkerFactory
 import org.springframework.core.ParameterizedTypeReference
 import java.lang.reflect.Type
 
@@ -152,7 +152,9 @@ open class JacksonOutputConverter<T : Any> protected constructor(
             return lenientMapper.readValue<Any?>(unwrapped, lenientMapper.constructType(this.type)) as T
         } catch (e: JacksonException) {
             logger.error(
-                LoggingMarkers.SENSITIVE_DATA_MARKER,
+                // Spring AI 2.0 removed org.springframework.ai.util.LoggingMarkers; reproduce the
+                // same SLF4J marker ("SENSITIVE") so existing sensitive-data log filtering still applies.
+                MarkerFactory.getMarker("SENSITIVE"),
                 "Could not parse the given text to the desired target type: \"{}\" into {}", unwrapped, this.type
             )
             throw RuntimeException(e)


### PR DESCRIPTION
This pull request updates the codebase to support Spring AI 2.0, removing deprecated APIs and adapting to breaking changes, especially around tool calling and options handling. It also updates model configuration and builder patterns to align with the new Spring AI APIs, and makes related test and import adjustments.

**Spring AI 2.0 migration and tool calling changes:**

* Removed usage of `internalToolExecutionEnabled` and `toolNames` from `ToolCallingChatOptions` and `OciGenAiChatOptions` as these are no longer part of the public API; these are now handled internally for OCI and not set on Spring AI objects. [[1]](diffhunk://#diff-da8f6d4dda2cdea488544ce57515c88bfa9620847ca6357abccabc8ed01fbd40L201-R214) [[2]](diffhunk://#diff-da8f6d4dda2cdea488544ce57515c88bfa9620847ca6357abccabc8ed01fbd40L223) [[3]](diffhunk://#diff-52c0223a33e7167b94ccaec13493a833123be576a3c8927ba74beeabc1cae69fL113-R121) [[4]](diffhunk://#diff-52c0223a33e7167b94ccaec13493a833123be576a3c8927ba74beeabc1cae69fR166-R169) [[5]](diffhunk://#diff-52c0223a33e7167b94ccaec13493a833123be576a3c8927ba74beeabc1cae69fL175-R190) [[6]](diffhunk://#diff-52c0223a33e7167b94ccaec13493a833123be576a3c8927ba74beeabc1cae69fL257-R270)
* Updated fallback and builder logic to remove references to per-request tool execution flags and related builder methods, relying on model-level configuration for tool execution. [[1]](diffhunk://#diff-da8f6d4dda2cdea488544ce57515c88bfa9620847ca6357abccabc8ed01fbd40L201-R214) [[2]](diffhunk://#diff-67581452551791f621364200f1a91fc89dda8f4d79e9b9970ca6cef459c7b256L316-L317) [[3]](diffhunk://#diff-67581452551791f621364200f1a91fc89dda8f4d79e9b9970ca6cef459c7b256L330-L335) [[4]](diffhunk://#diff-67581452551791f621364200f1a91fc89dda8f4d79e9b9970ca6cef459c7b256L405-R399) [[5]](diffhunk://#diff-0843bf13b6f90fcf25ecdc252e5dee6b3a046234ba2842749c16a10b80ac6416L65)

**Model options and builder API changes:**

* Replaced `.defaultOptions(...)` with `.options(...)` when configuring models, in line with Spring AI 2.0 API changes. [[1]](diffhunk://#diff-04cd9d09b045f18977108fb11a2fc5a552ad255338b3709dd6a35f643fca1c8bL155-R155) [[2]](diffhunk://#diff-2f53e1e66fa129636f8d92238f424e877d49f1f58dfdab7a87ab979c4872661fL153-R153) [[3]](diffhunk://#diff-1d2812b67733da7db801ceb2c239402027be49a7fa21afb4119f5dd6e0e471d4L164-R164) [[4]](diffhunk://#diff-1d2812b67733da7db801ceb2c239402027be49a7fa21afb4119f5dd6e0e471d4L209-R209)
* Updated how embedding options are constructed for Bedrock Cohere embeddings, using the new builder API.

**Test and import updates:**

* Adjusted tests and imports to use the new `ChatOptions` API and to reflect the removal of deprecated classes and methods. [[1]](diffhunk://#diff-a585e56220c813344f0d93db084f12980f76ce91b39bfa969d5c880193fc4281L53-R53) [[2]](diffhunk://#diff-a585e56220c813344f0d93db084f12980f76ce91b39bfa969d5c880193fc4281L196-R196) [[3]](diffhunk://#diff-a585e56220c813344f0d93db084f12980f76ce91b39bfa969d5c880193fc4281L384-R384) [[4]](diffhunk://#diff-845caf7a3a3e704214ae6a36d74ac614d550a83418b2b3a9243388dbd18bec8dL51-R51) [[5]](diffhunk://#diff-7c0727123b11bceed8d2c1c9ed9ee23e671fd82d2bddf2cdd6366be64647a95dL41-R41) [[6]](diffhunk://#diff-67581452551791f621364200f1a91fc89dda8f4d79e9b9970ca6cef459c7b256L41-L44) [[7]](diffhunk://#diff-0843bf13b6f90fcf25ecdc252e5dee6b3a046234ba2842749c16a10b80ac6416L26) [[8]](diffhunk://#diff-229a02cac77bb71c46144b2ef8e846eede222f946902bb52ddcfccb4e7ac0be5L31-R31)

These changes ensure compatibility with Spring AI 2.0 and clean up deprecated or removed APIs, while preserving provider-specific and internal behaviors where necessary.