### PR TITLE
Configure planner behavior for multiple goals with the same or different return types

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -37,6 +37,7 @@ import com.embabel.common.util.loggerFor
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.cglib.proxy.Enhancer
 import org.springframework.stereotype.Service
 import org.springframework.util.ClassUtils
@@ -112,6 +113,8 @@ class AgentMetadataReader(
     agentStructureValidator: AgentStructureAgentValidator = AgentStructureAgentValidator.PERMIT_ALL,
     pathToCompletionValidator: PathToCompletionAgentValidator = GoapPathToCompletionValidator(),
     private val requireInterfaceDeserializationAnnotations: Boolean = false,
+    @Value("\${embabel.agent.platform.planner.restricted-goals:false}")
+    private val restrictedGoals: Boolean = false,
 ) {
 
     private val supervisorAgentFactory = SupervisorAgentFactory()
@@ -258,12 +261,20 @@ class AgentMetadataReader(
             } else {
                 val distinctGoalTypes = goalActions.map { it.returnType }.toSet()
                 if (distinctGoalTypes.size > 1) {
-                    logger.warn(
-                        "Agent {} has {} @AchievesGoal actions, while one is supported",
+                    val typeNames = distinctGoalTypes.joinToString { it.simpleName.ifEmpty { it.name } }
+                    if (restrictedGoals) {
+                        logger.warn(
+                            "Agent {} has @AchievesGoal actions returning distinct types [{}] - rejected. Set embabel.agent.platform.planner.restricted-goals=false to allow",
+                            targetType.name,
+                            typeNames,
+                        )
+                        return null
+                    }
+                    logger.debug(
+                        "Agent {} has @AchievesGoal actions returning distinct types [{}] - allowing (restricted-goals=false)",
                         targetType.name,
-                        goalActions.size,
+                        typeNames,
                     )
-                    return null
                 }
                 CoreAgent(
                     name = agenticInfo.agentName(),

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderMetadataTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReaderMetadataTest.kt
@@ -97,11 +97,20 @@ class AgentMetadataReaderMetadataTest {
         }
 
         @Test
-        fun `agent with AchievesGoal actions returning distinct types is rejected`() {
-            val reader = AgentMetadataReader()
+        fun `agent with AchievesGoal actions returning distinct types is rejected when restricted`() {
+            val reader = AgentMetadataReader(restrictedGoals = true)
             assertNull(
                 reader.createAgentMetadata(AgentWithMultipleAchievesGoalActions()),
-                "@Agent with @AchievesGoal actions returning different types must be rejected (issue #797)",
+                "@Agent with @AchievesGoal actions returning different types must be rejected when restricted-goals=true (issue #797)",
+            )
+        }
+
+        @Test
+        fun `agent with AchievesGoal actions returning distinct types is allowed by default`() {
+            val reader = AgentMetadataReader()
+            assertNotNull(
+                reader.createAgentMetadata(AgentWithMultipleAchievesGoalActions()),
+                "@Agent with @AchievesGoal actions returning different types must be allowed by default (issue #1771)",
             )
         }
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
@@ -181,6 +181,31 @@ From `AgentPlatformProperties.ScanningConfig` - configures scanning of the class
 
 |===
 
+===== Planner Configuration
+
+Controls how the GOAP planner processes annotated agents during startup.
+
+[cols="3,2,1,4",options="header"]
+|===
+|Property |Type |Default |Description
+
+|`embabel.agent.platform.planner.restricted-goals`
+|Boolean
+|`false`
+|When `false` (default), allows `@Agent` to declare multiple `@AchievesGoal` actions with different distinct return types, enabling the planner to gate actions by mutually exclusive `@Condition` annotations. When `true`, restricts to a single unique return type across all `@AchievesGoal` actions; any `@Agent` violating this is rejected at startup.
+
+|===
+
+.Example - opt-in restriction for strict single-goal enforcement
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      planner:
+        restricted-goals: true
+----
+
 ===== Ranking Configuration
 
 From `AgentPlatformProperties.RankingConfig` - configures ranking of agents and goals based on user input when the platform should choose the agent or goal.


### PR DESCRIPTION
## Overview

Closes: #1771 

## Description

Currently, an agent with goals returning different types is not allowed.

This PR makes the behaviour configurable, controlled by conditions in the case of goals with different return types.