### PR TITLE
Promote Experimental APIs and update docs

### DIFF
--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/TokenCountEstimator.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/TokenCountEstimator.kt
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.ApiStatus
  * analogous abstractions so that users coming from those frameworks find a
  * familiar API.
  */
-@ApiStatus.Experimental
+
 fun interface TokenCountEstimator<T> {
 
     fun estimate(content: T): Int
@@ -56,7 +56,6 @@ fun interface TokenCountEstimator<T> {
  * Callers working with non-Latin scripts or code may supply a
  * different ratio.
  */
-@ApiStatus.Experimental
 class CharacterHeuristicTokenCountEstimator @JvmOverloads constructor(
     val charsPerToken: Int = DEFAULT_CHARS_PER_TOKEN,
 ) : TokenCountEstimator<String> {

--- a/embabel-agent-docs/src/main/asciidoc/reference/flow/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/flow/page.adoc
@@ -192,7 +192,7 @@ Kotlin::
 ----
 @Action
 fun extractPerson(userInput: UserInput, context: OperationContext): Person? {
-    val maybeAPerson = context.promptRunner().withLlm(LlmOptions.fromModel(OpenAiModels.GPT_41)).createObjectIfPossible(
+    val maybeAPerson = context.promptRunner().withLlm(LlmOptions.withModel(OpenAiModels.GPT_41)).createObjectIfPossible(
         """
         Create a person from this user input, extracting their name:
         ${userInput.content}


### PR DESCRIPTION
## OVERVIEW

Please refer to:

Issue #1187 
Issue #817 

1. Promote ```TokenCountEstimator``` to prod status (was - experimental)
2. Replace deprecated API in the doc with the prod API