### PR TITLE
Fix regex: path matcher to normalize separators cross-platform

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/file/FileReadTools.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/tools/file/FileReadTools.kt
@@ -278,8 +278,12 @@ internal class DefaultFileReadTools(
  */
 fun globMatcher(pattern: String): (Path) -> Boolean {
     if (pattern.startsWith("regex:")) {
-        val nio = FileSystems.getDefault().getPathMatcher(pattern)
-        return { path -> nio.matches(path) }
+        // Match against a forward-slash path string on every platform. NIO's path matcher runs against
+        // the OS-native Path, whose toString() uses '\' on Windows, so a pattern like "src/[AB]\.sol"
+        // would never match "src\A.sol". Normalising here keeps regex matching deterministic across OSes,
+        // consistent with the glob branch below.
+        val regex = Pattern.compile(pattern.removePrefix("regex:"))
+        return { path -> regex.matcher(path.toString().replace(File.separatorChar, '/')).matches() }
     }
     val regex = Pattern.compile(globToRegex(pattern.removePrefix("glob:")))
     return { path -> regex.matcher(path.toString().replace(File.separatorChar, '/')).matches() }


### PR DESCRIPTION
This pull request updates the file matching logic in `DefaultFileReadTools` to ensure regex patterns behave consistently across different operating systems. The main change is to normalize file paths to use forward slashes before applying regex patterns, which avoids issues with backslashes on Windows.

File matching improvements:

* Updated the regex branch in the `globMatcher` function to normalize all file paths to forward slashes before matching, ensuring consistent regex behavior across platforms and matching the behavior of the glob branch.