### PR TITLE
Address duplicate logging and logging of 'null'

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/LoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/LoggingAgenticEventListener.kt
@@ -301,10 +301,10 @@ open class LoggingAgenticEventListener(
         "[${e.processId}] executed action ${e.action.name} in ${e.actionStatus.runningTime}"
 
     protected open fun getToolLoopStartMessage(e: ToolLoopStartEvent): String =
-        "[${e.processId}] (${e.action?.shortName()}) starting tool loop [${e.toolNames.joinToString(", ")}] max=${e.maxIterations}"
+        "[${e.processId}] (${e.action?.shortName() ?: e.outputClass.simpleName.ifEmpty { e.outputClass.name }}) starting tool loop [${e.toolNames.joinToString(", ")}] max=${e.maxIterations}"
 
     protected open fun getToolLoopCompletedMessage(e: ToolLoopCompletedEvent): String =
-        "[${e.processId}] (${e.action?.shortName()}) tool loop completed in ${e.runningTime.toMillis()}ms iterations=${e.totalIterations} replan=${e.replanRequested}"
+        "[${e.processId}] (${e.action?.shortName() ?: e.outputClass.simpleName.ifEmpty { e.outputClass.name }}) tool loop completed in ${e.runningTime.toMillis()}ms iterations=${e.totalIterations} replan=${e.replanRequested}"
 
     protected open fun getProgressUpdateEventMessage(e: ProgressUpdateEvent): String =
         "[${e.processId}] progress: ${e.createProgressBar(length = 50).color(LumonColorPalette.MEMBRANE)}"

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/logging/LoggingAgenticEventListenerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/logging/LoggingAgenticEventListenerTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.logging
+
+import com.embabel.agent.api.event.ToolLoopCompletedEvent
+import com.embabel.agent.api.event.ToolLoopStartEvent
+import com.embabel.agent.core.Action
+import com.embabel.agent.core.AgentProcess
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+private class TestableLoggingAgenticEventListener : LoggingAgenticEventListener() {
+    public override fun getToolLoopStartMessage(e: ToolLoopStartEvent) = super.getToolLoopStartMessage(e)
+    public override fun getToolLoopCompletedMessage(e: ToolLoopCompletedEvent) = super.getToolLoopCompletedMessage(e)
+}
+
+class LoggingAgenticEventListenerTest {
+
+    private val listener = TestableLoggingAgenticEventListener()
+
+    private val agentProcess = mockk<AgentProcess>(relaxed = true).also {
+        every { it.id } returns "test-process-id"
+    }
+
+    private val action = mockk<Action>(relaxed = true).also {
+        every { it.name } returns "com.example.MyAgent.doSomething"
+        every { it.shortName() } returns "doSomething"
+    }
+
+    @Nested
+    inner class ToolLoopStartMessageTests {
+
+        @Test
+        fun `uses action shortName when action is present`() {
+            val event = ToolLoopStartEvent(
+                agentProcess = agentProcess,
+                action = action,
+                toolNames = listOf("search"),
+                maxIterations = 10,
+                interactionId = "i1",
+                outputClass = String::class.java,
+            )
+            val message = listener.getToolLoopStartMessage(event)
+            assertTrue(message.contains("doSomething"), "Expected action shortName in: $message")
+            assertFalse(message.contains("null"), "Expected no 'null' in: $message")
+        }
+
+        @Test
+        fun `uses outputClass simpleName when action is null`() {
+            val event = ToolLoopStartEvent(
+                agentProcess = agentProcess,
+                action = null,
+                toolNames = listOf("search"),
+                maxIterations = 10,
+                interactionId = "i1",
+                outputClass = String::class.java,
+            )
+            val message = listener.getToolLoopStartMessage(event)
+            assertTrue(message.contains("String"), "Expected output class name in: $message")
+            assertFalse(message.contains("null"), "Expected no 'null' in: $message")
+        }
+    }
+
+    @Nested
+    inner class ToolLoopCompletedMessageTests {
+
+        @Test
+        fun `uses action shortName when action is present`() {
+            val startEvent = ToolLoopStartEvent(
+                agentProcess = agentProcess,
+                action = action,
+                toolNames = listOf("search"),
+                maxIterations = 10,
+                interactionId = "i1",
+                outputClass = String::class.java,
+            )
+            val event = startEvent.completedEvent(totalIterations = 3, replanRequested = false)
+            val message = listener.getToolLoopCompletedMessage(event)
+            assertTrue(message.contains("doSomething"), "Expected action shortName in: $message")
+            assertFalse(message.contains("null"), "Expected no 'null' in: $message")
+        }
+
+        @Test
+        fun `uses outputClass simpleName when action is null`() {
+            val startEvent = ToolLoopStartEvent(
+                agentProcess = agentProcess,
+                action = null,
+                toolNames = listOf("search"),
+                maxIterations = 10,
+                interactionId = "i1",
+                outputClass = String::class.java,
+            )
+            val event = startEvent.completedEvent(totalIterations = 1, replanRequested = false)
+            val message = listener.getToolLoopCompletedMessage(event)
+            assertTrue(message.contains("String"), "Expected output class name in: $message")
+            assertFalse(message.contains("null"), "Expected no 'null' in: $message")
+        }
+    }
+}

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
@@ -148,7 +148,7 @@ open class JacksonOutputConverter<T> protected constructor(
         try {
             return lenientMapper.readValue<Any?>(unwrapped, lenientMapper.constructType(this.type)) as T?
         } catch (e: JsonProcessingException) {
-            logger.error(
+            logger.warn(
                 LoggingMarkers.SENSITIVE_DATA_MARKER,
                 "Could not parse the given text to the desired target type: \"{}\" into {}", unwrapped, this.type
             )

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
@@ -460,6 +460,26 @@ World"""
     }
 
     @Nested
+    inner class ParseFailureTests {
+
+        @Test
+        fun `convert throws RuntimeException and logs warn on invalid JSON`() {
+            val converter = JacksonOutputConverter(SimpleObject::class.java, objectMapper)
+            assertThrows<RuntimeException> {
+                converter.convert("this is not json at all")
+            }
+        }
+
+        @Test
+        fun `convert throws RuntimeException on structurally invalid JSON`() {
+            val converter = JacksonOutputConverter(SimpleObject::class.java, objectMapper)
+            assertThrows<RuntimeException> {
+                converter.convert("{ this is completely malformed JSON")
+            }
+        }
+    }
+
+    @Nested
     inner class KotlinAndDateTypeTests {
 
         @Test

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -113,10 +113,24 @@ data class ToolishRag @JvmOverloads constructor(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    private val validHints = hints.toMutableList()
+    private data class ToolishRagInitState(
+        val toolObjects: List<Any>,
+        val validHints: List<PromptContributor>,
+    )
 
-    private val toolObjects: List<Any> = run {
-        buildList {
+    /**
+     * Lazily initialized state grouping [toolObjects] and [validHints].
+     *
+     * [ToolishRag] is a data class — every [copy] call (e.g. [withHint], [withEagerSearchAbout])
+     * creates a new instance and would re-run any eager initializer, needlessly rebuilding
+     * [VectorSearchTools], [TextSearchTools] etc. even when only [hints] changed.
+     *
+     * Lazy deferral means initialization runs exactly once per instance, on first access to
+     * [tools] or [notes], not on construction or copy.
+     */
+    private val initState: ToolishRagInitState by lazy {
+        val mutableHints = hints.toMutableList()
+        val tools = buildList {
             // If the search operations already implement SearchTools, use them directly
             if (searchOperations is SearchTools) {
                 logger.info("Adding existing SearchTools to ToolishRag '{}'", name)
@@ -140,7 +154,7 @@ data class ToolishRag @JvmOverloads constructor(
                         "HyDE hint provided but no VectorSearch available in ToolishRag: Removing this hint {}",
                         name
                     )
-                    validHints.removeIf { it is TryHyDE }
+                    mutableHints.removeIf { it is TryHyDE }
                 }
             }
             if (searchOperations is TextSearch) {
@@ -156,7 +170,11 @@ data class ToolishRag @JvmOverloads constructor(
                 add(RegexSearchTools(searchOperations, metadataFilter, entityFilter, listener))
             }
         }
+        ToolishRagInitState(tools, mutableHints.toList())
     }
+
+    private val toolObjects: List<Any> get() = initState.toolObjects
+    private val validHints: List<PromptContributor> get() = initState.validHints
 
     /**
      * Set the types to search for with vector and text search

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -113,7 +113,7 @@ data class ToolishRag @JvmOverloads constructor(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    private data class ToolishRagInitState(
+    private class ToolishRagInitState(
         val toolObjects: List<Any>,
         val validHints: List<PromptContributor>,
     )

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
@@ -149,6 +149,64 @@ class ToolishRagTest {
         )
 
     @Nested
+    inner class LazyInitTests {
+
+        @Test
+        fun `tools are stable - repeated calls return same tool names`() {
+            val vectorSearch = mockk<VectorSearch>()
+            val rag = ToolishRag(name = "test-rag", description = "Test RAG", searchOperations = vectorSearch)
+
+            val first = rag.tools().map { it.definition.name }
+            val second = rag.tools().map { it.definition.name }
+
+            assertEquals(first, second)
+        }
+
+        @Test
+        fun `copy via withHint does not change tool structure of original`() {
+            val vectorSearch = mockk<VectorSearch>()
+            val rag = ToolishRag(name = "test-rag", description = "Test RAG", searchOperations = vectorSearch)
+
+            val toolsBefore = rag.tools().map { it.definition.name }
+            rag.withHint(TryHyDE(context = "ctx"))
+            val toolsAfter = rag.tools().map { it.definition.name }
+
+            assertEquals(toolsBefore, toolsAfter)
+        }
+
+        @Test
+        fun `copy via withHint produces correctly initialized independent tools`() {
+            val vectorSearch = mockk<VectorSearch>()
+            val rag = ToolishRag(name = "test-rag", description = "Test RAG", searchOperations = vectorSearch)
+            val copy = rag.withHint(TryHyDE(context = "ctx"))
+
+            val originalToolNames = rag.tools().map { it.definition.name }
+            val copyToolNames = copy.tools().map { it.definition.name }
+
+            assertEquals(originalToolNames, copyToolNames)
+            assertNotSame(rag.tools(), copy.tools())
+        }
+
+        @Test
+        fun `validHints are cached consistently with toolObjects`() {
+            val vectorSearch = mockk<VectorSearch>()
+            val hint = TryHyDE(context = "test context")
+            val rag = ToolishRag(
+                name = "test-rag",
+                description = "Test RAG",
+                searchOperations = vectorSearch,
+                hints = listOf(hint),
+            )
+
+            val notes1 = rag.notes()
+            val notes2 = rag.notes()
+
+            assertEquals(notes1, notes2)
+            assertTrue(notes1.contains("test context"))
+        }
+    }
+
+    @Nested
     inner class ToolsTests {
 
         @Test


### PR DESCRIPTION
## Summary

  - JacksonOutputConverter — downgrade parse failure log from ERROR to WARN. Parse failures are recoverable and retried
  by the caller; ERROR was misleading noise.
  - LoggingAgenticEventListener — replace (null) in tool loop start/completed messages with the output class name when
  no @Action is associated (standalone LLM call context).
```
10:02:46.125  INFO Colossus : [condescending_clarke] (null) starting tool loop [] max=20
10:02:47.063  INFO Colossus : [condescending_clarke] (null) tool loop completed in 937ms iterations=1 replan=false
```
  - ToolishRag — replace eager run {} initializer with lazy via ToolishRagInitState. ToolishRag is a data class and
  every copy() call (e.g. withHint, withEagerSearchAbout) was rebuilding VectorSearchTools, TextSearchTools etc.
  unnecessarily. Lazy deferral initializes exactly once on first access to tools() or notes(). 
```
0:26:41.100  INFO ToolishRag : Adding existing SearchTools to ToolishRag 'email_threads'
10:26:41.101  INFO ToolishRag : Adding existing SearchTools to ToolishRag 'email_threads'
```

 ## Files changed

  - embabel-agent-common/.../converters/JacksonOutputConverter.kt
  - embabel-agent-api/.../spi/logging/LoggingAgenticEventListener.kt
  - embabel-agent-rag/.../rag/tools/ToolishRag.kt
