### PR TITLE
 Fix #1557: close MCP SSE connections before Tomcat graceful shutdown…

### DIFF
--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpSseShutdownConfiguration.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/McpSseShutdownConfiguration.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.ApplicationListener
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.event.ContextClosedEvent
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * Closes open SSE connections before Tomcat's graceful shutdown phase begins.
+ *
+ * [WebMvcSseServerTransportProvider] keeps SSE connections open after MCP calls complete
+ * (by design — SSE is a persistent connection). When the application shuts down, Tomcat
+ * sees these as active requests and waits up to 30 seconds before aborting.
+ *
+ * This configuration listens for [ContextClosedEvent], which fires before Tomcat's
+ * graceful shutdown lifecycle phase, and calls
+ * [WebMvcSseServerTransportProvider.closeGracefully] to drain all active sessions.
+ * A [SHUTDOWN_TIMEOUT] prevents the shutdown from hanging if the Reactor pipeline
+ * stalls (see MCP Java SDK issue #635).
+ *
+ * [WebMvcSseServerTransportProvider] is injected with `required = false` because
+ * `@ConditionalOnBean` evaluates before Spring AI's autoconfiguration registers the
+ * transport bean, causing it to be skipped. Optional injection defers the check to
+ * after all beans are created; a null provider means SSE transport is not active and
+ * no action is taken.
+ *
+ * Upstream issues (open as of spring-ai-starter-mcp-server-webmvc 1.1.7 / MCP Java SDK 0.18.2):
+ * - [Spring AI #4002](https://github.com/spring-projects/spring-ai/issues/4002)
+ * - [MCP Java SDK #635](https://github.com/modelcontextprotocol/java-sdk/issues/635)
+ * - [MCP Java SDK #547](https://github.com/modelcontextprotocol/java-sdk/issues/547)
+ *
+ * Safe to remove when upstream ships a fix: [WebMvcSseServerTransportProvider.closeGracefully]
+ * is idempotent — a second call on an already-closed provider iterates an empty session map.
+ */
+@Configuration
+internal class McpSseShutdownConfiguration : ApplicationListener<ContextClosedEvent> {
+
+    @Autowired(required = false)
+    private var transportProvider: WebMvcSseServerTransportProvider? = null
+
+    private val logger = LoggerFactory.getLogger(McpSseShutdownConfiguration::class.java)
+
+    override fun onApplicationEvent(event: ContextClosedEvent) {
+        val provider = transportProvider ?: return
+        logger.info("Closing MCP SSE connections before Tomcat graceful shutdown")
+        provider.closeGracefully()
+            .timeout(SHUTDOWN_TIMEOUT)
+            .onErrorResume { error ->
+                logger.warn("MCP SSE graceful shutdown did not complete cleanly: {}", error.message)
+                Mono.empty()
+            }
+            .block()
+        logger.info("MCP SSE connections closed")
+    }
+
+    companion object {
+        private val SHUTDOWN_TIMEOUT: Duration = Duration.ofSeconds(5)
+    }
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpSseShutdownConfigurationTest.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpSseShutdownConfigurationTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import io.modelcontextprotocol.server.transport.WebMvcSseServerTransportProvider
+import org.springframework.context.event.ContextClosedEvent
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+class McpSseShutdownConfigurationTest {
+
+    private val transportProvider = mockk<WebMvcSseServerTransportProvider>()
+    private val config = McpSseShutdownConfiguration().also {
+        val field = McpSseShutdownConfiguration::class.java.getDeclaredField("transportProvider")
+        field.isAccessible = true
+        field.set(it, transportProvider)
+    }
+    private val event = mockk<ContextClosedEvent>(relaxed = true)
+
+    @Nested
+    inner class `on ContextClosedEvent` {
+
+        @Test
+        fun `calls closeGracefully on transport provider`() {
+            every { transportProvider.closeGracefully() } returns Mono.empty()
+            config.onApplicationEvent(event)
+            verify(exactly = 1) { transportProvider.closeGracefully() }
+        }
+
+        @Test
+        fun `completes without throwing when closeGracefully times out`() {
+            every { transportProvider.closeGracefully() } returns Mono.never()
+            config.onApplicationEvent(event)
+            // no exception propagated — shutdown proceeds regardless
+        }
+
+        @Test
+        fun `completes without throwing when closeGracefully errors`() {
+            every { transportProvider.closeGracefully() } returns Mono.error(RuntimeException("transport error"))
+            config.onApplicationEvent(event)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
                                 
  Adds McpSseShutdownConfiguration to embabel-agent-mcpserver to fix a 30-second shutdown stall when using the MCP
  server starter.

Closes:  #1557 

  WebMvcSseServerTransportProvider keeps SSE connections open after MCP calls complete — by design, as SSE is a
  persistent connection. On shutdown, Tomcat counts these as active requests and waits up to 30 seconds before
  force-closing them. This fix listens for ContextClosedEvent (which fires before Tomcat's graceful shutdown phase) and
  calls closeGracefully() to close all active sessions within a 5-second timeout.

  ## Root cause

  WebMvcSseServerTransportProvider.closeGracefully() exists in the MCP Java SDK but is not wired into the Spring
  lifecycle by either the MCP Java SDK or Spring AI's autoconfiguration. The following upstream issues have been open
  since late 2025 with no fix shipped:

  - Spring AI #4002 — Tomcat cannot shut down after MCP client connects (open since Oct 2025, waiting-for-triage)
  - MCP Java SDK #635 — closeGracefully() can hang with no timeout (open, needs-repro)
  - MCP Java SDK #547 — closeGracefully() may leak resources (open, P2)

  Versions affected: spring-ai-starter-mcp-server-webmvc 1.1.7 / MCP Java SDK 0.18.2.

 ##  Design notes

  - @Autowired(required = false) is used instead of @ConditionalOnBean — the conditional evaluates before Spring AI
  registers the transport bean and always resolves to false. Optional injection defers the check until after all beans
  are created.
  - closeGracefully()  — safe to keep when upstream ships a fix, as a second call on an already-closed
  provider iterates an empty session map.
  - 5-second timeout guards against the pipeline stalling (MCP Java SDK #635).

