### PR TITLE
fix: remove unreachable null checks flagged by Sonar (S2583)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/UnfoldingToolInjectionStrategy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/UnfoldingToolInjectionStrategy.kt
@@ -139,3 +139,4 @@ class UnfoldingToolInjectionStrategy : ToolInjectionStrategy {
         val INSTANCE = UnfoldingToolInjectionStrategy()
     }
 }
+

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/UnfoldingToolInjectionStrategy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/UnfoldingToolInjectionStrategy.kt
@@ -139,4 +139,3 @@ class UnfoldingToolInjectionStrategy : ToolInjectionStrategy {
         val INSTANCE = UnfoldingToolInjectionStrategy()
     }
 }
-

--- a/embabel-agent-observability/src/main/java/com/embabel/agent/observability/tracing/ChatModelObservationFilter.java
+++ b/embabel-agent-observability/src/main/java/com/embabel/agent/observability/tracing/ChatModelObservationFilter.java
@@ -211,9 +211,6 @@ public class ChatModelObservationFilter implements ObservationFilter {
      */
     private String buildInputMessages(ChatModelObservationContext chatContext) {
         var request = chatContext.getRequest();
-        if (request == null) {
-            return null;
-        }
         var instructions = request.getInstructions();
         if (instructions == null || instructions.isEmpty()) {
             return null;
@@ -277,10 +274,6 @@ public class ChatModelObservationFilter implements ObservationFilter {
      */
     private String extractPrompt(ChatModelObservationContext chatContext) {
         var request = chatContext.getRequest();
-        if (request == null) {
-            return null;
-        }
-
         var instructions = request.getInstructions();
         if (instructions == null || instructions.isEmpty()) {
             return null;

--- a/embabel-agent-observability/src/main/java/com/embabel/agent/observability/tracing/ObservationUtils.java
+++ b/embabel-agent-observability/src/main/java/com/embabel/agent/observability/tracing/ObservationUtils.java
@@ -58,7 +58,7 @@ final class ObservationUtils {
         StringBuilder sb = new StringBuilder();
         for (Message m : messages) {
             if (sb.length() > 0) sb.append("\n");
-            String role = m.getRole() == null ? "null" : m.getRole().name().toLowerCase(Locale.ROOT);
+            String role = m.getRole().name().toLowerCase(Locale.ROOT);
             sb.append("[").append(role).append("]: ").append(m.getContent());
         }
         return sb.toString();


### PR DESCRIPTION
  Remove unreachable null checks flagged by Sonar (S2583)                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  ## Summary                                                                                                                                                                                                                                                                                                                                                                         
  - SonarCloud flagged 3 dead-code null checks under rule `java:S2583` ("condition always evaluates to false") on the new-code leak period.                                                                                                                                                                                                                                          
  - `ChatModelObservationFilter.buildInputMessages` / `extractPrompt`: `chatContext.getRequest()` is guaranteed non-null by Spring AI's `ChatModelObservationContext` contract, so the `if (request == null)` guards were unreachable.                                                                                                                                               
  - `ObservationUtils.formatMessages`: `Message.role` is a non-nullable Kotlin `val`, so the `m.getRole() == null` check was unreachable.                                                                                                                                                                                                                                            
  - No behavior change — these were defensive checks against conditions that can't occur given the current contracts.                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                       
  - [x] `mvn -pl embabel-agent-observability -am compile -DskipTests`                                                                                                                                                                                                                                                                                                                
  - [x] `mvn -pl embabel-agent-observability test -Dtest=ChatModelObservationFilterTest,ObservationUtilsTest`