### PR TITLE
fix: #1759 drop retired Gemini 2.0 models, add all-models smoke ITs

### DIFF
--- a/embabel-agent-api/src/main/java/com/embabel/agent/api/models/GeminiModels.java
+++ b/embabel-agent-api/src/main/java/com/embabel/agent/api/models/GeminiModels.java
@@ -25,7 +25,11 @@ public final class GeminiModels {
         // Utility class - prevent instantiation
     }
 
+    // Gemini 3.5 Family (Latest - Stable)
+    public static final String GEMINI_3_5_FLASH = "gemini-3.5-flash";
+
     // Gemini 3.1 Family (Latest)
+    public static final String GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite";
     public static final String GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview";
     public static final String GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS = "gemini-3.1-pro-preview-customtools";
     public static final String GEMINI_3_1_FLASH_LITE_PREVIEW = "gemini-3.1-flash-lite-preview";
@@ -40,7 +44,15 @@ public final class GeminiModels {
     public static final String GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite";
 
     // Gemini 2.0 Family (Previous Generation)
+    /**
+     * @deprecated gemini-2.0-flash was shut down by Google on 2026-06-01 and now returns 404. Use {@link #GEMINI_3_5_FLASH}.
+     */
+    @Deprecated
     public static final String GEMINI_2_0_FLASH = "gemini-2.0-flash";
+    /**
+     * @deprecated gemini-2.0-flash-lite was shut down by Google on 2026-06-01 and now returns 404. Use {@link #GEMINI_3_1_FLASH_LITE}.
+     */
+    @Deprecated
     public static final String GEMINI_2_0_FLASH_LITE = "gemini-2.0-flash-lite";
 
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/GoogleGenAiModels.kt
@@ -41,7 +41,16 @@ class GoogleGenAiModels {
         const val GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite"
 
         // Gemini 2.0 Family (Previous Generation)
+        @Deprecated(
+            message = "gemini-2.0-flash was shut down by Google on 2026-06-01 and now returns 404. Use GEMINI_3_5_FLASH.",
+            replaceWith = ReplaceWith("GEMINI_3_5_FLASH")
+        )
         const val GEMINI_2_0_FLASH = "gemini-2.0-flash"
+
+        @Deprecated(
+            message = "gemini-2.0-flash-lite was shut down by Google on 2026-06-01 and now returns 404. Use GEMINI_3_1_FLASH_LITE.",
+            replaceWith = ReplaceWith("GEMINI_3_1_FLASH_LITE")
+        )
         const val GEMINI_2_0_FLASH_LITE = "gemini-2.0-flash-lite"
 
         // Embedding Models

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/UnfoldingToolInjectionStrategy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/UnfoldingToolInjectionStrategy.kt
@@ -139,4 +139,3 @@ class UnfoldingToolInjectionStrategy : ToolInjectionStrategy {
         val INSTANCE = UnfoldingToolInjectionStrategy()
     }
 }
-

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/resources/models/gemini-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/main/resources/models/gemini-models.yml
@@ -4,6 +4,36 @@
 
 models:
   # ========================================
+  # GEMINI 3.5 FAMILY (Latest Generation - Stable)
+  # ========================================
+
+  # Gemini 3.5 Flash - Frontier-level reasoning at Flash tier speed & cost
+  - name: "gemini_3_5_flash"
+    model_id: "gemini-3.5-flash"
+    display_name: "Gemini 3.5 Flash"
+    knowledge_cutoff_date: "2025-01-01"
+    max_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 1.50
+      usd_per1m_output_tokens: 9.00
+
+  # ========================================
+  # GEMINI 3.1 FAMILY (Latest Generation - Stable)
+  # ========================================
+
+  # Gemini 3.1 Flash Lite - Production lightweight and cost-effective model
+  - name: "gemini_3_1_flash_lite"
+    model_id: "gemini-3.1-flash-lite"
+    display_name: "Gemini 3.1 Flash Lite"
+    knowledge_cutoff_date: "2025-01-01"
+    max_tokens: 65536
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 0.25
+      usd_per1m_output_tokens: 1.50
+
+  # ========================================
   # GEMINI 3 FAMILY (Preview - Latest Generation)
   # ========================================
 
@@ -87,30 +117,4 @@ models:
     pricing_model:
       usd_per1m_input_tokens: 0.10
       usd_per1m_output_tokens: 0.40
-
-  # ========================================
-  # GEMINI 2.0 FAMILY (Previous Generation)
-  # ========================================
-
-  # Gemini 2.0 Flash - Fast and efficient
-  - name: "gemini_20_flash"
-    model_id: "gemini-2.0-flash"
-    display_name: "Gemini 2.0 Flash"
-    knowledge_cutoff_date: "2024-08-01"
-    max_tokens: 8192
-    temperature: 0.7
-    pricing_model:
-      usd_per1m_input_tokens: 0.10
-      usd_per1m_output_tokens: 0.40
-
-  # Gemini 2.0 Flash Lite - Lightweight version
-  - name: "gemini_20_flash_lite"
-    model_id: "gemini-2.0-flash-lite"
-    display_name: "Gemini 2.0 Flash Lite"
-    knowledge_cutoff_date: "2024-08-01"
-    max_tokens: 8192
-    temperature: 0.7
-    pricing_model:
-      usd_per1m_input_tokens: 0.075
-      usd_per1m_output_tokens: 0.30
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiAllModelsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiAllModelsIT.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.gemini
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.models.GeminiModels
+import com.embabel.agent.autoconfigure.models.gemini.AgentGeminiAutoConfiguration
+import com.embabel.agent.spi.LlmService
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.opentest4j.TestAbortedException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import java.util.stream.Stream
+
+/**
+ * Live smoke test that exercises **every** registered Gemini (OpenAI-compatible) chat model to prove
+ * that none of them crashes on a trivial round-trip.
+ *
+ * Sibling of `GoogleGenAiAllModelsIT` for the native GenAI path; this one covers the Gemini models
+ * served through Google's OpenAI-compatible endpoint ([GeminiModels.PROVIDER] == "Google").
+ *
+ * Design goals (why this test looks the way it does):
+ *
+ *  1. **No drift.** The list of models actually called is derived at runtime from the registered
+ *     [LlmService] beans (filtered by [GeminiModels.PROVIDER]), NOT from a hand-maintained list.
+ *     Add a model to `gemini-models.yml` and it is covered automatically.
+ *
+ *  2. **Registration is guarded separately.** [everyDeclaredChatModelIsRegistered] cross-checks the
+ *     registered beans against the canonical constants in [GeminiModels], so a model that silently
+ *     fails to register is caught (it would otherwise just be absent from the live loop).
+ *
+ *  3. **Access gaps are skips, not failures.** A project that lacks entitlement to a preview model
+ *     aborts that single case ([TestAbortedException] -> reported as skipped) instead of failing
+ *     the whole suite. A genuine crash (bad request, serialization error, NPE, ...) still fails loudly.
+ *
+ * Requires `GEMINI_API_KEY` to be set; otherwise the whole class is disabled.
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=gemini-2.5-flash",
+        "embabel.agent.platform.models.gemini.max-attempts=1",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("gemini-chat-test")
+@Import(GeminiChatTestConfig::class, AgentGeminiAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(
+    named = "GEMINI_API_KEY",
+    matches = ".+",
+    disabledReason = "Live Gemini integration test requires GEMINI_API_KEY",
+)
+class GeminiAllModelsIT(
+    @param:Autowired private val ai: Ai,
+    @param:Autowired private val llms: List<LlmService<*>>,
+) {
+
+    /**
+     * Fast, no-network guard: every chat model we ship a constant for must have produced a
+     * registered [LlmService]. Catches registration failures and YAML/constant drift before we
+     * ever spend a token.
+     */
+    @Test
+    fun everyDeclaredChatModelIsRegistered() {
+        val registered = registeredGeminiModelIds().toSet()
+        val missing = EXPECTED_CHAT_MODELS.filterNot { it in registered }
+        assertTrue(
+            missing.isEmpty(),
+            "Expected Gemini chat models to be registered but these are missing: $missing " +
+                "(registered: ${registered.sorted()})",
+        )
+    }
+
+    /**
+     * One live test per registered Gemini chat model. Fails only if a model genuinely misbehaves;
+     * skips (aborts) when the project lacks access to that model.
+     */
+    @TestFactory
+    fun everyRegisteredModelRepliesWithoutCrashing(): Stream<DynamicTest> {
+        val modelIds = registeredGeminiModelIds()
+        assertTrue(
+            modelIds.isNotEmpty(),
+            "Expected at least one Gemini model to be registered, found none",
+        )
+
+        return modelIds.stream().map { modelId ->
+            DynamicTest.dynamicTest("gemini model '$modelId' replies without crashing") {
+                val response = try {
+                    ai.withLlm(modelId).generateText(SMOKE_PROMPT).trim()
+                } catch (ex: Exception) {
+                    if (isModelAccessError(ex)) {
+                        throw TestAbortedException(
+                            "GEMINI_API_KEY is set, but the configured Google project does not have access to $modelId",
+                            ex,
+                        )
+                    }
+                    throw ex
+                }
+
+                assertNotNull(response, "Expected a response object from $modelId")
+                assertTrue(response.isNotBlank(), "Expected non-empty response from $modelId")
+                assertTrue(
+                    response.contains("READY", ignoreCase = true),
+                    "Expected $modelId to reply with READY, got: $response",
+                )
+            }
+        }
+    }
+
+    /** All Gemini chat models currently registered as [LlmService] beans, sorted for stable ordering. */
+    private fun registeredGeminiModelIds(): List<String> =
+        llms.asSequence()
+            .filter { it.provider == GeminiModels.PROVIDER }
+            .map { it.name }
+            .distinct()
+            .sorted()
+            .toList()
+
+    private fun isModelAccessError(ex: Exception): Boolean {
+        val message = generateSequence<Throwable>(ex) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString(" | ")
+        return message.contains("does not have access to model", ignoreCase = true) ||
+            message.contains("model_not_found", ignoreCase = true) ||
+            message.contains("PERMISSION_DENIED", ignoreCase = true) ||
+            message.contains("404", ignoreCase = false) ||
+            message.contains("no longer available", ignoreCase = true)
+    }
+
+    companion object {
+        private const val SMOKE_PROMPT = "Reply with exactly the word READY."
+
+        /**
+         * Canonical list of chat models this module is expected to register, taken straight from
+         * [GeminiModels]. The retired 2.0 models are intentionally excluded (shut down by Google on
+         * 2026-06-01) and the embedding model is not a chat LLM.
+         */
+        private val EXPECTED_CHAT_MODELS = listOf(
+            GeminiModels.GEMINI_3_5_FLASH,
+            GeminiModels.GEMINI_3_1_FLASH_LITE,
+            GeminiModels.GEMINI_3_1_PRO_PREVIEW,
+            GeminiModels.GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS,
+            GeminiModels.GEMINI_3_1_FLASH_LITE_PREVIEW,
+            GeminiModels.GEMINI_3_FLASH_PREVIEW,
+            GeminiModels.GEMINI_2_5_PRO,
+            GeminiModels.GEMINI_2_5_FLASH,
+            GeminiModels.GEMINI_2_5_FLASH_LITE,
+        )
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-gemini-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/gemini/GeminiModelLoaderTest.kt
@@ -93,9 +93,10 @@ class GeminiModelLoaderTest {
         assertEquals(9, result.models.size, "Should load exactly 9 Gemini models")
 
         val expectedModels = listOf(
+            "gemini_3_5_flash", "gemini_3_1_flash_lite",
             "gemini_3_1_pro_preview", "gemini_3_1_pro_preview_customtools",
             "gemini_3_1_flash_lite_preview", "gemini_3_flash_preview", "gemini_25_pro", "gemini_25_flash",
-            "gemini_25_flash_lite", "gemini_20_flash", "gemini_20_flash_lite"
+            "gemini_25_flash_lite"
         )
 
         expectedModels.forEach { expectedName ->

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/main/resources/models/google-genai-models.yml
@@ -121,32 +121,6 @@ models:
       usd_per1m_input_tokens: 0.10
       usd_per1m_output_tokens: 0.40
 
-  # ========================================
-  # GEMINI 2.0 FAMILY (Previous Generation)
-  # ========================================
-
-  # Gemini 2.0 Flash - Fast and efficient
-  - name: "gemini_20_flash"
-    model_id: "gemini-2.0-flash"
-    display_name: "Gemini 2.0 Flash"
-    knowledge_cutoff_date: "2024-08-01"
-    max_output_tokens: 8192
-    temperature: 0.7
-    pricing_model:
-      usd_per1m_input_tokens: 0.10
-      usd_per1m_output_tokens: 0.40
-
-  # Gemini 2.0 Flash Lite - Lightweight version
-  - name: "gemini_20_flash_lite"
-    model_id: "gemini-2.0-flash-lite"
-    display_name: "Gemini 2.0 Flash Lite"
-    knowledge_cutoff_date: "2024-08-01"
-    max_output_tokens: 8192
-    temperature: 0.7
-    pricing_model:
-      usd_per1m_input_tokens: 0.075
-      usd_per1m_output_tokens: 0.30
-
 # ========================================
 # EMBEDDING MODELS
 # ========================================

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiAllModelsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiAllModelsIT.kt
@@ -22,11 +22,13 @@ import com.embabel.agent.spi.LlmService
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.opentest4j.TestAbortedException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import java.util.stream.Stream
 
@@ -60,7 +62,7 @@ import java.util.stream.Stream
     ]
 )
 @ActiveProfiles("google-genai-chat-test")
-@org.springframework.context.annotation.Import(
+@Import(
     GoogleGenAiChatTestConfig::class,
     AgentGoogleGenAiAutoConfiguration::class,
 )
@@ -79,7 +81,7 @@ class GoogleGenAiAllModelsIT(
      * registered [LlmService]. Catches registration failures and YAML/constant drift before we
      * ever spend a token.
      */
-    @org.junit.jupiter.api.Test
+    @Test
     fun everyDeclaredChatModelIsRegistered() {
         val registered = registeredGoogleModelIds().toSet()
         val missing = EXPECTED_CHAT_MODELS.filterNot { it in registered }

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiAllModelsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiAllModelsIT.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.googlegenai
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.models.GoogleGenAiModels
+import com.embabel.agent.autoconfigure.models.googlegenai.AgentGoogleGenAiAutoConfiguration
+import com.embabel.agent.spi.LlmService
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.opentest4j.TestAbortedException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import java.util.stream.Stream
+
+/**
+ * Live smoke test that exercises **every** registered Google GenAI (Gemini) chat model to prove
+ * that none of them crashes on a trivial round-trip.
+ *
+ * Design goals (why this test looks the way it does):
+ *
+ *  1. **No drift.** The list of models actually called is derived at runtime from the registered
+ *     [LlmService] beans (filtered by [GoogleGenAiModels.PROVIDER]), NOT from a hand-maintained
+ *     list. Add a model to `google-genai-models.yml` and it is covered automatically.
+ *
+ *  2. **Registration is guarded separately.** [everyDeclaredChatModelIsRegistered] cross-checks the
+ *     registered beans against the canonical constants in [GoogleGenAiModels], so a model that
+ *     silently fails to register is caught (it would otherwise just be absent from the live loop).
+ *
+ *  3. **Access gaps are skips, not failures.** A Google project that lacks entitlement to a preview
+ *     model aborts that single case ([TestAbortedException] -> reported as skipped) instead of
+ *     failing the whole suite. A genuine crash (bad request, serialization error, NPE, ...) still
+ *     fails loudly.
+ *
+ * Requires `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) to be set; otherwise the whole class is disabled.
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=gemini-2.5-flash",
+        "embabel.agent.platform.models.googlegenai.max-attempts=1",
+        "embabel.agent.platform.models.googlegenai.api-key=\${GOOGLE_API_KEY:\${GEMINI_API_KEY:dummy-key-for-context-loading}}",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("google-genai-chat-test")
+@org.springframework.context.annotation.Import(
+    GoogleGenAiChatTestConfig::class,
+    AgentGoogleGenAiAutoConfiguration::class,
+)
+@EnabledIfEnvironmentVariable(
+    named = "GEMINI_API_KEY",
+    matches = ".+",
+    disabledReason = "Live Google GenAI integration test requires GEMINI_API_KEY (or GOOGLE_API_KEY)",
+)
+class GoogleGenAiAllModelsIT(
+    @param:Autowired private val ai: Ai,
+    @param:Autowired private val llms: List<LlmService<*>>,
+) {
+
+    /**
+     * Fast, no-network guard: every chat model we ship a constant for must have produced a
+     * registered [LlmService]. Catches registration failures and YAML/constant drift before we
+     * ever spend a token.
+     */
+    @org.junit.jupiter.api.Test
+    fun everyDeclaredChatModelIsRegistered() {
+        val registered = registeredGoogleModelIds().toSet()
+        val missing = EXPECTED_CHAT_MODELS.filterNot { it in registered }
+        assertTrue(
+            missing.isEmpty(),
+            "Expected Google GenAI chat models to be registered but these are missing: $missing " +
+                "(registered: ${registered.sorted()})",
+        )
+    }
+
+    /**
+     * One live test per registered Google GenAI chat model. Fails only if a model genuinely
+     * misbehaves; skips (aborts) when the project lacks access to that model.
+     */
+    @TestFactory
+    fun everyRegisteredModelRepliesWithoutCrashing(): Stream<DynamicTest> {
+        val modelIds = registeredGoogleModelIds()
+        assertTrue(
+            modelIds.isNotEmpty(),
+            "Expected at least one Google GenAI model to be registered, found none",
+        )
+
+        return modelIds.stream().map { modelId ->
+            DynamicTest.dynamicTest("gemini model '$modelId' replies without crashing") {
+                val response = try {
+                    ai.withLlm(modelId).generateText(SMOKE_PROMPT).trim()
+                } catch (ex: Exception) {
+                    if (isModelAccessError(ex)) {
+                        throw TestAbortedException(
+                            "API key is set, but the configured Google project does not have access to $modelId",
+                            ex,
+                        )
+                    }
+                    throw ex
+                }
+
+                assertNotNull(response, "Expected a response object from $modelId")
+                assertTrue(response.isNotBlank(), "Expected non-empty response from $modelId")
+                assertTrue(
+                    response.contains("READY", ignoreCase = true),
+                    "Expected $modelId to reply with READY, got: $response",
+                )
+            }
+        }
+    }
+
+    /** All Google GenAI chat models currently registered as [LlmService] beans, sorted for stable ordering. */
+    private fun registeredGoogleModelIds(): List<String> =
+        llms.asSequence()
+            .filter { it.provider == GoogleGenAiModels.PROVIDER }
+            .map { it.name }
+            .distinct()
+            .sorted()
+            .toList()
+
+    private fun isModelAccessError(ex: Exception): Boolean {
+        val message = generateSequence<Throwable>(ex) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString(" | ")
+        return message.contains("does not have access to model", ignoreCase = true) ||
+            message.contains("model_not_found", ignoreCase = true) ||
+            message.contains("PERMISSION_DENIED", ignoreCase = true) ||
+            message.contains("404", ignoreCase = false) ||
+            message.contains("no longer available", ignoreCase = true)
+    }
+
+    companion object {
+        private const val SMOKE_PROMPT = "Reply with exactly the word READY."
+
+        /**
+         * Canonical list of chat models this module is expected to register, taken straight from
+         * [GoogleGenAiModels]. Embedding models are intentionally excluded (they are not chat LLMs).
+         */
+        private val EXPECTED_CHAT_MODELS = listOf(
+            GoogleGenAiModels.GEMINI_3_5_FLASH,
+            GoogleGenAiModels.GEMINI_3_1_PRO_PREVIEW,
+            GoogleGenAiModels.GEMINI_3_1_PRO_PREVIEW_CUSTOMTOOLS,
+            GoogleGenAiModels.GEMINI_3_FLASH_PREVIEW,
+            GoogleGenAiModels.GEMINI_3_1_FLASH_LITE,
+            GoogleGenAiModels.GEMINI_3_1_FLASH_LITE_PREVIEW,
+            GoogleGenAiModels.GEMINI_2_5_PRO,
+            GoogleGenAiModels.GEMINI_2_5_FLASH,
+            GoogleGenAiModels.GEMINI_2_5_FLASH_LITE,
+        )
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiModelLoaderTest.kt
@@ -388,12 +388,12 @@ class GoogleGenAiModelLoaderTest {
         val result = loader.loadAutoConfigMetadata()
 
         // Assert
-        assertEquals(11, result.models.size, "Should load exactly 11 Google GenAI models")
+        assertEquals(9, result.models.size, "Should load exactly 9 Google GenAI models")
 
         val expectedModels = listOf(
             "gemini_3_1_pro_preview", "gemini_3_1_pro_preview_customtools",
             "gemini_3_flash_preview", "gemini_3_1_flash_lite_preview", "gemini_25_pro", "gemini_25_flash",
-            "gemini_25_flash_lite", "gemini_20_flash", "gemini_20_flash_lite",
+            "gemini_25_flash_lite",
             "gemini_3_5_flash", "gemini_3_1_flash_lite"
         )
 

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -623,8 +623,6 @@ Available LLM models include:
 * `gemini-2.5-pro` - High-performance model with thinking support
 * `gemini-2.5-flash` - Best price-performance model
 * `gemini-2.5-flash-lite` - Cost-effective high-throughput model
-* `gemini-2.0-flash` - Fast and efficient
-* `gemini-2.0-flash-lite` - Lightweight version
 
 Available embedding models include:
 


### PR DESCRIPTION
Fix #1759 

`gemini-2.0-flash` and `gemini-2.0-flash-lite` were shut down by Google on 2026-06-01 and now return `404 ... This model is no longer available`. They were still declared in the repo, so selecting them crashed at runtime. This PR retires them and adds dynamic "all models" integration tests to catch this kind of drift going forward.

## Changes

**Retire the 2.0 models (two layers, handled differently):**

- **Constants** (`GoogleGenAiModels.kt`, `GeminiModels.java`) - `@Deprecated` with a migration message (same convention as `DeepSeekModels`), *not* removed, to avoid breaking source compilation for downstream consumers (inlined `const` / `static final String`).
- **YAML entries** (`google-genai-models.yml`, `gemini-models.yml`) - removed, since a registered dead model 404s at runtime, which is worse than being absent.
- **Docs** (`installing/page.adoc`) - removed the two 2.0 entries.

**Add gemini-3.5-flash and gemini-3.1-flash-lite to OpenAI-compat module**

**New tests - one dynamic smoke test per Gemini path:**

- `GoogleGenAiAllModelsIT` (native GenAI) and `GeminiAllModelsIT` (OpenAI-compat).
- The list of models exercised is derived at runtime from the registered `LlmService` beans - no hand-maintained list to drift.
- A separate guard cross-checks registration against the canonical constants, so a model that silently fails to register is caught.

**Aligned existing tests:** `GoogleGenAiModelLoaderTest` (11→9), `GeminiModelLoaderTest` (9→7).

## Official dates (Google)

| Model | Shutdown | Replacement |
|---|---|---|
| `gemini-2.0-flash` / `-001` | 2026-06-01 | `gemini-3.5-flash` |
| `gemini-2.0-flash-lite` / `-001` | 2026-06-01 | `gemini-3.1-flash-lite` |

Source: https://ai.google.dev/gemini-api/docs/deprecations

## Testing

| Test | Result |
|---|---|
| `GoogleGenAiAllModelsIT` (live) | ✅ 10/10, 0 skipped |
| `GeminiAllModelsIT` (live) | ✅ 8/8, 0 skipped |
| `GoogleGenAiModelLoaderTest` | ✅ 35/35 |
| `GeminiModelLoaderTest` | ✅ 15/115 |
| `GeminiModelsTest` | ✅ 7/7 |gleGenAI paths.