### PR TITLE
Add ConfirmationAwareTool for LLM-driven confirmation

### DIFF
--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -126,6 +126,12 @@
             <version>0.3.2.Final</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jakarta-validation</artifactId>
+            <version>4.38.0</version>
+        </dependency>
+
         <!-- SpotBugs annotations for thread-safety documentation (@ThreadSafe, @GuardedBy) -->
         <dependency>
             <groupId>com.github.spotbugs</groupId>

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/TypeBasedInputSchema.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/TypeBasedInputSchema.kt
@@ -15,9 +15,12 @@
  */
 package com.embabel.agent.api.tool
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaType
 
 /**
@@ -29,13 +32,19 @@ class TypeBasedInputSchema(
 ) : Tool.InputSchema {
 
     companion object {
-        private val objectMapper = ObjectMapper()
-
         @JvmStatic
         fun of(type: Class<*>): TypeBasedInputSchema = TypeBasedInputSchema(type)
 
         @JvmStatic
         fun of(type: KClass<*>): TypeBasedInputSchema = TypeBasedInputSchema(type.java)
+
+        private fun propertyDescription(prop: KProperty1<*, *>): String =
+            prop.javaField?.getAnnotation(JsonPropertyDescription::class.java)?.value
+                ?: prop.findAnnotation<JsonPropertyDescription>()?.value
+                ?: prop.name
+
+        private fun fieldDescription(field: java.lang.reflect.Field): String =
+            field.getAnnotation(JsonPropertyDescription::class.java)?.value ?: field.name
 
         private fun mapPropertyTypeToParameterType(type: Class<*>): Tool.ParameterType = when {
             type == String::class.java || type == java.lang.String::class.java ->
@@ -63,46 +72,22 @@ class TypeBasedInputSchema(
         extractParameters()
     }
 
-    override fun toJsonSchema(): String {
-        val parameterInfos = mutableListOf<VictoolsSchemaGenerator.ParameterInfo>()
+    override fun toJsonSchema(): String =
+        VictoolsSchemaGenerator.generateClassInputSchema(type, requiredFieldNames())
 
-        try {
-            // Skip Kotlin reflection for Java records - go straight to fallback
-            if (type.isRecord) {
-                throw UnsupportedOperationException("Java records require fallback reflection")
-            }
-
-            val kClass = type.kotlin
-            for (prop in kClass.memberProperties) {
-                // Use javaType to get the full generic type (e.g., List<String> not just List)
-                val javaType = prop.returnType.javaType
-                parameterInfos.add(
-                    VictoolsSchemaGenerator.ParameterInfo(
-                        name = prop.name,
-                        type = javaType,
-                        description = prop.name,
-                        required = !prop.returnType.isMarkedNullable,
-                    )
-                )
-            }
+    private fun requiredFieldNames(): Set<String> {
+        return try {
+            if (type.isRecord) throw UnsupportedOperationException()
+            type.kotlin.memberProperties
+                .filter { !it.returnType.isMarkedNullable }
+                .map { it.name }
+                .toSet()
         } catch (e: Exception) {
-            // Fallback for non-Kotlin classes or reflection failures
-            // For Java classes, try to get generic type info from fields
-            for (field in type.declaredFields) {
-                if (java.lang.reflect.Modifier.isStatic(field.modifiers)) continue
-                parameterInfos.add(
-                    VictoolsSchemaGenerator.ParameterInfo(
-                        name = field.name,
-                        type = field.genericType, // Use genericType for full type info
-                        description = field.name,
-                        required = true,
-                    )
-                )
-            }
+            type.declaredFields
+                .filter { !java.lang.reflect.Modifier.isStatic(it.modifiers) }
+                .map { it.name }
+                .toSet()
         }
-
-        // Use victools to generate schema with proper generic handling
-        return VictoolsSchemaGenerator.generateToolInputSchema(parameterInfos)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -122,7 +107,7 @@ class TypeBasedInputSchema(
                     Tool.Parameter(
                         name = prop.name,
                         type = mapPropertyTypeToParameterType(propType),
-                        description = prop.name,
+                        description = propertyDescription(prop),
                         required = !prop.returnType.isMarkedNullable,
                     )
                 )
@@ -135,7 +120,7 @@ class TypeBasedInputSchema(
                     Tool.Parameter(
                         name = field.name,
                         type = mapPropertyTypeToParameterType(field.type),
-                        description = field.name,
+                        description = fieldDescription(field),
                         required = true,
                     )
                 )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/VictoolsSchemaGenerator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/VictoolsSchemaGenerator.kt
@@ -24,6 +24,8 @@ import com.github.victools.jsonschema.generator.OptionPreset
 import com.github.victools.jsonschema.generator.SchemaGenerator
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
 import com.github.victools.jsonschema.generator.SchemaVersion
+import com.github.victools.jsonschema.module.jackson.JacksonModule
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule
 import org.jetbrains.annotations.ApiStatus
 import java.lang.reflect.Method
 import java.lang.reflect.Type
@@ -42,10 +44,19 @@ internal object VictoolsSchemaGenerator {
             SchemaVersion.DRAFT_2020_12,
             OptionPreset.PLAIN_JSON
         )
-        // Don't include $schema and $id in generated schemas
         configBuilder.without(Option.SCHEMA_VERSION_INDICATOR)
-        val config = configBuilder.build()
-        SchemaGenerator(config)
+        SchemaGenerator(configBuilder.build())
+    }
+
+    private val jacksonAwareSchemaGenerator: SchemaGenerator by lazy {
+        val configBuilder = SchemaGeneratorConfigBuilder(
+            SchemaVersion.DRAFT_2020_12,
+            OptionPreset.PLAIN_JSON
+        )
+        configBuilder.without(Option.SCHEMA_VERSION_INDICATOR)
+        configBuilder.with(JacksonModule())
+        configBuilder.with(JakartaValidationModule())
+        SchemaGenerator(configBuilder.build())
     }
 
     /**
@@ -93,6 +104,27 @@ internal object VictoolsSchemaGenerator {
         }
 
         return objectMapper.writeValueAsString(rootNode)
+    }
+
+    /**
+     * Generate a complete tool input schema for a class, reading field descriptions from
+     * [com.fasterxml.jackson.annotation.JsonPropertyDescription] annotations via the
+     * victools Jackson module.
+     *
+     * @param type The class to generate the schema for
+     * @param requiredFields Names of fields that should be marked required in the schema
+     * @return JSON schema string
+     */
+    fun generateClassInputSchema(type: Class<*>, requiredFields: Set<String>): String {
+        val schema = jacksonAwareSchemaGenerator.generateSchema(type).deepCopy() as ObjectNode
+        if (requiredFields.isEmpty()) {
+            schema.remove("required")
+        } else {
+            val requiredArray = objectMapper.createArrayNode()
+            requiredFields.sorted().forEach { requiredArray.add(it) }
+            schema.set<JsonNode>("required", requiredArray)
+        }
+        return objectMapper.writeValueAsString(schema)
     }
 
     /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/AwaitingTools.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/hitl/AwaitingTools.kt
@@ -19,6 +19,9 @@ import com.embabel.agent.api.tool.DelegatingTool
 import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.api.tool.ToolCallContext
 import com.embabel.agent.core.AgentProcess
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 
 /**
  * Context provided to awaiting decision functions.
@@ -142,6 +145,80 @@ class TypeRequestingTool<T : Any>(
     }
 }
 
+/**
+ * Tool decorator that enables the LLM to resolve a [ConfirmationRequest] autonomously,
+ * without requiring a separate human-provided [ConfirmationResponse].
+ *
+ * **Flow:**
+ * 1. First call (no pending confirmation): throws [AwaitableResponseException] with a
+ *    [ConfirmationRequest], pausing the agent.
+ * 2. Subsequent call (confirmation pending): the tool's schema dynamically adds an `accepted`
+ *    boolean. The LLM provides `accepted=true` (optionally with updated parameters) or
+ *    `accepted=false` to cancel. The tool records a [ConfirmationResponse] and either
+ *    delegates execution or returns a cancellation message.
+ *
+ * @param delegate The tool to wrap
+ * @param messageProvider Function to generate the confirmation message from input
+ * @param objectMapper ObjectMapper for JSON manipulation
+ */
+class ConfirmationAwareTool @JvmOverloads constructor(
+    override val delegate: Tool,
+    private val messageProvider: (String) -> String,
+    private val objectMapper: ObjectMapper = jacksonObjectMapper(),
+) : DelegatingTool {
+
+    private val pendingDefinition: Tool.Definition = delegate.definition.withParameter(
+        Tool.Parameter(
+            name = "accepted",
+            type = Tool.ParameterType.BOOLEAN,
+            description = "Confirm (true) to proceed, or cancel (false) to abort",
+            required = true,
+        )
+    )
+
+    override val definition: Tool.Definition
+        get() = if (isPending()) pendingDefinition else delegate.definition
+
+    override val metadata: Tool.Metadata = delegate.metadata
+
+    override fun call(input: String, context: ToolCallContext): Tool.Result {
+        return if (isPending()) {
+            handleConfirmation(input, context)
+        } else {
+            throw AwaitableResponseException(
+                ConfirmationRequest(payload = input, message = messageProvider(input))
+            )
+        }
+    }
+
+    private fun handleConfirmation(input: String, context: ToolCallContext): Tool.Result {
+        val agentProcess = AgentProcess.get()
+            ?: throw IllegalStateException("No AgentProcess available for ConfirmationAwareTool")
+        val pending = agentProcess.last(ConfirmationRequest::class.java)
+            ?: throw IllegalStateException("No pending ConfirmationRequest found")
+
+        val node = objectMapper.readTree(input) as ObjectNode
+        val accepted = node.path("accepted").asBoolean(true)
+        node.remove("accepted")
+
+        agentProcess += ConfirmationResponse(awaitableId = pending.id, accepted = accepted)
+
+        return if (accepted) {
+            val effectiveInput = if (node.isEmpty) pending.payload as String else objectMapper.writeValueAsString(node)
+            delegate.call(effectiveInput, context)
+        } else {
+            Tool.Result.text("Action cancelled.")
+        }
+    }
+
+    private fun isPending(): Boolean {
+        val agentProcess = AgentProcess.get() ?: return false
+        val pending = agentProcess.last(ConfirmationRequest::class.java) ?: return false
+        val response = agentProcess.last(ConfirmationResponse::class.java)
+        return response == null || response.awaitableId != pending.id
+    }
+}
+
 // Extension functions for fluent tool decoration
 
 /**
@@ -188,3 +265,19 @@ fun <T : Any> Tool.requireType(
  */
 inline fun <reified T : Any> Tool.requireType(message: String? = null): Tool =
     TypeRequestingTool(this, T::class.java) { message }
+
+/**
+ * Wrap this tool so the LLM can confirm or cancel before execution.
+ *
+ * @param messageProvider Function to generate the confirmation message from input
+ */
+fun Tool.withLlmConfirmation(messageProvider: (String) -> String): Tool =
+    ConfirmationAwareTool(this, messageProvider)
+
+/**
+ * Wrap this tool so the LLM can confirm or cancel before execution.
+ *
+ * @param message Static confirmation message
+ */
+fun Tool.withLlmConfirmation(message: String): Tool =
+    ConfirmationAwareTool(this, { message })

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/tool/JavaAnnotatedRecord.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/tool/JavaAnnotatedRecord.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.tool;
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+public record JavaAnnotatedRecord(
+        @JsonPropertyDescription("The task title")
+        String title,
+        @JsonPropertyDescription("Priority level")
+        int priority,
+        String noDescription
+) {}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/TypeBasedInputSchemaTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/TypeBasedInputSchemaTest.kt
@@ -15,6 +15,8 @@
  */
 package com.embabel.agent.api.tool
 
+import com.embabel.agent.api.tool.JavaAnnotatedRecord
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
@@ -313,6 +315,61 @@ class TypeBasedInputSchemaTest {
      * Tests for array/list schemas - OpenAI requires `items` property for arrays.
      * See: https://platform.openai.com/docs/guides/function-calling
      */
+    data class AnnotatedKotlinClass(
+        @field:JsonPropertyDescription("The user's full name")
+        val name: String,
+        @field:JsonPropertyDescription("Age in years")
+        val age: Int,
+        val noDescription: String,
+    )
+
+    @Nested
+    inner class JsonPropertyDescriptionTest {
+
+        @Test
+        fun `uses JsonPropertyDescription annotation as description in parameters`() {
+            val schema = TypeBasedInputSchema.of(AnnotatedKotlinClass::class.java)
+
+            val nameParam = schema.parameters.find { it.name == "name" }
+            assertNotNull(nameParam)
+            assertEquals("The user's full name", nameParam!!.description)
+
+            val ageParam = schema.parameters.find { it.name == "age" }
+            assertNotNull(ageParam)
+            assertEquals("Age in years", ageParam!!.description)
+        }
+
+        @Test
+        fun `falls back to field name when no JsonPropertyDescription`() {
+            val schema = TypeBasedInputSchema.of(AnnotatedKotlinClass::class.java)
+
+            val param = schema.parameters.find { it.name == "noDescription" }
+            assertNotNull(param)
+            assertEquals("noDescription", param!!.description)
+        }
+
+        @Test
+        fun `uses JsonPropertyDescription in generated JSON schema`() {
+            val schema = TypeBasedInputSchema.of(AnnotatedKotlinClass::class.java)
+
+            val jsonSchema = schema.toJsonSchema()
+            val parsed = objectMapper.readTree(jsonSchema)
+            val properties = parsed.get("properties")
+
+            assertEquals("The user's full name", properties.get("name").get("description").asText())
+            assertEquals("Age in years", properties.get("age").get("description").asText())
+        }
+
+        @Test
+        fun `uses JsonPropertyDescription for Java class fields`() {
+            val schema = TypeBasedInputSchema.of(JavaAnnotatedRecord::class.java)
+
+            val param = schema.parameters.find { it.name == "title" }
+            assertNotNull(param)
+            assertEquals("The task title", param!!.description)
+        }
+    }
+
     @Nested
     inner class ArrayItemsSchemaTest {
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/VictoolsSchemaGeneratorTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/VictoolsSchemaGeneratorTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.tool
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class VictoolsSchemaGeneratorTest {
+
+    private val objectMapper = jacksonObjectMapper()
+
+    data class SimpleInput(val name: String, val age: Int)
+
+    data class NullableInput(val required: String, val optional: String?)
+
+    data class AnnotatedInput(
+        @field:JsonPropertyDescription("The user's full name")
+        val name: String,
+        val count: Int,
+    )
+
+    data class ListInput(val tags: List<String>, val scores: List<Double>)
+
+    data class ValidatedInput(
+        @field:Size(min = 1, max = 100)
+        val name: String,
+        @field:Min(0) @field:Max(150)
+        val age: Int,
+        @field:NotNull
+        val required: String,
+    )
+
+    @Nested
+    inner class GenerateSchemaForTypeTest {
+
+        @Test
+        fun `string type produces string schema`() {
+            val schema = VictoolsSchemaGenerator.generateSchemaForType(String::class.java)
+            assertEquals("string", schema.get("type").asText())
+        }
+
+        @Test
+        fun `int type produces integer schema`() {
+            val schema = VictoolsSchemaGenerator.generateSchemaForType(Int::class.java)
+            assertEquals("integer", schema.get("type").asText())
+        }
+
+        @Test
+        fun `List of String produces array schema with string items`() {
+            val listOfStringType = object : com.fasterxml.jackson.core.type.TypeReference<List<String>>() {}.type
+            val schema = VictoolsSchemaGenerator.generateSchemaForType(listOfStringType)
+            assertEquals("array", schema.get("type").asText())
+            assertEquals("string", schema.get("items").get("type").asText())
+        }
+    }
+
+    @Nested
+    inner class GenerateToolInputSchemaTest {
+
+        @Test
+        fun `produces valid object schema`() {
+            val params = listOf(
+                VictoolsSchemaGenerator.ParameterInfo("name", String::class.java, "the name", true),
+                VictoolsSchemaGenerator.ParameterInfo("age", Int::class.java, "the age", false),
+            )
+            val json = objectMapper.readTree(VictoolsSchemaGenerator.generateToolInputSchema(params))
+            assertEquals("object", json.get("type").asText())
+            assertTrue(json.get("properties").has("name"))
+            assertTrue(json.get("properties").has("age"))
+        }
+
+        @Test
+        fun `required array contains only required params`() {
+            val params = listOf(
+                VictoolsSchemaGenerator.ParameterInfo("a", String::class.java, "a", true),
+                VictoolsSchemaGenerator.ParameterInfo("b", String::class.java, "b", false),
+            )
+            val json = objectMapper.readTree(VictoolsSchemaGenerator.generateToolInputSchema(params))
+            val required = json.get("required").map { it.asText() }
+            assertTrue(required.contains("a"))
+            assertFalse(required.contains("b"))
+        }
+
+        @Test
+        fun `description is included in property schema`() {
+            val params = listOf(
+                VictoolsSchemaGenerator.ParameterInfo("x", String::class.java, "my description", true),
+            )
+            val json = objectMapper.readTree(VictoolsSchemaGenerator.generateToolInputSchema(params))
+            assertEquals("my description", json.get("properties").get("x").get("description").asText())
+        }
+    }
+
+    @Nested
+    inner class GenerateClassInputSchemaTest {
+
+        @Test
+        fun `produces object schema with all properties`() {
+            val json = objectMapper.readTree(
+                VictoolsSchemaGenerator.generateClassInputSchema(SimpleInput::class.java, setOf("name", "age"))
+            )
+            assertEquals("object", json.get("type").asText())
+            assertTrue(json.get("properties").has("name"))
+            assertTrue(json.get("properties").has("age"))
+        }
+
+        @Test
+        fun `required array reflects provided required fields`() {
+            val json = objectMapper.readTree(
+                VictoolsSchemaGenerator.generateClassInputSchema(NullableInput::class.java, setOf("required"))
+            )
+            val required = json.get("required").map { it.asText() }
+            assertEquals(listOf("required"), required)
+        }
+
+        @Test
+        fun `no required array when requiredFields is empty`() {
+            val json = objectMapper.readTree(
+                VictoolsSchemaGenerator.generateClassInputSchema(SimpleInput::class.java, emptySet())
+            )
+            assertNull(json.get("required"))
+        }
+
+        @Test
+        fun `picks up JsonPropertyDescription from annotated field`() {
+            val json = objectMapper.readTree(
+                VictoolsSchemaGenerator.generateClassInputSchema(AnnotatedInput::class.java, setOf("name", "count"))
+            )
+            assertEquals("The user's full name", json.get("properties").get("name").get("description").asText())
+        }
+
+        @Test
+        fun `List properties have array schema with items`() {
+            val json = objectMapper.readTree(
+                VictoolsSchemaGenerator.generateClassInputSchema(ListInput::class.java, setOf("tags", "scores"))
+            )
+            assertEquals("array", json.get("properties").get("tags").get("type").asText())
+            assertEquals("string", json.get("properties").get("tags").get("items").get("type").asText())
+        }
+    }
+
+    @Nested
+    inner class JakartaValidationTest {
+
+        @Test
+        fun `@Size adds minLength and maxLength to string property`() {
+            val json = objectMapper.readTree(
+                VictoolsSchemaGenerator.generateClassInputSchema(ValidatedInput::class.java, emptySet())
+            )
+            val nameProp = json.get("properties").get("name")
+            assertEquals(1, nameProp.get("minLength").asInt())
+            assertEquals(100, nameProp.get("maxLength").asInt())
+        }
+
+        @Test
+        fun `@Min and @Max add minimum and maximum to numeric property`() {
+            val json = objectMapper.readTree(
+                VictoolsSchemaGenerator.generateClassInputSchema(ValidatedInput::class.java, emptySet())
+            )
+            val ageProp = json.get("properties").get("age")
+            assertEquals(0, ageProp.get("minimum").asInt())
+            assertEquals(150, ageProp.get("maximum").asInt())
+        }
+
+        @Test
+        fun `@NotNull marks field as required via Jakarta module`() {
+            val json = objectMapper.readTree(
+                VictoolsSchemaGenerator.generateClassInputSchema(ValidatedInput::class.java, setOf("required"))
+            )
+            val required = json.get("required").map { it.asText() }
+            assertTrue(required.contains("required"))
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/hitl/AwaitingToolsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/hitl/AwaitingToolsTest.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.AgentProcess
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -234,6 +235,157 @@ class AwaitingToolsTest {
             val request = exception.awaitable as TypeRequest<*>
             assertEquals(PaymentDetails::class.java, request.type)
             assertEquals("Enter payment", request.message)
+        }
+    }
+
+    @Nested
+    inner class ConfirmationAwareToolTest {
+
+        @Test
+        fun `throws AwaitableResponseException when no confirmation pending`() {
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns null
+            val delegate = createMockTool()
+            val tool = ConfirmationAwareTool(delegate, { "Please confirm?" })
+
+            val exception = assertThrows<AwaitableResponseException> {
+                tool.call("{}")
+            }
+
+            assertInstanceOf(ConfirmationRequest::class.java, exception.awaitable)
+            assertEquals("Please confirm?", (exception.awaitable as ConfirmationRequest<*>).message)
+        }
+
+        @Test
+        fun `message provider receives input when awaiting`() {
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns null
+            val delegate = createMockTool()
+            var receivedInput: String? = null
+            val tool = ConfirmationAwareTool(delegate, { input ->
+                receivedInput = input
+                "Confirm?"
+            })
+
+            assertThrows<AwaitableResponseException> { tool.call("{\"key\": \"val\"}") }
+
+            assertEquals("{\"key\": \"val\"}", receivedInput)
+        }
+
+        @Test
+        fun `definition uses delegate schema when no confirmation pending`() {
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns null
+            val delegate = createMockTool("my_tool")
+            val tool = ConfirmationAwareTool(delegate, { "Confirm?" })
+
+            assertEquals("my_tool", tool.definition.name)
+            assertFalse(tool.definition.inputSchema.parameters.any { it.name == "accepted" })
+        }
+
+        @Test
+        fun `definition includes accepted parameter when confirmation pending`() {
+            val pendingRequest = ConfirmationRequest("{}", "Confirm?")
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns pendingRequest
+            every { mockAgentProcess.last(ConfirmationResponse::class.java) } returns null
+            val delegate = createMockTool()
+            val tool = ConfirmationAwareTool(delegate, { "Confirm?" })
+
+            val paramNames = tool.definition.inputSchema.parameters.map { it.name }
+            assertTrue(paramNames.contains("accepted"))
+        }
+
+        @Test
+        fun `executes delegate when accepted is true`() {
+            val input = "{}"
+            val pendingRequest = ConfirmationRequest(input, "Confirm?")
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns pendingRequest
+            every { mockAgentProcess.last(ConfirmationResponse::class.java) } returns null
+            val delegate = Tool.create("d", "desc") { Tool.Result.text("executed!") }
+            val tool = ConfirmationAwareTool(delegate, { "Confirm?" })
+
+            val result = tool.call("""{"accepted": true}""")
+
+            assertInstanceOf(Tool.Result.Text::class.java, result)
+            assertEquals("executed!", (result as Tool.Result.Text).content)
+        }
+
+        @Test
+        fun `returns cancellation when accepted is false`() {
+            val pendingRequest = ConfirmationRequest("{}", "Confirm?")
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns pendingRequest
+            every { mockAgentProcess.last(ConfirmationResponse::class.java) } returns null
+            val delegate = createMockTool()
+            val tool = ConfirmationAwareTool(delegate, { "Confirm?" })
+
+            val result = tool.call("""{"accepted": false}""")
+
+            assertInstanceOf(Tool.Result.Text::class.java, result)
+            assertTrue((result as Tool.Result.Text).content.contains("cancel", ignoreCase = true))
+        }
+
+        @Test
+        fun `records ConfirmationResponse on blackboard`() {
+            val pendingRequest = ConfirmationRequest("{}", "Confirm?")
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns pendingRequest
+            every { mockAgentProcess.last(ConfirmationResponse::class.java) } returns null
+            val delegate = createMockTool()
+            val tool = ConfirmationAwareTool(delegate, { "Confirm?" })
+
+            tool.call("""{"accepted": false}""")
+
+            verify { mockAgentProcess.plusAssign(match<Any> { it is ConfirmationResponse }) }
+        }
+
+        @Test
+        fun `passes updated parameters to delegate when provided with accepted`() {
+            val original = """{"amount": 5.0}"""
+            val pendingRequest = ConfirmationRequest(original, "Confirm?")
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns pendingRequest
+            every { mockAgentProcess.last(ConfirmationResponse::class.java) } returns null
+            var capturedInput: String? = null
+            val delegate = Tool.create("d", "desc") { input ->
+                capturedInput = input
+                Tool.Result.text("ok")
+            }
+            val tool = ConfirmationAwareTool(delegate, { "Confirm?" })
+
+            tool.call("""{"accepted": true, "amount": 99.0}""")
+
+            assertNotNull(capturedInput)
+            assertTrue(capturedInput!!.contains("99.0"))
+        }
+
+        @Test
+        fun `falls back to original payload when no updated parameters`() {
+            val original = """{"amount": 5.0}"""
+            val pendingRequest = ConfirmationRequest(original, "Confirm?")
+            every { mockAgentProcess.last(ConfirmationRequest::class.java) } returns pendingRequest
+            every { mockAgentProcess.last(ConfirmationResponse::class.java) } returns null
+            var capturedInput: String? = null
+            val delegate = Tool.create("d", "desc") { input ->
+                capturedInput = input
+                Tool.Result.text("ok")
+            }
+            val tool = ConfirmationAwareTool(delegate, { "Confirm?" })
+
+            tool.call("""{"accepted": true}""")
+
+            assertNotNull(capturedInput)
+            assertTrue(capturedInput!!.contains("5.0"))
+        }
+
+        @Test
+        fun `extension function withLlmConfirmation with lambda creates ConfirmationAwareTool`() {
+            val delegate = createMockTool()
+            val tool = delegate.withLlmConfirmation { "Confirm?" }
+
+            assertInstanceOf(ConfirmationAwareTool::class.java, tool)
+        }
+
+        @Test
+        fun `extension function withLlmConfirmation with message creates ConfirmationAwareTool`() {
+            val delegate = createMockTool()
+            val tool = delegate.withLlmConfirmation("Are you sure?")
+
+            assertInstanceOf(ConfirmationAwareTool::class.java, tool)
         }
     }
 }


### PR DESCRIPTION
Closes #1550

## Summary

- **`ConfirmationAwareTool`**: A `DelegatingTool` that lets the LLM resolve a `ConfirmationRequest` autonomously. On first call it throws `AwaitableResponseException(ConfirmationRequest(...))`. On the next call (pending state), the schema dynamically adds `accepted: Boolean` so the LLM can confirm (`true`) or cancel (`false`), optionally updating the original parameters.
- **`withLlmConfirmation()`** extension functions for fluent tool decoration.
- **`VictoolsSchemaGenerator.generateClassInputSchema()`**: New method using victools `JacksonModule` to read `@JsonPropertyDescription` annotations directly from class definitions.
- **`TypeBasedInputSchema.toJsonSchema()`**: Now delegates to `generateClassInputSchema()` instead of manual reflection, giving proper array `items`, nested object schemas, and annotation support.
- **Jakarta Validation module** (`jsonschema-module-jakarta-validation:4.38.0`): Wired alongside `JacksonModule` so `@Size`, `@Min`, `@Max`, `@NotNull` etc. generate `minLength`, `maximum`, `minimum` etc. in the schema.

## Test plan

- [ ] `ConfirmationAwareToolTest` (11 tests) — confirmation flow, schema switching, delegation, cancellation, blackboard recording
- [ ] `TypeBasedInputSchemaTest` — `JsonPropertyDescriptionTest` (4 tests), `ArrayItemsSchemaTest` (4 tests)
- [ ] `VictoolsSchemaGeneratorTest` — `GenerateClassInputSchemaTest` (5 tests), `JakartaValidationTest` (3 tests)
- [ ] Full module build: `mvn test` in `embabel-agent-api` — all tests pass

