### PR TITLE
fix(mistral): #1757 - two independent bugs in `embabel-agent-mistral-ai-autoconfigure`

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/MistralAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/MistralAiModels.kt
@@ -35,10 +35,22 @@ class MistralAiModels {
 
         const val CODESTRAL = "codestral-2508"
 
+        @Deprecated(
+            message = "devstral-medium-2507 (Devstral Medium 1.0) was retired by Mistral on 2026-05-31 and now returns 400 (invalid model). Use DEVSTRAL_2.",
+            replaceWith = ReplaceWith("DEVSTRAL_2")
+        )
         const val DEVSTRAL_MEDIUM_10 = "devstral-medium-2507"
 
+        @Deprecated(
+            message = "devstral-small-2507 (Devstral Small 1.1) was retired by Mistral on 2026-05-31 and now returns 400 (invalid model). Use DEVSTRAL_2.",
+            replaceWith = ReplaceWith("DEVSTRAL_2")
+        )
         const val DEVSTRAL_SMALL_11 = "devstral-small-2507"
 
+        @Deprecated(
+            message = "mistral-large-2411 (Mistral Large 2.1) was retired by Mistral on 2026-05-31 and now returns 400 (invalid model). Use MISTRAL_LARGE_3.",
+            replaceWith = ReplaceWith("MISTRAL_LARGE_3")
+        )
         const val MISTRAL_LARGE_21 = "mistral-large-2411"
 
         const val MISTRAL_LARGE_3 = "mistral-large-2512"

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/MistralAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/MistralAiModels.kt
@@ -27,6 +27,8 @@ class MistralAiModels {
 
 		const val MISTRAL_MEDIUM_31 = "mistral-medium-2508"
 
+        const val MISTRAL_MEDIUM_35 = "mistral-medium-2604"
+
         const val MISTRAL_SMALL_32 = "mistral-small-2506"
 
         const val MINISTRAL_8B = "ministral-8b-2410"

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/pom.xml
@@ -36,6 +36,14 @@
 			<artifactId>embabel-agent-test-internal</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- Reproduces the production classpath: presence of reactor-netty makes RestClient.builder()
+		     select ReactorClientHttpRequestFactory, whose default HttpClient carries a 10s responseTimeout. -->
+		<dependency>
+			<groupId>io.projectreactor.netty</groupId>
+			<artifactId>reactor-netty-http</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/java/com/embabel/agent/config/models/mistralai/MistralReasoningContent.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/java/com/embabel/agent/config/models/mistralai/MistralReasoningContent.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.mistralai;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Flattens a Mistral reasoning model's structured assistant content to plain text.
+ *
+ * <p>Reasoning models ({@code magistral-*}) return an assistant {@code content} that is a list of
+ * "thinking"/"text" chunks. {@code spring-ai-mistral-ai:1.1.7} assumes that content is a plain
+ * {@code String} and throws on every call; this turns the chunk list back into the final answer text
+ * so Spring AI can read it. Fixed natively in Spring AI 2.0.0 — this is temporary scaffolding.
+ *
+ * <p>Pure and side-effect free (no Spring, no HTTP), so it is unit-testable in isolation. Mirrors the
+ * per-provider boundary-adapter style of {@code ToolResponseContentAdapter}, applied here to the
+ * inbound (LLM&rarr;app) response rather than outbound tool content.
+ */
+final class MistralReasoningContent {
+
+    private MistralReasoningContent() {
+    }
+
+    /**
+     * Concatenates the final answer text from top-level {@code type=text} chunks. If the response is
+     * pure reasoning with no final text chunk, falls back to the thinking text so nothing is lost.
+     *
+     * @param chunks the assistant message's {@code rawContent}, already known to be a list
+     * @return the flattened text, possibly empty if no text could be extracted
+     */
+    static String flatten(List<?> chunks) {
+        StringBuilder text = new StringBuilder();
+        for (Object chunk : chunks) {
+            if (chunk instanceof Map<?, ?> map && "text".equals(map.get("type"))) {
+                append(text, map.get("text"));
+            }
+        }
+        if (text.isEmpty()) {
+            for (Object chunk : chunks) {
+                if (chunk instanceof Map<?, ?> map && "thinking".equals(map.get("type"))
+                        && map.get("thinking") instanceof List<?> thinking) {
+                    for (Object part : thinking) {
+                        if (part instanceof Map<?, ?> partMap && "text".equals(partMap.get("type"))) {
+                            append(text, partMap.get("text"));
+                        }
+                    }
+                }
+            }
+        }
+        return text.toString();
+    }
+
+    /** Appends {@code value}, separating consecutive chunks with a newline so text isn't run together. */
+    private static void append(StringBuilder sb, Object value) {
+        if (value == null) {
+            return;
+        }
+        String s = value.toString();
+        if (s.isEmpty()) {
+            return;
+        }
+        if (sb.length() > 0) {
+            sb.append('\n');
+        }
+        sb.append(s);
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/java/com/embabel/agent/config/models/mistralai/ReasoningFlatteningMistralAiApi.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/java/com/embabel/agent/config/models/mistralai/ReasoningFlatteningMistralAiApi.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.mistralai;
+
+import org.springframework.ai.mistralai.api.MistralAiApi;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Flattens reasoning-model ("thinking") response content to plain text before {@code MistralAiChatModel}
+ * reads it, working on Spring AI's own record types (no HTTP byte rewriting, no custom deserializer).
+ *
+ * <p>Reasoning models ({@code magistral-*}) return an assistant {@code content} that is a list of
+ * thinking/text chunks, but {@code spring-ai-mistral-ai:1.1.7} assumes a String and throws
+ * {@code IllegalStateException("The content is not a string!")} on every call. Fixed natively in Spring
+ * AI 2.0.0 — this decorator is temporary scaffolding, removed on that upgrade.
+ *
+ * <p>Only the blocking path ({@link #chatCompletionEntity}) is decorated; streaming is unchanged.
+ * The chunk-to-text flattening itself lives in {@link MistralReasoningContent}.
+ */
+public class ReasoningFlatteningMistralAiApi extends MistralAiApi {
+
+    private static final String DEFAULT_BASE_URL = "https://api.mistral.ai";
+
+    /** Applies {@code MistralAiApi.Builder}'s own defaults for base URL and error handler. */
+    public ReasoningFlatteningMistralAiApi(
+            String baseUrl,
+            String apiKey,
+            RestClient.Builder restClientBuilder,
+            WebClient.Builder webClientBuilder) {
+        super(
+                (baseUrl == null || baseUrl.isBlank()) ? DEFAULT_BASE_URL : baseUrl,
+                apiKey,
+                restClientBuilder,
+                webClientBuilder,
+                RetryUtils.DEFAULT_RESPONSE_ERROR_HANDLER);
+    }
+
+    @Override
+    public ResponseEntity<ChatCompletion> chatCompletionEntity(ChatCompletionRequest chatRequest) {
+        ResponseEntity<ChatCompletion> response = super.chatCompletionEntity(chatRequest);
+        ChatCompletion body = response.getBody();
+        if (body == null || body.choices() == null) {
+            return response;
+        }
+
+        List<ChatCompletion.Choice> rewrittenChoices = new ArrayList<>(body.choices().size());
+        for (ChatCompletion.Choice choice : body.choices()) {
+            ChatCompletionMessage message = choice.message();
+            if (message != null && message.rawContent() instanceof List<?> chunks) {
+                ChatCompletionMessage flatMessage = new ChatCompletionMessage(
+                        MistralReasoningContent.flatten(chunks),
+                        message.role(),
+                        message.name(),
+                        message.toolCalls(),
+                        message.toolCallId());
+                rewrittenChoices.add(new ChatCompletion.Choice(
+                        choice.index(), flatMessage, choice.finishReason(), choice.logprobs()));
+            } else {
+                rewrittenChoices.add(choice);
+            }
+        }
+
+        ChatCompletion rewritten = new ChatCompletion(
+                body.id(), body.object(), body.created(), body.model(), rewrittenChoices, body.usage());
+        return new ResponseEntity<>(rewritten, response.getHeaders(), response.getStatusCode());
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoader.kt
@@ -49,6 +49,9 @@ data class MistralAiModelDefinitions(
  * @property maxTokens maximum tokens for completion (default 8192)
  * @property temperature sampling temperature (default 1.0)
  * @property topP nucleus sampling parameter
+ * @property thinking whether this is a reasoning ("magistral") model that returns structured
+ *   thinking/text content. When true, the blocking client flattens that content to plain text so
+ *   spring-ai-mistral-ai:1.1.7 (which assumes string content) can parse it. Superseded by Spring AI 2.0.0.
  */
 data class MistralAiModelDefinition(
 	override val name: String,
@@ -59,6 +62,7 @@ data class MistralAiModelDefinition(
 	val maxTokens: Int = 32768,
 	val temperature: Double = 1.0,
 	val topP: Double? = null,
+	val thinking: Boolean = false,
 ) : LlmAutoConfigMetadata
 
 class MistralAiModelLoader(

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelsConfig.kt
@@ -33,14 +33,19 @@ import org.springframework.ai.mistralai.MistralAiChatOptions
 import org.springframework.ai.mistralai.api.MistralAiApi
 import org.springframework.ai.model.tool.ToolCallingManager
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.convert.DurationStyle
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder
+import org.springframework.boot.http.client.ClientHttpRequestFactorySettings
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.client.RestClient
 import org.springframework.web.reactive.function.client.WebClient
+import java.time.Duration
 
 /**
  * Configuration properties for Mistral AI models.
@@ -99,6 +104,12 @@ class MistralAiModelsConfig(
     private val properties: MistralAiProperties,
     private val observationRegistry: ObjectProvider<ObservationRegistry>,
     private val configurableBeanFactory: ConfigurableBeanFactory,
+    @param:Qualifier("aiModelRestClientBuilder")
+    private val restClientBuilderProvider: ObjectProvider<RestClient.Builder>,
+    @param:Qualifier("aiModelWebClientBuilder")
+    private val webClientBuilderProvider: ObjectProvider<WebClient.Builder>,
+    @param:Value("\${embabel.agent.platform.http-client.read-timeout:5m}")
+    private val httpReadTimeout: String,
     private val modelLoader: LlmAutoConfigMetadataLoader<MistralAiModelDefinitions> = MistralAiModelLoader(),
 ) {
     private val logger = LoggerFactory.getLogger(MistralAiModelsConfig::class.java)
@@ -151,7 +162,7 @@ class MistralAiModelsConfig(
         val mistralChatModel = MistralAiChatModel
             .builder()
             .defaultOptions(createDefaultOptions(modelDef))
-            .mistralAiApi(createMistralAiApi())
+            .mistralAiApi(mistralAiApiFor(modelDef))
             .toolCallingManager(
                 ToolCallingManager.builder()
                     .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
@@ -190,25 +201,67 @@ class MistralAiModelsConfig(
             .build()
     }
 
-    private fun createMistralAiApi(): MistralAiApi {
-        val builder = MistralAiApi.builder().apiKey(apiKey)
+    /**
+     * A [MistralAiApi] is stateless and model-agnostic — the model id and options live on
+     * [MistralAiChatOptions], not on the API — so all models share one instance, exactly as
+     * [org.springframework.ai.openai.api.OpenAiApi] is shared across providers built on
+     * OpenAiCompatibleModelFactory. Only two variants exist: the plain API for the 16 standard models and
+     * [ReasoningFlatteningMistralAiApi] for the "magistral" reasoning models. Built lazily so an unused
+     * variant is never created.
+     */
+    private val plainMistralAiApi: MistralAiApi by lazy { buildMistralAiApi(thinking = false) }
+    private val reasoningMistralAiApi: MistralAiApi by lazy { buildMistralAiApi(thinking = true) }
+
+    private fun mistralAiApiFor(modelDef: MistralAiModelDefinition): MistralAiApi =
+        if (modelDef.thinking) reasoningMistralAiApi else plainMistralAiApi
+
+    private fun buildMistralAiApi(thinking: Boolean): MistralAiApi {
         if (!baseUrl.isNullOrBlank()) {
             logger.info("Using custom Mistral AI base URL: {}", baseUrl)
+        }
+
+        // Build the HTTP client from the shared platform builder (aiModelRestClientBuilder /
+        // aiModelWebClientBuilder), like every other model provider, so the platform read/connect timeouts
+        // and the use-reactor-netty opt-out live in one place (NettyClientAutoConfiguration). Clone so adding
+        // the observation registry never mutates the shared singleton. When that bean is absent (e.g. an app
+        // without the netty client autoconfigure), fall back to a builder that still honours the platform read
+        // timeout rather than the ~10s ReactorClientHttpRequestFactory default, which otherwise aborts slow
+        // generations (e.g. reasoning models) with a ReadTimeoutException.
+        val restClientBuilder = restClientBuilderProvider.getIfAvailable(::fallbackRestClientBuilder)
+            .clone()
+            .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+        val webClientBuilder = webClientBuilderProvider.getIfAvailable(WebClient::builder)
+            .clone()
+            .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+
+        // Reasoning models ("magistral") return structured "thinking" content that Spring AI 1.1.7 cannot
+        // parse (it assumes string content). Decorate the API to flatten it to plain text on the typed
+        // response, at the Spring AI boundary — leaving the 16 plain models on the plain builder. Superseded
+        // by the Spring AI 2.0.0 upgrade, which supports reasoning content natively.
+        if (thinking) {
+            return ReasoningFlatteningMistralAiApi(baseUrl, apiKey, restClientBuilder, webClientBuilder)
+        }
+
+        val builder = MistralAiApi.builder()
+            .apiKey(apiKey)
+            .restClientBuilder(restClientBuilder)
+            .webClientBuilder(webClientBuilder)
+        if (!baseUrl.isNullOrBlank()) {
             builder.baseUrl(baseUrl)
         }
-        // add observation registry to rest and web client builders
-        builder
-            .restClientBuilder(
-                RestClient.builder()
-                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
-            )
-        builder
-            .webClientBuilder(
-                WebClient.builder()
-                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
-            )
-
         return builder.build()
+    }
+
+    /**
+     * Fallback client builder for contexts where the shared [aiModelRestClientBuilder] bean is absent.
+     * Applies the platform read timeout ([httpReadTimeout]) so a slow response is not aborted at the
+     * ~10s ReactorClientHttpRequestFactory default.
+     */
+    private fun fallbackRestClientBuilder(): RestClient.Builder {
+        val readTimeout: Duration = DurationStyle.detectAndParse(httpReadTimeout)
+        val requestFactory = ClientHttpRequestFactoryBuilder.detect()
+            .build(ClientHttpRequestFactorySettings.defaults().withReadTimeout(readTimeout))
+        return RestClient.builder().requestFactory(requestFactory)
     }
 }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
@@ -47,22 +47,6 @@ models:
       usd_per1m_input_tokens: 0.3
       usd_per1m_output_tokens: 0.9
 
-  - name: "devstral-small-2507"
-    model_id: "devstral-small-2507"
-    display_name: "Devstral Small 1.1"
-    max_tokens: 131072
-    pricing_model:
-      usd_per1m_input_tokens: 0.1
-      usd_per1m_output_tokens: 0.3
-
-  - name: "devstral-medium-2507"
-    model_id: "devstral-medium-2507"
-    display_name: "Devstral Medium 1.0"
-    max_tokens: 131072
-    pricing_model:
-      usd_per1m_input_tokens: 0.4
-      usd_per1m_output_tokens: 2.0
-
   - name: "open-mistral-nemo-2407"
     model_id: "open-mistral-nemo-2407"
     display_name: "Mistral Nemo 12B"
@@ -78,14 +62,6 @@ models:
     pricing_model:
       usd_per1m_input_tokens: 0.4
       usd_per1m_output_tokens: 2.0
-
-  - name: "mistral-large-2411"
-    model_id: "mistral-large-2411"
-    display_name: "Mistral Large 2.1"
-    max_tokens: 131072
-    pricing_model:
-      usd_per1m_input_tokens: 2.0
-      usd_per1m_output_tokens: 6.0
 
   - name: "mistral-large-2512"
     model_id: "mistral-large-2512"

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
@@ -19,6 +19,7 @@ models:
     model_id: "mistral-medium-2604"
     display_name: "Mistral Medium 3.5"
     max_tokens: 131072
+    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 1.5
       usd_per1m_output_tokens: 7.5
@@ -83,6 +84,7 @@ models:
     model_id: "mistral-small-2603"
     display_name: "Mistral Small 4"
     max_tokens: 262144
+    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 0.15
       usd_per1m_output_tokens: 0.6

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
@@ -15,6 +15,14 @@ models:
       usd_per1m_input_tokens: 0.4
       usd_per1m_output_tokens: 2.0
 
+  - name: "mistral-medium-2604"
+    model_id: "mistral-medium-2604"
+    display_name: "Mistral Medium 3.5"
+    max_tokens: 131072
+    pricing_model:
+      usd_per1m_input_tokens: 1.5
+      usd_per1m_output_tokens: 7.5
+
   - name: "ministral-3b-2410"
     model_id: "ministral-3b-2410"
     display_name: "Ministral 3B"

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/main/resources/models/mistral-ai-models.yml
@@ -107,6 +107,7 @@ models:
     model_id: "magistral-medium-2509"
     display_name: "Magistral Medium 1.2"
     max_tokens: 131072
+    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 2.0
       usd_per1m_output_tokens: 5.0
@@ -115,6 +116,7 @@ models:
     model_id: "magistral-small-2509"
     display_name: "Magistral Small 1.2"
     max_tokens: 131072
+    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 0.5
       usd_per1m_output_tokens: 1.5

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiHttpClientTimeoutIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiHttpClientTimeoutIT.java
@@ -16,20 +16,12 @@
 package com.embabel.agent.autoconfigure.models.mistralai;
 
 import com.embabel.agent.spi.support.springai.SpringAiLlmService;
-import com.sun.net.httpserver.HttpServer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,81 +36,37 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class MistralAiHttpClientTimeoutIT {
 
-    /** A valid, plain-string chat completion (no reasoning content) so parsing is trivial. */
-    private static final String RESPONSE = """
-            {"id":"cmpl-test","created":1700000000,"model":"mistral-small-2603","object":"chat.completion",\
-            "usage":{"prompt_tokens":1,"total_tokens":2,"completion_tokens":1},\
-            "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"OK"}}]}""";
-
     private static final Duration SERVER_DELAY = Duration.ofSeconds(12);
 
-    private HttpServer slowServer;
-    private ExecutorService serverExecutor;
-    private int port;
-
-    /** Replies only after {@link #SERVER_DELAY}; a dedicated executor lets teardown interrupt the sleep. */
-    @BeforeEach
-    void startSlowServer() throws IOException {
-        serverExecutor = Executors.newCachedThreadPool();
-        slowServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        slowServer.setExecutor(serverExecutor);
-        slowServer.createContext("/", exchange -> {
-            try {
-                Thread.sleep(SERVER_DELAY.toMillis());
-                var bytes = RESPONSE.getBytes(StandardCharsets.UTF_8);
-                exchange.getResponseHeaders().add("Content-Type", "application/json");
-                exchange.sendResponseHeaders(200, bytes.length);
-                try (OutputStream os = exchange.getResponseBody()) {
-                    os.write(bytes);
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                exchange.close();
-            } catch (IOException e) {
-                exchange.close();
-            }
-        });
-        slowServer.start();
-        port = slowServer.getAddress().getPort();
-    }
-
-    @AfterEach
-    void stopServer() {
-        if (slowServer != null) {
-            slowServer.stop(0);
-        }
-        if (serverExecutor != null) {
-            serverExecutor.shutdownNow();
-        }
-    }
-
     @Test
-    void mistralHonoursPlatformReadTimeoutForSlowResponses() {
-        new ApplicationContextRunner()
-                .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
-                .withPropertyValues(
-                        "embabel.agent.platform.models.mistralai.api-key=test-key",
-                        "embabel.agent.platform.models.mistralai.base-url=http://127.0.0.1:" + port,
-                        // Single attempt: no retries muddying the timing.
-                        "embabel.agent.platform.models.mistralai.max-attempts=1",
-                        // The platform read timeout the client must honour: comfortably above SERVER_DELAY.
-                        "embabel.agent.platform.http-client.read-timeout=30s"
-                )
-                .run(context -> {
-                    var model = context.getBeansOfType(SpringAiLlmService.class).values().stream()
-                            .filter(s -> "mistral-small-2603".equals(s.getName()))
-                            .findFirst()
-                            .orElseThrow(() -> new AssertionError("mistral-small-2603 model not registered"));
+    void mistralHonoursPlatformReadTimeoutForSlowResponses() throws IOException {
+        try (var server = StubMistralServer.replyingAfter(SERVER_DELAY, StubMistralServer.OK_RESPONSE)) {
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
+                    .withPropertyValues(
+                            "embabel.agent.platform.models.mistralai.api-key=test-key",
+                            "embabel.agent.platform.models.mistralai.base-url=" + server.baseUrl(),
+                            // Single attempt: no retries muddying the timing.
+                            "embabel.agent.platform.models.mistralai.max-attempts=1",
+                            // The platform read timeout the client must honour: comfortably above SERVER_DELAY.
+                            "embabel.agent.platform.http-client.read-timeout=30s"
+                    )
+                    .run(context -> {
+                        var model = context.getBeansOfType(SpringAiLlmService.class).values().stream()
+                                .filter(s -> "mistral-small-2603".equals(s.getName()))
+                                .findFirst()
+                                .orElseThrow(() -> new AssertionError("mistral-small-2603 model not registered"));
 
-                    var start = System.nanoTime();
-                    var response = model.getChatModel().call("hello");
-                    var elapsed = Duration.ofNanos(System.nanoTime() - start);
+                        var start = System.nanoTime();
+                        var response = model.getChatModel().call("hello");
+                        var elapsed = Duration.ofNanos(System.nanoTime() - start);
 
-                    // The slow response is awaited and returned — the ~10s default did not abort it.
-                    assertThat(response).isEqualTo("OK");
-                    assertThat(elapsed)
-                            .as("the call waited for the ~12s reply, so the platform read timeout was honoured")
-                            .isGreaterThan(Duration.ofSeconds(11));
-                });
+                        // The slow response is awaited and returned — the ~10s default did not abort it.
+                        assertThat(response).isEqualTo("OK");
+                        assertThat(elapsed)
+                                .as("the call waited for the ~12s reply, so the platform read timeout was honoured")
+                                .isGreaterThan(Duration.ofSeconds(11));
+                    });
+        }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiHttpClientTimeoutIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiHttpClientTimeoutIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.mistralai;
+
+import com.embabel.agent.spi.support.springai.SpringAiLlmService;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test: Mistral must honour the platform read timeout
+ * ({@code embabel.agent.platform.http-client.read-timeout}) instead of the ~10s
+ * {@code ReactorClientHttpRequestFactory} default that aborts slow generations.
+ *
+ * <p>Drives the real config against a local server replying after ~12s with the read timeout set to 30s:
+ * a correctly-wired client waits and returns the reply; the bug aborts at ~10s. {@code ...IT} because the
+ * deliberate ~12s wait would otherwise slow every unit-test run.
+ */
+class MistralAiHttpClientTimeoutIT {
+
+    /** A valid, plain-string chat completion (no reasoning content) so parsing is trivial. */
+    private static final String RESPONSE = """
+            {"id":"cmpl-test","created":1700000000,"model":"mistral-small-2603","object":"chat.completion",\
+            "usage":{"prompt_tokens":1,"total_tokens":2,"completion_tokens":1},\
+            "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"OK"}}]}""";
+
+    private static final Duration SERVER_DELAY = Duration.ofSeconds(12);
+
+    private HttpServer slowServer;
+    private ExecutorService serverExecutor;
+    private int port;
+
+    /** Replies only after {@link #SERVER_DELAY}; a dedicated executor lets teardown interrupt the sleep. */
+    @BeforeEach
+    void startSlowServer() throws IOException {
+        serverExecutor = Executors.newCachedThreadPool();
+        slowServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        slowServer.setExecutor(serverExecutor);
+        slowServer.createContext("/", exchange -> {
+            try {
+                Thread.sleep(SERVER_DELAY.toMillis());
+                var bytes = RESPONSE.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, bytes.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(bytes);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                exchange.close();
+            } catch (IOException e) {
+                exchange.close();
+            }
+        });
+        slowServer.start();
+        port = slowServer.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (slowServer != null) {
+            slowServer.stop(0);
+        }
+        if (serverExecutor != null) {
+            serverExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void mistralHonoursPlatformReadTimeoutForSlowResponses() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
+                .withPropertyValues(
+                        "embabel.agent.platform.models.mistralai.api-key=test-key",
+                        "embabel.agent.platform.models.mistralai.base-url=http://127.0.0.1:" + port,
+                        // Single attempt: no retries muddying the timing.
+                        "embabel.agent.platform.models.mistralai.max-attempts=1",
+                        // The platform read timeout the client must honour: comfortably above SERVER_DELAY.
+                        "embabel.agent.platform.http-client.read-timeout=30s"
+                )
+                .run(context -> {
+                    var model = context.getBeansOfType(SpringAiLlmService.class).values().stream()
+                            .filter(s -> "mistral-small-2603".equals(s.getName()))
+                            .findFirst()
+                            .orElseThrow(() -> new AssertionError("mistral-small-2603 model not registered"));
+
+                    var start = System.nanoTime();
+                    var response = model.getChatModel().call("hello");
+                    var elapsed = Duration.ofNanos(System.nanoTime() - start);
+
+                    // The slow response is awaited and returned — the ~10s default did not abort it.
+                    assertThat(response).isEqualTo("OK");
+                    assertThat(elapsed)
+                            .as("the call waited for the ~12s reply, so the platform read timeout was honoured")
+                            .isGreaterThan(Duration.ofSeconds(11));
+                });
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiModelsSmokeIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiModelsSmokeIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.mistralai;
+
+import com.embabel.agent.spi.support.springai.SpringAiLlmService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test: calls <b>every</b> registered Mistral model against the real API with a trivial prompt,
+ * each must return a non-blank response. Iterates the models from the bundled YAML so it stays in sync
+ * with the catalogue automatically.
+ *
+ * <p>Only runs when {@code MISTRAL_API_KEY} is set — one real, billable call per model.
+ */
+@EnabledIfEnvironmentVariable(
+        named = "MISTRAL_API_KEY",
+        matches = ".+",
+        disabledReason = "Integration test requires MISTRAL_API_KEY and makes real calls to api.mistral.ai")
+class MistralAiModelsSmokeIT {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
+            .withPropertyValues(
+                    "embabel.agent.platform.models.mistralai.max-attempts=1",
+                    "embabel.agent.platform.http-client.read-timeout=5m"
+            );
+
+    @Test
+    void everyRegisteredMistralModelResponds() {
+        contextRunner.run(context -> {
+            var models = new TreeMap<String, SpringAiLlmService>();
+            context.getBeansOfType(SpringAiLlmService.class).values()
+                    .forEach(s -> models.put(s.getName(), s));
+
+            assertThat(models).as("no Mistral models were registered").isNotEmpty();
+
+            var failures = new ArrayList<String>();
+            var report = new StringBuilder("\nMistral model smoke test:\n");
+
+            for (Map.Entry<String, SpringAiLlmService> entry : models.entrySet()) {
+                var modelId = entry.getKey();
+                var start = System.nanoTime();
+                try {
+                    var response = entry.getValue().getChatModel().call("Reply with exactly the word READY.");
+                    var elapsed = Duration.ofNanos(System.nanoTime() - start);
+                    if (response == null || response.isBlank()) {
+                        failures.add(modelId + " (blank response)");
+                        report.append(String.format("  FAIL  %-24s blank response (%s)%n", modelId, elapsed));
+                    } else {
+                        report.append(String.format("  OK    %-24s %s%n", modelId, elapsed));
+                    }
+                } catch (Exception ex) {
+                    var elapsed = Duration.ofNanos(System.nanoTime() - start);
+                    var cause = rootCause(ex);
+                    failures.add(modelId + " (" + cause.getClass().getSimpleName() + ": " + cause.getMessage() + ")");
+                    report.append(String.format("  FAIL  %-24s %s after %s -> %s: %s%n",
+                            modelId, cause.getClass().getSimpleName(), elapsed,
+                            cause.getClass().getSimpleName(), cause.getMessage()));
+                    // Full stack trace so a single run pins the exact throw site of the failure.
+                    System.out.println("---- full stack trace for " + modelId + " ----");
+                    ex.printStackTrace(System.out);
+                }
+            }
+
+            System.out.println(report);
+            assertThat(failures)
+                    .as("models that did not return a valid response: %s", failures)
+                    .isEmpty();
+        });
+    }
+
+    private static Throwable rootCause(Throwable t) {
+        var current = t;
+        while (current.getCause() != null && current.getCause() != current) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiReasoningContentTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiReasoningContentTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.mistralai;
+
+import com.embabel.agent.spi.support.springai.SpringAiLlmService;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Hermetic reproduction and fix verification for the Mistral reasoning-content bug.
+ *
+ * <p>{@code spring-ai-mistral-ai:1.1.7} assumes an assistant message's content is a plain string
+ * ({@code ChatCompletionMessage.content()} throws {@code IllegalStateException: The content is not a
+ * string!} otherwise). Reasoning models ({@code magistral-*}) return structured "thinking"/"text"
+ * chunks, so every call throws.
+ *
+ * <p>This test serves a canned magistral response (content is a chunk array) from a local server and
+ * asserts the model returns the final text {@code "READY"}. It fails before the fix (with the
+ * {@code IllegalStateException}) and passes once the Mistral client flattens reasoning content to plain
+ * text before Spring AI parses it.
+ */
+class MistralAiReasoningContentTest {
+
+    /** A real magistral-medium-2509 response body: content is a [thinking, text] chunk array. */
+    private static final String MAGISTRAL_RESPONSE = """
+            {"id":"cmpl-test","created":1700000000,"model":"magistral-medium-2509",\
+            "usage":{"prompt_tokens":11,"total_tokens":48,"completion_tokens":37},\
+            "object":"chat.completion",\
+            "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","tool_calls":null,\
+            "content":[\
+            {"type":"thinking","thinking":[{"type":"text","text":"The user wants exactly READY."}],"closed":true},\
+            {"type":"text","text":"READY"}\
+            ]}}]}""";
+
+    private HttpServer server;
+    private int port;
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            var bytes = MAGISTRAL_RESPONSE.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, bytes.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(bytes);
+            }
+        });
+        server.start();
+        port = server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void reasoningModelContentIsFlattenedToPlainText() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
+                .withPropertyValues(
+                        "embabel.agent.platform.models.mistralai.api-key=test-key",
+                        "embabel.agent.platform.models.mistralai.base-url=http://127.0.0.1:" + port,
+                        "embabel.agent.platform.models.mistralai.max-attempts=1"
+                )
+                .run(context -> {
+                    var magistral = context.getBeansOfType(SpringAiLlmService.class).values().stream()
+                            .filter(s -> "magistral-medium-2509".equals(s.getName()))
+                            .findFirst()
+                            .orElseThrow(() -> new AssertionError("magistral-medium-2509 not registered"));
+
+                    var response = magistral.getChatModel().call("Reply READY.");
+
+                    assertThat(response).isEqualTo("READY");
+                });
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiReasoningContentTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralAiReasoningContentTest.java
@@ -16,17 +16,11 @@
 package com.embabel.agent.autoconfigure.models.mistralai;
 
 import com.embabel.agent.spi.support.springai.SpringAiLlmService;
-import com.sun.net.httpserver.HttpServer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,10 +32,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * string!} otherwise). Reasoning models ({@code magistral-*}) return structured "thinking"/"text"
  * chunks, so every call throws.
  *
- * <p>This test serves a canned magistral response (content is a chunk array) from a local server and
- * asserts the model returns the final text {@code "READY"}. It fails before the fix (with the
- * {@code IllegalStateException}) and passes once the Mistral client flattens reasoning content to plain
- * text before Spring AI parses it.
+ * <p>Serves a canned magistral response (content is a chunk array) from a local server and asserts the
+ * model returns the final text {@code "READY"}. Fails before the fix, passes once the client flattens
+ * reasoning content to plain text before Spring AI parses it. The parser itself is unit-tested in
+ * {@code MistralReasoningContentFlattenTest}; this test covers the end-to-end wiring.
  */
 class MistralAiReasoningContentTest {
 
@@ -56,49 +50,26 @@ class MistralAiReasoningContentTest {
             {"type":"text","text":"READY"}\
             ]}}]}""";
 
-    private HttpServer server;
-    private int port;
-
-    @BeforeEach
-    void startServer() throws IOException {
-        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        server.createContext("/", exchange -> {
-            var bytes = MAGISTRAL_RESPONSE.getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().add("Content-Type", "application/json");
-            exchange.sendResponseHeaders(200, bytes.length);
-            try (OutputStream os = exchange.getResponseBody()) {
-                os.write(bytes);
-            }
-        });
-        server.start();
-        port = server.getAddress().getPort();
-    }
-
-    @AfterEach
-    void stopServer() {
-        if (server != null) {
-            server.stop(0);
-        }
-    }
-
     @Test
-    void reasoningModelContentIsFlattenedToPlainText() {
-        new ApplicationContextRunner()
-                .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
-                .withPropertyValues(
-                        "embabel.agent.platform.models.mistralai.api-key=test-key",
-                        "embabel.agent.platform.models.mistralai.base-url=http://127.0.0.1:" + port,
-                        "embabel.agent.platform.models.mistralai.max-attempts=1"
-                )
-                .run(context -> {
-                    var magistral = context.getBeansOfType(SpringAiLlmService.class).values().stream()
-                            .filter(s -> "magistral-medium-2509".equals(s.getName()))
-                            .findFirst()
-                            .orElseThrow(() -> new AssertionError("magistral-medium-2509 not registered"));
+    void reasoningModelContentIsFlattenedToPlainText() throws IOException {
+        try (var server = StubMistralServer.replyingWith(MAGISTRAL_RESPONSE)) {
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
+                    .withPropertyValues(
+                            "embabel.agent.platform.models.mistralai.api-key=test-key",
+                            "embabel.agent.platform.models.mistralai.base-url=" + server.baseUrl(),
+                            "embabel.agent.platform.models.mistralai.max-attempts=1"
+                    )
+                    .run(context -> {
+                        var magistral = context.getBeansOfType(SpringAiLlmService.class).values().stream()
+                                .filter(s -> "magistral-medium-2509".equals(s.getName()))
+                                .findFirst()
+                                .orElseThrow(() -> new AssertionError("magistral-medium-2509 not registered"));
 
-                    var response = magistral.getChatModel().call("Reply READY.");
+                        var response = magistral.getChatModel().call("Reply READY.");
 
-                    assertThat(response).isEqualTo("READY");
-                });
+                        assertThat(response).isEqualTo("READY");
+                    });
+        }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralSharedClientBuilderTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralSharedClientBuilderTest.java
@@ -16,9 +16,6 @@
 package com.embabel.agent.autoconfigure.models.mistralai;
 
 import com.embabel.agent.spi.support.springai.SpringAiLlmService;
-import com.sun.net.httpserver.HttpServer;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -27,9 +24,6 @@ import org.springframework.web.client.RestClient;
 import reactor.netty.http.client.HttpClient;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,46 +40,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class MistralSharedClientBuilderTest {
 
-    private static final String RESPONSE = """
-            {"id":"cmpl-test","created":1700000000,"model":"mistral-small-2603","object":"chat.completion",\
-            "usage":{"prompt_tokens":1,"total_tokens":2,"completion_tokens":1},\
-            "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"OK"}}]}""";
-
     private static final Duration SERVER_DELAY = Duration.ofSeconds(3);
     private static final Duration SHARED_BUILDER_TIMEOUT = Duration.ofMillis(300);
-
-    private HttpServer slowServer;
-    private int port;
-
-    @BeforeEach
-    void startSlowServer() throws IOException {
-        slowServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        slowServer.createContext("/", exchange -> {
-            try {
-                Thread.sleep(SERVER_DELAY.toMillis());
-                var bytes = RESPONSE.getBytes(StandardCharsets.UTF_8);
-                exchange.getResponseHeaders().add("Content-Type", "application/json");
-                exchange.sendResponseHeaders(200, bytes.length);
-                try (OutputStream os = exchange.getResponseBody()) {
-                    os.write(bytes);
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                exchange.close();
-            } catch (IOException e) {
-                exchange.close();
-            }
-        });
-        slowServer.start();
-        port = slowServer.getAddress().getPort();
-    }
-
-    @AfterEach
-    void stopServer() {
-        if (slowServer != null) {
-            slowServer.stop(0);
-        }
-    }
 
     /** A shared platform builder whose reactor-netty client aborts any reply slower than 300ms. */
     private static RestClient.Builder shortTimeoutSharedBuilder() {
@@ -94,31 +50,33 @@ class MistralSharedClientBuilderTest {
     }
 
     @Test
-    void usesTheSharedPlatformRestClientBuilder() {
-        new ApplicationContextRunner()
-                .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
-                .withBean("aiModelRestClientBuilder", RestClient.Builder.class,
-                        MistralSharedClientBuilderTest::shortTimeoutSharedBuilder)
-                .withPropertyValues(
-                        "embabel.agent.platform.models.mistralai.api-key=test-key",
-                        "embabel.agent.platform.models.mistralai.base-url=http://127.0.0.1:" + port,
-                        "embabel.agent.platform.models.mistralai.max-attempts=1"
-                )
-                .run(context -> {
-                    var model = context.getBeansOfType(SpringAiLlmService.class).values().stream()
-                            .filter(s -> "mistral-small-2603".equals(s.getName()))
-                            .findFirst()
-                            .orElseThrow(() -> new AssertionError("mistral-small-2603 model not registered"));
+    void usesTheSharedPlatformRestClientBuilder() throws IOException {
+        try (var server = StubMistralServer.replyingAfter(SERVER_DELAY, StubMistralServer.OK_RESPONSE)) {
+            new ApplicationContextRunner()
+                    .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
+                    .withBean("aiModelRestClientBuilder", RestClient.Builder.class,
+                            MistralSharedClientBuilderTest::shortTimeoutSharedBuilder)
+                    .withPropertyValues(
+                            "embabel.agent.platform.models.mistralai.api-key=test-key",
+                            "embabel.agent.platform.models.mistralai.base-url=" + server.baseUrl(),
+                            "embabel.agent.platform.models.mistralai.max-attempts=1"
+                    )
+                    .run(context -> {
+                        var model = context.getBeansOfType(SpringAiLlmService.class).values().stream()
+                                .filter(s -> "mistral-small-2603".equals(s.getName()))
+                                .findFirst()
+                                .orElseThrow(() -> new AssertionError("mistral-small-2603 model not registered"));
 
-                    var start = System.nanoTime();
-                    assertThatThrownBy(() -> model.getChatModel().call("hello"))
-                            .as("the shared builder's 300ms timeout must abort the 3s reply")
-                            .isNotNull();
-                    var elapsed = Duration.ofNanos(System.nanoTime() - start);
+                        var start = System.nanoTime();
+                        assertThatThrownBy(() -> model.getChatModel().call("hello"))
+                                .as("the shared builder's 300ms timeout must abort the 3s reply")
+                                .hasStackTraceContaining("ReadTimeout");
+                        var elapsed = Duration.ofNanos(System.nanoTime() - start);
 
-                    assertThat(elapsed)
-                            .as("aborted via the injected shared builder, not after the full 3s server delay")
-                            .isLessThan(Duration.ofSeconds(2));
-                });
+                        assertThat(elapsed)
+                                .as("aborted via the injected shared builder, not after the full 3s server delay")
+                                .isLessThan(Duration.ofSeconds(2));
+                    });
+        }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralSharedClientBuilderTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralSharedClientBuilderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.mistralai;
+
+import com.embabel.agent.spi.support.springai.SpringAiLlmService;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.http.client.ReactorClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies that {@code MistralAiModelsConfig} builds its HTTP client from the shared platform
+ * {@code aiModelRestClientBuilder} bean (like every other provider), not from its own
+ * {@code RestClient.builder()}.
+ *
+ * <p>Registers a sentinel builder with a tiny 300ms timeout and points Mistral at a server replying
+ * after 3s: if the config consumes the shared bean the call aborts fast; if it ignores it and builds its
+ * own client, the call waits and returns. Red before the refactor, green after.
+ */
+class MistralSharedClientBuilderTest {
+
+    private static final String RESPONSE = """
+            {"id":"cmpl-test","created":1700000000,"model":"mistral-small-2603","object":"chat.completion",\
+            "usage":{"prompt_tokens":1,"total_tokens":2,"completion_tokens":1},\
+            "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"OK"}}]}""";
+
+    private static final Duration SERVER_DELAY = Duration.ofSeconds(3);
+    private static final Duration SHARED_BUILDER_TIMEOUT = Duration.ofMillis(300);
+
+    private HttpServer slowServer;
+    private int port;
+
+    @BeforeEach
+    void startSlowServer() throws IOException {
+        slowServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        slowServer.createContext("/", exchange -> {
+            try {
+                Thread.sleep(SERVER_DELAY.toMillis());
+                var bytes = RESPONSE.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, bytes.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(bytes);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                exchange.close();
+            } catch (IOException e) {
+                exchange.close();
+            }
+        });
+        slowServer.start();
+        port = slowServer.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        if (slowServer != null) {
+            slowServer.stop(0);
+        }
+    }
+
+    /** A shared platform builder whose reactor-netty client aborts any reply slower than 300ms. */
+    private static RestClient.Builder shortTimeoutSharedBuilder() {
+        var httpClient = HttpClient.create().responseTimeout(SHARED_BUILDER_TIMEOUT);
+        return RestClient.builder().requestFactory(new ReactorClientHttpRequestFactory(httpClient));
+    }
+
+    @Test
+    void usesTheSharedPlatformRestClientBuilder() {
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration.class))
+                .withBean("aiModelRestClientBuilder", RestClient.Builder.class,
+                        MistralSharedClientBuilderTest::shortTimeoutSharedBuilder)
+                .withPropertyValues(
+                        "embabel.agent.platform.models.mistralai.api-key=test-key",
+                        "embabel.agent.platform.models.mistralai.base-url=http://127.0.0.1:" + port,
+                        "embabel.agent.platform.models.mistralai.max-attempts=1"
+                )
+                .run(context -> {
+                    var model = context.getBeansOfType(SpringAiLlmService.class).values().stream()
+                            .filter(s -> "mistral-small-2603".equals(s.getName()))
+                            .findFirst()
+                            .orElseThrow(() -> new AssertionError("mistral-small-2603 model not registered"));
+
+                    var start = System.nanoTime();
+                    assertThatThrownBy(() -> model.getChatModel().call("hello"))
+                            .as("the shared builder's 300ms timeout must abort the 3s reply")
+                            .isNotNull();
+                    var elapsed = Duration.ofNanos(System.nanoTime() - start);
+
+                    assertThat(elapsed)
+                            .as("aborted via the injected shared builder, not after the full 3s server delay")
+                            .isLessThan(Duration.ofSeconds(2));
+                });
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/StubMistralServer.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/StubMistralServer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.mistralai;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A local HTTP server that returns a canned Mistral chat-completion body, optionally after a delay.
+ * Shared fixture for the hermetic Mistral tests so each one doesn't re-implement server setup/teardown.
+ *
+ * <p>Handlers run on a dedicated executor so {@link #close()} can interrupt an in-flight delayed reply.
+ * Use with try-with-resources: {@code try (var server = StubMistralServer.replyingWith(BODY)) { ... }}.
+ */
+final class StubMistralServer implements AutoCloseable {
+
+    /** A valid, plain-string chat completion (no reasoning content) for {@code mistral-small-2603}. */
+    static final String OK_RESPONSE = """
+            {"id":"cmpl-test","created":1700000000,"model":"mistral-small-2603","object":"chat.completion",\
+            "usage":{"prompt_tokens":1,"total_tokens":2,"completion_tokens":1},\
+            "choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"OK"}}]}""";
+
+    private final HttpServer server;
+    private final ExecutorService executor;
+    private final int port;
+
+    private StubMistralServer(String responseBody, Duration delay) throws IOException {
+        executor = Executors.newCachedThreadPool();
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.setExecutor(executor);
+        server.createContext("/", exchange -> {
+            try {
+                if (!delay.isZero()) {
+                    Thread.sleep(delay.toMillis());
+                }
+                var bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, bytes.length);
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(bytes);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                exchange.close();
+            } catch (IOException e) {
+                exchange.close();
+            }
+        });
+        server.start();
+        port = server.getAddress().getPort();
+    }
+
+    /** Starts a server that replies immediately with {@code responseBody}. */
+    static StubMistralServer replyingWith(String responseBody) throws IOException {
+        return new StubMistralServer(responseBody, Duration.ZERO);
+    }
+
+    /** Starts a server that replies with {@code responseBody} only after {@code delay}. */
+    static StubMistralServer replyingAfter(Duration delay, String responseBody) throws IOException {
+        return new StubMistralServer(responseBody, delay);
+    }
+
+    String baseUrl() {
+        return "http://127.0.0.1:" + port;
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+        executor.shutdownNow();
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/config/models/mistralai/MistralReasoningContentFlattenTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/config/models/mistralai/MistralReasoningContentFlattenTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.mistralai;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pure unit tests for {@link MistralReasoningContent#flatten}, the parser that turns a reasoning
+ * model's structured chunk list into plain text. No Spring context, no HTTP — unlike
+ * {@code MistralAiReasoningContentTest}, which drives the whole decorator over a local server.
+ *
+ * <p>Same package as the class under test so the package-private entry point is visible.
+ */
+class MistralReasoningContentFlattenTest {
+
+    @Test
+    void topLevelTextChunkIsReturned() {
+        var chunks = List.<Object> of(Map.of("type", "text", "text", "READY"));
+
+        assertThat(MistralReasoningContent.flatten(chunks)).isEqualTo("READY");
+    }
+
+    @Test
+    void finalTextWinsOverThinking() {
+        var chunks = List.<Object> of(
+                Map.of("type", "thinking",
+                        "thinking", List.of(Map.of("type", "text", "text", "The user wants exactly READY.")),
+                        "closed", true),
+                Map.of("type", "text", "text", "READY"));
+
+        assertThat(MistralReasoningContent.flatten(chunks)).isEqualTo("READY");
+    }
+
+    @Test
+    void pureReasoningFallsBackToThinkingText() {
+        var chunks = List.<Object> of(
+                Map.of("type", "thinking",
+                        "thinking", List.of(Map.of("type", "text", "text", "only thinking here")),
+                        "closed", true));
+
+        assertThat(MistralReasoningContent.flatten(chunks)).isEqualTo("only thinking here");
+    }
+
+    @Test
+    void multipleTextChunksAreJoinedWithNewline() {
+        var chunks = List.<Object> of(
+                Map.of("type", "text", "text", "first"),
+                Map.of("type", "text", "text", "second"));
+
+        assertThat(MistralReasoningContent.flatten(chunks)).isEqualTo("first\nsecond");
+    }
+
+    @Test
+    void emptyTextChunksDoNotProduceDanglingNewlines() {
+        var chunks = List.<Object> of(
+                Map.of("type", "text", "text", "kept"),
+                Map.of("type", "text", "text", ""));
+
+        assertThat(MistralReasoningContent.flatten(chunks)).isEqualTo("kept");
+    }
+
+    @Test
+    void emptyChunkListYieldsEmptyText() {
+        assertThat(MistralReasoningContent.flatten(List.of())).isEmpty();
+    }
+
+    @Test
+    void unknownChunkTypesAreIgnored() {
+        var chunks = List.<Object> of(Map.of("type", "redacted_reasoning", "data", "x"));
+
+        assertThat(MistralReasoningContent.flatten(chunks)).isEmpty();
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoaderTest.kt
@@ -74,10 +74,10 @@ class MistralAiModelLoaderTest {
         val result = loader.loadAutoConfigMetadata()
 
         // Assert
-        assertEquals(15, result.models.size, "Should load exactly 15 Mistral AI models")
+        assertEquals(16, result.models.size, "Should load exactly 16 Mistral AI models")
 
         val expectedModels = listOf(
-            "mistral-medium-2508", "mistral-small-2506", "codestral-2508",
+            "mistral-medium-2508", "mistral-medium-2604", "mistral-small-2506", "codestral-2508",
             "open-mistral-nemo-2407", "mistral-medium-2505",
             "mistral-large-2512", "mistral-small-2603",
             "magistral-medium-2509", "magistral-small-2509", "ministral-14b-2512",

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/mistralai/MistralAiModelLoaderTest.kt
@@ -74,12 +74,12 @@ class MistralAiModelLoaderTest {
         val result = loader.loadAutoConfigMetadata()
 
         // Assert
-        assertEquals(18, result.models.size, "Should load exactly 18 Mistral AI models")
+        assertEquals(15, result.models.size, "Should load exactly 15 Mistral AI models")
 
         val expectedModels = listOf(
-            "mistral-medium-2508", "mistral-small-2506", "codestral-2508", "devstral-small-2507",
-            "devstral-medium-2507", "open-mistral-nemo-2407", "mistral-medium-2505",
-            "mistral-large-2411", "mistral-large-2512", "mistral-small-2603",
+            "mistral-medium-2508", "mistral-small-2506", "codestral-2508",
+            "open-mistral-nemo-2407", "mistral-medium-2505",
+            "mistral-large-2512", "mistral-small-2603",
             "magistral-medium-2509", "magistral-small-2509", "ministral-14b-2512",
             "ministral-8b-2512", "ministral-3b-2512", "ministral-3b-2410",
             "ministral-8b-2410", "devstral-2512"

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -721,10 +721,14 @@ See the configuration reference for the full OCI property list.
 
 ===== Mistral AI
 
+Uses the native Spring AI Mistral client for Mistral's chat, code (Codestral, Devstral) and reasoning (Magistral) models.
+
 * Required:
 - `MISTRAL_API_KEY`: API key for Mistral AI services
 * Optional:
 - `MISTRAL_BASE_URL`: base URL for Mistral AI API (default: `https://api.mistral.ai`)
+
+NOTE: Mistral's reasoning models (the Magistral family, plus the reasoning-capable Mistral Medium and Mistral Small releases) return their final answer as plain text; their intermediate reasoning is not exposed through Embabel's thinking API. As they can take longer to respond, increase `embabel.agent.platform.http-client.read-timeout` if you hit timeouts.
 
 Alternatively, configure via `application.yml`:
 
@@ -772,6 +776,33 @@ dependencies {
 }
 ----
 ====
+
+Available LLM models include:
+
+* `mistral-large-2512` - Mistral Large 3, top-tier flagship
+* `mistral-medium-2604` - Mistral Medium 3.5, reasoning-capable mid tier
+* `mistral-medium-2508` - Mistral Medium 3.1
+* `mistral-small-2603` - Mistral Small 4, reasoning-capable small tier
+* `mistral-small-2506` - Mistral Small 3.2
+* `magistral-medium-2509` - Magistral Medium 1.2, dedicated reasoning model
+* `magistral-small-2509` - Magistral Small 1.2, dedicated reasoning model
+* `codestral-2508` - Codestral, code generation
+* `devstral-2512` - Devstral 2, agentic coding
+* `ministral-8b-2512` - Ministral 8B, lightweight
+* `ministral-3b-2512` - Ministral 3B, lightweight
+
+Example configuration in `application.yml`:
+
+[source,yaml]
+----
+embabel:
+  models:
+    default-llm: mistral-medium-2508
+    llms:
+      fast: mistral-small-2506
+      best: mistral-large-2512
+      reasoning: magistral-medium-2509
+----
 
 ===== LM Studio
 


### PR DESCRIPTION
Fixes #1757 - two independent bugs in `embabel-agent-mistral-ai-autoconfigure`, both on `spring-ai-mistral-ai:1.1.7`.

### Bug 1 - reasoning models (`magistral-*`) fail: `IllegalStateException: The content is not a string!`

1.1.7 assumes assistant `content` is a plain string, but reasoning models return an array of `thinking`/`text` chunks, so every call throws (fixed natively in Spring AI 2.0.0). We add a boundary decorator `ReasoningFlatteningMistralAiApi` that flattens that content to plain text before `MistralAiChatModel` parses it; the pure chunk->text logic lives in `MistralReasoningContent` (no Spring, no HTTP), unit-tested in isolation.

### Bug 2 - platform read-timeout ignored (aborts at ~10s)

`MistralAiModelsConfig` built its own bare `RestClient.builder()`, so it kept `ReactorClientHttpRequestFactory`'s ~10s default and slow generations died with `ReadTimeoutException`.
It now consumes the shared platform `aiModelRestClientBuilder` / `aiModelWebClientBuilder` beans like every other provider, with a property-driven fallback that honours `embabel.agent.platform.http-client.read-timeout` when those beans are absent.

### Scope + catalogue

- A `thinking: true` flag gates the decorator, set on the 4 reasoning-capable models (verified against   the API `reasoning` capability); the 12 plain models use the undecorated client. The stateless   `MistralAiApi` is built once per variant, not once per model. `thinkingSupported` stays `false` (the shim discards reasoning to survive 1.1.7).
- Dropped `devstral-medium-2507`, `devstral-small-2507`, `mistral-large-2411` (retired by Mistral  2026-05-31, now `400 invalid model`); constants kept `@Deprecated`. Added `mistral-medium-2604`  (Mistral Medium 3.5).
- update doc

### Tests

- `MistralReasoningContentFlattenTest` - pure unit tests of the chunk->text parser.
- `MistralAiReasoningContentTest` - hermetic end-to-end: a magistral chunk response is flattened to `"READY"`.
- `MistralSharedClientBuilderTest` - the client is built from the shared `aiModelRestClientBuilder` bean.
- `MistralAiHttpClientTimeoutIT` - a ~12s response is awaited under a 30s read-timeout.
- `MistralAiModelsSmokeIT` - opt-in (`MISTRAL_API_KEY`): every registered model (16/16) against the real API.
