### PR TITLE
fix(tools): glob '**/' now matches zero or more directories (root & direct children)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/file/FileReadTools.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/file/FileReadTools.kt
@@ -271,6 +271,10 @@ internal class DefaultFileReadTools(
  * "a/&#42;&#42;/b/&#42;&#42;/c" matches "a/b/c", "a/x/b/c", "a/b/y/c", and so on, all at once. The rest of the
  * glob works as usual: "*" and "?" stay inside one folder or file name, and "{a,b}" choices and
  * "[a-z]"/"[!a]" character sets keep working. A pattern starting with "regex:" is used as-is.
+ *
+ * Matching is case-sensitive on every platform, for cross-platform determinism: results depend
+ * only on the pattern, not the host OS. (NIO's getPathMatcher was case-insensitive on Windows.)
+ * For case-insensitivity, spell it out in the glob, e.g. "*.{kt,KT}".
  */
 fun globMatcher(pattern: String): (Path) -> Boolean {
     if (pattern.startsWith("regex:")) {
@@ -284,8 +288,9 @@ fun globMatcher(pattern: String): (Path) -> Boolean {
 /** Regex metacharacters that must be escaped when they appear literally in a glob. */
 private const val REGEX_META = ".^$+{}[]()|"
 
-// Translate a glob to a regex, mirroring the JDK glob translator (sun.nio.fs.Globs) with ONE change:
-// "**/" matches zero or more directories, so a file needs no folder in front of it to match.
+// Translate a glob to a regex, mirroring the JDK glob translator (sun.nio.fs.Globs) except for three
+// deliberate deviations. (1) "**/" matches zero or more directories, so a file needs no folder in
+// front of it to match.
 //
 //     root/
 //     ├── top.sol          ← root-level file
@@ -303,6 +308,11 @@ private const val REGEX_META = ".^$+{}[]()|"
 // A "**" on its own or at the end (not right before a slash) becomes ".*" and reaches into any
 // folder, like the JDK does. A single "*" and "?" stay inside one folder or file name; "{a,b}"
 // choices and "[...]" character sets are kept.
+//
+// The other two deviations from the JDK: (2) matching is case-sensitive on every platform (see
+// globMatcher) rather than case-insensitive on Windows; (3) a literal "/" inside a "[...]" class is
+// accepted and neutralised (it can never match, thanks to the "[^/]" intersection) instead of
+// raising a PatternSyntaxException.
 private fun globToRegex(glob: String): String {
     val regex = StringBuilder()
     var inGroup = false        // true while we are inside a "{a,b}" choice
@@ -323,7 +333,9 @@ private fun globToRegex(glob: String): String {
 
             // "[...]": a set of allowed characters. Glob writes "not these" as "[!..]", regex as "[^..]".
             '[' -> {
-                regex.append('[')
+                // Intersect with "[^/]" so a class never matches the path separator, even when negated:
+                // "[!x]" -> "[[^/]&&[^x]]" stays within one segment (JDK sun.nio.fs.Globs does the same).
+                regex.append("[[^/]&&[")
                 when {
                     i < glob.length && glob[i] == '!' -> {
                         regex.append('^'); i++         // "[!..]" (none of these) -> "[^..]"
@@ -339,12 +351,15 @@ private fun globToRegex(glob: String): String {
                             regex.append('\\'); if (i < glob.length) regex.append(glob[i++])
                         }
 
-                        '&' -> regex.append("\\&")     // '&' has a meaning inside Java "[...]", so keep it plain
+                        // '[' and '&' have a meaning inside a Java "[...]" class, so keep them literal
+                        // (the JDK glob translator escapes '\', '[' and "&&" the same way).
+                        '[' -> regex.append("\\[")
+                        '&' -> regex.append("\\&")
                         else -> regex.append(cc)
                     }
                 }
                 require(i < glob.length && glob[i] == ']') { "Missing ']' in glob: $glob" }
-                regex.append(']'); i++
+                regex.append("]]"); i++                 // close the inner class and the outer intersection
             }
 
             // "{a,b}": match a or b. Open the group, and turn its commas into "or" ("|").

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/file/FileReadTools.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/file/FileReadTools.kt
@@ -263,13 +263,14 @@ internal class DefaultFileReadTools(
 ) : FileReadTools, FileReadLog by DefaultFileReadLog()
 
 /**
- * A predicate matching relative paths against [pattern] with ripgrep/gitignore glob semantics.
+ * Builds a test that tells whether a path matches [pattern], using the same glob rules as
+ * ripgrep and .gitignore.
  *
- * The glob is translated to a single regular expression (see [globToRegex]), so a double-star-slash
- * segment matches ZERO or more directories independently, however many appear in one pattern:
- * "a/&#42;&#42;/b/&#42;&#42;/c" matches every 0/1/n combination in a single pass. Every other glob feature is
- * preserved: "*" and "?" stay within a path segment, braces "{a,b}" and character classes "[a-z]"/"[!a]"
- * keep working. `regex:` patterns are matched verbatim via the platform [PathMatcher].
+ * The glob is turned into one regular expression (see [globToRegex]). Because of that, every
+ * "&#42;&#42;/" in the pattern matches zero or more folders on its own, however many there are:
+ * "a/&#42;&#42;/b/&#42;&#42;/c" matches "a/b/c", "a/x/b/c", "a/b/y/c", and so on, all at once. The rest of the
+ * glob works as usual: "*" and "?" stay inside one folder or file name, and "{a,b}" choices and
+ * "[a-z]"/"[!a]" character sets keep working. A pattern starting with "regex:" is used as-is.
  */
 fun globMatcher(pattern: String): (Path) -> Boolean {
     if (pattern.startsWith("regex:")) {
@@ -283,19 +284,33 @@ fun globMatcher(pattern: String): (Path) -> Boolean {
 /** Regex metacharacters that must be escaped when they appear literally in a glob. */
 private const val REGEX_META = ".^$+{}[]()|"
 
-/**
- * Translate a glob to a regex, mirroring the JDK glob translator (sun.nio.fs.Globs) with ONE change:
- * a double-star-slash segment becomes "(?:[^/]+/)*" (zero or more directory segments) instead of
- * forcing a literal separator. That literal separator is exactly why NIO skipped direct children and
- * root-level files. A bare or trailing double-star (not isolated before a slash) still becomes ".*",
- * crossing directories like NIO. "*" and "?" stay inside one segment; braces and classes are preserved.
- */
+// Translate a glob to a regex, mirroring the JDK glob translator (sun.nio.fs.Globs) with ONE change:
+// "**/" matches zero or more directories, so a file needs no folder in front of it to match.
+//
+//     root/
+//     ├── top.sol          ← root-level file
+//     ├── README.md        ← root-level file
+//     ├── src/
+//     │   ├── Foo.sol      ← direct child of src/
+//     │   └── sub/
+//     │       └── C.sol    ← nested
+//
+// "**/*.sol" (leading double-star) catches files at the root: top.sol, README.md.
+// "src/**/*.sol" catches the direct children of src/: src/Foo.sol (0 dirs between src/ and the file)
+// and src/sub/C.sol (nested — already worked). JDK always required a directory after "**", so it
+// missed the 0-directory cases: top.sol (0 slashes) and src/Foo.sol (1 slash).
+//
+// A "**" on its own or at the end (not right before a slash) becomes ".*" and reaches into any
+// folder, like the JDK does. A single "*" and "?" stay inside one folder or file name; "{a,b}"
+// choices and "[...]" character sets are kept.
 private fun globToRegex(glob: String): String {
     val regex = StringBuilder()
-    var inGroup = false
-    var i = 0
+    var inGroup = false        // true while we are inside a "{a,b}" choice
+    var i = 0                  // where we are in the glob
+    // Read the glob one character at a time and append the matching regex piece.
     while (i < glob.length) {
         when (val c = glob[i++]) {
+            // "\x": keep x as a plain character (add a backslash if regex would treat it specially).
             '\\' -> {
                 require(i < glob.length) { "No character to escape at end of glob: $glob" }
                 val next = glob[i++]
@@ -303,17 +318,19 @@ private fun globToRegex(glob: String): String {
                 regex.append(next)
             }
 
+            // "/": a folder separator, the same in both.
             '/' -> regex.append('/')
 
+            // "[...]": a set of allowed characters. Glob writes "not these" as "[!..]", regex as "[^..]".
             '[' -> {
                 regex.append('[')
                 when {
                     i < glob.length && glob[i] == '!' -> {
-                        regex.append('^'); i++
+                        regex.append('^'); i++         // "[!..]" (none of these) -> "[^..]"
                     }
 
                     i < glob.length && glob[i] == '^' -> {
-                        regex.append("\\^"); i++
+                        regex.append("\\^"); i++        // a real '^' here must be kept as a plain char
                     }
                 }
                 while (i < glob.length && glob[i] != ']') {
@@ -322,7 +339,7 @@ private fun globToRegex(glob: String): String {
                             regex.append('\\'); if (i < glob.length) regex.append(glob[i++])
                         }
 
-                        '&' -> regex.append("\\&")
+                        '&' -> regex.append("\\&")     // '&' has a meaning inside Java "[...]", so keep it plain
                         else -> regex.append(cc)
                     }
                 }
@@ -330,6 +347,7 @@ private fun globToRegex(glob: String): String {
                 regex.append(']'); i++
             }
 
+            // "{a,b}": match a or b. Open the group, and turn its commas into "or" ("|").
             '{' -> {
                 require(!inGroup) { "Nested '{' in glob: $glob" }
                 inGroup = true
@@ -338,26 +356,29 @@ private fun globToRegex(glob: String): String {
 
             '}' -> if (inGroup) {
                 regex.append(')'); inGroup = false
-            } else regex.append('}')
+            } else regex.append('}')                     // a plain '}' when we are not in a "{a,b}"
 
             ',' -> if (inGroup) regex.append('|') else regex.append(',')
 
+            // Stars: the one place we change the JDK behaviour (see the note above the function).
             '*' -> {
                 if (i < glob.length && glob[i] == '*') {
                     i++ // consume the second '*'
                     if (i < glob.length && glob[i] == '/') {
-                        i++ // consume the slash: '**/' -> zero or more directory segments
+                        i++ // consume the slash: "**/" -> zero or more folders
                         regex.append("(?:[^/]+/)*")
                     } else {
-                        regex.append(".*") // bare/trailing '**' crosses directories
+                        regex.append(".*") // "**" on its own reaches into any folder
                     }
                 } else {
-                    regex.append("[^/]*")
+                    regex.append("[^/]*") // one "*" stays inside a single folder or file name
                 }
             }
 
+            // "?": any one character except the folder separator.
             '?' -> regex.append("[^/]")
 
+            // Anything else is itself; add a backslash if regex would treat it specially.
             else -> {
                 if (c in REGEX_META) regex.append('\\')
                 regex.append(c)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/file/FileReadTools.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/file/FileReadTools.kt
@@ -20,11 +20,13 @@ import com.embabel.agent.api.common.support.SelfToolPublisher
 import com.embabel.agent.tools.DirectoryBased
 import com.embabel.common.util.StringTransformer
 import com.embabel.common.util.loggerFor
+import java.io.File
 import java.io.IOException
 import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.regex.Pattern
 
 /**
  * LLM-ready ToolCallbacks and convenience methods for file operations.
@@ -115,13 +117,15 @@ interface FileReadTools : DirectoryBased, FileReadLog, FileAccessLog, SelfToolPu
         findHighest: Boolean,
     ): List<String> {
         val basePath = Paths.get(root).toAbsolutePath().normalize()
-        val syntaxAndPattern = if (glob.startsWith("glob:") || glob.startsWith("regex:")) glob else "glob:$glob"
-        val matcher = FileSystems.getDefault().getPathMatcher(syntaxAndPattern)
+        // Ripgrep/gitignore '**' semantics ('**/' matches zero or more directories), preserving every
+        // other NIO glob feature ({...}, [...], ?). See Globs.
+        val matches = globMatcher(glob)
         val results = mutableListOf<String>()
 
         if (!findHighest) {
             return Files.walk(basePath).use { paths ->
-                paths.filter { matcher.matches(basePath.relativize(it)) }
+                paths.filter { Files.isRegularFile(it) }
+                    .filter { matches(basePath.relativize(it)) }
                     .map { it.toAbsolutePath().toString() }
                     .toList()
             }
@@ -143,7 +147,7 @@ interface FileReadTools : DirectoryBased, FileReadLog, FileAccessLog, SelfToolPu
             processedDirs.add(dirStr)
 
             // First, check if this directory itself matches
-            if (Files.isRegularFile(dir) && matcher.matches(basePath.relativize(dir))) {
+            if (Files.isRegularFile(dir) && matches(basePath.relativize(dir))) {
                 results.add(dirStr)
                 continue
             }
@@ -157,7 +161,7 @@ interface FileReadTools : DirectoryBased, FileReadLog, FileAccessLog, SelfToolPu
                     stream.forEach { entry ->
                         if (Files.isDirectory(entry)) {
                             subdirs.add(entry)
-                        } else if (matcher.matches(basePath.relativize(entry))) {
+                        } else if (matches(basePath.relativize(entry))) {
                             matchesInDir.add(entry.toAbsolutePath().toString())
                         }
                     }
@@ -257,3 +261,109 @@ internal class DefaultFileReadTools(
     override val root: String,
     override val fileContentTransformers: List<StringTransformer> = emptyList(),
 ) : FileReadTools, FileReadLog by DefaultFileReadLog()
+
+/**
+ * A predicate matching relative paths against [pattern] with ripgrep/gitignore glob semantics.
+ *
+ * The glob is translated to a single regular expression (see [globToRegex]), so a double-star-slash
+ * segment matches ZERO or more directories independently, however many appear in one pattern:
+ * "a/&#42;&#42;/b/&#42;&#42;/c" matches every 0/1/n combination in a single pass. Every other glob feature is
+ * preserved: "*" and "?" stay within a path segment, braces "{a,b}" and character classes "[a-z]"/"[!a]"
+ * keep working. `regex:` patterns are matched verbatim via the platform [PathMatcher].
+ */
+fun globMatcher(pattern: String): (Path) -> Boolean {
+    if (pattern.startsWith("regex:")) {
+        val nio = FileSystems.getDefault().getPathMatcher(pattern)
+        return { path -> nio.matches(path) }
+    }
+    val regex = Pattern.compile(globToRegex(pattern.removePrefix("glob:")))
+    return { path -> regex.matcher(path.toString().replace(File.separatorChar, '/')).matches() }
+}
+
+/** Regex metacharacters that must be escaped when they appear literally in a glob. */
+private const val REGEX_META = ".^$+{}[]()|"
+
+/**
+ * Translate a glob to a regex, mirroring the JDK glob translator (sun.nio.fs.Globs) with ONE change:
+ * a double-star-slash segment becomes "(?:[^/]+/)*" (zero or more directory segments) instead of
+ * forcing a literal separator. That literal separator is exactly why NIO skipped direct children and
+ * root-level files. A bare or trailing double-star (not isolated before a slash) still becomes ".*",
+ * crossing directories like NIO. "*" and "?" stay inside one segment; braces and classes are preserved.
+ */
+private fun globToRegex(glob: String): String {
+    val regex = StringBuilder()
+    var inGroup = false
+    var i = 0
+    while (i < glob.length) {
+        when (val c = glob[i++]) {
+            '\\' -> {
+                require(i < glob.length) { "No character to escape at end of glob: $glob" }
+                val next = glob[i++]
+                if (next in REGEX_META || next in "\\*?[{") regex.append('\\')
+                regex.append(next)
+            }
+
+            '/' -> regex.append('/')
+
+            '[' -> {
+                regex.append('[')
+                when {
+                    i < glob.length && glob[i] == '!' -> {
+                        regex.append('^'); i++
+                    }
+
+                    i < glob.length && glob[i] == '^' -> {
+                        regex.append("\\^"); i++
+                    }
+                }
+                while (i < glob.length && glob[i] != ']') {
+                    when (val cc = glob[i++]) {
+                        '\\' -> {
+                            regex.append('\\'); if (i < glob.length) regex.append(glob[i++])
+                        }
+
+                        '&' -> regex.append("\\&")
+                        else -> regex.append(cc)
+                    }
+                }
+                require(i < glob.length && glob[i] == ']') { "Missing ']' in glob: $glob" }
+                regex.append(']'); i++
+            }
+
+            '{' -> {
+                require(!inGroup) { "Nested '{' in glob: $glob" }
+                inGroup = true
+                regex.append("(?:")
+            }
+
+            '}' -> if (inGroup) {
+                regex.append(')'); inGroup = false
+            } else regex.append('}')
+
+            ',' -> if (inGroup) regex.append('|') else regex.append(',')
+
+            '*' -> {
+                if (i < glob.length && glob[i] == '*') {
+                    i++ // consume the second '*'
+                    if (i < glob.length && glob[i] == '/') {
+                        i++ // consume the slash: '**/' -> zero or more directory segments
+                        regex.append("(?:[^/]+/)*")
+                    } else {
+                        regex.append(".*") // bare/trailing '**' crosses directories
+                    }
+                } else {
+                    regex.append("[^/]*")
+                }
+            }
+
+            '?' -> regex.append("[^/]")
+
+            else -> {
+                if (c in REGEX_META) regex.append('\\')
+                regex.append(c)
+            }
+        }
+    }
+    require(!inGroup) { "Missing '}' in glob: $glob" }
+    return regex.toString()
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsGlobTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsGlobTest.kt
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.tools.file
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Comprehensive glob-semantics spec for [FileReadTools.findFiles], serving as a regression net for the
+ * ripgrep/gitignore matching behaviour.
+ *
+ * Every test asserts the DESIRED (ripgrep/gitignore) semantics:
+ * - a double-star crosses directory boundaries and, when followed by a slash, matches ZERO or more
+ *   directories (so prefixed and leading double-star patterns include files at the top level);
+ * - a single star / question mark stays within one path segment;
+ * - brace alternation and character classes keep working (must not regress);
+ * - findFiles returns regular files only, never directories.
+ */
+class FileReadToolsGlobTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private lateinit var fileReadTools: FileReadTools
+    private lateinit var rootPath: String
+
+    /** Every regular file created in the fixture (forward-slash, relative to the working dir). */
+    private val allFiles = setOf(
+        "top.sol",
+        "R.sol",
+        "src/A.sol",
+        "src/B.sol",
+        "src/Foo.sol",
+        "src/sub/C.sol",
+        "src/sub/deep/D.sol",
+        "test/T.t.sol",
+        "README.md",
+        "docs/guide.md",
+    )
+
+    /** Every .sol file, at any depth, root included. */
+    private val allSol = allFiles.filter { it.endsWith(".sol") }.toSet()
+
+    @BeforeEach
+    fun setUp() {
+        rootPath = tempDir.toString()
+        fileReadTools = FileTools.readOnly(rootPath, emptyList())
+        allFiles.forEach { rel ->
+            val p = tempDir.resolve(rel)
+            Files.createDirectories(p.parent)
+            Files.writeString(p, "// $rel")
+        }
+        // An empty directory, to assert directories are never returned as matches.
+        Files.createDirectories(tempDir.resolve("emptydir"))
+    }
+
+    /** Absolute results → forward-slash paths relative to the working dir, for stable assertions. */
+    private fun find(glob: String, findHighest: Boolean = false): Set<String> {
+        val base = Paths.get(rootPath).toAbsolutePath().normalize()
+        return fileReadTools.findFiles(glob, findHighest)
+            .map { base.relativize(Paths.get(it)).toString().replace('\\', '/') }
+            .toSet()
+    }
+
+    @Nested
+    inner class ZeroOrMoreDirectories {
+
+        @Test
+        fun `prefixed double-star slash matches direct children and nested`() {
+            assertEquals(
+                setOf("src/A.sol", "src/B.sol", "src/Foo.sol", "src/sub/C.sol", "src/sub/deep/D.sol"),
+                find("src/**/*.sol"),
+            )
+        }
+
+        @Test
+        fun `leading double-star slash matches the root level too`() {
+            assertEquals(allSol, find("**/*.sol"))
+        }
+
+        @Test
+        fun `leading double-star slash for md matches root readme`() {
+            assertEquals(setOf("README.md", "docs/guide.md"), find("**/*.md"))
+        }
+
+        @Test
+        fun `middle double-star slash matches zero directories`() {
+            // 'src/**/Foo.sol' must match src/Foo.sol (zero dirs between src and Foo).
+            assertEquals(setOf("src/Foo.sol"), find("src/**/Foo.sol"))
+        }
+
+        @Test
+        fun `middle double-star slash matches across directories`() {
+            // A '**/' between segments also matches one-or-more dirs; guard this stays working.
+            assertEquals(setOf("src/sub/C.sol"), find("src/**/C.sol"))
+        }
+    }
+
+    @Nested
+    inner class SingleSegmentWildcards {
+
+        @Test
+        fun `single star matches only the root level`() {
+            assertEquals(setOf("top.sol", "R.sol"), find("*.sol"))
+        }
+
+        @Test
+        fun `single star under a directory matches only its direct children, not nested`() {
+            // src/*.sol matches the direct children but must NOT reach src/sub/C.sol.
+            assertEquals(setOf("src/A.sol", "src/B.sol", "src/Foo.sol"), find("src/*.sol"))
+        }
+
+        @Test
+        fun `question mark matches exactly one character within a segment`() {
+            assertEquals(setOf("src/A.sol", "src/B.sol"), find("src/?.sol")) // not Foo.sol
+            assertEquals(setOf("R.sol"), find("?.sol")) // not top.sol
+        }
+
+        @Test
+        fun `star in a specific directory`() {
+            assertEquals(setOf("test/T.t.sol"), find("test/*.sol"))
+        }
+    }
+
+    @Nested
+    inner class GlobCharacterFeatures {
+
+        @Test
+        fun `brace alternation must keep working`() {
+            assertEquals(setOf("src/A.sol", "src/B.sol"), find("src/{A,B}.sol"))
+        }
+
+        @Test
+        fun `character class must keep working`() {
+            assertEquals(setOf("src/A.sol", "src/B.sol"), find("src/[AB].sol"))
+        }
+
+        @Test
+        fun `negated character class must keep working`() {
+            assertEquals(setOf("src/B.sol"), find("src/[!A].sol")) // single char, not 'A'; excludes Foo
+        }
+    }
+
+    @Nested
+    inner class DoubleStarCrossing {
+
+        @Test
+        fun `bare double-star returns every file at any depth`() {
+            assertEquals(allFiles, find("**"))
+        }
+
+        @Test
+        fun `directory prefix double-star returns every file under it`() {
+            assertEquals(
+                setOf("src/A.sol", "src/B.sol", "src/Foo.sol", "src/sub/C.sol", "src/sub/deep/D.sol"),
+                find("src/**"),
+            )
+        }
+
+        @Test
+        fun `double-star without a slash crosses directories including root`() {
+            assertEquals(allSol, find("**.sol"))
+        }
+    }
+
+    @Nested
+    inner class FilesOnlyNotDirectories {
+
+        @Test
+        fun `a glob whose literal target is a directory returns nothing`() {
+            // Even when the pattern names a directory outright, findFiles yields regular files only.
+            assertEquals(emptySet<String>(), find("src"))
+            assertEquals(emptySet<String>(), find("src/sub"))
+            assertEquals(emptySet<String>(), find("emptydir"))
+        }
+
+        @Test
+        fun `a wildcard never matches a directory entry`() {
+            // '*' at the root would match the 'src'/'test'/'docs'/'emptydir' segment names, but they are
+            // directories, so only the root-level regular files come back.
+            assertEquals(setOf("top.sol", "R.sol", "README.md"), find("*"))
+        }
+    }
+
+    @Nested
+    inner class OverMatchGuards {
+
+        // A '**/' segment matches zero-or-more whole directories; it must NOT glue onto an adjacent name.
+        // 'src/**/Foo.sol' must match only paths whose last segment is exactly Foo.sol, never src/BarFoo.sol.
+        // Extra files are created locally so the shared exact-set tests keep holding.
+        @Test
+        fun `zero-dir match does not over-match a similar file name`() {
+            Files.writeString(tempDir.resolve("src/BarFoo.sol"), "// look-alike")
+            // Only the file whose last segment IS exactly Foo.sol; BarFoo.sol must be excluded.
+            assertEquals(setOf("src/Foo.sol"), find("src/**/Foo.sol"))
+        }
+
+        @Test
+        fun `zero-dir match does not over-match a sibling directory with the same prefix`() {
+            Files.createDirectories(tempDir.resolve("srcTest"))
+            Files.writeString(tempDir.resolve("srcTest/A.sol"), "// sibling dir")
+            // 'src' is a whole segment; the neighbouring 'srcTest/' dir must not leak in.
+            assertEquals(
+                setOf("src/A.sol", "src/B.sol", "src/Foo.sol", "src/sub/C.sol", "src/sub/deep/D.sol"),
+                find("src/**/*.sol"),
+            )
+        }
+    }
+
+    /**
+     * Edge cases that reference implementations (git :(glob), minimatch, micromatch, bash globstar)
+     * cover. Each asserts the DESIRED ripgrep/gitignore semantics; they exercise the harder corners of
+     * the single-regex double-star-slash translation.
+     */
+    @Nested
+    inner class ReferenceEdgeCases {
+
+        @Test
+        fun `two double-star-slash segments each match zero or more dirs independently`() {
+            // Fixture: a literal 'a' .. 'b' .. 'c' skeleton with 0/1 dirs in each gap (all four combos).
+            listOf("a/b/c", "a/x/b/c", "a/b/y/c", "a/x/b/y/c").forEach {
+                val p = tempDir.resolve(it)
+                Files.createDirectories(p.parent)
+                Files.writeString(p, "// $it")
+            }
+            // Every combination matches: each '**/' resolves zero-or-more dirs independently, including
+            // the mixed cases (a/x/b/c and a/b/y/c).
+            assertEquals(
+                setOf("a/b/c", "a/x/b/c", "a/b/y/c", "a/x/b/y/c"),
+                find("a/**/b/**/c"),
+            )
+        }
+
+        @Test
+        fun `adjacent double-star-slash segments collapse to one`() {
+            // 'src/**/**/*.sol' must behave exactly like 'src/**/*.sol' (all .sol under src, any depth).
+            assertEquals(
+                setOf("src/A.sol", "src/B.sol", "src/Foo.sol", "src/sub/C.sol", "src/sub/deep/D.sol"),
+                find("src/**/**/*.sol"),
+            )
+        }
+
+        @Test
+        @Disabled("Semantic divergence (not strictly a bug): our '**'->'.*' fallback lets a non-isolated '**' cross '/', so 'src/**Foo.sol' reaches src/sub/. minimatch/bash treat it as a plain '*'. Product decision.")
+        fun `GAP - double-star NOT isolated in a segment should behave like a single star`() {
+            // minimatch/bash: '**' only globstars when alone in a segment; 'src/**Foo.sol' is a plain
+            // single-segment wildcard, so it must NOT reach into src/sub/.
+            Files.writeString(tempDir.resolve("src/BarFoo.sol"), "// same segment")
+            Files.createDirectories(tempDir.resolve("src/sub"))
+            Files.writeString(tempDir.resolve("src/sub/DeepFoo.sol"), "// nested, must be excluded")
+            assertEquals(setOf("src/Foo.sol", "src/BarFoo.sol"), find("src/**Foo.sol"))
+        }
+
+        @Test
+        fun `dotfiles - leading double-star-slash and hidden directories (product decision)`() {
+            // Does '**/*.sol' see files under a hidden '.git'-style directory? Reference libs hide these
+            // by default (dot option). This test documents whatever the current behaviour is.
+            Files.createDirectories(tempDir.resolve(".hidden"))
+            Files.writeString(tempDir.resolve(".hidden/Secret.sol"), "// hidden")
+            // Asserting INCLUSION (NIO has no dot-hiding); flip if a dotfile policy is added later.
+            assertEquals(allSol + ".hidden/Secret.sol", find("**/*.sol"))
+        }
+    }
+
+    @Nested
+    inner class Prefixes {
+
+        @Test
+        fun `explicit glob prefix behaves like an implicit glob`() {
+            assertEquals(
+                setOf("src/A.sol", "src/B.sol", "src/Foo.sol", "src/sub/C.sol", "src/sub/deep/D.sol"),
+                find("glob:src/**/*.sol"),
+            )
+        }
+
+        @Test
+        fun `regex prefix is honoured verbatim`() {
+            assertEquals(setOf("test/T.t.sol"), find("regex:.*\\.t\\.sol"))
+            assertEquals(setOf("src/A.sol", "src/B.sol"), find("regex:src/[AB]\\.sol"))
+        }
+    }
+
+    /**
+     * [FileReadTools.findFiles] with findHighest=true walks breadth-first and, as soon as a directory
+     * yields a match, returns those matches and prunes the whole subtree. The canonical use case is
+     * "find every Maven project" by locating the shallowest pom.xml on each branch, never the nested ones.
+     */
+    @Nested
+    inner class FindHighest {
+
+        /** Create a pom.xml at each given relative path under the working dir. */
+        private fun poms(vararg rel: String) = rel.forEach {
+            val p = tempDir.resolve(it)
+            Files.createDirectories(p.parent)
+            Files.writeString(p, "<project/>")
+        }
+
+        @Test
+        fun `a match at the root prunes every deeper match`() {
+            poms("pom.xml", "moduleA/pom.xml", "moduleA/sub/pom.xml")
+            // The root pom is highest; nothing below it is returned.
+            assertEquals(setOf("pom.xml"), find("**/pom.xml", findHighest = true))
+        }
+
+        @Test
+        fun `the highest match on each independent branch is returned`() {
+            poms("moduleA/pom.xml", "moduleA/sub/pom.xml", "moduleB/pom.xml")
+            // No root pom, so each top-level module contributes its own highest pom; sub/ is pruned.
+            assertEquals(
+                setOf("moduleA/pom.xml", "moduleB/pom.xml"),
+                find("**/pom.xml", findHighest = true),
+            )
+        }
+
+        @Test
+        fun `findHighest false returns matches at every depth`() {
+            poms("moduleA/pom.xml", "moduleA/sub/pom.xml", "moduleB/pom.xml")
+            // Contrast with the pruning above: without findHighest, every pom at any depth comes back.
+            assertEquals(
+                setOf("moduleA/pom.xml", "moduleA/sub/pom.xml", "moduleB/pom.xml"),
+                find("**/pom.xml"),
+            )
+        }
+
+        @Test
+        fun `no match returns empty`() {
+            poms("moduleA/pom.xml")
+            assertEquals(emptySet<String>(), find("**/build.gradle", findHighest = true))
+        }
+    }
+
+    @Nested
+    inner class NoMatches {
+
+        @Test
+        fun `unknown extension returns empty`() {
+            assertEquals(emptySet<String>(), find("**/*.rs"))
+        }
+
+        @Test
+        fun `unknown directory returns empty`() {
+            assertEquals(emptySet<String>(), find("nope/**/*.sol"))
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsGlobTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsGlobTest.kt
@@ -159,6 +159,37 @@ class FileReadToolsGlobTest {
         fun `negated character class must keep working`() {
             assertEquals(setOf("src/B.sol"), find("src/[!A].sol")) // single char, not 'A'; excludes Foo
         }
+
+        @Test
+        fun `character range must keep working`() {
+            // [A-C] matches a single char in A..C: A.sol and B.sol (no C.sol at src root), not Foo.sol.
+            assertEquals(setOf("src/A.sol", "src/B.sol"), find("src/[A-C].sol"))
+        }
+    }
+
+    @Nested
+    inner class LiteralsAndEscaping {
+
+        @Test
+        fun `a literal pattern with no wildcards matches exactly that one file`() {
+            assertEquals(setOf("top.sol"), find("top.sol"))
+            assertEquals(setOf("src/A.sol"), find("src/A.sol"))
+        }
+
+        @Test
+        fun `dot is matched literally, not as a regex any-char`() {
+            // Trap: if '.' were not escaped, the glob regex '[^/]*.md' would also grab this file.
+            Files.writeString(tempDir.resolve("READMEXmd"), "// trap")
+            assertEquals(setOf("README.md"), find("*.md"))
+        }
+
+        @Test
+        fun `a backslash escapes a glob metacharacter to match it literally`() {
+            // '{' is legal in filenames on every platform (unlike '*'/'?'); '\{' must match a literal
+            // brace, not open a brace group.
+            Files.writeString(tempDir.resolve("a{b.sol"), "// literal brace")
+            assertEquals(setOf("a{b.sol"), find("a\\{b.sol"))
+        }
     }
 
     @Nested

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsGlobTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsGlobTest.kt
@@ -165,6 +165,24 @@ class FileReadToolsGlobTest {
             // [A-C] matches a single char in A..C: A.sol and B.sol (no C.sol at src root), not Foo.sol.
             assertEquals(setOf("src/A.sol", "src/B.sol"), find("src/[A-C].sol"))
         }
+
+        @Test
+        fun `character class matches a single char and must not cross a directory boundary`() {
+            // A class '[...]' stands for ONE char within a segment; like the JDK glob it must never
+            // match the path separator. 'foo[!x]bar' must match 'fooZbar' but NOT 'foo/bar'.
+            Files.writeString(tempDir.resolve("fooZbar"), "// same-segment match")
+            Files.createDirectories(tempDir.resolve("foo"))
+            Files.writeString(tempDir.resolve("foo/bar"), "// separator must not be swallowed")
+            assertEquals(setOf("fooZbar"), find("foo[!x]bar"))
+        }
+
+        @Test
+        fun `a literal bracket inside a class must match a bracket file name`() {
+            // '[[]' is a class containing a literal '['; like the JDK glob it must match a file named
+            // '[' rather than throwing. NIO's getPathMatcher accepts it, so we must too.
+            Files.writeString(tempDir.resolve("["), "// literal bracket")
+            assertEquals(setOf("["), find("[[]"))
+        }
     }
 
     @Nested

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/tools/file/FileReadToolsTest.kt
@@ -61,31 +61,30 @@ class FileReadToolsTest {
         }
 
         @Test
-        fun `should find files by extension excluding root`() {
+        fun `should find files by extension at any depth including root`() {
+            // '**/' matches zero or more directories (ripgrep/gitignore semantics), so a root-level
+            // file is included alongside the nested ones.
             val result = fileReadTools.findFiles("**/*.txt")
 
-            assertEquals(3, result.size)
+            assertEquals(4, result.size, "Should find .txt files at every depth including root")
 
             val paths = result.toPaths()
 
+            assertTrue(paths.any { it.endsWith(Paths.get("file1.txt")) })
             assertTrue(paths.any { it.endsWith(Paths.get("dir1", "file3.txt")) })
             assertTrue(paths.any { it.endsWith(Paths.get("dir2", "file4.txt")) })
             assertTrue(paths.any { it.endsWith(Paths.get("dir2", "subdir", "file5.txt")) })
-            assertTrue(
-                paths.none { it.endsWith(Paths.get("dir1")) }, "" +
-                        "Expected file1.txt NOT to be found:\n${result.joinToString("\n")}"
-            )
         }
 
         @Test
         fun `should find files by extension in root`() {
             val result = fileReadTools.findFiles("*.txt")
-            assertEquals(1, result.size)
+            assertEquals(1, result.size, "'*' must not cross directories, so only the root .txt matches")
 
             val paths = result.toPaths()
             assertTrue(
-                paths.any { it.endsWith(Paths.get("file1.txt")) }, "" +
-                        "Expected file1.txt to be found:\n${result.joinToString("\n")}"
+                paths.any { it.endsWith(Paths.get("file1.txt")) },
+                "Expected file1.txt to be found:\n${result.joinToString("\n")}"
             )
         }
 
@@ -137,10 +136,10 @@ class FileReadToolsTest {
             Files.createDirectories(tempDir.resolve("that"))
             Files.createDirectories(tempDir.resolve(Paths.get("that", "foo")))
             Files.writeString(tempDir.resolve(Paths.get("thing", "pom.xml")), "maven stuff")
-            // Not parallel
+            // Sibling branch: not nested under thing/pom.xml
             Files.writeString(tempDir.resolve(Paths.get("that", "foo", "pom.xml")), "maven stuff")
-            val result = fileReadTools.findFiles("**/pom.xml")
-            assertEquals(2, result.size, "Should not exclude when not nested")
+            val result = fileReadTools.findFiles("**/pom.xml", findHighest = true)
+            assertEquals(2, result.size, "Should keep highest match in each parallel branch")
         }
     }
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearch.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearch.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.RegexSearchOperations
 import com.embabel.agent.rag.service.TextSearch
 import com.embabel.agent.tools.file.FileTools
+import com.embabel.agent.tools.file.globMatcher
 import com.embabel.common.core.types.SimilarityResult
 import com.embabel.common.core.types.SimpleSimilaritySearchResult
 import com.embabel.common.core.types.TextSimilaritySearchRequest
@@ -98,9 +99,8 @@ class DirectoryTextSearch @JvmOverloads constructor(
     private val logger = LoggerFactory.getLogger(DirectoryTextSearch::class.java)
     private val fileReadTools = FileTools.readOnly(directory)
     private val rootPath = Path.of(directory).toAbsolutePath().normalize()
-    private val globMatcher = config.fileGlob?.let {
-        java.nio.file.FileSystems.getDefault().getPathMatcher("glob:$it")
-    }
+    // Ripgrep/gitignore '**' semantics ('**/' matches zero or more directories). See globMatcher.
+    private val globMatch: ((Path) -> Boolean)? = config.fileGlob?.let { globMatcher(it) }
 
     override val luceneSyntaxNotes: String = "Not supported"
 
@@ -228,12 +228,7 @@ class DirectoryTextSearch @JvmOverloads constructor(
             }
             .filter { path ->
                 // Apply glob filter if specified
-                if (globMatcher != null) {
-                    val relativePath = rootPath.relativize(path)
-                    globMatcher.matches(relativePath)
-                } else {
-                    true
-                }
+                globMatch == null || globMatch(rootPath.relativize(path))
             }
             .iterator()
             .asSequence()
@@ -253,14 +248,15 @@ class DirectoryTextSearch @JvmOverloads constructor(
         queryTerms: List<String>,
         score: Double,
     ): List<Chunk> {
-        // Find all match positions (case-insensitive)
-        val contentLower = content.lowercase()
+        // Find all match positions in the original content (case-insensitive). We must
+        // index into `content` directly rather than a lowercased copy: lowercasing can
+        // change string length for some characters (e.g. 'İ' -> "i̇"), which would shift
+        // offsets and slice chunks that no longer contain the match.
         val matchPositions = queryTerms.flatMap { term ->
-            val termLower = term.lowercase()
             var index = 0
             val positions = mutableListOf<Int>()
             while (true) {
-                val pos = contentLower.indexOf(termLower, index)
+                val pos = content.indexOf(term, index, ignoreCase = true)
                 if (pos < 0) break
                 positions.add(pos)
                 index = pos + 1

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearch.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearch.kt
@@ -99,7 +99,7 @@ class DirectoryTextSearch @JvmOverloads constructor(
     private val logger = LoggerFactory.getLogger(DirectoryTextSearch::class.java)
     private val fileReadTools = FileTools.readOnly(directory)
     private val rootPath = Path.of(directory).toAbsolutePath().normalize()
-    // Ripgrep/gitignore '**' semantics ('**/' matches zero or more directories). See globMatcher.
+    // Same '**' rules as ripgrep and .gitignore: '**/' matches zero or more folders. See globMatcher.
     private val globMatch: ((Path) -> Boolean)? = config.fileGlob?.let { globMatcher(it) }
 
     override val luceneSyntaxNotes: String = "Not supported"

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearchGlobTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearchGlobTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.service.support
+
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.service.RagRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Glob-filtering spec for [DirectoryTextSearch.Config.fileGlob], which filters files through the shared
+ * [com.embabel.agent.tools.file.globMatcher].
+ *
+ * Asserts ripgrep/gitignore semantics: a double-star followed by a slash matches ZERO or more
+ * directories, so a leading or prefixed double-star also selects files at the root / directly under a
+ * directory (Java NIO's raw `PathMatcher` required at least one directory there, silently dropping
+ * root/direct-child files from indexing). These tests guard that the RAG path inherits the fix, and
+ * that single-segment globs, brace alternation and no-match cases keep behaving.
+ */
+class DirectoryTextSearchGlobTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    // Every file contains the search term, so results are driven purely by the glob filter.
+    private val allFiles = setOf(
+        "Root.kt",
+        "src/Nested.kt",
+        "src/sub/Deep.kt",
+        "Root.md",
+        "docs/guide.md",
+        "notes.txt",
+    )
+
+    @BeforeEach
+    fun setUp() {
+        allFiles.forEach { rel ->
+            val p = tempDir.resolve(rel)
+            Files.createDirectories(p.parent)
+            Files.writeString(p, "needle in $rel")
+        }
+    }
+
+    /** Relative ids of files selected by the glob (one chunk per small file → id == relative path). */
+    private fun matched(glob: String?): Set<String> {
+        val config = if (glob == null) {
+            DirectoryTextSearch.Config()
+        } else {
+            DirectoryTextSearch.Config().withFileGlob(glob)
+        }
+        val search = DirectoryTextSearch(tempDir.toString(), config)
+        val request = RagRequest.query("needle").withSimilarityThreshold(0.0).withTopK(100)
+        return search.textSearch(request, Chunk::class.java).map { it.match.id }.toSet()
+    }
+
+    @Test
+    fun `leading double-star slash includes root-level kt files`() {
+        assertEquals(setOf("Root.kt", "src/Nested.kt", "src/sub/Deep.kt"), matched("**/*.kt"))
+    }
+
+    @Test
+    fun `leading double-star slash includes root-level md files`() {
+        assertEquals(setOf("Root.md", "docs/guide.md"), matched("**/*.md"))
+    }
+
+    @Test
+    fun `prefixed double-star slash includes files directly under the directory`() {
+        // 'src/**/*.kt' must include src/Nested.kt (zero dirs) as well as the nested one
+        assertEquals(setOf("src/Nested.kt", "src/sub/Deep.kt"), matched("src/**/*.kt"))
+    }
+
+    @Test
+    fun `single star matches only root level`() {
+        assertEquals(setOf("Root.kt"), matched("*.kt"))
+    }
+
+    @Test
+    fun `single star under a directory matches only direct children`() {
+        assertEquals(setOf("src/Nested.kt"), matched("src/*.kt"))
+    }
+
+    @Test
+    fun `brace alternation selects every listed extension at any depth`() {
+        assertEquals(
+            setOf("Root.kt", "src/Nested.kt", "src/sub/Deep.kt", "Root.md", "docs/guide.md"),
+            matched("**/*.{kt,md}"),
+        )
+    }
+
+    @Test
+    fun `glob matching nothing indexes no files`() {
+        assertEquals(emptySet<String>(), matched("**/*.java"))
+    }
+
+    @Test
+    fun `no glob selects every file`() {
+        assertEquals(allFiles, matched(null))
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearchTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearchTest.kt
@@ -604,6 +604,34 @@ class DirectoryTextSearchTest {
         }
     }
 
+    @Nested
+    inner class EncodingTests {
+
+        /**
+         * `content.lowercase()` can change the string length for some Unicode characters
+         * (e.g. 'İ' U+0130 lowercases to two chars). Match positions computed on the
+         * lowercased content must not be used to slice the original content, otherwise
+         * the chunk is shifted and no longer contains the matched term.
+         */
+        @Test
+        fun `chunk should contain the matched term even with length-changing lowercase chars`() {
+            // 'İ'.lowercase() == "i̇" (2 chars), so each prefix char shifts positions by +1.
+            val prefix = "İ".repeat(600)
+            val content = prefix + "machine" + "y".repeat(600)
+            createFile("unicode.txt", content)
+
+            // File is > default chunk size (1000) so chunking (substring) is exercised.
+            val request = RagRequest.query("machine").withSimilarityThreshold(0.0).withTopK(100)
+            val results = search.textSearch(request, Chunk::class.java)
+
+            assertTrue(results.isNotEmpty(), "Should match the file containing 'machine'")
+            assertTrue(
+                results.any { it.match.text.contains("machine") },
+                "At least one chunk should actually contain the matched term",
+            )
+        }
+    }
+
     // Helper methods
 
     private fun createFile(relativePath: String, content: String) {


### PR DESCRIPTION
## Problem

Fixes #1751.

Glob matching used Java NIO `PathMatcher` (`glob:…`), where a `/` after `**` requires **at least one** directory, unlike ripgrep/git/bash globstar, which treat `**/` as **zero or more**. As a result:

- `src/**/*.sol` silently skipped files **directly** in `src/` (only returned nested ones)
- `**/*.sol` missed **root-level** files
- `FileReadTools.findFiles` also returned **directories** as if they were files

The failure was **silent** (no error), hit the documented recommended pattern `**/*.kt`, and caused two concrete harms:

1. **Agents** (`FileReadTools.findFiles`, an `@LlmTool`) acted on incomplete file listings.
2. **RAG** (`DirectoryTextSearch.fileGlob`) silently never indexed top-level files, causing context loss / hallucinations.

Separately, `DirectoryTextSearch.extractChunksAroundMatches` located match positions on a lowercased copy of the file content (`content.lowercase()`) and then used those offsets to slice the **original** content via `substring`. `String.lowercase()` can change the string length for some Unicode characters (e.g. `İ` U+0130 → `i̇`, 2 chars). When such a character appears before a match, the offsets computed on the lowercased copy are shifted relative to the original, so the resulting chunk is sliced from the wrong region and no longer contains the matched term.

## Fix

**Glob semantics.** Translate the glob to a **single regex** in the shared `globMatcher` helper (`FileReadTools.kt`), mirroring the JDK translator (`sun.nio.fs.Globs`) with one change: a `**/` segment becomes `(?:[^/]+/)*` (zero or more directory segments) instead of forcing a literal separator.

Each `**/` now matches **independently in a single pass**, so any number of them in one pattern works: `a/**/b/**/c` matches all 0/1/n combinations, not just the all-zero or all-≥1 extremes. Every other glob feature is preserved: `*` / `?` stay within a segment, braces `{a,b}`, char classes `[a-z]` / `[!a]`, and `regex:` passthrough. `findFiles` also gained an `isRegularFile` filter so directories are never returned.

`DirectoryTextSearch` (RAG) previously built its own inline `PathMatcher`; it now switches to the shared `globMatcher` helper (a one-line swap) and inherits the same semantics. `globMatcher`'s public signature is unchanged.

**Unicode offsets.** Search the original content directly, case-insensitively, via `content.indexOf(term, index, ignoreCase = true)`. Offsets are then valid for `substring`, and the redundant `content.lowercase()` in this method is removed.

## Behavior change

`findFiles` now applies an `isRegularFile` filter, so **directories matching the glob are no longer returned**, only files.

## Why a hand-rolled glob to regex translator?

Glob patterns here are written by the **LLM**, so the matcher must support the full glob vocabulary it will reach for, otherwise a pattern silently matches nothing and the agent acts on a partial/empty file list.

## Tests

- `FileReadToolsGlobTest`: full glob spec: zero/one/many dirs, leading & prefixed `**/`, single-segment wildcards, braces/classes/ranges, literal-dot and backslash escaping, `regex:` passthrough, files-only, over-match guards (a look-alike filename and a sibling directory must not leak in), multiple/adjacent globstars, and `findHighest` pruning.
- `DirectoryTextSearchGlobTest`: same glob semantics for the RAG file filter.
- `DirectoryTextSearchTest.EncodingTests`: failing-first test: a file with length-changing lowercase chars before the match now yields a chunk that actually contains the searched term.
- One `@Disabled` test documents a deliberate semantic divergence: a non-isolated `**` (`src/**Foo.sol`) falls back to `.*` and crosses `/`, where minimatch/bash treat it as a plain `*`. Product decision, not a bug.

`mvn test` on `embabel-agent-api` and `embabel-agent-rag` passes green.