### PR TITLE
Resolve circular dependencies

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/OperationContext.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/OperationContext.kt
@@ -19,7 +19,7 @@ import com.embabel.agent.api.common.support.DelegatingStreamingPromptRunner
 import com.embabel.agent.api.common.support.OperationContextDelegate
 import com.embabel.agent.api.dsl.TypedAgentScopeBuilder
 import com.embabel.agent.api.event.AgenticEventListener
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.User
 import com.embabel.agent.api.invocation.AgentInvocation
 import com.embabel.agent.api.tool.ToolObject
 import com.embabel.agent.core.Action

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/PromptRunner.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.api.common
 
 import com.embabel.agent.api.common.PromptRunner.Creating
+import com.embabel.agent.core.TerminationScope
 import com.embabel.agent.api.reference.LlmReference
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolCallContext

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/MultiTransformationAction.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/MultiTransformationAction.kt
@@ -16,7 +16,7 @@
 package com.embabel.agent.api.common.support
 
 import com.embabel.agent.api.annotation.support.isStateType
-import com.embabel.agent.api.common.SomeOf
+import com.embabel.agent.core.SomeOf
 import com.embabel.agent.api.common.Transformation
 import com.embabel.agent.api.common.TransformationActionContext
 import com.embabel.agent.api.event.StateTransitionEvent

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/TransformationAction.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/TransformationAction.kt
@@ -15,7 +15,6 @@
  */
 package com.embabel.agent.api.common.support
 
-import com.embabel.agent.api.common.Aggregation
 import com.embabel.agent.api.common.Transformation
 import com.embabel.agent.api.common.TransformationActionContext
 import com.embabel.agent.core.*

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/bindFieldsToBlackboard.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/bindFieldsToBlackboard.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.api.common.support
 
-import com.embabel.agent.api.common.SomeOf
+import com.embabel.agent.core.SomeOf
 import com.embabel.agent.core.Blackboard
 import com.embabel.agent.core.IoBinding
 import org.slf4j.Logger

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/termination/TerminationExtensions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/termination/TerminationExtensions.kt
@@ -17,8 +17,8 @@
 
 package com.embabel.agent.api.termination
 
-import com.embabel.agent.api.common.TerminationScope
-import com.embabel.agent.api.common.TerminationSignal
+import com.embabel.agent.core.TerminationScope
+import com.embabel.agent.core.TerminationSignal
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.EarlyTermination
 import com.embabel.agent.core.EarlyTerminationPolicy

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/TerminationExceptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/TerminationExceptions.kt
@@ -15,6 +15,8 @@
  */
 package com.embabel.agent.api.tool
 
+import com.embabel.agent.core.ToolControlFlowSignal
+
 /**
  * Base class for termination exceptions.
  *

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/TypedTool.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/TypedTool.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.api.tool
 
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.util.function.Function

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionRunner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionRunner.kt
@@ -15,7 +15,6 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.tool.ToolControlFlowSignal
 import com.embabel.agent.core.hitl.AwaitableResponseException
 import com.embabel.common.util.time
 import org.slf4j.LoggerFactory

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/Aggregation.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/Aggregation.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.api.common
+package com.embabel.agent.core
 
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/Blackboard.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/Blackboard.kt
@@ -15,7 +15,6 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.common.Aggregation
 import com.embabel.common.core.types.HasInfoString
 import com.embabel.common.util.findAllSupertypes
 import com.embabel.common.util.loggerFor

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/JvmType.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/JvmType.kt
@@ -15,7 +15,6 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.common.SomeOf
 import com.embabel.common.util.indentLines
 import com.fasterxml.jackson.annotation.JsonClassDescription
 import com.fasterxml.jackson.annotation.JsonCreator

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/LlmInvocation.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/LlmInvocation.kt
@@ -15,7 +15,6 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.common.ToolsStats
 import com.embabel.common.ai.model.LlmMetadata
 import com.embabel.common.core.types.Timed
 import com.embabel.common.core.types.Timestamped

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
@@ -19,7 +19,7 @@ import com.embabel.agent.api.channel.DevNullOutputChannel
 import com.embabel.agent.api.channel.OutputChannel
 import com.embabel.agent.api.common.PlannerType
 import com.embabel.agent.api.event.AgenticEventListener
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.Identities
 import com.embabel.agent.api.tool.ToolCallContext
 
 /**
@@ -154,33 +154,6 @@ data class Budget @JvmOverloads constructor(
 
         @JvmField
         val DEFAULT = Budget()
-
-    }
-
-}
-
-/**
- * Identities associated with an agent process.
- * @param forUser the user for whom the process is running. Can be null.
- * @param runAs the user under which the process is running. Can be null.
- */
-data class Identities
-@JvmOverloads
-constructor(
-    val forUser: User? = null,
-    val runAs: User? = null,
-) {
-
-    fun withForUser(forUser: User?): Identities =
-        this.copy(forUser = forUser)
-
-    fun withRunAs(runAs: User?): Identities =
-        this.copy(runAs = runAs)
-
-    companion object {
-
-        @JvmField
-        val DEFAULT = Identities()
 
     }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ReplanRequestedException.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ReplanRequestedException.kt
@@ -15,7 +15,6 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.tool.ToolControlFlowSignal
 
 /**
  * Callback to update the blackboard before replanning.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/TerminationSignal.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/TerminationSignal.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.api.common
+package com.embabel.agent.core
 
 /**
  * Scope of termination - whether to terminate the current action only

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolConsumer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolConsumer.kt
@@ -15,7 +15,6 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.common.TerminationScope
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.tool.Tool

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolControlFlowSignal.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolControlFlowSignal.kt
@@ -13,19 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.api.tool
+package com.embabel.agent.core
 
 /**
  * Marker interface for exceptions that represent control flow signals
  * rather than errors. These exceptions are allowed to propagate through
- * [TypedTool.call] without being caught and converted to error results.
+ * [com.embabel.agent.api.tool.TypedTool.call] without being caught and converted to error results.
  *
  * Control flow signals are also excluded from retry policies.
  *
  * Examples include:
  * - [com.embabel.agent.core.ReplanRequestedException]
  * - [com.embabel.agent.core.hitl.AwaitableResponseException]
- * - [TerminateActionException]
- * - [TerminateAgentException]
+ * - [com.embabel.agent.api.tool.TerminateActionException]
+ * - [com.embabel.agent.api.tool.TerminateAgentException]
  */
 interface ToolControlFlowSignal

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolGroup.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolGroup.kt
@@ -15,7 +15,6 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.common.TerminationScope
 import com.embabel.agent.api.tool.Tool
 import com.embabel.common.core.types.AssetCoordinates
 import com.embabel.common.core.types.HasInfoString

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolsStats.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ToolsStats.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.api.common
+package com.embabel.agent.core
 
 import com.embabel.common.core.types.HasInfoString
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/wait.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/wait.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.core.hitl
 
-import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.embabel.ux.form.SimpleFormGenerator
 
 /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/identity/Identities.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/identity/Identities.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core.identity
+
+/**
+ * Identities associated with an agent process.
+ * @param forUser the user for whom the process is running. Can be null.
+ * @param runAs the user under which the process is running. Can be null.
+ */
+data class Identities
+@JvmOverloads
+constructor(
+    val forUser: User? = null,
+    val runAs: User? = null,
+) {
+
+    fun withForUser(forUser: User?): Identities =
+        this.copy(forUser = forUser)
+
+    fun withRunAs(runAs: User?): Identities =
+        this.copy(runAs = runAs)
+
+    companion object {
+
+        @JvmField
+        val DEFAULT = Identities()
+
+    }
+
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/identity/User.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/identity/User.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.api.identity
+package com.embabel.agent.core.identity
 
 /**
  * Superinterface for all users in the system.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/identity/UserService.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/identity/UserService.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.api.identity
+package com.embabel.agent.core.identity
 
 /**
  * Common interface for working with users in the system.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
@@ -25,7 +25,6 @@ import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.common.StuckHandlingResultCode
-import com.embabel.agent.api.common.ToolsStats
 import com.embabel.agent.api.event.*
 import com.embabel.agent.api.event.observation.ActionObservationContext
 import com.embabel.agent.api.event.observation.AgentObservationContext

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
@@ -17,8 +17,8 @@
 
 package com.embabel.agent.core.support
 
-import com.embabel.agent.api.common.TerminationScope
-import com.embabel.agent.api.common.TerminationSignal
+import com.embabel.agent.core.TerminationScope
+import com.embabel.agent.core.TerminationSignal
 import com.embabel.agent.api.event.observation.InternalObservabilityApi
 import com.embabel.agent.api.termination.TerminationSignalPolicy
 import com.embabel.agent.api.tool.TerminateActionException

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/SimpleAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/SimpleAgentProcess.kt
@@ -21,7 +21,7 @@ import com.embabel.agent.api.event.GoalAchievedEvent
 import com.embabel.agent.api.event.ReplanRequestedEvent
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
-import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.embabel.agent.core.Action
 import com.embabel.agent.core.Agent
 import com.embabel.agent.core.AgentProcess

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/common/RetryProperties.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.spi.common
 
-import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.embabel.agent.spi.support.LlmDataBindingProperties.Companion.isRateLimitError
 import com.embabel.agent.spi.support.springai.SpringAiRetryPolicy
 import com.embabel.common.util.loggerFor

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
@@ -20,7 +20,7 @@ import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.core.support.AbstractAgentProcess
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolCallContext
-import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.embabel.agent.api.tool.callback.AfterToolCallContext
 import com.embabel.agent.api.tool.callback.BeforeToolCallContext
 import com.embabel.agent.api.tool.callback.ToolCallInspector

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.spi.loop.support
 
-import com.embabel.agent.api.common.TerminationScope
+import com.embabel.agent.core.TerminationScope
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.core.support.AbstractAgentProcess
 import com.embabel.agent.api.tool.Tool

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoop.kt
@@ -20,7 +20,7 @@ import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolCallContext
-import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.embabel.agent.api.tool.callback.ToolCallInspector
 import com.embabel.agent.api.tool.callback.ToolLoopInspector
 import com.embabel.agent.api.tool.callback.ToolLoopTransformer

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AgenticEventListenerToolsStats.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AgenticEventListenerToolsStats.kt
@@ -15,8 +15,8 @@
  */
 package com.embabel.agent.spi.support
 
-import com.embabel.agent.api.common.ToolStats
-import com.embabel.agent.api.common.ToolsStats
+import com.embabel.agent.core.ToolStats
+import com.embabel.agent.core.ToolsStats
 import com.embabel.agent.api.event.AgentProcessEvent
 import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.api.event.ToolCallResponseEvent

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.spi.support
 
-import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.embabel.agent.api.validation.guardrails.GuardRailViolationException
 import com.embabel.agent.core.ReplanRequestedException
 import com.embabel.agent.spi.common.RetryTemplateProvider

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolDecorators.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolDecorators.kt
@@ -19,7 +19,7 @@ import com.embabel.agent.api.event.ToolCallRequestEvent
 import com.embabel.agent.api.tool.DelegatingTool
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolCallContext
-import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.embabel.agent.core.Action
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.ToolGroupMetadata

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
@@ -17,7 +17,7 @@ package com.embabel.agent.spi.support.springai
 
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
-import com.embabel.agent.api.tool.ToolControlFlowSignal
+import com.embabel.agent.core.ToolControlFlowSignal
 import com.embabel.agent.core.NonRetryable
 import com.embabel.agent.core.ReplanRequestedException
 import com.embabel.agent.core.Retryable

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/ChatSession.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/ChatSession.kt
@@ -17,7 +17,7 @@ package com.embabel.chat
 
 import com.embabel.agent.api.channel.MessageOutputChannelEvent
 import com.embabel.agent.api.channel.OutputChannel
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.User
 
 /**
  * Simplest possible conversation session implementation

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/ChatTrigger.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/ChatTrigger.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.chat
 
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.User
 
 /**
  * System-initiated event that triggers a chatbot response without entering the conversation.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/Chatbot.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/Chatbot.kt
@@ -16,7 +16,7 @@
 package com.embabel.chat
 
 import com.embabel.agent.api.channel.OutputChannel
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.User
 import com.embabel.agent.core.Budget
 
 /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/Conversation.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/Conversation.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.chat
 
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.User
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.core.StableIdentified
 import com.embabel.common.core.types.HasInfoString

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/ConversationFactory.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/ConversationFactory.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.chat
 
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.User
 
 /**
  * Type of conversation storage.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/agent/AgentProcessChatbot.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/agent/AgentProcessChatbot.kt
@@ -20,7 +20,8 @@ import com.embabel.agent.api.channel.OutputChannel
 import com.embabel.agent.api.common.PlannerType
 import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.api.event.progress.OutputChannelHighlightingEventListener
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.Identities
+import com.embabel.agent.core.identity.User
 import com.embabel.agent.api.invocation.UtilityInvocation
 import com.embabel.agent.core.*
 import com.embabel.chat.ChatSession

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/termination/TerminationJavaTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/termination/TerminationJavaTest.java
@@ -15,8 +15,8 @@
  */
 package com.embabel.agent.api.termination;
 
-import com.embabel.agent.api.common.TerminationScope;
-import com.embabel.agent.api.common.TerminationSignal;
+import com.embabel.agent.core.TerminationScope;
+import com.embabel.agent.core.TerminationSignal;
 import com.embabel.agent.api.tool.TerminateActionException;
 import com.embabel.agent.api.tool.TerminateAgentException;
 import com.embabel.agent.api.tool.TerminationException;

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/termination/TerminationJavaTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/termination/TerminationJavaTest.java
@@ -20,7 +20,7 @@ import com.embabel.agent.api.common.TerminationSignal;
 import com.embabel.agent.api.tool.TerminateActionException;
 import com.embabel.agent.api.tool.TerminateAgentException;
 import com.embabel.agent.api.tool.TerminationException;
-import com.embabel.agent.api.tool.ToolControlFlowSignal;
+import com.embabel.agent.core.ToolControlFlowSignal;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/embabel-agent-api/src/test/java/com/embabel/agent/core/ProcessOptionsBuilderTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/core/ProcessOptionsBuilderTest.java
@@ -19,6 +19,7 @@ import com.embabel.agent.api.channel.DevNullOutputChannel;
 import com.embabel.agent.api.channel.OutputChannel;
 import com.embabel.agent.api.common.PlannerType;
 import com.embabel.agent.api.event.AgenticEventListener;
+import com.embabel.agent.core.identity.Identities;
 import com.embabel.agent.core.support.InMemoryBlackboard;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/embabel-agent-api/src/test/java/com/embabel/chat/ChatbotJavaTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/chat/ChatbotJavaTest.java
@@ -17,7 +17,7 @@ package com.embabel.chat;
 
 import com.embabel.agent.api.channel.DevNullOutputChannel;
 import com.embabel.agent.api.channel.OutputChannel;
-import com.embabel.agent.api.identity.User;
+import com.embabel.agent.core.identity.User;
 import com.embabel.agent.core.Budget;
 import com.embabel.chat.support.InMemoryConversation;
 import org.jetbrains.annotations.NotNull;

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
@@ -25,7 +25,7 @@ import com.embabel.agent.api.annotation.RequireNameMatch
 import com.embabel.agent.api.common.ActionContext
 import com.embabel.agent.api.common.Ai
 import com.embabel.agent.api.common.OperationContext
-import com.embabel.agent.api.common.SomeOf
+import com.embabel.agent.core.SomeOf
 import com.embabel.agent.api.common.TransformationActionContext
 import com.embabel.agent.api.common.createObject
 import com.embabel.agent.api.dsl.Frog

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/BindFieldsToBlackboardTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/BindFieldsToBlackboardTest.kt
@@ -16,7 +16,7 @@
 package com.embabel.agent.api.common.support
 
 import com.embabel.agent.api.annotation.support.PersonWithReverseTool
-import com.embabel.agent.api.common.SomeOf
+import com.embabel.agent.core.SomeOf
 import com.embabel.agent.core.support.InMemoryBlackboard
 import com.embabel.agent.support.Dog
 import com.embabel.common.util.loggerFor

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingPromptRunnerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/DelegatingStreamingPromptRunnerTest.kt
@@ -17,7 +17,7 @@ package com.embabel.agent.api.common.support
 
 import com.embabel.agent.api.common.AgentImage
 import com.embabel.agent.api.common.InteractionId
-import com.embabel.agent.api.common.TerminationScope
+import com.embabel.agent.core.TerminationScope
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolCallContext
 import com.embabel.agent.api.tool.ToolObject

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ToolConsumerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ToolConsumerTest.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.common.TerminationScope
+import com.embabel.agent.core.TerminationScope
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.tool.Tool

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ToolGroupTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ToolGroupTest.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.core
 
-import com.embabel.agent.api.common.TerminationScope
+import com.embabel.agent.core.TerminationScope
 import com.embabel.agent.api.tool.Tool
 import com.embabel.common.core.types.Semver
 import org.junit.jupiter.api.Assertions.*

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ToolsStatsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/ToolsStatsTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.api.common
+package com.embabel.agent.core
 
 import io.mockk.every
 import io.mockk.mockk

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/ToolLoopTerminationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/ToolLoopTerminationTest.kt
@@ -15,8 +15,8 @@
  */
 package com.embabel.agent.spi.loop
 
-import com.embabel.agent.api.common.TerminationScope
-import com.embabel.agent.api.common.TerminationSignal
+import com.embabel.agent.core.TerminationScope
+import com.embabel.agent.core.TerminationSignal
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.tool.Tool

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoopTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoopTest.kt
@@ -15,8 +15,8 @@
  */
 package com.embabel.agent.spi.loop.support
 
-import com.embabel.agent.api.common.TerminationScope
-import com.embabel.agent.api.common.TerminationSignal
+import com.embabel.agent.core.TerminationScope
+import com.embabel.agent.core.TerminationSignal
 import com.embabel.agent.api.tool.TerminateActionException
 import com.embabel.agent.api.tool.TerminateAgentException
 import com.embabel.agent.api.tool.Tool

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsGuardRailTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsGuardRailTest.kt
@@ -19,7 +19,7 @@ package com.embabel.agent.spi.support
 
 import com.embabel.agent.api.annotation.support.Wumpus
 import com.embabel.agent.api.common.InteractionId
-import com.embabel.agent.api.common.ToolsStats
+import com.embabel.agent.core.ToolsStats
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.event.observation.InternalObservabilityApi
 import com.embabel.agent.api.tool.ToolObject

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmTransformerTest.kt
@@ -19,7 +19,7 @@ package com.embabel.agent.spi.support
 
 import com.embabel.agent.api.common.InteractionId
 import com.embabel.agent.api.common.PlatformServices
-import com.embabel.agent.api.common.ToolsStats
+import com.embabel.agent.core.ToolsStats
 import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.api.event.LlmInvocationEvent
 import com.embabel.agent.api.event.observation.InternalObservabilityApi

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsGuardRailTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperationsGuardRailTest.kt
@@ -18,7 +18,7 @@
 package com.embabel.agent.spi.support.springai.streaming
 
 import com.embabel.agent.api.common.InteractionId
-import com.embabel.agent.api.common.ToolsStats
+import com.embabel.agent.core.ToolsStats
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.event.observation.InternalObservabilityApi
 import com.embabel.agent.api.validation.guardrails.GuardRailViolationException

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/BlackboardWorldStateDeterminerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/BlackboardWorldStateDeterminerTest.kt
@@ -17,7 +17,6 @@ package com.embabel.agent.support
 
 import com.embabel.agent.api.annotation.support.PersonWithReverseTool
 import com.embabel.agent.api.channel.DevNullOutputChannel
-import com.embabel.agent.api.common.Aggregation
 import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.dsl.agent
 import com.embabel.agent.core.*

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/LlmInvocationHistoryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/support/LlmInvocationHistoryTest.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.support
 
-import com.embabel.agent.api.common.ToolsStats
+import com.embabel.agent.core.ToolsStats
 import com.embabel.agent.core.LlmInvocation
 import com.embabel.agent.core.LlmInvocationHistory
 import com.embabel.agent.spi.support.springai.toEmbabelUsage

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/ChatSessionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/ChatSessionTest.kt
@@ -19,7 +19,7 @@ import com.embabel.agent.api.channel.MessageOutputChannelEvent
 import com.embabel.agent.api.channel.OutputChannel
 import com.embabel.agent.api.channel.OutputChannelEvent
 import com.embabel.agent.api.reference.LlmReference
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.User
 import com.embabel.agent.core.hitl.ConfirmationRequest
 import com.embabel.chat.support.InMemoryConversation
 import org.assertj.core.api.Assertions.assertThat

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/ConversationFactoryProviderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/ConversationFactoryProviderTest.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.chat
 
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.User
 import com.embabel.chat.support.InMemoryConversation
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/ConversationFactoryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/ConversationFactoryTest.kt
@@ -46,7 +46,7 @@ class ConversationFactoryTest {
 
         val result = factory.createForParticipants(
             id = "test-id",
-            user = com.embabel.agent.api.identity.SimpleUser(
+            user = com.embabel.agent.core.identity.SimpleUser(
                 id = "user-1",
                 displayName = "Test User",
                 username = "testuser",

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/ConversationMethodsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/ConversationMethodsTest.kt
@@ -15,8 +15,8 @@
  */
 package com.embabel.chat
 
-import com.embabel.agent.api.identity.SimpleUser
-import com.embabel.agent.api.identity.User
+import com.embabel.agent.core.identity.SimpleUser
+import com.embabel.agent.core.identity.User
 import com.embabel.chat.support.InMemoryConversation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/agent/AgentProcessChatbotTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/agent/AgentProcessChatbotTest.kt
@@ -16,7 +16,7 @@
 package com.embabel.chat.agent
 
 import com.embabel.agent.api.channel.DevNullOutputChannel
-import com.embabel.agent.api.identity.SimpleUser
+import com.embabel.agent.core.identity.SimpleUser
 import com.embabel.agent.core.Agent
 import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcess

--- a/embabel-agent-autoconfigure/embabel-agent-shell-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/shell/AgentShellAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-shell-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/shell/AgentShellAutoConfigurationTest.java
@@ -16,7 +16,7 @@
 package com.embabel.agent.autoconfigure.shell;
 
 import com.embabel.agent.api.common.Asyncer;
-import com.embabel.agent.api.common.ToolsStats;
+import com.embabel.agent.core.ToolsStats;
 import com.embabel.agent.api.common.autonomy.Autonomy;
 import com.embabel.agent.core.AgentPlatform;
 import com.embabel.agent.shell.TerminalServices;

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt
@@ -16,7 +16,7 @@
 package com.embabel.agent.shell
 
 import com.embabel.agent.api.common.Asyncer
-import com.embabel.agent.api.common.ToolsStats
+import com.embabel.agent.core.ToolsStats
 import com.embabel.agent.api.common.autonomy.*
 import com.embabel.agent.api.tool.ToolCallContext
 import com.embabel.agent.core.*

--- a/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/ShellCommandsContextTest.kt
+++ b/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/ShellCommandsContextTest.kt
@@ -15,7 +15,7 @@
  */
 package com.embabel.agent.shell
 
-import com.embabel.agent.api.common.ToolsStats
+import com.embabel.agent.core.ToolsStats
 import com.embabel.agent.api.common.autonomy.Autonomy
 import com.embabel.agent.api.common.autonomy.AutonomyProperties
 import com.embabel.agent.api.common.autonomy.NoAgentFound

--- a/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/test/type/testTypes.kt
+++ b/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/test/type/testTypes.kt
@@ -24,7 +24,7 @@ import com.embabel.agent.api.annotation.LlmTool
 import com.embabel.agent.api.annotation.RequireNameMatch
 import com.embabel.agent.api.common.ActionContext
 import com.embabel.agent.api.common.OperationContext
-import com.embabel.agent.api.common.SomeOf
+import com.embabel.agent.core.SomeOf
 import com.embabel.agent.api.common.TransformationActionContext
 import com.embabel.agent.api.common.createObject
 import com.embabel.agent.api.dsl.chain


### PR DESCRIPTION
This PR resolves several circular dependencies between the `core` and `api` package. See individual commits for more information.

See #1024 