### PR TITLE
Improve error message when default llm is not available

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -65,8 +65,13 @@ class ConfigurableModelProvider(
 
     private val logger = loggerFor<ConfigurableModelProvider>()
 
-    private val defaultLlm = llms.firstOrNull { it.name == properties.defaultLlm }
-        ?: throw IllegalArgumentException("Default LLM '${properties.defaultLlm}' not found in available models: ${llms.map { it.name }}")
+    private val defaultLlm =
+        if (llms.isNotEmpty())
+            llms.firstOrNull { it.name == properties.defaultLlm }
+                ?: throw IllegalArgumentException(
+                    "Default LLM '${properties.defaultLlm}' not found. Set the 'embabel.models.default-llm' property to one of the available models: ${llms.map { it.name }}.")
+        else
+            throw IllegalArgumentException("No models detected. Ensure that at least one Embabel Agent Starter (e.g. embabel-agent-starter-openai) is on the classpath.")
 
     // Compute this lazily as embedding services may not be available
     private fun defaultEmbeddingService() =

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -71,7 +71,7 @@ class ConfigurableModelProvider(
                 ?: throw IllegalArgumentException(
                     "Default LLM '${properties.defaultLlm}' not found. Set the 'embabel.models.default-llm' property to one of the available models: ${llms.map { it.name }}.")
         else
-            throw IllegalArgumentException("No models detected. Ensure that at least one Embabel Agent Starter (e.g. embabel-agent-starter-openai) is on the classpath.")
+            throw IllegalArgumentException("No models detected. Ensure that at least one Embabel Agent Starter (e.g. embabel-agent-starter-openai) is on the classpath and models are loaded into it.")
 
     // Compute this lazily as embedding services may not be available
     private fun defaultEmbeddingService() =


### PR DESCRIPTION
This PR improves the error message when the default LLM model is not available, either by suggesting to set embabel.models.default-llm to an LLM that is available, or by suggesting to load models from the Embabel Agent Starter.

Closes gh-1733