### PR TITLE
refactor(anthropic): extract AnthropicModelFactory into plain embabel…

### DIFF
--- a/embabel-agent-anthropic/pom.xml
+++ b/embabel-agent-anthropic/pom.xml
@@ -3,14 +3,13 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.embabel.agent</groupId>
-        <artifactId>embabel-agent-autoconfigure</artifactId>
+        <artifactId>embabel-agent-parent</artifactId>
         <version>1.0.0-RC1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
     </parent>
-    <artifactId>embabel-agent-anthropic-autoconfigure</artifactId>
+    <artifactId>embabel-agent-anthropic</artifactId>
     <packaging>jar</packaging>
-    <name>Embabel Agent Autoconfiguration Models Anthropic</name>
-    <description>Anthropic Models for Embabel Agent API</description>
+    <name>Embabel Agent Anthropic</name>
+    <description>Embabel Agent Anthropic Utilities</description>
     <url>https://github.com/embabel/embabel-agent</url>
 
     <scm>
@@ -28,24 +27,33 @@
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
-            <artifactId>embabel-agent-anthropic</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-byok</artifactId>
         </dependency>
 
         <dependency>
-           <groupId>org.springframework.ai</groupId>
-           <artifactId>spring-ai-anthropic</artifactId>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-anthropic</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test-internal</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+        </plugins>
+    </build>
 
 </project>

--- a/embabel-agent-anthropic/src/main/kotlin/com/embabel/agent/anthropic/AnthropicCachingConfig.kt
+++ b/embabel-agent-anthropic/src/main/kotlin/com/embabel/agent/anthropic/AnthropicCachingConfig.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.config.models.anthropic
+package com.embabel.agent.anthropic
 
 import com.embabel.chat.MessageRole
 import com.embabel.common.ai.model.LlmOptions
@@ -78,7 +78,7 @@ data class AnthropicCachingConfig(
 /**
  * Add Anthropic caching configuration to LlmOptions.
  *
- * This extension function is only available when the embabel-agent-anthropic-autoconfigure
+ * This extension function is only available when the embabel-agent-anthropic
  * module is on the classpath.
  *
  * Example:

--- a/embabel-agent-anthropic/src/main/kotlin/com/embabel/agent/anthropic/AnthropicModelFactory.kt
+++ b/embabel-agent-anthropic/src/main/kotlin/com/embabel/agent/anthropic/AnthropicModelFactory.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.config.models.anthropic
+package com.embabel.agent.anthropic
 
 import com.embabel.agent.api.models.AnthropicModels
 import com.embabel.agent.spi.LlmService

--- a/embabel-agent-anthropic/src/main/kotlin/com/embabel/agent/anthropic/AnthropicOptionsConverter.kt
+++ b/embabel-agent-anthropic/src/main/kotlin/com/embabel/agent/anthropic/AnthropicOptionsConverter.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.anthropic
+
+import com.embabel.chat.MessageRole
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.OptionsConverter
+import org.springframework.ai.anthropic.AnthropicChatOptions
+import org.springframework.ai.anthropic.api.AnthropicApi
+import org.springframework.ai.anthropic.api.AnthropicCacheOptions
+import org.springframework.ai.anthropic.api.AnthropicCacheStrategy
+import org.springframework.ai.chat.messages.MessageType
+
+object AnthropicOptionsConverter : OptionsConverter<AnthropicChatOptions> {
+
+    private val logger = org.slf4j.LoggerFactory.getLogger(AnthropicOptionsConverter::class.java)
+
+    /**
+     * Anthropic's default is too low and results in truncated responses.
+     */
+    const val DEFAULT_MAX_TOKENS = 8192
+
+    override fun convertOptions(options: LlmOptions): AnthropicChatOptions {
+        val builder = AnthropicChatOptions.builder()
+            .temperature(options.temperature)
+            .topP(options.topP)
+            .maxTokens(options.maxTokens ?: DEFAULT_MAX_TOKENS)
+            .thinking(
+                if (options.thinking?.enabled == true) AnthropicApi.ChatCompletionRequest.ThinkingConfig(
+                    AnthropicApi.ThinkingType.ENABLED,
+                    options.thinking!!.tokenBudget,
+                ) else AnthropicApi.ChatCompletionRequest.ThinkingConfig(
+                    AnthropicApi.ThinkingType.DISABLED,
+                    null,
+                )
+            )
+            .topK(options.topK)
+
+        // Apply Anthropic caching if configured
+        options.getAnthropicCaching()?.let { caching ->
+            val strategy = resolveStrategy(caching)
+            logger.debug("Applying Anthropic caching: config={}, strategy={}", caching, strategy)
+
+            val cacheOptionsBuilder = AnthropicCacheOptions.builder()
+                .strategy(strategy)
+
+            // Apply message type minimum content lengths
+            caching.messageTypeMinContentLengths.forEach { (role, minLength) ->
+                cacheOptionsBuilder.messageTypeMinContentLength(toMessageType(role), minLength)
+            }
+
+            // Apply message type TTLs
+            caching.messageTypeTtls.forEach { (role, ttl) ->
+                cacheOptionsBuilder.messageTypeTtl(toMessageType(role), ttl)
+            }
+
+            builder.cacheOptions(cacheOptionsBuilder.build())
+        }
+
+        return builder.build()
+    }
+
+    /**
+     * Resolve Anthropic cache strategy from caching configuration.
+     *
+     * Strategy selection follows this priority:
+     * 1. CONVERSATION_HISTORY - if conversation caching enabled
+     * 2. SYSTEM_AND_TOOLS - if both system and tools enabled
+     * 3. SYSTEM_ONLY - if only system enabled
+     * 4. TOOLS_ONLY - if only tools enabled
+     * 5. NONE - if nothing enabled
+     */
+    private fun resolveStrategy(config: AnthropicCachingConfig): AnthropicCacheStrategy {
+        return when {
+            config.conversationHistory -> AnthropicCacheStrategy.CONVERSATION_HISTORY
+            config.systemPrompt && config.tools -> AnthropicCacheStrategy.SYSTEM_AND_TOOLS
+            config.systemPrompt -> AnthropicCacheStrategy.SYSTEM_ONLY
+            config.tools -> AnthropicCacheStrategy.TOOLS_ONLY
+            else -> AnthropicCacheStrategy.NONE
+        }
+    }
+
+    /**
+     * Convert MessageRole to Spring AI's MessageType.
+     */
+    private fun toMessageType(role: MessageRole): MessageType {
+        return when (role) {
+            MessageRole.SYSTEM -> MessageType.SYSTEM
+            MessageRole.USER -> MessageType.USER
+            MessageRole.ASSISTANT -> MessageType.ASSISTANT
+        }
+    }
+}

--- a/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicCachingConfigTest.kt
+++ b/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicCachingConfigTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.config.models.anthropic
+package com.embabel.agent.anthropic
 
 import com.embabel.chat.MessageRole
 import org.junit.jupiter.api.Assertions.*

--- a/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicModelFactoryTest.kt
+++ b/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicModelFactoryTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.config.models.anthropic
+package com.embabel.agent.anthropic
 
 import com.embabel.agent.api.models.AnthropicModels
 import com.embabel.agent.spi.support.springai.SpringAiLlmService

--- a/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicOptionsConverterTest.kt
+++ b/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicOptionsConverterTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.config.models.anthropic
+package com.embabel.agent.anthropic
 
 import com.embabel.agent.test.models.OptionsConverterTestSupport
 import com.embabel.chat.MessageRole

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
@@ -15,27 +15,23 @@
  */
 package com.embabel.agent.config.models.anthropic
 
+import com.embabel.agent.anthropic.AnthropicModelFactory
+import com.embabel.agent.anthropic.AnthropicOptionsConverter
 import com.embabel.agent.api.models.AnthropicModels
 import com.embabel.agent.config.models.anthropic.AnthropicProperties.Companion.PREFIX
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.common.RetryProperties
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.agent.spi.support.springai.SpringAiNativeStructuredOutputConfigurer
-import com.embabel.chat.MessageRole
 import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadataLoader
 import com.embabel.common.ai.autoconfig.ProviderInitialization
 import com.embabel.common.ai.autoconfig.RegisteredModel
-import com.embabel.common.ai.model.LlmOptions
-import com.embabel.common.ai.model.OptionsConverter
 import com.embabel.common.ai.model.PerTokenPricingModel
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import io.micrometer.observation.ObservationRegistry
 import org.springframework.ai.anthropic.AnthropicChatModel
 import org.springframework.ai.anthropic.AnthropicChatOptions
 import org.springframework.ai.anthropic.api.AnthropicApi
-import org.springframework.ai.anthropic.api.AnthropicCacheOptions
-import org.springframework.ai.anthropic.api.AnthropicCacheStrategy
-import org.springframework.ai.chat.messages.MessageType
 import org.springframework.ai.model.tool.ToolCallingManager
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
@@ -227,86 +223,5 @@ class AnthropicModelsConfig(
                 )
             }
             .build()
-    }
-}
-
-object AnthropicOptionsConverter : OptionsConverter<AnthropicChatOptions> {
-
-    private val logger = org.slf4j.LoggerFactory.getLogger(AnthropicOptionsConverter::class.java)
-
-    /**
-     * Anthropic's default is too low and results in truncated responses.
-     */
-    const val DEFAULT_MAX_TOKENS = 8192
-
-    override fun convertOptions(options: LlmOptions): AnthropicChatOptions {
-        val builder = AnthropicChatOptions.builder()
-            .temperature(options.temperature)
-            .topP(options.topP)
-            .maxTokens(options.maxTokens ?: DEFAULT_MAX_TOKENS)
-            .thinking(
-                if (options.thinking?.enabled == true) AnthropicApi.ChatCompletionRequest.ThinkingConfig(
-                    AnthropicApi.ThinkingType.ENABLED,
-                    options.thinking!!.tokenBudget,
-                ) else AnthropicApi.ChatCompletionRequest.ThinkingConfig(
-                    AnthropicApi.ThinkingType.DISABLED,
-                    null,
-                )
-            )
-            .topK(options.topK)
-
-        // Apply Anthropic caching if configured
-        options.getAnthropicCaching()?.let { caching ->
-            val strategy = resolveStrategy(caching)
-            logger.debug("Applying Anthropic caching: config={}, strategy={}", caching, strategy)
-
-            val cacheOptionsBuilder = AnthropicCacheOptions.builder()
-                .strategy(strategy)
-
-            // Apply message type minimum content lengths
-            caching.messageTypeMinContentLengths.forEach { (role, minLength) ->
-                cacheOptionsBuilder.messageTypeMinContentLength(toMessageType(role), minLength)
-            }
-
-            // Apply message type TTLs
-            caching.messageTypeTtls.forEach { (role, ttl) ->
-                cacheOptionsBuilder.messageTypeTtl(toMessageType(role), ttl)
-            }
-
-            builder.cacheOptions(cacheOptionsBuilder.build())
-        }
-
-        return builder.build()
-    }
-
-    /**
-     * Resolve Anthropic cache strategy from caching configuration.
-     *
-     * Strategy selection follows this priority:
-     * 1. CONVERSATION_HISTORY - if conversation caching enabled
-     * 2. SYSTEM_AND_TOOLS - if both system and tools enabled
-     * 3. SYSTEM_ONLY - if only system enabled
-     * 4. TOOLS_ONLY - if only tools enabled
-     * 5. NONE - if nothing enabled
-     */
-    private fun resolveStrategy(config: AnthropicCachingConfig): AnthropicCacheStrategy {
-        return when {
-            config.conversationHistory -> AnthropicCacheStrategy.CONVERSATION_HISTORY
-            config.systemPrompt && config.tools -> AnthropicCacheStrategy.SYSTEM_AND_TOOLS
-            config.systemPrompt -> AnthropicCacheStrategy.SYSTEM_ONLY
-            config.tools -> AnthropicCacheStrategy.TOOLS_ONLY
-            else -> AnthropicCacheStrategy.NONE
-        }
-    }
-
-    /**
-     * Convert MessageRole to Spring AI's MessageType.
-     */
-    private fun toMessageType(role: MessageRole): MessageType {
-        return when (role) {
-            MessageRole.SYSTEM -> MessageType.SYSTEM
-            MessageRole.USER -> MessageType.USER
-            MessageRole.ASSISTANT -> MessageType.ASSISTANT
-        }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LlmAnthropicCachingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LlmAnthropicCachingIT.java
@@ -38,10 +38,12 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.embabel.agent.anthropic.AnthropicCachingConfig;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.embabel.agent.config.models.anthropic.AnthropicCachingConfigKt.withAnthropicCaching;
+import static com.embabel.agent.anthropic.AnthropicCachingConfigKt.withAnthropicCaching;
 import static com.embabel.agent.config.models.anthropic.AnthropicUsage.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -74,7 +76,7 @@ import static org.junit.jupiter.api.Assertions.*;
                 "spring.main.allow-bean-definition-overriding=true",
 
                 // Debug logging for caching
-                "logging.level.com.embabel.agent.config.models.anthropic.AnthropicOptionsConverter=DEBUG",
+                "logging.level.com.embabel.agent.anthropic.AnthropicOptionsConverter=DEBUG",
                 "logging.level.org.springframework.ai.anthropic=DEBUG",
                 "logging.level.org.springframework.ai.anthropic.api=DEBUG",
                 "logging.level.com.embabel.agent.spi.support.springai.ChatClientLlmOperations=TRACE"

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/spi/InternalExtensionApi.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/spi/InternalExtensionApi.kt
@@ -19,7 +19,7 @@ package com.embabel.common.ai.model.spi
  * Marks APIs that are internal extension mechanisms for LlmOptions.
  *
  * These APIs are intended for use by provider-specific modules
- * (e.g., embabel-agent-anthropic-autoconfigure) to add provider-specific
+ * (e.g., embabel-agent-anthropic) to add provider-specific
  * configuration without coupling the core LlmOptions to specific providers.
  *
  * Application code should use provider-specific extension functions instead

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -223,6 +223,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-anthropic</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-onnx</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <module>embabel-agent-starters</module>
         <module>embabel-agent-test-support</module>
         <module>embabel-agent-openai</module>
+        <module>embabel-agent-anthropic</module>
         <module>embabel-agent-onnx</module>
     </modules>
 


### PR DESCRIPTION
# Extract `AnthropicModelFactory` into plain `embabel-agent-anthropic` module

Relates to #1744 (multiple model starters on classpath throw at startup when their key is unset).

## Why

The OpenAI BYOK factory (`OpenAiCompatibleModelFactory`) lives in a plain `embabel-agent-openai`
module with no autoconfiguration, so it can be pulled in directly without the starter and without
an eager "API key required" startup throw. Anthropic was the odd one out: `AnthropicModelFactory`
shipped *inside* `embabel-agent-anthropic-autoconfigure`, so you couldn't get the factory without
also pulling the autoconfig that fails fast on a missing key.

This change makes Anthropic symmetric with OpenAI: a plain factory module you can depend on for
BYOK / `detectProvider` without any Spring Boot autoconfiguration.

## What changed

**New module `embabel-agent-anthropic`** (sibling of `embabel-agent-openai`), package
`com.embabel.agent.anthropic`:
- `AnthropicModelFactory` (moved)
- `AnthropicOptionsConverter` (extracted from its inline declaration in `AnthropicModelsConfig.kt`)
- `AnthropicCachingConfig` + `withAnthropicCaching` / `getAnthropicCaching` extensions (moved;
  pure, user-facing API)
- The three corresponding unit tests, relocated

**`embabel-agent-anthropic-autoconfigure`**:
- Now depends on `embabel-agent-anthropic`
- `AnthropicModelsConfig` still `extends AnthropicModelFactory`, references the converter via import;
  dropped six now-unused imports
- `LlmAnthropicCachingIT` repointed (static import, logger-name string, added type import)
- `UsageExtensions` (`AnthropicUsage`) intentionally stays — autoconfig concern, not used by the factory

**Wiring**: registered in root `pom.xml` `<modules>` and the `embabel-agent-dependencies` BOM.

**Doc/consumer touch-ups**: `InternalExtensionApi.kt` comment now names `embabel-agent-anthropic`.

## Breaking change

The public BYOK import path for Anthropic moves:

```
- com.embabel.agent.config.models.anthropic.AnthropicModelFactory
+ com.embabel.agent.anthropic.AnthropicModelFactory
```

(Also applies to `AnthropicOptionsConverter`, `AnthropicCachingConfig`, and the
`withAnthropicCaching` / `getAnthropicCaching` extensions.) OpenAI is unchanged.

Follow-ups outside this PR:
- Update the BYOK blog post import path.
- `guide`: `UserModelFactory.kt` import already updated. Optional clarity step — swap its
  `embabel-agent-anthropic-autoconfigure` dependency for `embabel-agent-anthropic` and
  `spring.autoconfigure.exclude` `AgentAnthropicAutoConfiguration` to be truly starter-free.

## Verification

- `embabel-agent-anthropic`: 40 tests, BUILD SUCCESS
- `embabel-agent-anthropic-autoconfigure` (clean): 34 tests, BUILD SUCCESS

## Not included

Bedrock / OCI GenAI BYOK (their auth is credentials/region, not an API key — needs a broader
abstraction) and native Google GenAI BYOK (key-based, fits the interface, deferred by request).
