### PR TITLE
Prepare for 1.0.0-RC1 development

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.14</version>
+        <version>0.1.15-SNAPSHOT</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.14</version>
+        <version>0.1.15-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,7 +16,7 @@
 
     <properties>
         <argLine />
-        <embabel-common.version>0.1.13</embabel-common.version>
+        <embabel-common.version>0.1.14-SNAPSHOT</embabel-common.version>
         <netty.version>4.2.13.Final</netty.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>


### PR DESCRIPTION
This pull request updates project and dependency versions to the latest snapshot releases. The main changes ensure the codebase uses the most recent parent POMs and the latest snapshot of the `embabel-common` dependency.

Dependency and parent POM updates:

* Updated the parent POM version in `pom.xml` to `0.1.15-SNAPSHOT` to use the latest build parent.
* Updated the `embabel-common.version` property in `pom.xml` to `0.1.14-SNAPSHOT` for the latest common library snapshot.
* Updated the parent POM version in `embabel-agent-dependencies/pom.xml` to `0.1.15-SNAPSHOT`.