### PR TITLE
Feature/zai GLM  model integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,6 +617,7 @@ Optional:
 
 - `ANTHROPIC_API_KEY`: For the Anthropic API. Necessary for the coding agent.
 - `MINIMAX_API_KEY`: For the [MiniMax](https://www.minimax.io) API. Supports MiniMax-M3, MiniMax-M2.7 and MiniMax-M2.7-highspeed models.
+- `ZAI_API_KEY`: For the [Z.ai](https://z.ai) (Zhipu AI) API. Supports GLM-5.2, GLM-4.7, GLM-4.6, GLM-4.5-Air and GLM-4.7-Flash models.
 - OCI Generative AI uses OCI SDK authentication providers. Add `embabel-agent-starter-oci-genai` and set
   `embabel.agent.platform.models.ocigenai.compartment-id`; OCI config file, instance principal, resource principal,
   workload identity, session token and simple key authentication are supported.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/ZaiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/ZaiModels.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.models
+
+/**
+ * Provides constants for Z.ai (Zhipu AI) GLM model identifiers.
+ * Z.ai offers the GLM family of large language models, including models with
+ * up to 1M token context windows, via an OpenAI-compatible API.
+ *
+ * @see <a href="https://z.ai">Z.ai</a>
+ */
+class ZaiModels {
+
+    companion object {
+
+        const val GLM_5_2 = "glm-5.2"
+        const val GLM_4_7 = "glm-4.7"
+        const val GLM_4_6 = "glm-4.6"
+        const val GLM_4_5_AIR = "glm-4.5-air"
+        const val GLM_4_7_FLASH = "glm-4.7-flash"
+
+        const val PROVIDER = "Z.ai"
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/ZaiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/ZaiModels.kt
@@ -18,7 +18,8 @@ package com.embabel.agent.api.models
 /**
  * Provides constants for Z.ai (Zhipu AI) GLM model identifiers.
  * Z.ai offers the GLM family of large language models, including models with
- * up to 1M token context windows, via an OpenAI-compatible API.
+ * up to 1M token context windows, accessed via the native ZhiPuAI client
+ * (spring-ai-zhipuai) pointed at Z.ai's international endpoint.
  *
  * @see <a href="https://z.ai">Z.ai</a>
  */

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-autoconfigure</artifactId>
+        <version>1.0.0-RC1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>embabel-agent-zai-autoconfigure</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Autoconfiguration Models Z.ai</name>
+    <description>Z.ai (Zhipu AI) GLM Models Auto-Configuration for Embabel Agent API</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-zhipuai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/zai/AgentZaiAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/zai/AgentZaiAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.zai;
+
+import com.embabel.agent.config.models.zai.ZaiModelsConfig;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Autoconfiguration for Z.ai (Zhipu AI) GLM models in the Embabel Agent system.
+ * <p>
+ * This class serves as a Spring Boot autoconfiguration entry point that:
+ * - Imports the {@link ZaiModelsConfig} configuration to register Z.ai model beans
+ * <p>
+ * The configuration is automatically activated when the Z.ai
+ * dependencies are present on the classpath and the ZAI_API_KEY
+ * environment variable is set.
+ */
+@AutoConfiguration
+@AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
+@Import(ZaiModelsConfig.class)
+public class AgentZaiAutoConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(AgentZaiAutoConfiguration.class);
+
+    @PostConstruct
+    public void logEvent() {
+        logger.info("AgentZaiAutoConfiguration about to proceed...");
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelLoader.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.zai
+
+import com.embabel.common.ai.autoconfig.AbstractYamlModelLoader
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadata
+import com.embabel.common.ai.autoconfig.LlmAutoConfigProvider
+import com.embabel.common.ai.model.PerTokenPricingModel
+import org.springframework.core.io.DefaultResourceLoader
+import org.springframework.core.io.ResourceLoader
+import java.time.LocalDate
+
+/**
+ * Container for Z.ai (Zhipu AI) GLM model definitions loaded from YAML.
+ *
+ * Implements [LlmAutoConfigProvider] to supply Z.ai-specific model metadata
+ * for auto-configuration purposes.
+ *
+ * @property models list of Z.ai GLM model definitions
+ */
+data class ZaiModelDefinitions(
+    override val models: List<ZaiModelDefinition> = emptyList()
+) : LlmAutoConfigProvider<ZaiModelDefinition>
+
+/**
+ * Z.ai (Zhipu AI) GLM-specific model definition.
+ *
+ * Implements [LlmAutoConfigMetadata]. GLM models require the sampling temperature
+ * to be in the range (0.0, 1.0]; the default and validation reflect that.
+ *
+ * @property name the unique bean name of the model
+ * @property modelId the Z.ai API model identifier (e.g. "glm-4.7")
+ * @property displayName optional human-readable name
+ * @property knowledgeCutoffDate optional knowledge cutoff date
+ * @property pricingModel optional per-token pricing information
+ * @property maxTokens maximum tokens for completion
+ * @property temperature default sampling temperature, in (0.0, 1.0]
+ * @property topP nucleus sampling parameter
+ * @property thinking whether the model natively supports reasoning ("thinking")
+ */
+data class ZaiModelDefinition(
+    override val name: String,
+    override val modelId: String,
+    override val displayName: String? = null,
+    override val knowledgeCutoffDate: LocalDate? = null,
+    override val pricingModel: PerTokenPricingModel? = null,
+    val maxTokens: Int = 32768,
+    val temperature: Double = 0.7,
+    val topP: Double? = null,
+    val thinking: Boolean = false,
+) : LlmAutoConfigMetadata
+
+/**
+ * Loader for Z.ai GLM model definitions from YAML configuration.
+ *
+ * Reads model metadata from the configured resource path
+ * (default: `classpath:models/zai-models.yml`) and deserializes it into
+ * [ZaiModelDefinitions]. Validates loaded models to ensure data integrity.
+ *
+ * @property resourceLoader Spring resource loader for accessing classpath resources
+ * @property configPath path to the YAML configuration file
+ */
+class ZaiModelLoader(
+    resourceLoader: ResourceLoader = DefaultResourceLoader(),
+    configPath: String = DEFAULT_CONFIG_PATH
+) : AbstractYamlModelLoader<ZaiModelDefinitions>(resourceLoader, configPath) {
+
+    override fun getProviderClass() = ZaiModelDefinitions::class
+
+    override fun createEmptyProvider() = ZaiModelDefinitions()
+
+    override fun getProviderName() = "Z.ai"
+
+    override fun validateModels(provider: ZaiModelDefinitions) {
+        provider.models.forEach { model ->
+            validateCommonFields(model)
+            require(model.maxTokens > 0) { "Max tokens must be positive for model ${model.name}" }
+            require(model.temperature > 0.0 && model.temperature <= 1.0) {
+                "Temperature must be in (0.0, 1.0] for GLM model ${model.name}"
+            }
+            model.topP?.let {
+                require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Default path to the Z.ai models YAML configuration file.
+         */
+        private const val DEFAULT_CONFIG_PATH = "classpath:models/zai-models.yml"
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelLoader.kt
@@ -49,7 +49,6 @@ data class ZaiModelDefinitions(
  * @property maxTokens maximum tokens for completion
  * @property temperature default sampling temperature, in (0.0, 1.0]
  * @property topP nucleus sampling parameter
- * @property thinking whether the model natively supports reasoning ("thinking")
  */
 data class ZaiModelDefinition(
     override val name: String,
@@ -60,7 +59,6 @@ data class ZaiModelDefinition(
     val maxTokens: Int = 32768,
     val temperature: Double = 0.7,
     val topP: Double? = null,
-    val thinking: Boolean = false,
 ) : LlmAutoConfigMetadata
 
 /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelsConfig.kt
@@ -157,7 +157,7 @@ class ZaiModelsConfig(
 
                     logger.info("Registered Z.ai model bean: {} -> {}", modelDef.name, modelDef.modelId)
                 } catch (e: Exception) {
-                    logger.error("Failed to create model: {} ({})", modelDef.name, modelDef.modelId, e)
+                    logger.error("Failed to create model: {} ({})", modelDef.name, modelDef.modelId)
                     throw e
                 }
             }

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelsConfig.kt
@@ -189,7 +189,9 @@ class ZaiModelsConfig(
             provider = ZaiModels.PROVIDER,
             optionsConverter = ZaiOptionsConverter,
             knowledgeCutoffDate = modelDef.knowledgeCutoffDate,
-            thinkingSupported = modelDef.thinking,
+            // All GLM models exposed by Z.ai support native reasoning ("thinking"),
+            // matching the GoogleGenAi provider which also declares this statically.
+            thinkingSupported = true,
             pricingModel = modelDef.pricingModel?.let {
                 PerTokenPricingModel(
                     usdPer1mInputTokens = it.usdPer1mInputTokens,

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/zai/ZaiModelsConfig.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.zai
+
+import com.embabel.agent.api.models.ZaiModels
+import com.embabel.agent.config.models.zai.ZaiProperties.Companion.PREFIX
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.common.RetryProperties
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadataLoader
+import com.embabel.common.ai.autoconfig.ProviderInitialization
+import com.embabel.common.ai.autoconfig.RegisteredModel
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.OptionsConverter
+import com.embabel.common.ai.model.PerTokenPricingModel
+import com.embabel.common.ai.model.Thinking
+import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
+import com.embabel.common.util.loggerFor
+import io.micrometer.observation.ObservationRegistry
+import org.slf4j.LoggerFactory
+import org.springframework.ai.model.tool.ToolCallingManager
+import org.springframework.ai.zhipuai.ZhiPuAiChatModel
+import org.springframework.ai.zhipuai.ZhiPuAiChatOptions
+import org.springframework.ai.zhipuai.api.ZhiPuAiApi
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * Configuration properties for Z.ai (Zhipu AI) GLM models.
+ * These properties are bound from the Spring configuration with the prefix
+ * "embabel.agent.platform.models.zai" and control retry behavior
+ * when calling Z.ai APIs.
+ */
+@ConfigurationProperties(prefix = PREFIX)
+class ZaiProperties : RetryProperties {
+    /**
+     * Base URL for Z.ai API requests. Z.ai exposes the same Zhipu "PaaS v4"
+     * API surface as the native Spring AI ZhiPuAI client, on an international host.
+     *
+     * The native client appends the version + path (`/v4/chat/completions`) itself,
+     * so this is the host + `/api/paas` prefix only — do NOT include `/v4`.
+     */
+    var baseUrl: String = "https://api.z.ai/api/paas"
+
+    /**
+     * API key for authenticating with Z.ai services.
+     */
+    var apiKey: String? = null
+
+    /**
+     *  Maximum number of attempts.
+     */
+    override var maxAttempts: Int = 4
+
+    /**
+     * Initial backoff interval (in milliseconds).
+     */
+    override var backoffMillis: Long = 1500L
+
+    /**
+     * Backoff interval multiplier.
+     */
+    override var backoffMultiplier: Double = 2.0
+
+    /**
+     * Maximum backoff interval (in milliseconds).
+     */
+    override var backoffMaxInterval: Long = 60000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.zai"
+    }
+}
+
+/**
+ * Configuration class for Z.ai (Zhipu AI) GLM models.
+ *
+ * Uses native Spring AI ZhiPuAI support (spring-ai-zhipuai) — the [ZhiPuAiChatModel]
+ * pointed at Z.ai's international "PaaS v4" endpoint — rather than the OpenAI-compatible
+ * wire protocol. This unlocks native GLM features such as reasoning ("thinking").
+ *
+ * Model definitions are loaded from `classpath:models/zai-models.yml` and each is
+ * registered as a singleton [LlmService] bean via [ConfigurableBeanFactory.registerSingleton],
+ * following the same pattern as the Google GenAI and Mistral AI providers.
+ *
+ * GLM models require temperature values in the range (0.0, 1.0]. The [ZaiOptionsConverter]
+ * clamps temperature into this range.
+ *
+ * To use, set the following environment variables:
+ * ```
+ * ZAI_API_KEY=your-api-key
+ * ```
+ *
+ * @see <a href="https://z.ai">Z.ai</a>
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(ZaiProperties::class)
+@ExcludeFromJacocoGeneratedReport(reason = "Z.ai configuration can't be unit tested")
+class ZaiModelsConfig(
+    @param:Value("\${ZAI_BASE_URL:#{null}}")
+    private val envBaseUrl: String?,
+    @param:Value("\${ZAI_API_KEY:#{null}}")
+    private val envApiKey: String?,
+    private val properties: ZaiProperties,
+    private val observationRegistry: ObjectProvider<ObservationRegistry>,
+    private val configurableBeanFactory: ConfigurableBeanFactory,
+    @Qualifier("aiModelRestClientBuilder")
+    private val restClientBuilder: ObjectProvider<RestClient.Builder>,
+    @Qualifier("aiModelWebClientBuilder")
+    private val webClientBuilder: ObjectProvider<WebClient.Builder>,
+    private val modelLoader: LlmAutoConfigMetadataLoader<ZaiModelDefinitions> = ZaiModelLoader(),
+) {
+    private val logger = LoggerFactory.getLogger(ZaiModelsConfig::class.java)
+
+    private val baseUrl: String = envBaseUrl?.trim()?.takeIf { it.isNotEmpty() } ?: properties.baseUrl
+
+    private val apiKey: String = envApiKey?.trim()?.takeIf { it.isNotEmpty() }
+        ?: properties.apiKey?.trim()?.takeIf { it.isNotEmpty() }
+        ?: error("Z.ai API key required: set ZAI_API_KEY env var or embabel.agent.platform.models.zai.api-key")
+
+    init {
+        logger.info("Z.ai models are available: {}", properties)
+    }
+
+    @Bean
+    fun zaiModelsInitializer(): ProviderInitialization {
+        val registeredLlms = buildList {
+            modelLoader.loadAutoConfigMetadata().models.forEach { modelDef ->
+                try {
+                    val llm = createZaiLlm(modelDef)
+
+                    // Register as singleton bean with the configured bean name
+                    configurableBeanFactory.registerSingleton(modelDef.name, llm)
+                    add(RegisteredModel(beanName = modelDef.name, modelId = modelDef.modelId))
+
+                    logger.info("Registered Z.ai model bean: {} -> {}", modelDef.name, modelDef.modelId)
+                } catch (e: Exception) {
+                    logger.error("Failed to create model: {} ({})", modelDef.name, modelDef.modelId, e)
+                    throw e
+                }
+            }
+        }
+
+        return ProviderInitialization(
+            provider = ZaiModels.PROVIDER,
+            registeredLlms = registeredLlms,
+        ).also { logger.info(it.summary()) }
+    }
+
+    /**
+     * Creates an individual Z.ai GLM model from configuration.
+     */
+    private fun createZaiLlm(modelDef: ZaiModelDefinition): LlmService<*> {
+        val chatModel = ZhiPuAiChatModel(
+            createZhiPuAiApi(),
+            createDefaultOptions(modelDef),
+            ToolCallingManager.builder()
+                .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+                .build(),
+            properties.retryTemplate("zai-${modelDef.modelId}"),
+            observationRegistry.getIfUnique { ObservationRegistry.NOOP },
+        )
+
+        return SpringAiLlmService(
+            name = modelDef.modelId,
+            chatModel = chatModel,
+            provider = ZaiModels.PROVIDER,
+            optionsConverter = ZaiOptionsConverter,
+            knowledgeCutoffDate = modelDef.knowledgeCutoffDate,
+            thinkingSupported = modelDef.thinking,
+            pricingModel = modelDef.pricingModel?.let {
+                PerTokenPricingModel(
+                    usdPer1mInputTokens = it.usdPer1mInputTokens,
+                    usdPer1mOutputTokens = it.usdPer1mOutputTokens,
+                )
+            },
+        )
+    }
+
+    /**
+     * Creates default options for a model based on YAML configuration.
+     */
+    private fun createDefaultOptions(modelDef: ZaiModelDefinition): ZhiPuAiChatOptions =
+        ZhiPuAiChatOptions.builder()
+            .model(modelDef.modelId)
+            .maxTokens(modelDef.maxTokens)
+            .temperature(modelDef.temperature)
+            .apply { modelDef.topP?.let { topP(it) } }
+            .build()
+
+    private fun createZhiPuAiApi(): ZhiPuAiApi {
+        logger.info("Using Z.ai base URL: {}", baseUrl)
+        return ZhiPuAiApi.builder()
+            .baseUrl(baseUrl)
+            .apiKey(apiKey)
+            .restClientBuilder(
+                restClientBuilder.getIfAvailable { RestClient.builder() }
+                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+            )
+            .webClientBuilder(
+                webClientBuilder.getIfAvailable { WebClient.builder() }
+                    .observationRegistry(observationRegistry.getIfUnique { ObservationRegistry.NOOP })
+            )
+            .build()
+    }
+}
+
+/**
+ * Options converter for Z.ai (Zhipu AI) GLM models.
+ * GLM models require temperature to be in the range (0.0, 1.0].
+ * Values outside this range are clamped accordingly. Reasoning ("thinking") is
+ * enabled natively when requested via [LlmOptions.thinking].
+ */
+object ZaiOptionsConverter : OptionsConverter<ZhiPuAiChatOptions> {
+
+    private const val MIN_TEMPERATURE = 0.01
+    private const val MAX_TEMPERATURE = 1.0
+
+    override fun convertOptions(options: LlmOptions): ZhiPuAiChatOptions {
+        val temperature = options.temperature?.let { temp ->
+            temp.coerceIn(MIN_TEMPERATURE, MAX_TEMPERATURE).also { clamped ->
+                if (clamped != temp) {
+                    loggerFor<ZaiOptionsConverter>().debug(
+                        "Z.ai temperature clamped from {} to {} (valid range: ({}, {}])",
+                        temp, clamped, 0.0, MAX_TEMPERATURE
+                    )
+                }
+            }
+        }
+        return ZhiPuAiChatOptions.builder()
+            .temperature(temperature)
+            .topP(options.topP)
+            .maxTokens(options.maxTokens)
+            .apply {
+                options.thinking.toZhiPuAiThinking()?.let { thinking(it) }
+            }
+            .build()
+    }
+
+    private fun Thinking?.toZhiPuAiThinking(): ZhiPuAiApi.ChatCompletionRequest.Thinking? =
+        this?.takeIf { it.enabled }?.let { ZhiPuAiApi.ChatCompletionRequest.Thinking.enabled() }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2025-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.embabel.agent.autoconfigure.models.zai.AgentZaiAutoConfiguration

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/resources/models/zai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/resources/models/zai-models.yml
@@ -15,7 +15,6 @@ models:
     knowledge_cutoff_date: "2025-04-01"
     max_tokens: 32768
     temperature: 0.7
-    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 1.40
       usd_per1m_output_tokens: 4.40
@@ -27,7 +26,6 @@ models:
     knowledge_cutoff_date: "2025-04-01"
     max_tokens: 32768
     temperature: 0.7
-    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 0.60
       usd_per1m_output_tokens: 2.20
@@ -39,7 +37,6 @@ models:
     knowledge_cutoff_date: "2025-04-01"
     max_tokens: 32768
     temperature: 0.7
-    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 0.60
       usd_per1m_output_tokens: 2.20
@@ -51,7 +48,6 @@ models:
     knowledge_cutoff_date: "2025-04-01"
     max_tokens: 32768
     temperature: 0.7
-    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 0.20
       usd_per1m_output_tokens: 1.10
@@ -63,7 +59,6 @@ models:
     knowledge_cutoff_date: "2025-04-01"
     max_tokens: 32768
     temperature: 0.7
-    thinking: true
     pricing_model:
       usd_per1m_input_tokens: 0.0
       usd_per1m_output_tokens: 0.0

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/resources/models/zai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/main/resources/models/zai-models.yml
@@ -1,0 +1,69 @@
+# ============================================
+# zai-models.yml
+# ============================================
+# Z.ai (Zhipu AI) GLM models configuration
+# Using native Spring AI ZhiPuAI support (spring-ai-zhipuai)
+#
+# GLM models require temperature in the range (0.0, 1.0]; the
+# ZaiOptionsConverter clamps runtime values into that range.
+
+models:
+  # GLM-5.2 - flagship reasoning model
+  - name: "zaiGlm52"
+    model_id: "glm-5.2"
+    display_name: "GLM-5.2"
+    knowledge_cutoff_date: "2025-04-01"
+    max_tokens: 32768
+    temperature: 0.7
+    thinking: true
+    pricing_model:
+      usd_per1m_input_tokens: 1.40
+      usd_per1m_output_tokens: 4.40
+
+  # GLM-4.7 - high-performance reasoning model
+  - name: "zaiGlm47"
+    model_id: "glm-4.7"
+    display_name: "GLM-4.7"
+    knowledge_cutoff_date: "2025-04-01"
+    max_tokens: 32768
+    temperature: 0.7
+    thinking: true
+    pricing_model:
+      usd_per1m_input_tokens: 0.60
+      usd_per1m_output_tokens: 2.20
+
+  # GLM-4.6 - reasoning model
+  - name: "zaiGlm46"
+    model_id: "glm-4.6"
+    display_name: "GLM-4.6"
+    knowledge_cutoff_date: "2025-04-01"
+    max_tokens: 32768
+    temperature: 0.7
+    thinking: true
+    pricing_model:
+      usd_per1m_input_tokens: 0.60
+      usd_per1m_output_tokens: 2.20
+
+  # GLM-4.5-Air - cost-effective lightweight reasoning model
+  - name: "zaiGlm45Air"
+    model_id: "glm-4.5-air"
+    display_name: "GLM-4.5-Air"
+    knowledge_cutoff_date: "2025-04-01"
+    max_tokens: 32768
+    temperature: 0.7
+    thinking: true
+    pricing_model:
+      usd_per1m_input_tokens: 0.20
+      usd_per1m_output_tokens: 1.10
+
+  # GLM-4.7-Flash - free high-throughput model
+  - name: "zaiGlm47Flash"
+    model_id: "glm-4.7-flash"
+    display_name: "GLM-4.7-Flash"
+    knowledge_cutoff_date: "2025-04-01"
+    max_tokens: 32768
+    temperature: 0.7
+    thinking: true
+    pricing_model:
+      usd_per1m_input_tokens: 0.0
+      usd_per1m_output_tokens: 0.0

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/zai/AgentZaiAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/zai/AgentZaiAutoConfigurationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.zai;
+
+import com.embabel.agent.spi.LlmService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the Z.ai entrypoint auto-configuration imports the provider config and exposes the configured GLM model beans when credentials are present.
+ */
+class AgentZaiAutoConfigurationTest {
+
+   /**
+    * Context runner configured with a test API key so the provider configuration can instantiate its model beans without depending on real environment variables.
+    */
+   private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+           .withConfiguration(AutoConfigurations.of(AgentZaiAutoConfiguration.class))
+           .withPropertyValues("embabel.agent.platform.models.zai.api-key=test-key");
+
+   /**
+    * Confirms that all Z.ai GLM model beans are registered and backed by the generic LLM service abstraction exposed to the rest of the platform.
+    */
+   @Test
+   void registersZaiModelBeans() {
+      // Act
+      contextRunner.run(context -> {
+         // Assert
+         assertThat(context).hasBean("zaiGlm52");
+         assertThat(context).hasBean("zaiGlm47");
+         assertThat(context).hasBean("zaiGlm46");
+         assertThat(context).hasBean("zaiGlm45Air");
+         assertThat(context).hasBean("zaiGlm47Flash");
+         assertThat(context.getBean("zaiGlm52")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("zaiGlm47")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("zaiGlm46")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("zaiGlm45Air")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("zaiGlm47Flash")).isInstanceOf(LlmService.class);
+      });
+   }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiAllModelsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiAllModelsIT.kt
@@ -21,6 +21,7 @@ import com.embabel.agent.autoconfigure.models.zai.AgentZaiAutoConfiguration
 import com.embabel.agent.spi.LlmService
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.Thinking
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DynamicTest
@@ -149,6 +150,77 @@ class ZaiAllModelsIT(
                 assertTrue(
                     response.contains("READY", ignoreCase = true),
                     "Expected $modelId to reply with READY, got: $response",
+                )
+            }
+        }
+    }
+
+    /**
+     * No-network guard, one case per model declared in `zai-models.yml`: the runtime thinking
+     * capability advertised by each registered model must match its declared `thinking` flag.
+     * Catches a YAML entry claiming `thinking: true` for a model that does not actually wire the
+     * native reasoning path (or vice-versa).
+     */
+    @TestFactory
+    fun everyModelAdvertisesDeclaredThinkingSupport(): Stream<DynamicTest> {
+        val definitions = ZaiModelLoader().loadAutoConfigMetadata().models
+        assertTrue(
+            definitions.isNotEmpty(),
+            "Expected zai-models.yml to declare at least one model, found none",
+        )
+
+        return definitions.stream().map { def ->
+            DynamicTest.dynamicTest("model '${def.modelId}' advertises thinking=${def.thinking}") {
+                val runner = ai.withLlm(
+                    LlmOptions(def.modelId).withThinking(Thinking.withExtraction())
+                )
+                assertEquals(
+                    def.thinking,
+                    runner.supportsThinking(),
+                    "Model ${def.modelId} thinking support should match zai-models.yml (declared thinking=${def.thinking})",
+                )
+            }
+        }
+    }
+
+    /**
+     * One **live** reasoning round-trip per registered Z.ai chat model. Proves that every model
+     * flagged for thinking actually completes a request with reasoning enabled (not just that it
+     * advertises support). Skips (aborts) when the key lacks access to a model; a genuine crash
+     * still fails.
+     */
+    @TestFactory
+    fun everyRegisteredModelCompletesThinkingRoundTrip(): Stream<DynamicTest> {
+        val modelIds = registeredZaiModelIds()
+        assertTrue(
+            modelIds.isNotEmpty(),
+            "Expected at least one Z.ai model to be registered, found none",
+        )
+
+        return modelIds.stream().map { modelId ->
+            DynamicTest.dynamicTest("GLM model '$modelId' completes a reasoning round-trip") {
+                val response = try {
+                    ai.withLlm(LlmOptions(modelId).withThinking(Thinking.withExtraction()))
+                        .generateText(SMOKE_PROMPT)
+                        .trim()
+                } catch (ex: Exception) {
+                    if (isModelAccessError(ex)) {
+                        throw TestAbortedException(
+                            "ZAI_API_KEY is set, but it does not have access to (or balance for) $modelId",
+                            ex,
+                        )
+                    }
+                    throw ex
+                }
+
+                assertNotNull(response, "Expected a response object from $modelId with thinking enabled")
+                assertTrue(
+                    response.isNotBlank(),
+                    "Expected non-empty response from $modelId with thinking enabled",
+                )
+                assertTrue(
+                    response.contains("READY", ignoreCase = true),
+                    "Expected $modelId to reply with READY (thinking enabled), got: $response",
                 )
             }
         }

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiAllModelsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiAllModelsIT.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.zai
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.models.ZaiModels
+import com.embabel.agent.autoconfigure.models.zai.AgentZaiAutoConfiguration
+import com.embabel.agent.spi.LlmService
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.Thinking
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.opentest4j.TestAbortedException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.test.context.ActiveProfiles
+import java.util.stream.Stream
+
+/**
+ * Test-only configuration that brings up the platform beans (including [Ai]) alongside the
+ * Z.ai auto-configuration, so the live smoke test can resolve a real prompt runner.
+ */
+@Profile("zai-chat-test")
+@ConfigurationPropertiesScan(basePackages = ["com.embabel.agent", "com.embabel.example"])
+@ComponentScan(basePackages = ["com.embabel.agent", "com.embabel.example"])
+class ZaiChatTestConfig
+
+/**
+ * Live smoke test that exercises **every** registered Z.ai (Zhipu GLM) chat model to prove
+ * that none of them crashes on a trivial round-trip against the native ZhiPuAI endpoint.
+ *
+ * Design goals (mirrors `GoogleGenAiAllModelsIT`):
+ *
+ *  1. **No drift.** The list of models actually called is derived at runtime from the registered
+ *     [LlmService] beans (filtered by [ZaiModels.PROVIDER]), NOT from a hand-maintained list.
+ *     Add a model to `zai-models.yml` and it is covered automatically.
+ *
+ *  2. **Registration is guarded separately.** [everyDeclaredChatModelIsRegistered] cross-checks the
+ *     registered beans against the canonical constants in [ZaiModels], so a model that silently
+ *     fails to register is caught (it would otherwise just be absent from the live loop).
+ *
+ *  3. **Access gaps are skips, not failures.** A key that lacks entitlement (or balance) for a
+ *     model aborts that single case ([TestAbortedException] -> reported as skipped) instead of
+ *     failing the whole suite. A genuine crash (bad request, serialization error, NPE, ...) still
+ *     fails loudly.
+ *
+ * Requires `ZAI_API_KEY` to be set; otherwise the whole class is disabled.
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=glm-4.7-flash",
+        "embabel.agent.platform.models.zai.max-attempts=1",
+        "embabel.agent.platform.models.zai.api-key=\${ZAI_API_KEY:dummy-key-for-context-loading}",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("zai-chat-test")
+@Import(
+    ZaiChatTestConfig::class,
+    AgentZaiAutoConfiguration::class,
+)
+@EnabledIfEnvironmentVariable(
+    named = "ZAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Live Z.ai integration test requires ZAI_API_KEY",
+)
+class ZaiAllModelsIT(
+    @param:Autowired private val ai: Ai,
+    @param:Autowired private val llms: List<LlmService<*>>,
+) {
+
+    /**
+     * Fast, no-network guard: every chat model we ship a constant for must have produced a
+     * registered [LlmService]. Catches registration failures and YAML/constant drift before we
+     * ever spend a token.
+     */
+    @Test
+    fun everyDeclaredChatModelIsRegistered() {
+        val registered = registeredZaiModelIds().toSet()
+        val missing = EXPECTED_CHAT_MODELS.filterNot { it in registered }
+        assertTrue(
+            missing.isEmpty(),
+            "Expected Z.ai chat models to be registered but these are missing: $missing " +
+                "(registered: ${registered.sorted()})",
+        )
+    }
+
+    /**
+     * No-network guard: reasoning-capable GLM models must advertise thinking support so the
+     * native reasoning path is actually wired, not silently dropped.
+     */
+    @Test
+    fun reasoningModelsAdvertiseThinkingSupport() {
+        val runner = ai.withLlm(
+            LlmOptions(ZaiModels.GLM_4_7).withThinking(Thinking.withExtraction())
+        )
+        assertTrue(runner.supportsThinking(), "Expected Z.ai prompt runner to advertise thinking support")
+    }
+
+    /**
+     * One live test per registered Z.ai chat model. Fails only if a model genuinely misbehaves;
+     * skips (aborts) when the key lacks access to that model.
+     */
+    @TestFactory
+    fun everyRegisteredModelRepliesWithoutCrashing(): Stream<DynamicTest> {
+        val modelIds = registeredZaiModelIds()
+        assertTrue(
+            modelIds.isNotEmpty(),
+            "Expected at least one Z.ai model to be registered, found none",
+        )
+
+        return modelIds.stream().map { modelId ->
+            DynamicTest.dynamicTest("GLM model '$modelId' replies without crashing") {
+                val response = try {
+                    ai.withLlm(modelId).generateText(SMOKE_PROMPT).trim()
+                } catch (ex: Exception) {
+                    if (isModelAccessError(ex)) {
+                        throw TestAbortedException(
+                            "ZAI_API_KEY is set, but it does not have access to (or balance for) $modelId",
+                            ex,
+                        )
+                    }
+                    throw ex
+                }
+
+                assertNotNull(response, "Expected a response object from $modelId")
+                assertTrue(response.isNotBlank(), "Expected non-empty response from $modelId")
+                assertTrue(
+                    response.contains("READY", ignoreCase = true),
+                    "Expected $modelId to reply with READY, got: $response",
+                )
+            }
+        }
+    }
+
+    /** All Z.ai chat models currently registered as [LlmService] beans, sorted for stable ordering. */
+    private fun registeredZaiModelIds(): List<String> =
+        llms.asSequence()
+            .filter { it.provider == ZaiModels.PROVIDER }
+            .map { it.name }
+            .distinct()
+            .sorted()
+            .toList()
+
+    private fun isModelAccessError(ex: Exception): Boolean {
+        val message = generateSequence<Throwable>(ex) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString(" | ")
+        return message.contains("does not have access", ignoreCase = true) ||
+            message.contains("model_not_found", ignoreCase = true) ||
+            message.contains("permission", ignoreCase = true) ||
+            message.contains("insufficient", ignoreCase = true) ||
+            message.contains("balance", ignoreCase = true) ||
+            message.contains("404", ignoreCase = false) ||
+            message.contains("no longer available", ignoreCase = true)
+    }
+
+    companion object {
+        private const val SMOKE_PROMPT = "Reply with exactly the word READY."
+
+        /**
+         * Canonical list of chat models this module is expected to register, taken straight from
+         * [ZaiModels].
+         */
+        private val EXPECTED_CHAT_MODELS = listOf(
+            ZaiModels.GLM_5_2,
+            ZaiModels.GLM_4_7,
+            ZaiModels.GLM_4_6,
+            ZaiModels.GLM_4_5_AIR,
+            ZaiModels.GLM_4_7_FLASH,
+        )
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiAllModelsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiAllModelsIT.kt
@@ -21,7 +21,6 @@ import com.embabel.agent.autoconfigure.models.zai.AgentZaiAutoConfiguration
 import com.embabel.agent.spi.LlmService
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.Thinking
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DynamicTest
@@ -156,28 +155,26 @@ class ZaiAllModelsIT(
     }
 
     /**
-     * No-network guard, one case per model declared in `zai-models.yml`: the runtime thinking
-     * capability advertised by each registered model must match its declared `thinking` flag.
-     * Catches a YAML entry claiming `thinking: true` for a model that does not actually wire the
-     * native reasoning path (or vice-versa).
+     * No-network guard, one case per registered model: every GLM model exposed by Z.ai must
+     * advertise native reasoning ("thinking") support, which the provider declares statically.
+     * Catches a model that fails to wire the reasoning path.
      */
     @TestFactory
-    fun everyModelAdvertisesDeclaredThinkingSupport(): Stream<DynamicTest> {
-        val definitions = ZaiModelLoader().loadAutoConfigMetadata().models
+    fun everyRegisteredModelAdvertisesThinkingSupport(): Stream<DynamicTest> {
+        val modelIds = registeredZaiModelIds()
         assertTrue(
-            definitions.isNotEmpty(),
-            "Expected zai-models.yml to declare at least one model, found none",
+            modelIds.isNotEmpty(),
+            "Expected at least one Z.ai model to be registered, found none",
         )
 
-        return definitions.stream().map { def ->
-            DynamicTest.dynamicTest("model '${def.modelId}' advertises thinking=${def.thinking}") {
+        return modelIds.stream().map { modelId ->
+            DynamicTest.dynamicTest("model '$modelId' advertises thinking support") {
                 val runner = ai.withLlm(
-                    LlmOptions(def.modelId).withThinking(Thinking.withExtraction())
+                    LlmOptions(modelId).withThinking(Thinking.withExtraction())
                 )
-                assertEquals(
-                    def.thinking,
+                assertTrue(
                     runner.supportsThinking(),
-                    "Model ${def.modelId} thinking support should match zai-models.yml (declared thinking=${def.thinking})",
+                    "Expected Z.ai model $modelId to advertise thinking support",
                 )
             }
         }

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiOptionsConverterTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.zai
+
+import com.embabel.agent.test.models.OptionsConverterTestSupport
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.Thinking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.ai.zhipuai.ZhiPuAiChatOptions
+
+class ZaiOptionsConverterTest : OptionsConverterTestSupport<ZhiPuAiChatOptions>(
+    optionsConverter = ZaiOptionsConverter
+) {
+    @Test
+    fun `should set override maxTokens default`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withMaxTokens(200))
+        assertEquals(200, options.maxTokens)
+    }
+
+    @Test
+    fun `should clamp temperature below minimum to minimum`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTemperature(0.0))
+        val temperature = requireNotNull(options.temperature) { "Temperature should not be null after clamping" }
+        assertTrue(temperature >= 0.01, "Temperature should be clamped to at least 0.01")
+    }
+
+    @Test
+    fun `should clamp temperature above maximum to maximum`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTemperature(2.0))
+        assertEquals(1.0, options.temperature)
+    }
+
+    @Test
+    fun `should preserve valid temperature`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTemperature(0.7))
+        assertEquals(0.7, options.temperature)
+    }
+
+    @Test
+    fun `should handle null temperature`() {
+        val options = optionsConverter.convertOptions(LlmOptions())
+        assertNull(options.temperature)
+    }
+
+    @Test
+    fun `should preserve topP`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTopP(0.9))
+        assertEquals(0.9, options.topP)
+    }
+
+    @Test
+    fun `should enable native thinking when requested`() {
+        val options = optionsConverter.convertOptions(
+            LlmOptions().withThinking(Thinking.withTokenBudget(1024))
+        )
+        assertNotNull(options.thinking, "Thinking should be set when enabled")
+        assertEquals("enabled", options.thinking.type())
+    }
+
+    @Test
+    fun `should not set thinking by default`() {
+        val options = optionsConverter.convertOptions(LlmOptions())
+        assertNull(options.thinking, "Thinking should be null when not requested")
+    }
+}

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -39,6 +39,7 @@
         <module>models/embabel-agent-google-genai-autoconfigure</module>
         <module>models/embabel-agent-oci-genai-autoconfigure</module>
         <module>models/embabel-agent-minimax-autoconfigure</module>
+        <module>models/embabel-agent-zai-autoconfigure</module>
         <module>models/embabel-agent-mistral-ai-autoconfigure</module>
         <module>models/embabel-agent-onnx-autoconfigure</module>
     </modules>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -193,6 +193,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-zai-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-mistral-ai-autoconfigure</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -332,6 +338,12 @@
             <dependency>
                 <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-minimax</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-zai</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
@@ -254,6 +254,12 @@ The following are modules intended for direct use (versus supporting infrastruct
 | Quick start with Mistral
 | Stable
 
+| `embabel-agent-starter-zai`
+| This repo
+| Z.ai (Zhipu GLM) starter
+| Quick start with Z.ai GLM models
+| Stable
+
 | `embabel-agent-starter-dockermodels`
 | This repo
 | Docker Models starter

--- a/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
@@ -35,6 +35,8 @@ include::bedrock/page.adoc[]
 
 include::minimax/page.adoc[]
 
+include::zai/page.adoc[]
+
 include::streaming/page.adoc[]
 
 include::thinking/page.adoc[]

--- a/embabel-agent-docs/src/main/asciidoc/reference/zai/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/zai/page.adoc
@@ -1,0 +1,227 @@
+[[reference.zai]]
+=== Z.ai Integration
+
+https://z.ai[Z.ai] (Zhipu AI) is a Chinese AI company offering the GLM family of high-performance LLMs.
+Embabel integrates Z.ai as a first-class provider using the native Spring AI ZhiPuAI client (`spring-ai-zhipuai`) — pointed at Z.ai's international "PaaS v4" endpoint — following the same pattern as the Google GenAI and Mistral AI providers.
+This native integration unlocks GLM-specific features such as reasoning ("thinking"), rather than relying on the OpenAI-compatible wire protocol.
+
+Model definitions (ids, pricing, knowledge cutoff, reasoning support) are loaded from `classpath:models/zai-models.yml` and each is registered as an `LlmService` bean.
+
+==== Add the Dependency
+
+[tabs]
+====
+Maven::
++
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-zai</artifactId>
+</dependency>
+----
+
+Gradle (Kotlin)::
++
+[source,kotlin]
+----
+implementation("com.embabel.agent:embabel-agent-starter-zai")
+----
+
+Gradle (Groovy)::
++
+[source,groovy]
+----
+implementation 'com.embabel.agent:embabel-agent-starter-zai'
+----
+====
+
+==== API Key Configuration
+
+Set your Z.ai API key via environment variable (recommended) or Spring property:
+
+[source,bash]
+----
+export ZAI_API_KEY=your-api-key
+----
+
+Or in `application.yml`:
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        zai:
+          api-key: your-api-key
+----
+
+TIP: The environment variable `ZAI_API_KEY` takes precedence over the property value.
+Use the property for local development and the environment variable in production deployments.
+
+==== Available Models
+
+[cols="2,3,1,1",options="header"]
+|===
+|Model Name |Model ID |Input (per 1M tokens) |Output (per 1M tokens)
+
+|`GLM-5.2`
+|`glm-5.2`
+|$1.40
+|$4.40
+
+|`GLM-4.7`
+|`glm-4.7`
+|$0.60
+|$2.20
+
+|`GLM-4.6`
+|`glm-4.6`
+|$0.60
+|$2.20
+
+|`GLM-4.5-Air`
+|`glm-4.5-air`
+|$0.20
+|$1.10
+
+|`GLM-4.7-Flash`
+|`glm-4.7-flash`
+|Free
+|Free
+
+|===
+
+`glm-5.2` is the latest flagship model, supporting up to a 1M token context window — the best default choice for demanding reasoning and coding tasks.
+`glm-4.7` and `glm-4.6` are strong, cost-effective general-purpose models.
+`glm-4.5-air` trades some quality for significantly lower latency and cost — a good choice for intermediate steps in a multi-action agent flow.
+`glm-4.7-flash` is free, well-suited to high-volume extraction and classification steps.
+
+TIP: Embabel's per-step LLM selection makes Z.ai models particularly well-suited to mixed strategies: use `glm-4.7-flash` or `glm-4.5-air` for extraction and classification steps, and reserve `glm-5.2` (or a premium model) only for the final reasoning step.
+
+==== Using Z.ai Models
+
+Reference models by name in `@LlmCall` or programmatically via `ai.withLlm()`:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+// Declarative
+@LlmCall(llm = "glm-5.2")
+fun summarize(article: Article): Summary
+
+// Programmatic
+ai.withLlm("glm-4.5-air")
+    .create<Classification>("Classify this input")
+----
+
+Java::
++
+[source,java]
+----
+// Declarative
+@LlmCall(llm = "glm-5.2")
+Summary summarize(Article article);
+
+// Programmatic
+ai.withLlm("glm-4.5-air")
+    .create("Classify this input", Classification.class);
+----
+====
+
+Or map Z.ai models to roles in your configuration:
+
+[source,yaml]
+----
+embabel:
+  models:
+    llms:
+      cheapest: glm-4.7-flash
+      best: glm-5.2
+----
+
+Then reference by role with the `#` prefix:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+@LlmCall(llm = "#cheapest")
+fun extractEntities(text: String): EntityList
+----
+
+Java::
++
+[source,java]
+----
+@LlmCall(llm = "#cheapest")
+EntityList extractEntities(String text);
+----
+====
+
+==== Temperature Clamping
+
+GLM models require temperature in the range `(0.0, 1.0]` — a value of exactly `0.0` is not permitted.
+Embabel's `ZaiOptionsConverter` clamps temperature automatically:
+
+* Values `<= 0.0` are raised to `0.01`
+* Values `> 1.0` are lowered to `1.0`
+
+A `DEBUG` log message is emitted whenever clamping occurs.
+No action is required on your part — this is handled transparently.
+
+==== Reasoning (Thinking)
+
+GLM models support native reasoning. Because Embabel uses the native ZhiPuAI client, enabling
+`Thinking` on an `LlmOptions` turns on GLM's native reasoning mode rather than relying on prompt
+conventions:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+ai.withLlm(
+    LlmOptions.withModel("glm-4.7").withThinking(Thinking.withTokenBudget(2048))
+).create<Answer>("Solve this step by step")
+----
+
+Java::
++
+[source,java]
+----
+ai.withLlm(
+    LlmOptions.withModel("glm-4.7").withThinking(Thinking.withTokenBudget(2048))
+).create("Solve this step by step", Answer.class);
+----
+====
+
+==== Configuration Reference
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        zai:
+          api-key: your-api-key                   # Alternative to ZAI_API_KEY env var
+          base-url: https://api.z.ai/api/paas       # Default; host + /api/paas prefix (no /v4)
+          max-attempts: 4                          # Retry attempts (default: 4)
+          backoff-millis: 1500                     # Initial backoff ms (default: 1500)
+          backoff-multiplier: 2.0                  # Backoff multiplier (default: 2.0)
+          backoff-max-interval: 60000              # Max backoff ms (default: 60000)
+----
+
+==== See Also
+
+* <<reference.llms,Working with LLMs>>
+* <<reference.configuration,Configuration Reference>>
+* https://z.ai[Z.ai]

--- a/embabel-agent-starters/embabel-agent-starter-zai/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-zai/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>1.0.0-RC1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>embabel-agent-starter-zai</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Z.ai Starter</name>
+    <description>Embabel Agent Z.ai Starter</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-zai-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -38,6 +38,7 @@
         <module>embabel-agent-starter-google-genai</module>
         <module>embabel-agent-starter-oci-genai</module>
         <module>embabel-agent-starter-minimax</module>
+        <module>embabel-agent-starter-zai</module>
         <module>embabel-agent-starter-mistral-ai</module>
         <module>embabel-agent-starter-a2a</module>
         <module>embabel-agent-starter-webmvc</module>


### PR DESCRIPTION
# Summary

Adds Z.ai (Zhipu AI) as a first-class LLM provider, exposing the GLM model family via Z.ai's OpenAI-compatible API. The integration mirrors the existing dynamic-loader pattern used by the Gemini provider: models are declared in a YAML file and registered at runtime, so adding a model requires no code change and the live tests never drift from the shipped catalog.

## What's included

- New provider module `embabel-agent-zai-autoconfigure` + starter `embabel-agent-starter-zai`, wired into `embabel-agent-dependencies`, `embabel-agent-autoconfigure`, and `embabel-agent-starters`.
- Dynamic model loader (`ZaiModelLoader` + `zai-models.yml`) registering the GLM family: `glm-5.2`, `glm-4.7`, `glm-4.6`, `glm-4.5-air`, `glm-4.7-flash`.
- `ZaiOptionsConverter` - clamps temperature to GLM's valid `(0.0, 1.0]` range.
- Spring Boot autoconfiguration activated on `ZAI_API_KEY`.
- Documentation - `reference/zai/page.adoc` + `README.md`.

## Testing

- Unit: `ZaiOptionsConverterTest` (9) + `AgentZaiAutoConfigurationTest` (1) - green.
- Live IT: `ZaiAllModelsIT` - 7 tests, 0 failures, 0 skips against the real endpoint; all five GLM models replied.