### PR TITLE
feat(mcpserver): expose MCP server health via Spring Boot Actuator

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/pom.xml
@@ -26,6 +26,13 @@
             <artifactId>embabel-agent-mcpserver</artifactId>
         </dependency>
 
+        <!-- Optional: health indicator only when Actuator is present -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/mcpserver/McpServerActuatorAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/mcpserver/McpServerActuatorAutoConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.mcpserver;
+
+import com.embabel.agent.mcpserver.health.McpServerHealthEvaluator;
+import com.embabel.agent.mcpserver.health.McpServerInitializationTracker;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Registers an Actuator {@link HealthIndicator} for the MCP server when Actuator is present.
+ *
+ * <p>Does not create a hard dependency on Actuator for consumers of
+ * {@code embabel-agent-starter-mcpserver}; Actuator must be on the classpath separately.
+ */
+@AutoConfiguration(after = AgentMcpServerAutoConfiguration.class)
+@ConditionalOnClass(HealthIndicator.class)
+@ConditionalOnBean(McpServerHealthEvaluator.class)
+@ConditionalOnProperty(
+        prefix = "embabel.agent.mcpserver.health",
+        name = "enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class McpServerActuatorAutoConfiguration {
+
+    @Bean(name = "mcpServer")
+    @ConditionalOnMissingBean(name = "mcpServer")
+    public HealthIndicator mcpServerHealthIndicator(
+            McpServerHealthEvaluator evaluator,
+            McpServerInitializationTracker tracker) {
+        return new McpServerHealthIndicator(evaluator, tracker);
+    }
+}

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/mcpserver/McpServerHealthIndicator.java
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/mcpserver/McpServerHealthIndicator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.mcpserver;
+
+import com.embabel.agent.mcpserver.domain.ServerHealthStatus;
+import com.embabel.agent.mcpserver.health.McpServerHealthEvaluator;
+import com.embabel.agent.mcpserver.health.McpServerInitializationState;
+import com.embabel.agent.mcpserver.health.McpServerInitializationTracker;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+
+/**
+ * Actuator health indicator for the Embabel MCP server.
+ *
+ * <p>Exposed as the {@code mcpServer} component under {@code /actuator/health}.
+ */
+public class McpServerHealthIndicator implements HealthIndicator {
+
+    private final McpServerHealthEvaluator evaluator;
+    private final McpServerInitializationTracker tracker;
+
+    public McpServerHealthIndicator(
+            McpServerHealthEvaluator evaluator,
+            McpServerInitializationTracker tracker) {
+        this.evaluator = evaluator;
+        this.tracker = tracker;
+    }
+
+    @Override
+    public Health health() {
+        ServerHealthStatus status = evaluator.evaluate();
+        McpServerInitializationState state = tracker.getState();
+
+        Health.Builder builder = switch (state) {
+            case NOT_STARTED, INITIALIZING -> Health.outOfService();
+            case FAILED -> Health.down();
+            case READY -> status.isHealthy() ? Health.up() : Health.down();
+        };
+
+        return builder
+                .withDetail("mode", status.getMode().name())
+                .withDetail("toolCount", status.getToolCount())
+                .withDetail("initializationState", state.name())
+                .withDetail("timestamp", status.getTimestamp().toString())
+                .withDetail("issues", status.getIssues())
+                .build();
+    }
+}

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 com.embabel.agent.autoconfigure.mcpserver.AgentMcpServerAutoConfiguration
+com.embabel.agent.autoconfigure.mcpserver.McpServerActuatorAutoConfiguration

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/mcpserver/McpServerActuatorAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/mcpserver/McpServerActuatorAutoConfigurationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.mcpserver;
+
+import com.embabel.agent.api.common.autonomy.Autonomy;
+import com.embabel.agent.core.AgentPlatform;
+import com.embabel.agent.mcpserver.health.McpServerHealthEvaluator;
+import com.embabel.agent.mcpserver.health.McpServerInitializationTracker;
+import io.modelcontextprotocol.server.McpAsyncServer;
+import io.modelcontextprotocol.server.McpSyncServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class McpServerActuatorAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    AgentMcpServerAutoConfiguration.class,
+                    McpServerActuatorAutoConfiguration.class))
+            .withBean(Autonomy.class, () -> {
+                Autonomy autonomy = mock(Autonomy.class);
+                when(autonomy.getAgentPlatform()).thenReturn(mock(AgentPlatform.class));
+                return autonomy;
+            })
+            .withBean(McpSyncServer.class, () -> mock(McpSyncServer.class))
+            .withBean(McpAsyncServer.class, () -> mock(McpAsyncServer.class));
+
+    @Test
+    void registersMcpServerHealthIndicatorByDefault() {
+        contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(McpServerInitializationTracker.class);
+            assertThat(context).hasSingleBean(McpServerHealthEvaluator.class);
+            assertThat(context).hasBean("mcpServer");
+            assertThat(context.getBean("mcpServer")).isInstanceOf(HealthIndicator.class);
+        });
+    }
+
+    @Test
+    void skipsHealthIndicatorWhenDisabled() {
+        contextRunner
+                .withPropertyValues("embabel.agent.mcpserver.health.enabled=false")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(McpServerInitializationTracker.class);
+                    assertThat(context).doesNotHaveBean("mcpServer");
+                });
+    }
+}

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/mcpserver/McpServerHealthIndicatorTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/mcpserver/McpServerHealthIndicatorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.mcpserver;
+
+import com.embabel.agent.mcpserver.domain.McpExecutionMode;
+import com.embabel.agent.mcpserver.domain.ServerHealthStatus;
+import com.embabel.agent.mcpserver.health.McpServerHealthEvaluator;
+import com.embabel.agent.mcpserver.health.McpServerInitializationState;
+import com.embabel.agent.mcpserver.health.McpServerInitializationTracker;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class McpServerHealthIndicatorTest {
+
+    @Test
+    void reportsOutOfServiceWhileInitializing() {
+        McpServerInitializationTracker tracker = new McpServerInitializationTracker();
+        tracker.markInitializing();
+        McpServerHealthEvaluator evaluator = mock(McpServerHealthEvaluator.class);
+        when(evaluator.evaluate()).thenReturn(new ServerHealthStatus(
+                false, McpExecutionMode.SYNC, 0, List.of("MCP server is still initializing")));
+
+        Health health = new McpServerHealthIndicator(evaluator, tracker).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(health.getDetails()).containsEntry("initializationState", "INITIALIZING");
+        assertThat(health.getDetails()).containsEntry("mode", "SYNC");
+        assertThat(health.getDetails()).containsKey("toolCount");
+        assertThat(health.getDetails()).containsKey("timestamp");
+        assertThat(health.getDetails()).containsKey("issues");
+    }
+
+    @Test
+    void reportsUpWhenReadyAndHealthy() {
+        McpServerInitializationTracker tracker = new McpServerInitializationTracker();
+        tracker.markInitializing();
+        tracker.markReady();
+        McpServerHealthEvaluator evaluator = mock(McpServerHealthEvaluator.class);
+        when(evaluator.evaluate()).thenReturn(new ServerHealthStatus(
+                true, McpExecutionMode.ASYNC, 3, List.of()));
+
+        Health health = new McpServerHealthIndicator(evaluator, tracker).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("initializationState", "READY");
+        assertThat(health.getDetails()).containsEntry("mode", "ASYNC");
+        assertThat(health.getDetails()).containsEntry("toolCount", 3);
+    }
+
+    @Test
+    void reportsDownWhenFailed() {
+        McpServerInitializationTracker tracker = new McpServerInitializationTracker();
+        tracker.markInitializing();
+        tracker.markFailed("boom");
+        McpServerHealthEvaluator evaluator = mock(McpServerHealthEvaluator.class);
+        when(evaluator.evaluate()).thenReturn(new ServerHealthStatus(
+                false, McpExecutionMode.SYNC, 1, List.of("boom")));
+
+        Health health = new McpServerHealthIndicator(evaluator, tracker).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("initializationState", "FAILED");
+    }
+
+    @Test
+    void reportsDownWhenReadyButUnhealthy() {
+        McpServerInitializationTracker tracker = new McpServerInitializationTracker();
+        tracker.markInitializing();
+        tracker.markReady();
+        McpServerHealthEvaluator evaluator = mock(McpServerHealthEvaluator.class);
+        when(evaluator.evaluate()).thenReturn(new ServerHealthStatus(
+                false, McpExecutionMode.SYNC, 0, List.of("Registered tool count 0 is below minimum 1")));
+
+        Health health = new McpServerHealthIndicator(evaluator, tracker).health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("initializationState", "READY");
+    }
+}

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/mcpserver/McpServerHealthIndicatorTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/mcpserver/McpServerHealthIndicatorTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +39,7 @@ class McpServerHealthIndicatorTest {
         tracker.markInitializing();
         McpServerHealthEvaluator evaluator = mock(McpServerHealthEvaluator.class);
         when(evaluator.evaluate()).thenReturn(new ServerHealthStatus(
-                false, McpExecutionMode.SYNC, 0, List.of("MCP server is still initializing")));
+                false, McpExecutionMode.SYNC, 0, List.of("MCP server is still initializing"), Instant.now()));
 
         Health health = new McpServerHealthIndicator(evaluator, tracker).health();
 
@@ -57,7 +58,7 @@ class McpServerHealthIndicatorTest {
         tracker.markReady();
         McpServerHealthEvaluator evaluator = mock(McpServerHealthEvaluator.class);
         when(evaluator.evaluate()).thenReturn(new ServerHealthStatus(
-                true, McpExecutionMode.ASYNC, 3, List.of()));
+                true, McpExecutionMode.ASYNC, 3, List.of(), Instant.now()));
 
         Health health = new McpServerHealthIndicator(evaluator, tracker).health();
 
@@ -74,7 +75,7 @@ class McpServerHealthIndicatorTest {
         tracker.markFailed("boom");
         McpServerHealthEvaluator evaluator = mock(McpServerHealthEvaluator.class);
         when(evaluator.evaluate()).thenReturn(new ServerHealthStatus(
-                false, McpExecutionMode.SYNC, 1, List.of("boom")));
+                false, McpExecutionMode.SYNC, 1, List.of("boom"), Instant.now()));
 
         Health health = new McpServerHealthIndicator(evaluator, tracker).health();
 
@@ -89,7 +90,7 @@ class McpServerHealthIndicatorTest {
         tracker.markReady();
         McpServerHealthEvaluator evaluator = mock(McpServerHealthEvaluator.class);
         when(evaluator.evaluate()).thenReturn(new ServerHealthStatus(
-                false, McpExecutionMode.SYNC, 0, List.of("Registered tool count 0 is below minimum 1")));
+                false, McpExecutionMode.SYNC, 0, List.of("Registered tool count 0 is below minimum 1"), Instant.now()));
 
         Health health = new McpServerHealthIndicator(evaluator, tracker).health();
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/integrations/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/integrations/page.adoc
@@ -503,6 +503,49 @@ Every MCP server includes a built-in `helloBanner` tool that displays server inf
 }
 ----
 
+====== Health (Spring Boot Actuator)
+
+When `spring-boot-starter-actuator` is on the classpath, Embabel registers an `mcpServer`
+health component. It reports execution mode, registered tool count, initialization state,
+and any issues collected during MCP server startup.
+
+[source,yaml]
+----
+management:
+  endpoint:
+    health:
+      show-details: always
+      probes:
+        enabled: true
+embabel:
+  agent:
+    mcpserver:
+      health:
+        enabled: true
+        min-tools: 1
+----
+
+`min-tools` marks the component `DOWN` after initialization when fewer tools are registered
+than the threshold. Use that for readiness probes that should wait until agent tools are
+exported (the built-in `helloBanner` tool alone may not be enough for your deployment).
+
+Kubernetes example:
+
+[source,yaml]
+----
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: 8080
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: 8080
+----
+
+While the MCP exposure pipeline is still running, the `mcpServer` component reports
+`OUT_OF_SERVICE`. After a failed initialization it reports `DOWN`.
+
 [[reference.integrations__mcp_security]]
 ===== Security
 

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/AbstractMcpServerConfiguration.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/AbstractMcpServerConfiguration.kt
@@ -19,10 +19,12 @@ import com.embabel.agent.api.annotation.LlmTool
 import com.embabel.agent.mcpserver.domain.McpExecutionMode
 import com.embabel.agent.mcpserver.domain.ServerInfo
 import com.embabel.agent.mcpserver.domain.ToolSpecification
+import com.embabel.agent.mcpserver.health.McpServerInitializationTracker
 import com.embabel.agent.spi.support.AgentScanningBeanPostProcessorEvent
 import org.slf4j.Logger
 import org.springframework.ai.tool.ToolCallbackProvider
 import org.springframework.ai.tool.annotation.Tool
+import org.springframework.beans.factory.getBeanProvider
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.event.EventListener
 import reactor.core.publisher.Flux
@@ -52,23 +54,35 @@ abstract class AbstractMcpServerConfiguration(
      */
     @EventListener(AgentScanningBeanPostProcessorEvent::class)
     fun exposeMcpFunctionality() {
-        val strategy = createServerStrategy()
-
-        logger.info("Initializing {} MCP Server", strategy.executionMode)
+        val tracker = initializationTracker()
+        tracker?.markInitializing()
 
         try {
+            val strategy = createServerStrategy()
+
+            logger.info("Initializing {} MCP Server", strategy.executionMode)
+
             initializeServer(strategy)
                 .doOnSuccess {
+                    tracker?.markReady()
                     logger.info("{} MCP Server initialization completed successfully", strategy.executionMode)
                 }
                 .doOnError { error ->
+                    tracker?.markFailed(error.message ?: error.javaClass.simpleName)
                     logger.error("${strategy.executionMode} MCP Server initialization failed", error)
                 }
                 .subscribe()
         } catch (e: Exception) {
+            tracker?.markFailed(e.message ?: e.javaClass.simpleName)
             logger.error("Failed to initialize MCP server", e)
         }
     }
+
+    /**
+     * Optional initialization tracker for health / readiness reporting.
+     */
+    protected open fun initializationTracker(): McpServerInitializationTracker? =
+        applicationContext.getBeanProvider<McpServerInitializationTracker>().ifAvailable
 
     /**
      * Initializes the MCP server by cleaning up tools and exposing new ones.

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerHealthConfiguration.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerHealthConfiguration.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver.health
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Registers MCP server health tracking beans (no Actuator dependency).
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(McpServerHealthProperties::class)
+class McpServerHealthConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun mcpServerInitializationTracker(): McpServerInitializationTracker =
+        McpServerInitializationTracker()
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun mcpServerHealthEvaluator(
+        tracker: McpServerInitializationTracker,
+        properties: McpServerHealthProperties,
+        applicationContext: ConfigurableApplicationContext,
+    ): McpServerHealthEvaluator =
+        McpServerHealthEvaluator(tracker, properties, applicationContext)
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerHealthEvaluator.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerHealthEvaluator.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver.health
+
+import com.embabel.agent.mcpserver.async.AsyncToolRegistry
+import com.embabel.agent.mcpserver.domain.McpExecutionMode
+import com.embabel.agent.mcpserver.domain.ServerHealthStatus
+import com.embabel.agent.mcpserver.sync.SyncToolRegistry
+import io.modelcontextprotocol.server.McpAsyncServer
+import io.modelcontextprotocol.server.McpSyncServer
+import org.springframework.context.ConfigurableApplicationContext
+
+/**
+ * Builds a [ServerHealthStatus] from initialization state, tool registry, and health properties.
+ */
+class McpServerHealthEvaluator(
+    private val tracker: McpServerInitializationTracker,
+    private val properties: McpServerHealthProperties,
+    private val applicationContext: ConfigurableApplicationContext,
+) {
+
+    fun evaluate(): ServerHealthStatus {
+        val mode = currentMode()
+        val toolCount = currentToolCount()
+        val issues = mutableListOf<String>()
+        issues.addAll(tracker.issues)
+
+        when (tracker.state) {
+            McpServerInitializationState.NOT_STARTED ->
+                issues.add("MCP server has not started initialization")
+
+            McpServerInitializationState.INITIALIZING ->
+                issues.add("MCP server is still initializing")
+
+            McpServerInitializationState.FAILED -> {
+                if (issues.isEmpty()) {
+                    issues.add("MCP server initialization failed")
+                }
+            }
+
+            McpServerInitializationState.READY -> {
+                if (toolCount < properties.minTools) {
+                    issues.add(
+                        "Registered tool count $toolCount is below minimum ${properties.minTools}",
+                    )
+                }
+            }
+        }
+
+        val healthy = tracker.state == McpServerInitializationState.READY &&
+            toolCount >= properties.minTools &&
+            tracker.issues.isEmpty()
+
+        return ServerHealthStatus(
+            isHealthy = healthy,
+            mode = mode,
+            toolCount = toolCount,
+            issues = issues,
+        )
+    }
+
+    fun currentMode(): McpExecutionMode {
+        val type = applicationContext.environment.getProperty("spring.ai.mcp.server.type", "SYNC")
+        return if (type.equals("ASYNC", ignoreCase = true)) {
+            McpExecutionMode.ASYNC
+        } else {
+            McpExecutionMode.SYNC
+        }
+    }
+
+    fun currentToolCount(): Int {
+        return when (currentMode()) {
+            McpExecutionMode.ASYNC -> {
+                val server = applicationContext.getBeanProvider(McpAsyncServer::class.java).ifAvailable
+                    ?: return 0
+                AsyncToolRegistry(server).getToolCount()
+            }
+
+            McpExecutionMode.SYNC -> {
+                val server = applicationContext.getBeanProvider(McpSyncServer::class.java).ifAvailable
+                    ?: return 0
+                SyncToolRegistry(server).getToolCount()
+            }
+        }
+    }
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerHealthProperties.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerHealthProperties.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver.health
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Health / readiness settings for the Embabel MCP server.
+ *
+ * Bound from `embabel.agent.mcpserver.health.*`.
+ */
+@ConfigurationProperties(prefix = "embabel.agent.mcpserver.health")
+class McpServerHealthProperties {
+
+    /**
+     * When false, the Actuator health indicator bean is not registered.
+     */
+    var enabled: Boolean = true
+
+    /**
+     * Minimum registered tool count required for health to report UP once the
+     * server is [McpServerInitializationState.READY]. Useful for readiness probes.
+     * Default `0` means any tool count is acceptable.
+     */
+    var minTools: Int = 0
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerInitializationState.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerInitializationState.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver.health
+
+/**
+ * Lifecycle state for MCP server tool/resource/prompt exposure.
+ */
+enum class McpServerInitializationState {
+    /** Initialization has not been triggered yet. */
+    NOT_STARTED,
+
+    /** Exposure pipeline is running. */
+    INITIALIZING,
+
+    /** Exposure pipeline completed successfully. */
+    READY,
+
+    /** Exposure pipeline failed. */
+    FAILED,
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerInitializationTracker.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/main/kotlin/com/embabel/agent/mcpserver/health/McpServerInitializationTracker.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver.health
+
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Tracks MCP server initialization for health / readiness checks.
+ *
+ * Updated by [com.embabel.agent.mcpserver.AbstractMcpServerConfiguration] as the
+ * async exposure pipeline starts, succeeds, or fails.
+ */
+class McpServerInitializationTracker {
+
+    private val stateRef = AtomicReference(McpServerInitializationState.NOT_STARTED)
+    private val issueList = CopyOnWriteArrayList<String>()
+
+    val state: McpServerInitializationState
+        get() = stateRef.get()
+
+    val issues: List<String>
+        get() = issueList.toList()
+
+    fun markInitializing() {
+        issueList.clear()
+        stateRef.set(McpServerInitializationState.INITIALIZING)
+    }
+
+    fun markReady() {
+        stateRef.set(McpServerInitializationState.READY)
+    }
+
+    fun markFailed(issue: String) {
+        issueList.add(issue)
+        stateRef.set(McpServerInitializationState.FAILED)
+    }
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/AbstractMcpServerConfigurationTest.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/AbstractMcpServerConfigurationTest.kt
@@ -16,6 +16,8 @@
 package com.embabel.agent.mcpserver
 
 import com.embabel.agent.mcpserver.domain.McpExecutionMode
+import com.embabel.agent.mcpserver.health.McpServerInitializationState
+import com.embabel.agent.mcpserver.health.McpServerInitializationTracker
 import com.embabel.agent.spi.support.AgentScanningBeanPostProcessorEvent
 import io.mockk.every
 import io.mockk.mockk
@@ -183,6 +185,41 @@ class AbstractMcpServerConfigurationTest {
         assertFalse(configuration.testShouldPreserveTool("HELLOBANNER"))
     }
 
+    @Test
+    fun `exposeMcpFunctionality should mark tracker ready on success`() {
+        val tracker = McpServerInitializationTracker()
+        every { mockServerStrategy.executionMode } returns McpExecutionMode.SYNC
+        every { mockServerStrategy.getToolRegistry() } returns mockToolRegistry
+        every { mockToolRegistry.getToolNames() } returns emptyList()
+        every { mockServerStrategy.addTool(any()) } returns Mono.empty()
+        every { mockServerStrategy.addResource(any()) } returns Mono.empty()
+        every { mockServerStrategy.addPrompt(any()) } returns Mono.empty()
+
+        configuration.mockServerStrategy = mockServerStrategy
+        configuration.mockTracker = tracker
+
+        configuration.exposeMcpFunctionality()
+
+        assertEquals(McpServerInitializationState.READY, tracker.state)
+    }
+
+    @Test
+    fun `exposeMcpFunctionality should mark tracker failed on sync error`() {
+        val tracker = McpServerInitializationTracker()
+        every { mockServerStrategy.executionMode } returns McpExecutionMode.SYNC
+        every { mockServerStrategy.getToolRegistry() } throws RuntimeException("Test error")
+
+        configuration.mockServerStrategy = mockServerStrategy
+        configuration.mockTracker = tracker
+
+        assertDoesNotThrow {
+            configuration.exposeMcpFunctionality()
+        }
+
+        assertEquals(McpServerInitializationState.FAILED, tracker.state)
+        assertTrue(tracker.issues.any { it.contains("Test error") })
+    }
+
     // Test implementation of abstract class
     inner class TestAbstractMcpServerConfiguration(
         applicationContext: ConfigurableApplicationContext,
@@ -197,6 +234,7 @@ class AbstractMcpServerConfigurationTest {
         var mockResourceSpecs: List<Any> = emptyList()
         var mockPromptSpecs: List<Any> = emptyList()
         var mockExecutionMode: String = "SYNC"
+        var mockTracker: McpServerInitializationTracker? = null
 
         override fun createServerStrategy(): McpServerStrategy {
             createServerStrategyCalled = true
@@ -226,6 +264,8 @@ class AbstractMcpServerConfigurationTest {
         }
 
         override fun getExecutionMode(): String = mockExecutionMode
+
+        override fun initializationTracker(): McpServerInitializationTracker? = mockTracker
 
         // Expose protected methods for testing
         fun testShouldPreserveTool(toolName: String): Boolean = shouldPreserveTool(toolName)

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/health/McpServerHealthEvaluatorTest.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/health/McpServerHealthEvaluatorTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver.health
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.modelcontextprotocol.server.McpSyncServer
+import com.embabel.agent.mcpserver.support.toolNames
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.ConfigurableEnvironment
+
+class McpServerHealthEvaluatorTest {
+
+    private lateinit var tracker: McpServerInitializationTracker
+    private lateinit var properties: McpServerHealthProperties
+    private lateinit var applicationContext: ConfigurableApplicationContext
+    private lateinit var environment: ConfigurableEnvironment
+    private lateinit var syncServer: McpSyncServer
+    private lateinit var evaluator: McpServerHealthEvaluator
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic("com.embabel.agent.mcpserver.support.ExtensionsKt")
+        tracker = McpServerInitializationTracker()
+        properties = McpServerHealthProperties()
+        applicationContext = mockk(relaxed = true)
+        environment = mockk(relaxed = true)
+        syncServer = mockk(relaxed = true)
+
+        every { applicationContext.environment } returns environment
+        every { environment.getProperty("spring.ai.mcp.server.type", "SYNC") } returns "SYNC"
+        every { applicationContext.getBeanProvider(McpSyncServer::class.java).ifAvailable } returns syncServer
+        every { syncServer.toolNames() } returns listOf("helloBanner", "otherTool")
+
+        evaluator = McpServerHealthEvaluator(tracker, properties, applicationContext)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("com.embabel.agent.mcpserver.support.ExtensionsKt")
+    }
+
+    @Test
+    fun `not started is unhealthy`() {
+        val status = evaluator.evaluate()
+
+        assertFalse(status.isHealthy)
+        assertEquals(McpServerInitializationState.NOT_STARTED, tracker.state)
+        assertTrue(status.issues.any { it.contains("has not started") })
+        assertEquals(2, status.toolCount)
+    }
+
+    @Test
+    fun `initializing is unhealthy`() {
+        tracker.markInitializing()
+
+        val status = evaluator.evaluate()
+
+        assertFalse(status.isHealthy)
+        assertTrue(status.issues.any { it.contains("still initializing") })
+    }
+
+    @Test
+    fun `failed is unhealthy and keeps tracker issues`() {
+        tracker.markInitializing()
+        tracker.markFailed("boom")
+
+        val status = evaluator.evaluate()
+
+        assertFalse(status.isHealthy)
+        assertTrue(status.issues.contains("boom"))
+    }
+
+    @Test
+    fun `ready with enough tools is healthy`() {
+        tracker.markInitializing()
+        tracker.markReady()
+        properties.minTools = 1
+
+        val status = evaluator.evaluate()
+
+        assertTrue(status.isHealthy)
+        assertTrue(status.issues.isEmpty())
+        assertEquals(2, status.toolCount)
+    }
+
+    @Test
+    fun `ready below min tools is unhealthy`() {
+        tracker.markInitializing()
+        tracker.markReady()
+        properties.minTools = 5
+
+        val status = evaluator.evaluate()
+
+        assertFalse(status.isHealthy)
+        assertTrue(status.issues.any { it.contains("below minimum") })
+    }
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/health/McpServerInitializationTrackerTest.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/health/McpServerInitializationTrackerTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver.health
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class McpServerInitializationTrackerTest {
+
+    @Test
+    fun `starts as not started`() {
+        val tracker = McpServerInitializationTracker()
+        assertEquals(McpServerInitializationState.NOT_STARTED, tracker.state)
+        assertTrue(tracker.issues.isEmpty())
+    }
+
+    @Test
+    fun `markInitializing clears prior issues`() {
+        val tracker = McpServerInitializationTracker()
+        tracker.markFailed("old")
+        tracker.markInitializing()
+
+        assertEquals(McpServerInitializationState.INITIALIZING, tracker.state)
+        assertTrue(tracker.issues.isEmpty())
+    }
+
+    @Test
+    fun `markReady and markFailed update state`() {
+        val tracker = McpServerInitializationTracker()
+        tracker.markInitializing()
+        tracker.markReady()
+        assertEquals(McpServerInitializationState.READY, tracker.state)
+
+        tracker.markInitializing()
+        tracker.markFailed("pipeline failed")
+        assertEquals(McpServerInitializationState.FAILED, tracker.state)
+        assertEquals(listOf("pipeline failed"), tracker.issues)
+    }
+}


### PR DESCRIPTION
## Summary
- Track MCP server initialization (NOT_STARTED / INITIALIZING / READY / FAILED) during tool/resource/prompt exposure
- Register an optional `mcpServer` Actuator HealthIndicator when `spring-boot-starter-actuator` is on the classpath
- Add `embabel.agent.mcpserver.health.min-tools` for readiness-style thresholds, plus docs in the integrations reference

Fixes #1728

## Test plan
- [x] Unit tests for tracker, evaluator (healthy / unhealthy / not-initialized), and HealthIndicator status mapping
- [x] Autoconfig tests for indicator registration and `health.enabled=false`
- [x] CI green on this PR