### PR TITLE
Fix #1694: Remove spring.threads.virtual.enabled fom application prop…

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformProperties.kt
@@ -75,9 +75,6 @@ class AgentPlatformProperties {
     var actionQos: ActionQosProperties = ActionQosProperties()
 
     @field:NestedConfigurationProperty
-    var virtual: VirtualProperties = VirtualProperties()
-
-    @field:NestedConfigurationProperty
     var threading: ThreadingProperties = ThreadingProperties()
 
     /**
@@ -373,41 +370,27 @@ class AgentPlatformProperties {
     }
 
     /**
-     * Virtual threads configuration.
-     * Maps to: embabel.agent.platform.virtual.threads.*
-     */
-    class VirtualProperties {
-        @field:NestedConfigurationProperty
-        var threads: ThreadsProperties = ThreadsProperties()
-
-        /**
-         * Thread configuration
-         */
-        class ThreadsProperties {
-            /**
-             * Override the application's threading model.
-             * - false (default): Inherit from spring.threads.virtual.enabled
-             * - true: Use opposite of application (platform ↔ virtual)
-             *
-             * Property: embabel.agent.platform.virtual.threads.override
-             */
-            var override: Boolean = false
-        }
-    }
-
-    /**
-     * Threading instance configuration (shared vs isolated executor).
-     * Only applies when both application and embabel use platform threads.
+     * Threading configuration.
      *
      * Maps to: embabel.agent.platform.threading.*
      */
     class ThreadingProperties {
         /**
-         * Share the application's executor when both use platform threads.
-         * - false (default): Embabel uses separate platform thread pool (isolated)
-         * - true: Embabel shares application's executor (shared)
+         * Override the application's threading model.
+         * - false (default): Inherit from spring.threads.virtual.enabled
+         * - true: Flip the threading model (platform ↔ virtual)
          *
-         * Note: Ignored when virtual threads are in use (shared/isolated is moot with unbounded threads)
+         * Property: embabel.agent.platform.threading.override
+         */
+        var override: Boolean = false
+
+        /**
+         * Share the application's executor when threading models match.
+         * - false (default): Embabel creates its own executor (isolated)
+         * - true: Embabel shares application's executor when both use the same threading model
+         *
+         * Applies to both platform/platform and virtual/virtual scenarios.
+         * Ignored when threading models differ (e.g., app uses virtual, Embabel uses platform).
          *
          * Property: embabel.agent.platform.threading.shared
          */

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformProperties.kt
@@ -74,6 +74,12 @@ class AgentPlatformProperties {
     @field:NestedConfigurationProperty
     var actionQos: ActionQosProperties = ActionQosProperties()
 
+    @field:NestedConfigurationProperty
+    var virtual: VirtualProperties = VirtualProperties()
+
+    @field:NestedConfigurationProperty
+    var threading: ThreadingProperties = ThreadingProperties()
+
     /**
      * Agent Process Type
      */
@@ -364,5 +370,47 @@ class AgentPlatformProperties {
          */
         var default: ActionProperties = ActionProperties()
 
+    }
+
+    /**
+     * Virtual threads configuration.
+     * Maps to: embabel.agent.platform.virtual.threads.*
+     */
+    class VirtualProperties {
+        @field:NestedConfigurationProperty
+        var threads: ThreadsProperties = ThreadsProperties()
+
+        /**
+         * Thread configuration
+         */
+        class ThreadsProperties {
+            /**
+             * Override the application's threading model.
+             * - false (default): Inherit from spring.threads.virtual.enabled
+             * - true: Use opposite of application (platform ↔ virtual)
+             *
+             * Property: embabel.agent.platform.virtual.threads.override
+             */
+            var override: Boolean = false
+        }
+    }
+
+    /**
+     * Threading instance configuration (shared vs isolated executor).
+     * Only applies when both application and embabel use platform threads.
+     *
+     * Maps to: embabel.agent.platform.threading.*
+     */
+    class ThreadingProperties {
+        /**
+         * Share the application's executor when both use platform threads.
+         * - false (default): Embabel uses separate platform thread pool (isolated)
+         * - true: Embabel shares application's executor (shared)
+         *
+         * Note: Ignored when virtual threads are in use (shared/isolated is moot with unbounded threads)
+         *
+         * Property: embabel.agent.platform.threading.shared
+         */
+        var shared: Boolean = false
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AsyncConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AsyncConfiguration.kt
@@ -17,25 +17,157 @@ package com.embabel.agent.spi.config.spring
 
 import com.embabel.agent.api.common.Asyncer
 import com.embabel.agent.spi.support.ExecutorAsyncer
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
+/**
+ * Configures async execution for the Embabel agent platform.
+ *
+ * Threading model based on:
+ * 1. Application's spring.threads.virtual.enabled property (inheritance)
+ * 2. embabel.agent.platform.virtual.threads.override (flip threading model)
+ * 3. embabel.agent.platform.threading.shared (share executor when models match)
+ */
 @Configuration
-class AsyncConfiguration {
+class AsyncConfiguration(
+    private val properties: AgentPlatformProperties,
+    @Value("\${spring.threads.virtual.enabled:false}")
+    private val appUsesVirtualThreads: Boolean
+) {
 
+    companion object {
+        private val logger = LoggerFactory.getLogger(AsyncConfiguration::class.java)
+        private const val JAVA_21_MAJOR_VERSION = 21
+
+        // Threading model names
+        private const val VIRTUAL_THREAD_MODEL = "virtual"
+        private const val PLATFORM_THREAD_MODEL = "platform"
+
+        // Thread name prefixes
+        private const val VIRTUAL_THREAD_NAME_PREFIX = "embabel-virtual-"
+        private const val PLATFORM_THREAD_NAME_PREFIX = "embabel-platform-"
+    }
+
+    /**
+     * Creates the Asyncer abstraction for Embabel agent operations.
+     *
+     * Threading model determination:
+     * 1. Inherit app's threading model (virtual vs platform)
+     * 2. Apply override if configured (flips the choice)
+     * 3. Share app's executor when threading models match + sharing enabled
+     * 4. Otherwise create isolated raw JDK executor (no Spring lifecycle management)
+     */
     @Bean
     fun asyncer(
         @Qualifier(TaskExecutionAutoConfiguration.APPLICATION_TASK_EXECUTOR_BEAN_NAME)
-        executorProvider: ObjectProvider<Executor>,
+        applicationExecutor: ObjectProvider<Executor>
     ): Asyncer {
-        val executor = executorProvider.getIfAvailable {
-            Executors.newCachedThreadPool() // default fallback, Consider Executors.newVirtualThreadPerTaskExecutor()
+        // Step 1 & 2: Determine Embabel's threading model (inherit + override)
+        val embabelUsesVirtual = shouldUseVirtualThreads()
+
+        // Step 3: Attempt to get shared executor if enabled
+        val sharedExecutor = if (shouldUseSharedExecutor(embabelUsesVirtual)) {
+            applicationExecutor.getIfAvailable()
+        } else {
+            null
         }
+
+        // Use shared executor if available, otherwise create isolated
+        val executor = if (sharedExecutor != null) {
+            val threadModel = if (embabelUsesVirtual) VIRTUAL_THREAD_MODEL else PLATFORM_THREAD_MODEL
+            logger.info("Sharing app's $threadModel executor (models match, shared=true)")
+            sharedExecutor
+        } else {
+            // Step 4: Create isolated raw JDK executor (no Spring lifecycle)
+            createExecutorWithLogging(embabelUsesVirtual)
+        }
+
         return ExecutorAsyncer(executor)
+    }
+
+    /**
+     * Creates executor with appropriate logging.
+     *
+     * Three scenarios:
+     * 1. Embabel uses virtual + Java 21+ → virtual threads
+     * 2. Embabel uses virtual + Java < 21 → platform threads (fallback)
+     * 3. Embabel uses platform → platform threads
+     */
+    private fun createExecutorWithLogging(embabelUsesVirtual: Boolean): Executor {
+        val useVirtual = embabelUsesVirtual && isJava21Plus()
+        val isFallbackToPlatform = embabelUsesVirtual && !isJava21Plus()
+        val isPlatformRequested = !embabelUsesVirtual
+
+        when {
+            isFallbackToPlatform -> logger.info("Creating $PLATFORM_THREAD_MODEL executor (fallback from $VIRTUAL_THREAD_MODEL, Java < 21)")
+            useVirtual -> logger.info("Creating $VIRTUAL_THREAD_MODEL executor")
+            isPlatformRequested -> logger.info("Creating $PLATFORM_THREAD_MODEL executor")
+        }
+
+        return createExecutor(useVirtual = useVirtual)
+    }
+
+    /**
+     * Determines if Embabel should use virtual threads.
+     *
+     * Logic: Inherit from app, then flip if override is enabled.
+     */
+    private fun shouldUseVirtualThreads(): Boolean =
+        if (properties.virtual.threads.override) {
+            !appUsesVirtualThreads  // Flip: virtual → platform or platform → virtual
+        } else {
+            appUsesVirtualThreads   // Inherit: same as app
+        }
+
+    /**
+     * Checks if should use shared executor with application.
+     *
+     * Sharing applies when both app and Embabel use the same threading model
+     * (either platform/platform or virtual/virtual).
+     */
+    private fun shouldUseSharedExecutor(embabelUsesVirtual: Boolean): Boolean =
+        (embabelUsesVirtual == appUsesVirtualThreads) && properties.threading.shared
+
+    /**
+     * Creates a raw JDK executor (no Spring lifecycle management).
+     *
+     * Uses custom thread factories for observability:
+     * - Virtual threads: "embabel-virtual-N"
+     * - Platform threads: "embabel-platform-N" with CachedThreadPool behavior
+     *
+     * Raw JDK executors avoid Spring's SmartLifecycle 30-second shutdown timeout.
+     */
+    private fun createExecutor(useVirtual: Boolean): Executor =
+        if (useVirtual && isJava21Plus()) {
+            Executors.newThreadPerTaskExecutor(
+                Thread.ofVirtual()
+                    .name(VIRTUAL_THREAD_NAME_PREFIX, 0)
+                    .factory()
+            )
+        } else {
+            Executors.newCachedThreadPool(
+                Thread.ofPlatform()
+                    .name(PLATFORM_THREAD_NAME_PREFIX, 0)
+                    .factory()
+            )
+        }
+
+    /**
+     * Checks if running on Java 21+ (virtual threads support).
+     */
+    internal fun isJava21Plus(): Boolean {
+        val version = System.getProperty("java.version")
+        val majorVersion = version.substringBefore('.').toIntOrNull()
+            ?: version.substringBefore('-').toIntOrNull()
+            ?: return false
+        return majorVersion >= JAVA_21_MAJOR_VERSION
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AsyncConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AsyncConfiguration.kt
@@ -24,8 +24,10 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import jakarta.annotation.PreDestroy
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 /**
@@ -55,6 +57,12 @@ class AsyncConfiguration(
         private const val VIRTUAL_THREAD_NAME_PREFIX = "embabel-virtual-"
         private const val PLATFORM_THREAD_NAME_PREFIX = "embabel-platform-"
     }
+
+    /**
+     * Tracks executor created by Embabel (for shutdown).
+     * Null when sharing app's executor.
+     */
+    private var embabelOwnedExecutor: ExecutorService? = null
 
     /**
      * Creates the Asyncer abstraction for Embabel agent operations.
@@ -87,7 +95,9 @@ class AsyncConfiguration(
             sharedExecutor
         } else {
             // Step 4: Create isolated raw JDK executor (no Spring lifecycle)
-            createExecutorWithLogging(embabelUsesVirtual)
+            createExecutorWithLogging(embabelUsesVirtual).also {
+                embabelOwnedExecutor = it as? ExecutorService
+            }
         }
 
         return ExecutorAsyncer(executor)
@@ -121,7 +131,7 @@ class AsyncConfiguration(
      * Logic: Inherit from app, then flip if override is enabled.
      */
     private fun shouldUseVirtualThreads(): Boolean =
-        if (properties.virtual.threads.override) {
+        if (properties.threading.override) {
             !appUsesVirtualThreads  // Flip: virtual → platform or platform → virtual
         } else {
             appUsesVirtualThreads   // Inherit: same as app
@@ -169,5 +179,14 @@ class AsyncConfiguration(
             ?: version.substringBefore('-').toIntOrNull()
             ?: return false
         return majorVersion >= JAVA_21_MAJOR_VERSION
+    }
+
+    /**
+     * Shuts down executor created by Embabel.
+     * Does nothing when sharing app's executor.
+     */
+    @PreDestroy
+    fun shutdownOwnedExecutor() {
+        embabelOwnedExecutor?.shutdown()
     }
 }

--- a/embabel-agent-api/src/main/resources/agent-application.properties
+++ b/embabel-agent-api/src/main/resources/agent-application.properties
@@ -3,7 +3,14 @@
 # spring.application.name=agent-api
 # Naming strategy prefixes - used for MCP tools
 embabel.agent.application.name=agent-api
-spring.threads.virtual.enabled=true
+
+# Threading Configuration
+# Embabel inherits threading model from spring.threads.virtual.enabled by default.
+# Configure Embabel threading behavior in agent-platform.properties:
+# - embabel.agent.platform.virtual.threads.override: flip inherited threading model (virtual-to-platform, platform-to-virtual)
+# - embabel.agent.platform.threading.shared: share app's executor (platform threads only)
+#spring.threads.virtual.enabled=true
+
 spring.output.ansi.enabled=ALWAYS
 
 # AI Configuration - Temporarily Fallback, subject to Decommission in future

--- a/embabel-agent-api/src/main/resources/agent-application.properties
+++ b/embabel-agent-api/src/main/resources/agent-application.properties
@@ -7,8 +7,8 @@ embabel.agent.application.name=agent-api
 # Threading Configuration
 # Embabel inherits threading model from spring.threads.virtual.enabled by default.
 # Configure Embabel threading behavior in agent-platform.properties:
-# - embabel.agent.platform.virtual.threads.override: flip inherited threading model (virtual-to-platform, platform-to-virtual)
-# - embabel.agent.platform.threading.shared: share app's executor (platform threads only)
+# - embabel.agent.platform.threading.override: flip inherited threading model (virtual-to-platform, platform-to-virtual)
+# - embabel.agent.platform.threading.shared: share app's executor when threading models match
 #spring.threads.virtual.enabled=true
 
 spring.output.ansi.enabled=ALWAYS

--- a/embabel-agent-api/src/main/resources/agent-platform.properties
+++ b/embabel-agent-api/src/main/resources/agent-platform.properties
@@ -1,6 +1,13 @@
 # Agent Platform Default Configuration
 # These properties control internal platform behavior
 
+# Threading Configuration
+# Embabel inherits threading model from spring.threads.virtual.enabled by default
+# virtual.threads.override: flip inherited threading model (virtual-to-platform, platform-to-virtual)
+embabel.agent.platform.virtual.threads.override=false
+# threading.shared: share app's executor when both use the same threading model
+embabel.agent.platform.threading.shared=false
+
 # Agent Scanning Configuration
 embabel.agent.platform.scanning.annotation=true
 embabel.agent.platform.scanning.bean=false

--- a/embabel-agent-api/src/main/resources/agent-platform.properties
+++ b/embabel-agent-api/src/main/resources/agent-platform.properties
@@ -3,8 +3,8 @@
 
 # Threading Configuration
 # Embabel inherits threading model from spring.threads.virtual.enabled by default
-# virtual.threads.override: flip inherited threading model (virtual-to-platform, platform-to-virtual)
-embabel.agent.platform.virtual.threads.override=false
+# threading.override: flip inherited threading model (virtual-to-platform, platform-to-virtual)
+embabel.agent.platform.threading.override=false
 # threading.shared: share app's executor when both use the same threading model
 embabel.agent.platform.threading.shared=false
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AsyncConfigurationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AsyncConfigurationTest.kt
@@ -314,7 +314,7 @@ class AsyncConfigurationTest {
         shared: Boolean = false
     ): AsyncConfiguration {
         val properties = AgentPlatformProperties()
-        properties.virtual.threads.override = override
+        properties.threading.override = override
         properties.threading.shared = shared
         return AsyncConfiguration(properties, appUsesVirtual)
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AsyncConfigurationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AsyncConfigurationTest.kt
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.config.spring
+
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.spi.support.ExecutorAsyncer
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationHandler
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.beans.factory.ObjectProvider
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Comprehensive tests for AsyncConfiguration covering:
+ * 1. Threading model inheritance and override logic
+ * 2. Executor sharing when threading models match (platform/platform AND virtual/virtual)
+ * 3. Isolated raw JDK executors (no Spring lifecycle management)
+ * 4. ThreadLocal propagation (AgentProcess, Micrometer Observation)
+ * 5. Thread naming conventions
+ * 6. Java version detection and fallback
+ */
+class AsyncConfigurationTest {
+
+    @AfterEach
+    fun cleanup() {
+        AgentProcess.remove()
+    }
+
+    @Nested
+    inner class ThreadingModelTests {
+
+        @Test
+        fun `should use virtual threads when app uses virtual and override is false - inheritance`() {
+            val config = createConfig(appUsesVirtual = true, override = false)
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            if (config.isJava21Plus()) {
+                assertVirtualThreads(asyncer)
+            } else {
+                assertPlatformThreads(asyncer)
+            }
+        }
+
+        @Test
+        fun `should use platform threads when app uses virtual and override is true - flip to platform`() {
+            val config = createConfig(appUsesVirtual = true, override = true)
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            assertPlatformThreads(asyncer)
+        }
+
+        @Test
+        fun `should use platform threads when app uses platform and override is false - inheritance`() {
+            val config = createConfig(appUsesVirtual = false, override = false)
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            assertPlatformThreads(asyncer)
+        }
+
+        @Test
+        fun `should use virtual threads when app uses platform and override is true - flip to virtual`() {
+            val config = createConfig(appUsesVirtual = false, override = true)
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            if (config.isJava21Plus()) {
+                assertVirtualThreads(asyncer)
+            } else {
+                assertPlatformThreads(asyncer)
+            }
+        }
+    }
+
+    @Nested
+    inner class ExecutorSharingTests {
+
+        @Test
+        fun `should share app executor when both use platform and shared is true`() {
+            val appExecutor = Executors.newCachedThreadPool()
+            val config = createConfig(appUsesVirtual = false, override = false, shared = true)
+
+            try {
+                val asyncer = config.asyncer(providedAppExecutor(appExecutor))
+                val usedExecutor = extractExecutor(asyncer)
+                assertThat(usedExecutor).isSameAs(appExecutor)
+            } finally {
+                appExecutor.shutdown()
+            }
+        }
+
+        @Test
+        fun `should share app executor when both use virtual and shared is true`() {
+            val config = createConfig(appUsesVirtual = true, override = false, shared = true)
+            if (!config.isJava21Plus()) {
+                println("Skipping virtual thread test on Java < 21")
+                return
+            }
+
+            val appExecutor = Executors.newVirtualThreadPerTaskExecutor()
+            try {
+                val asyncer = config.asyncer(providedAppExecutor(appExecutor))
+                val usedExecutor = extractExecutor(asyncer)
+                assertThat(usedExecutor).isSameAs(appExecutor)
+            } finally {
+                appExecutor.shutdown()
+            }
+        }
+
+        @Test
+        fun `should not share executor when app uses virtual but embabel uses platform`() {
+            val appExecutor = Executors.newCachedThreadPool()
+            val config = createConfig(appUsesVirtual = true, override = true, shared = true)
+
+            try {
+                val asyncer = config.asyncer(providedAppExecutor(appExecutor))
+                val usedExecutor = extractExecutor(asyncer)
+                assertThat(usedExecutor).isNotSameAs(appExecutor)
+            } finally {
+                appExecutor.shutdown()
+            }
+        }
+
+        @Test
+        fun `should not share executor when app uses platform but embabel uses virtual`() {
+            val appExecutor = Executors.newCachedThreadPool()
+            val config = createConfig(appUsesVirtual = false, override = true, shared = true)
+
+            try {
+                val asyncer = config.asyncer(providedAppExecutor(appExecutor))
+                val usedExecutor = extractExecutor(asyncer)
+                assertThat(usedExecutor).isNotSameAs(appExecutor)
+            } finally {
+                appExecutor.shutdown()
+            }
+        }
+
+        @Test
+        fun `should create isolated executor when platform-platform but shared is false`() {
+            val appExecutor = Executors.newCachedThreadPool()
+            val config = createConfig(appUsesVirtual = false, override = false, shared = false)
+
+            try {
+                val asyncer = config.asyncer(providedAppExecutor(appExecutor))
+                val usedExecutor = extractExecutor(asyncer)
+                assertThat(usedExecutor).isNotSameAs(appExecutor)
+            } finally {
+                appExecutor.shutdown()
+            }
+        }
+
+        @Test
+        fun `should create isolated executor when virtual-virtual but shared is false`() {
+            val config = createConfig(appUsesVirtual = true, override = false, shared = false)
+            if (!config.isJava21Plus()) {
+                println("Skipping virtual thread test on Java < 21")
+                return
+            }
+
+            val appExecutor = Executors.newVirtualThreadPerTaskExecutor()
+            try {
+                val asyncer = config.asyncer(providedAppExecutor(appExecutor))
+                val usedExecutor = extractExecutor(asyncer)
+                assertThat(usedExecutor).isNotSameAs(appExecutor)
+            } finally {
+                appExecutor.shutdown()
+            }
+        }
+
+        @Test
+        fun `should create fallback platform executor when app executor unavailable and shared is true`() {
+            val config = createConfig(appUsesVirtual = false, override = false, shared = true)
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            assertPlatformThreads(asyncer)
+        }
+    }
+
+    @Nested
+    inner class ThreadLocalPropagationTests {
+
+        @Test
+        fun `AgentProcess should propagate through virtual executor`() {
+            val config = createConfig(appUsesVirtual = true, override = false)
+            if (!config.isJava21Plus()) {
+                println("Skipping virtual thread test on Java < 21")
+                return
+            }
+
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            val testProcess = mock(AgentProcess::class.java)
+            AgentProcess.set(testProcess)
+
+            val result = asyncer.async {
+                AgentProcess.get()
+            }.get(5, TimeUnit.SECONDS)
+
+            assertEquals(testProcess, result)
+        }
+
+        @Test
+        fun `AgentProcess should propagate through platform executor`() {
+            val config = createConfig(appUsesVirtual = false, override = false)
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            val testProcess = mock(AgentProcess::class.java)
+            AgentProcess.set(testProcess)
+
+            val result = asyncer.async {
+                AgentProcess.get()
+            }.get(5, TimeUnit.SECONDS)
+
+            assertEquals(testProcess, result)
+        }
+
+        @Test
+        fun `Micrometer Observation should propagate through virtual executor`() {
+            val config = createConfig(appUsesVirtual = true, override = false)
+            if (!config.isJava21Plus()) {
+                println("Skipping virtual thread test on Java < 21")
+                return
+            }
+
+            testObservationPropagation(config)
+        }
+
+        @Test
+        fun `Micrometer Observation should propagate through platform executor`() {
+            val config = createConfig(appUsesVirtual = false, override = false)
+            testObservationPropagation(config)
+        }
+    }
+
+    @Nested
+    inner class ExecutorConfigurationTests {
+
+        @Test
+        fun `asyncer bean should wrap executor with ExecutorAsyncer`() {
+            val config = createConfig(appUsesVirtual = false, override = false)
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            assertThat(asyncer).isInstanceOf(ExecutorAsyncer::class.java)
+        }
+
+        @Test
+        fun `virtual executor should create threads with embabel-virtual prefix`() {
+            val config = createConfig(appUsesVirtual = true, override = false)
+            if (!config.isJava21Plus()) {
+                println("Skipping virtual thread test on Java < 21")
+                return
+            }
+
+            val asyncer = config.asyncer(emptyAppExecutor())
+            val threadName = asyncer.async {
+                Thread.currentThread().name
+            }.get(5, TimeUnit.SECONDS)
+
+            assertThat(threadName).startsWith("embabel-virtual-")
+        }
+
+        @Test
+        fun `virtual executor should create actual virtual threads`() {
+            val config = createConfig(appUsesVirtual = true, override = false)
+            if (!config.isJava21Plus()) {
+                println("Skipping virtual thread test on Java < 21")
+                return
+            }
+
+            val asyncer = config.asyncer(emptyAppExecutor())
+            assertVirtualThreads(asyncer)
+        }
+
+        @Test
+        fun `platform executor should create threads with embabel-platform prefix`() {
+            val config = createConfig(appUsesVirtual = false, override = false)
+            val asyncer = config.asyncer(emptyAppExecutor())
+
+            val threadName = asyncer.async {
+                Thread.currentThread().name
+            }.get(5, TimeUnit.SECONDS)
+
+            assertThat(threadName).startsWith("embabel-platform-")
+        }
+    }
+
+    // ==================== Helper Methods ====================
+
+    private fun createConfig(
+        appUsesVirtual: Boolean,
+        override: Boolean = false,
+        shared: Boolean = false
+    ): AsyncConfiguration {
+        val properties = AgentPlatformProperties()
+        properties.virtual.threads.override = override
+        properties.threading.shared = shared
+        return AsyncConfiguration(properties, appUsesVirtual)
+    }
+
+    private fun emptyAppExecutor(): ObjectProvider<Executor> {
+        return object : ObjectProvider<Executor> {
+            override fun getObject(): Executor = throw NoSuchElementException("No executor available")
+            override fun getObject(vararg args: Any?): Executor = throw NoSuchElementException("No executor available")
+            override fun getIfAvailable(): Executor? = null
+            override fun getIfUnique(): Executor? = null
+            override fun iterator(): MutableIterator<Executor> = mutableListOf<Executor>().iterator()
+            override fun orderedStream(): java.util.stream.Stream<Executor> = java.util.stream.Stream.empty()
+            override fun stream(): java.util.stream.Stream<Executor> = java.util.stream.Stream.empty()
+        }
+    }
+
+    private fun providedAppExecutor(executor: Executor): ObjectProvider<Executor> {
+        return object : ObjectProvider<Executor> {
+            override fun getObject(): Executor = executor
+            override fun getObject(vararg args: Any?): Executor = executor
+            override fun getIfAvailable(): Executor = executor
+            override fun getIfUnique(): Executor = executor
+            override fun iterator(): MutableIterator<Executor> = mutableListOf(executor).iterator()
+            override fun orderedStream(): java.util.stream.Stream<Executor> = java.util.stream.Stream.of(executor)
+            override fun stream(): java.util.stream.Stream<Executor> = java.util.stream.Stream.of(executor)
+        }
+    }
+
+    private fun extractExecutor(asyncer: com.embabel.agent.api.common.Asyncer): Executor {
+        // Access the private executor field via reflection
+        val field = ExecutorAsyncer::class.java.getDeclaredField("executor")
+        field.isAccessible = true
+        return field.get(asyncer) as Executor
+    }
+
+    private fun assertVirtualThreads(asyncer: com.embabel.agent.api.common.Asyncer) {
+        val isVirtual = asyncer.async {
+            Thread.currentThread().isVirtual
+        }.get(5, TimeUnit.SECONDS)
+
+        assertTrue(isVirtual, "Executor should create virtual threads")
+    }
+
+    private fun assertPlatformThreads(asyncer: com.embabel.agent.api.common.Asyncer) {
+        val isVirtual = asyncer.async {
+            Thread.currentThread().isVirtual
+        }.get(5, TimeUnit.SECONDS)
+
+        assertThat(isVirtual).isFalse
+    }
+
+    private fun testObservationPropagation(config: AsyncConfiguration) {
+        val asyncer = config.asyncer(emptyAppExecutor())
+
+        val registry = ObservationRegistry.create().apply {
+            observationConfig().observationHandler(object : ObservationHandler<Observation.Context> {
+                override fun supportsContext(context: Observation.Context) = true
+            })
+        }
+        ObservationThreadLocalAccessor.getInstance().observationRegistry = registry
+
+        try {
+            val parent = Observation.start("parent", registry)
+            parent.openScope().use {
+                val seenOnWorker = asyncer.async {
+                    registry.currentObservation
+                }.get(5, TimeUnit.SECONDS)
+
+                assertEquals(parent, seenOnWorker, "Observation should propagate across threads")
+            }
+            parent.stop()
+        } finally {
+            ObservationThreadLocalAccessor.getInstance().observationRegistry = ObservationRegistry.NOOP
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ExecutorAsyncerVirtualThreadTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ExecutorAsyncerVirtualThreadTest.kt
@@ -35,8 +35,10 @@ import kotlin.test.assertTrue
 
 /**
  * Confirms [ExecutorAsyncer] works correctly when backed by a virtual-thread executor
- * (`Executors.newVirtualThreadPerTaskExecutor()`), as used when
- * `spring.threads.virtual.enabled=true`.
+ * (`Executors.newVirtualThreadPerTaskExecutor()`), as used when Embabel is configured
+ * to use virtual threads via AsyncConfiguration (either inherited from
+ * `spring.threads.virtual.enabled=true` or flipped via
+ * `embabel.agent.platform.virtual.threads.override=true`).
  *
  * Answers the review question "Please confirm it works with virtual threads" by proving:
  * 1. work actually runs on a virtual thread,

--- a/embabel-agent-docs/src/main/asciidoc/reference/asynch-mode/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/asynch-mode/page.adoc
@@ -5,13 +5,15 @@ Async Configuration is defined in _AsyncConfiguration.kt_.
 
 === Threading Model
 
-Embabel uses a dedicated executor (`embabelTaskExecutor`) for all agent operations with an inheritance-based threading model.
+Embabel uses a dedicated executor for all agent operations with an inheritance-based threading model.
+
+IMPORTANT: **Upgrade Note** - Prior to this version, Embabel set `spring.threads.virtual.enabled=true` by default, forcing all applications to use virtual threads. This has been removed to avoid interfering with host application threading configuration. Embabel now inherits the threading model from `spring.threads.virtual.enabled` (defaults to platform threads if not set). To enable virtual threads, explicitly set `spring.threads.virtual.enabled=true` in your `application.properties`.
 
 ==== Configuration Properties
 
 Two orthogonal properties control Embabel's threading behavior:
 
-1. **Threading Model Inheritance** (`embabel.agent.platform.virtual.threads.override`)
+1. **Threading Model Inheritance** (`embabel.agent.platform.threading.override`)
    - `false` (default): Inherit threading model from `spring.threads.virtual.enabled`
    - `true`: Flip the threading model (virtual→platform or platform→virtual)
 
@@ -22,7 +24,7 @@ Two orthogonal properties control Embabel's threading behavior:
 Configuration in `agent-platform.properties`:
 ----
 # Flip inherited threading model (virtual-to-platform, platform-to-virtual)
-embabel.agent.platform.virtual.threads.override=false
+embabel.agent.platform.threading.override=false
 
 # Share app's executor when both use the same threading model
 embabel.agent.platform.threading.shared=false
@@ -119,7 +121,7 @@ Also, note: modern (post 1.3) Kotlin  coroutines implementation in Dispatchers.D
 ==== Why Embabel is Safe
 
 1. Asyncer Abstraction — All parallel execution routes through ExecutorAsyncer
-2. Dedicated Executor — Uses `embabelTaskExecutor` (virtual or unbounded platform threads), not ForkJoinPool
+2. Dedicated Executor — Uses a dedicated executor (virtual or unbounded platform threads), not ForkJoinPool
 3. Unbounded Execution — Configured as unbounded to support parallel action execution
 4. Coroutine Defaults — Production code uses Dispatchers.IO, not Dispatchers.Default
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/asynch-mode/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/asynch-mode/page.adoc
@@ -1,16 +1,93 @@
 [[reference.asynch-mode]]
 == Asynchronous Mode and Java 25
 
-Async Configuration got defined in _AsyncConfiguration.kt_.
-Default implementation employs spring-managed task executor with virtual threads being configured in:
-----
-agent-application.properties
+Async Configuration is defined in _AsyncConfiguration.kt_.
 
-spring.threads.virtual.enabled=true
-----
-If spring managed task executor cannot be obtained,  implementation falls back to default task executor, _Executors.newCachedThreadPool()_.
+=== Threading Model
 
-Framework employs _Asyncer_ abstraction consistently cross Agent Invocation (see <<reference.invoking>> ), Agent Actions, Tool Loop, ShellCommands, and other scenarios.
+Embabel uses a dedicated executor (`embabelTaskExecutor`) for all agent operations with an inheritance-based threading model.
+
+==== Configuration Properties
+
+Two orthogonal properties control Embabel's threading behavior:
+
+1. **Threading Model Inheritance** (`embabel.agent.platform.virtual.threads.override`)
+   - `false` (default): Inherit threading model from `spring.threads.virtual.enabled`
+   - `true`: Flip the threading model (virtual→platform or platform→virtual)
+
+2. **Executor Sharing** (`embabel.agent.platform.threading.shared`)
+   - `false` (default): Create isolated executor for Embabel operations
+   - `true`: Share app's `applicationTaskExecutor` bean when threading models match
+
+Configuration in `agent-platform.properties`:
+----
+# Flip inherited threading model (virtual-to-platform, platform-to-virtual)
+embabel.agent.platform.virtual.threads.override=false
+
+# Share app's executor when both use the same threading model
+embabel.agent.platform.threading.shared=false
+----
+
+==== Behavior Matrix
+
+[cols="1,1,1,2,2", options="header", frame="all", grid="all"]
+|===
+|App Threads |Override |Shared |Embabel Threading Model |Executor Type
+
+|Platform
+|false
+|false
+|Platform (inherit)
+|Isolated platform executor (default)
+
+|Platform
+|false
+|true
+|Platform (inherit)
+|Shared app's platform executor
+
+|Platform
+|true
+|false
+|Virtual (flip)
+|Isolated virtual executor
+
+|Platform
+|true
+|true
+|Virtual (flip)
+|Isolated virtual executor (models differ)
+
+|Virtual
+|false
+|false
+|Virtual (inherit)
+|Isolated virtual executor
+
+|Virtual
+|false
+|true
+|Virtual (inherit)
+|Shared app's virtual executor
+
+|Virtual
+|true
+|false
+|Platform (flip)
+|Isolated platform executor
+
+|Virtual
+|true
+|true
+|Platform (flip)
+|Isolated platform executor (models differ)
+|===
+
+**Key insight**: `shared=true` enables executor sharing when both app and Embabel use the **same threading model** (either platform/platform or virtual/virtual). When threading models differ, Embabel always creates an isolated executor.
+
+**Note**: Virtual threads require Java 21+. On Java 17-20, Embabel automatically falls back to platform threads even if virtual threads are requested.
+
+Framework employs _Asyncer_ abstraction consistently across Agent Invocation (see <<reference.invoking>> ), Agent Actions, Tool Loop, ShellCommands, and other scenarios.
 
 === Java 25 Implications
 
@@ -42,8 +119,8 @@ Also, note: modern (post 1.3) Kotlin  coroutines implementation in Dispatchers.D
 ==== Why Embabel is Safe
 
 1. Asyncer Abstraction — All parallel execution routes through ExecutorAsyncer
-2. Spring Executor — Uses applicationTaskExecutor (ThreadPoolTaskExecutor), not ForkJoinPool
-3. Fallback Safety — Even fallback uses newCachedThreadPool(), not ForkJoinPool
+2. Dedicated Executor — Uses `embabelTaskExecutor` (virtual or unbounded platform threads), not ForkJoinPool
+3. Unbounded Execution — Configured as unbounded to support parallel action execution
 4. Coroutine Defaults — Production code uses Dispatchers.IO, not Dispatchers.Default
 
 If Users report serialization issues on Java 25, recommendation is to check for:

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -385,7 +385,7 @@ Embabel uses a dedicated executor for agent operations. You can customize the th
 [source,properties]
 ----
 # Flip inherited threading model (virtual-to-platform, platform-to-virtual)
-embabel.agent.platform.virtual.threads.override=false
+embabel.agent.platform.threading.override=false
 
 # Share app's executor when both use the same threading model
 embabel.agent.platform.threading.shared=false

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -378,6 +378,21 @@ see <<reference.llms.custom-integration>>.
 You can specify Spring configuration, your own configuration and Embabel configuration in the regular Spring configuration files.
 Profile usage will work as expected.
 
+==== Customizing threading configuration
+
+Embabel uses a dedicated executor for agent operations. You can customize the threading model using properties in `agent-platform.properties`:
+
+[source,properties]
+----
+# Flip inherited threading model (virtual-to-platform, platform-to-virtual)
+embabel.agent.platform.virtual.threads.override=false
+
+# Share app's executor when both use the same threading model
+embabel.agent.platform.threading.shared=false
+----
+
+See <<reference.asynch-mode>> for details about the threading model and configuration options.
+
 ==== Customizing logging
 
 You can customize logging as in any Spring application.


### PR DESCRIPTION
## OVERVIEW

Please refer to #1694 

  - Remove spring.threads.virtual.enabled=true from agent-application.properties to stop interfering with host application threading configuration
  - Implement inheritance-based threading model: Embabel inherits from spring.threads.virtual.enabled by default, with embabel.agent.platform.virtual.threads.override to flip the model (virtual→platform or platform→virtual)
  - Add embabel.agent.platform.threading.shared property to enable executor sharing when threading models match (platform/platform or virtual/virtual), using raw JDK Executors
  - Update documentation with a comprehensive  behavior matrix and update tests to cover all scenarios