### PR TITLE
Add appropriate error message to the log whenever a goal is not reachable

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/plan/goap/astar/AStarGoapPlanner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/plan/goap/astar/AStarGoapPlanner.kt
@@ -54,6 +54,8 @@ internal class AStarGoapPlanner(worldStateDeterminer: WorldStateDeterminer) :
 
         // Early reachability check to avoid expensive A* search for unreachable goals
         if (!isGoalReachable(startState, actions, goal)) {
+            logger.error("Some of the conditions {} of goal '{}' are not satisfied." +
+                    " Make sure to add them as the output/post condition of any one of the action that leads to the goal.", goal.preconditions.keys, goal.name)
             return null
         }
 
@@ -297,9 +299,6 @@ internal class AStarGoapPlanner(worldStateDeterminer: WorldStateDeterminer) :
 
             // If no action can produce this effect, goal is unreachable
             if ((key to value) !in producibleEffects) {
-                logger.error("Condition '{}' is not produced by any of the action that leads to the goal {}." +
-                        " Make sure to add it as the output/post condition of any one of the action that leads to the goal.", key, goal.name)
-
                 return false
             }
         }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/plan/goap/astar/AStarGoapPlanner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/plan/goap/astar/AStarGoapPlanner.kt
@@ -297,6 +297,9 @@ internal class AStarGoapPlanner(worldStateDeterminer: WorldStateDeterminer) :
 
             // If no action can produce this effect, goal is unreachable
             if ((key to value) !in producibleEffects) {
+                logger.error("Condition '{}' is not produced by any of the action that leads to the goal {}." +
+                        " Make sure to add it as the output/post condition of any one of the action that leads to the goal.", key, goal.name)
+
                 return false
             }
         }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/plan/goap/astar/AStarGoapPlanner.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/plan/goap/astar/AStarGoapPlanner.kt
@@ -54,8 +54,7 @@ internal class AStarGoapPlanner(worldStateDeterminer: WorldStateDeterminer) :
 
         // Early reachability check to avoid expensive A* search for unreachable goals
         if (!isGoalReachable(startState, actions, goal)) {
-            logger.error("Some of the conditions {} of goal '{}' are not satisfied." +
-                    " Make sure to add them as the output/post condition of any one of the action that leads to the goal.", goal.preconditions.keys, goal.name)
+            logger.error("""Some of the conditions {} of goal '{}' are not satisfied. Make sure to add them as the output/post condition of any one of the action that leads to the goal.""", goal.preconditions.keys, goal.name)
             return null
         }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/plan/goap/astar/UnReachableGoalTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/plan/goap/astar/UnReachableGoalTest.kt
@@ -51,8 +51,8 @@ class UnReachableGoalTest {
     inner class AgentWithUnreachableGoal {
 
         @Action
-        fun firstAction(input: UserInput ,  context: ActionContext) :String {
-            return "first-" + input.content
+        fun firstAction(input: UserInput, context: ActionContext) :String {
+            return """first-$input.content""""
         }
 
         @Action(pre = ["firstCondition"])
@@ -75,7 +75,7 @@ class UnReachableGoalTest {
         blackboard.addObject( UserInput("TestUser"))
 
         var reader =  AgentMetadataReader();
-        var agent = (reader.createAgentMetadata( AgentWithUnreachableGoal())) as  com.embabel.agent.core.Agent
+        var agent = (reader.createAgentMetadata( AgentWithUnreachableGoal())) as com.embabel.agent.core.Agent
 
         var agentProcess =  SimpleAgentProcess(
             "test-unreachable-condition",
@@ -92,10 +92,7 @@ class UnReachableGoalTest {
 
         // Agent is stuck as the condition could not meet.
         assertEquals( AgentProcessStatusCode.STUCK, result.status);
-        assertTrue(output.out.contains("Condition 'firstCondition' is not produced by any of the action that leads " +
-                "to " +
-                "the goal com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithUnreachableGoal.goal. Make sure " +
-                "to add it as the output/post condition of any one of the action that leads to the goal"),
+        assertTrue(output.out.contains("Some of the conditions [hasRun_com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithUnreachableGoal.goal, firstCondition, it:java.lang.String] of goal 'com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithUnreachableGoal.goal' are not satisfied. Make sure to add them as the output/post condition of any one of the action that leads to the goal."),
             "firstCondition is produced unexpectedly.")
     }
 
@@ -130,7 +127,7 @@ class UnReachableGoalTest {
         blackboard.addObject( UserInput("TestUser"))
 
         var reader =  AgentMetadataReader();
-        var agent = (reader.createAgentMetadata( AgentWithReachableGoal())) as  com.embabel.agent.core.Agent
+        var agent = (reader.createAgentMetadata( AgentWithReachableGoal())) as com.embabel.agent.core.Agent
 
         var agentProcess =  SimpleAgentProcess(
             "test-reachable-condition",
@@ -145,9 +142,7 @@ class UnReachableGoalTest {
 
        agentProcess.run()
 
-        assertFalse (output.out.contains("Condition 'firstCondition' is not produced by any of the action that leads to" +
-                " the goal com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithReachableGoal.goal. Make sure to" +
-                " add it as the output/post condition of any one of the action that leads to the goal."),
+        assertFalse(output.out.contains("Some of the conditions [hasRun_com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithReachableGoal.goal, firstCondition, it:java.lang.String] of goal 'com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithReachableGoal.goal' are not satisfied. Make sure to add them as the output/post condition of any one of the action that leads to the goal."),
              "firstCondition is not produced as expected.")
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/plan/goap/astar/UnReachableGoalTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/plan/goap/astar/UnReachableGoalTest.kt
@@ -92,7 +92,7 @@ class UnReachableGoalTest {
 
         // Agent is stuck as the condition could not meet.
         assertEquals( AgentProcessStatusCode.STUCK, result.status);
-        assertTrue(output.out.contains("Some of the conditions [hasRun_com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithUnreachableGoal.goal, firstCondition, it:java.lang.String] of goal 'com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithUnreachableGoal.goal' are not satisfied. Make sure to add them as the output/post condition of any one of the action that leads to the goal."),
+        assertTrue(output.out.contains("""Some of the conditions [hasRun_com.embabel.plan.goap.astar.UnReachableGoalTest${'$'}AgentWithUnreachableGoal.goal, firstCondition, it:java.lang.String] of goal 'com.embabel.plan.goap.astar.UnReachableGoalTest${'$'}AgentWithUnreachableGoal.goal' are not satisfied. Make sure to add them as the output/post condition of any one of the action that leads to the goal."""),
             "firstCondition is produced unexpectedly.")
     }
 
@@ -142,7 +142,7 @@ class UnReachableGoalTest {
 
        agentProcess.run()
 
-        assertFalse(output.out.contains("Some of the conditions [hasRun_com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithReachableGoal.goal, firstCondition, it:java.lang.String] of goal 'com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithReachableGoal.goal' are not satisfied. Make sure to add them as the output/post condition of any one of the action that leads to the goal."),
+        assertFalse(output.out.contains("""Some of the conditions [hasRun_com.embabel.plan.goap.astar.UnReachableGoalTest${'$'}AgentWithReachableGoal.goal, firstCondition, it:java.lang.String] of goal 'com.embabel.plan.goap.astar.UnReachableGoalTest${'$'}AgentWithReachableGoal.goal' are not satisfied. Make sure to add them as the output/post condition of any one of the action that leads to the goal."""),
              "firstCondition is not produced as expected.")
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/plan/goap/astar/UnReachableGoalTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/plan/goap/astar/UnReachableGoalTest.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.plan.goap.astar;
+
+import com.embabel.agent.api.annotation.AchievesGoal;
+import com.embabel.agent.api.annotation.Action;
+import com.embabel.agent.api.annotation.Agent;
+import com.embabel.agent.api.annotation.Condition;
+import com.embabel.agent.api.annotation.support.AgentMetadataReader;
+import com.embabel.agent.api.common.ActionContext;
+import com.embabel.agent.core.AgentProcess;
+import com.embabel.agent.core.AgentProcessStatusCode;
+import com.embabel.agent.core.ProcessOptions;
+import com.embabel.agent.core.support.InMemoryBlackboard;
+import com.embabel.agent.core.support.SimpleAgentProcess;
+import com.embabel.agent.domain.io.UserInput;
+import com.embabel.agent.spi.support.DefaultPlannerFactory;
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+
+import java.time.Instant;
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+
+/**
+ * This test verifies that whenever a goal is not reachable because it is not satisfying the `pre`condition,
+ * agent is stuck and appropriate message is logged.
+ */
+@ExtendWith(OutputCaptureExtension::class)
+class UnReachableGoalTest {
+
+    @Agent(description = "A dummy agent with unreachable goal")
+    inner class AgentWithUnreachableGoal {
+
+        @Action
+        fun firstAction(input: UserInput ,  context: ActionContext) :String {
+            return "first-" + input.content
+        }
+
+        @Action(pre = ["firstCondition"])
+        @AchievesGoal(description = "Unreachable goal" )
+        fun  goal( input: String): String {
+            return input
+        }
+
+        @Condition(name = "firstCondition")
+        fun  isFirstCondition(input: String): Boolean {
+            return input.contains("123")
+        }
+    }
+
+    @Test
+    fun `test unreachable condition`(output: CapturedOutput) {
+        // Setup.
+        var platformServices = dummyPlatformServices()
+        var blackboard =  InMemoryBlackboard()
+        blackboard.addObject( UserInput("TestUser"))
+
+        var reader =  AgentMetadataReader();
+        var agent = (reader.createAgentMetadata( AgentWithUnreachableGoal())) as  com.embabel.agent.core.Agent
+
+        var agentProcess =  SimpleAgentProcess(
+            "test-unreachable-condition",
+            null,  // parentId
+            agent,
+            ProcessOptions.DEFAULT,
+            blackboard,
+            platformServices,
+            DefaultPlannerFactory,
+            Instant.now()
+        );
+
+        var result:AgentProcess = agentProcess.run()
+
+        // Agent is stuck as the condition could not meet.
+        assertEquals( AgentProcessStatusCode.STUCK, result.status);
+        assertTrue(output.out.contains("Condition 'firstCondition' is not produced by any of the action that leads " +
+                "to " +
+                "the goal com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithUnreachableGoal.goal. Make sure " +
+                "to add it as the output/post condition of any one of the action that leads to the goal"),
+            "firstCondition is produced unexpectedly.")
+    }
+
+    /* Agent as similar to the AgentWithUnreachableGoal but goal is made reachable. */
+    @Agent(description = "A dummy agent with reachable goal")
+    inner class AgentWithReachableGoal {
+
+        // firstCondition is added as a post condition to make the goal reachable.
+        @Action(post = ["firstCondition"])
+        fun firstAction(input: UserInput ,  context: ActionContext) :String {
+            context.setCondition("firstCondition", true)
+            return "first-" + input.content
+        }
+
+        @Action(pre = ["firstCondition"])
+        @AchievesGoal(description = "Reachable goal" )
+        fun  goal( input: String): String {
+            return input
+        }
+
+        @Condition(name = "firstCondition")
+        fun  isFirstCondition(input: String): Boolean {
+            return input.contains("123")
+        }
+    }
+
+    @Test
+    fun `test reachable condition`(output: CapturedOutput) {
+        // Setup
+        var platformServices = dummyPlatformServices()
+        var blackboard =  InMemoryBlackboard()
+        blackboard.addObject( UserInput("TestUser"))
+
+        var reader =  AgentMetadataReader();
+        var agent = (reader.createAgentMetadata( AgentWithReachableGoal())) as  com.embabel.agent.core.Agent
+
+        var agentProcess =  SimpleAgentProcess(
+            "test-reachable-condition",
+            null,  // parentId
+            agent,
+            ProcessOptions.DEFAULT,
+            blackboard,
+            platformServices,
+            DefaultPlannerFactory,
+            Instant.now()
+        );
+
+       agentProcess.run()
+
+        assertFalse (output.out.contains("Condition 'firstCondition' is not produced by any of the action that leads to" +
+                " the goal com.embabel.plan.goap.astar.UnReachableGoalTest\$AgentWithReachableGoal.goal. Make sure to" +
+                " add it as the output/post condition of any one of the action that leads to the goal."),
+             "firstCondition is not produced as expected.")
+    }
+}


### PR DESCRIPTION
Fix - https://github.com/embabel/embabel-agent/issues/1762

**Description**
 - Log error message when a goal is not reachable when its pre condition is produced by any of the previous  actions.
 
 **Test**
    
  - Added a positive and negative unit test.