### PR TITLE
Add chat message events and event-publishing in-memory conversation t…

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/event/MessageEvent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/event/MessageEvent.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.event
+
+import com.embabel.chat.Message
+import com.embabel.chat.MessageRole
+import com.embabel.common.core.types.Timestamped
+import java.time.Instant
+
+/**
+ * Event published for message lifecycle changes in a conversation.
+ *
+ * ## Status Flow
+ *
+ * | Conversation Type | Events Fired |
+ * |-------------------|--------------|
+ * | In-memory | `ADDED` |
+ * | Persistent | `ADDED` → `PERSISTED` or `PERSISTENCE_FAILED` |
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * @EventListener
+ * fun onMessage(event: MessageEvent) {
+ *     when (event.status) {
+ *         MessageStatus.ADDED -> {
+ *             // Message appeared in conversation - show in UI
+ *         }
+ *         MessageStatus.PERSISTED -> {
+ *             // Message saved - can update UI indicator
+ *         }
+ *         MessageStatus.PERSISTENCE_FAILED -> {
+ *             // Handle failure - event.error has details
+ *         }
+ *     }
+ * }
+ *
+ * // Or filter to specific status:
+ * @EventListener(condition = "#event.status.name() == 'ADDED'")
+ * fun onMessageAdded(event: MessageEvent) { ... }
+ * ```
+ *
+ * @param conversationId the conversation the message belongs to
+ * @param status the current status of the message
+ * @param fromUserId the ID of the user who sent this message (author)
+ * @param toUserId the ID of the user who should receive this message (for routing, e.g., WebSocket)
+ * @param title the session/conversation title (for UI display)
+ * @param message the message (always present for ADDED, present for PERSISTED)
+ * @param content the message content (useful for PERSISTENCE_FAILED when message ref may be stale)
+ * @param role the message role
+ * @param error the exception if persistence failed (present for PERSISTENCE_FAILED)
+ * @param timestamp when the event occurred
+ */
+data class MessageEvent(
+    val conversationId: String,
+    val status: MessageStatus,
+    val fromUserId: String? = null,
+    val toUserId: String? = null,
+    val title: String? = null,
+    val message: Message? = null,
+    val content: String? = null,
+    val role: MessageRole? = null,
+    val error: Throwable? = null,
+    override val timestamp: Instant = Instant.now()
+) : Timestamped {
+
+    companion object {
+        /**
+         * Create an ADDED event - message was added to conversation.
+         */
+        fun added(
+            conversationId: String,
+            message: Message,
+            fromUserId: String? = null,
+            toUserId: String? = null,
+            title: String? = null
+        ) = MessageEvent(
+            conversationId = conversationId,
+            status = MessageStatus.ADDED,
+            fromUserId = fromUserId,
+            toUserId = toUserId,
+            title = title,
+            message = message,
+            content = message.content,
+            role = message.role
+        )
+
+        /**
+         * Create a PERSISTED event - message was saved to storage.
+         */
+        fun persisted(
+            conversationId: String,
+            message: Message,
+            fromUserId: String? = null,
+            toUserId: String? = null,
+            title: String? = null
+        ) = MessageEvent(
+            conversationId = conversationId,
+            status = MessageStatus.PERSISTED,
+            fromUserId = fromUserId,
+            toUserId = toUserId,
+            title = title,
+            message = message,
+            content = message.content,
+            role = message.role
+        )
+
+        /**
+         * Create a PERSISTENCE_FAILED event.
+         */
+        fun persistenceFailed(
+            conversationId: String,
+            content: String,
+            role: MessageRole,
+            error: Throwable,
+            fromUserId: String? = null,
+            toUserId: String? = null,
+            title: String? = null
+        ) = MessageEvent(
+            conversationId = conversationId,
+            status = MessageStatus.PERSISTENCE_FAILED,
+            fromUserId = fromUserId,
+            toUserId = toUserId,
+            title = title,
+            content = content,
+            role = role,
+            error = error
+        )
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/event/MessageStatus.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/event/MessageStatus.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.event
+
+/**
+ * Status of a message in its lifecycle.
+ */
+enum class MessageStatus {
+    /**
+     * Message has been added to the conversation.
+     *
+     * For in-memory conversations, this is the terminal state.
+     * For persistent conversations, this may be followed by [PERSISTED] or [PERSISTENCE_FAILED].
+     */
+    ADDED,
+
+    /**
+     * Message has been successfully persisted to storage.
+     *
+     * Only fired by persistent conversation implementations.
+     */
+    PERSISTED,
+
+    /**
+     * Message persistence failed.
+     *
+     * Only fired by persistent conversation implementations.
+     * Check [MessageEvent.error] for details.
+     */
+    PERSISTENCE_FAILED
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/EventPublishingConversation.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/EventPublishingConversation.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.support
+
+import com.embabel.agent.api.identity.User
+import com.embabel.chat.AssetTracker
+import com.embabel.chat.Conversation
+import com.embabel.chat.Message
+import com.embabel.chat.event.MessageEvent
+import org.springframework.context.ApplicationEventPublisher
+
+/**
+ * A decorator that wraps any [Conversation] to publish [MessageEvent]s when messages are added.
+ *
+ * This enables event-driven patterns for any conversation implementation, including
+ * [InMemoryConversation].
+ *
+ * ## Usage
+ *
+ * ```kotlin
+ * val conversation = InMemoryConversation(id = "session-1")
+ * val eventPublishing = EventPublishingConversation(conversation, applicationEventPublisher)
+ *
+ * // Now fires MessageEvent(status=ADDED) on every addMessage
+ * eventPublishing.addMessage(UserMessage("Hello!"))
+ * ```
+ *
+ * ## Event Flow
+ *
+ * This decorator fires [MessageEvent] with status [MessageStatus.ADDED][com.embabel.chat.event.MessageStatus.ADDED]
+ * synchronously after the delegate adds the message.
+ *
+ * For persistent conversations (like StoredConversation), additional events
+ * ([MessageStatus.PERSISTED][com.embabel.chat.event.MessageStatus.PERSISTED] or
+ * [MessageStatus.PERSISTENCE_FAILED][com.embabel.chat.event.MessageStatus.PERSISTENCE_FAILED])
+ * may be fired asynchronously by the underlying implementation.
+ *
+ * @param delegate the underlying Conversation implementation
+ * @param eventPublisher Spring's event publisher
+ * @param fromUserId optional default sender ID for published events
+ * @param toUserId optional default recipient ID for published events
+ */
+class EventPublishingConversation(
+    private val delegate: Conversation,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val fromUserId: String? = null,
+    private val toUserId: String? = null
+) : Conversation {
+
+    override val id: String
+        get() = delegate.id
+
+    override val messages: List<Message>
+        get() = delegate.messages
+
+    override val assetTracker: AssetTracker
+        get() = delegate.assetTracker
+
+    override fun persistent(): Boolean = delegate.persistent()
+
+    /**
+     * Add a message and publish a [MessageEvent] with status ADDED.
+     *
+     * The event is published synchronously after the delegate adds the message.
+     */
+    override fun addMessage(message: Message): Message {
+        return delegate.addMessage(message).also { added ->
+            eventPublisher.publishEvent(MessageEvent.added(id, added, fromUserId, toUserId))
+        }
+    }
+
+    override fun addMessageFrom(message: Message, author: User?): Message {
+        return delegate.addMessageFrom(message, author).also { added ->
+            eventPublisher.publishEvent(MessageEvent.added(id, added, author?.id ?: fromUserId, toUserId))
+        }
+    }
+
+    override fun addMessageFromTo(
+        message: Message,
+        from: User?,
+        to: User?
+    ): Message {
+        return delegate.addMessageFromTo(message, from, to).also { added ->
+            eventPublisher.publishEvent(MessageEvent.added(id, added, from?.id ?: fromUserId, to?.id ?: toUserId))
+        }
+    }
+
+    override fun last(n: Int): Conversation {
+        return delegate.last(n)
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/EventPublishingConversation.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/EventPublishingConversation.kt
@@ -16,7 +16,6 @@
 package com.embabel.chat.support
 
 import com.embabel.agent.api.identity.User
-import com.embabel.chat.AssetTracker
 import com.embabel.chat.Conversation
 import com.embabel.chat.Message
 import com.embabel.chat.event.MessageEvent
@@ -58,18 +57,7 @@ class EventPublishingConversation(
     private val eventPublisher: ApplicationEventPublisher,
     private val fromUserId: String? = null,
     private val toUserId: String? = null
-) : Conversation {
-
-    override val id: String
-        get() = delegate.id
-
-    override val messages: List<Message>
-        get() = delegate.messages
-
-    override val assetTracker: AssetTracker
-        get() = delegate.assetTracker
-
-    override fun persistent(): Boolean = delegate.persistent()
+) : Conversation by delegate {
 
     /**
      * Add a message and publish a [MessageEvent] with status ADDED.
@@ -78,13 +66,13 @@ class EventPublishingConversation(
      */
     override fun addMessage(message: Message): Message {
         return delegate.addMessage(message).also { added ->
-            eventPublisher.publishEvent(MessageEvent.added(id, added, fromUserId, toUserId))
+            eventPublisher.publishEvent(MessageEvent.added(delegate.id, added, fromUserId, toUserId))
         }
     }
 
     override fun addMessageFrom(message: Message, author: User?): Message {
         return delegate.addMessageFrom(message, author).also { added ->
-            eventPublisher.publishEvent(MessageEvent.added(id, added, author?.id ?: fromUserId, toUserId))
+            eventPublisher.publishEvent(MessageEvent.added(delegate.id, added, author?.id ?: fromUserId, toUserId))
         }
     }
 
@@ -94,11 +82,7 @@ class EventPublishingConversation(
         to: User?
     ): Message {
         return delegate.addMessageFromTo(message, from, to).also { added ->
-            eventPublisher.publishEvent(MessageEvent.added(id, added, from?.id ?: fromUserId, to?.id ?: toUserId))
+            eventPublisher.publishEvent(MessageEvent.added(delegate.id, added, from?.id ?: fromUserId, to?.id ?: toUserId))
         }
-    }
-
-    override fun last(n: Int): Conversation {
-        return delegate.last(n)
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/InMemoryConversation.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/InMemoryConversation.kt
@@ -19,14 +19,17 @@ import com.embabel.chat.AssetTracker
 import com.embabel.chat.Conversation
 import com.embabel.chat.Message
 import com.embabel.common.core.MobyNameGenerator
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Simple in-memory implementation of [Conversation] for testing and ephemeral use cases.
+ *
+ * Thread-safe: uses [CopyOnWriteArrayList] for message storage.
  */
 class InMemoryConversation private constructor(
     override val id: String = MobyNameGenerator.generateName(),
     private val persistent: Boolean = false,
-    private val _messages: MutableList<Message> = mutableListOf(),
+    private val _messages: MutableList<Message> = CopyOnWriteArrayList(),
     override val assetTracker: AssetTracker = InMemoryAssetTracker(),
 ) : Conversation {
 
@@ -39,7 +42,7 @@ class InMemoryConversation private constructor(
     ) : this(
         id = id,
         persistent = persistent,
-        _messages = messages.toMutableList(),
+        _messages = CopyOnWriteArrayList(messages),
         assetTracker = assets,
     )
 
@@ -57,7 +60,7 @@ class InMemoryConversation private constructor(
         InMemoryConversation(
             id = this.id,
             persistent = false,
-            _messages = this._messages.takeLast(n).toMutableList(),
+            _messages = CopyOnWriteArrayList(this._messages.takeLast(n)),
             assetTracker = this.assetTracker,
         )
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/InMemoryConversationFactory.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/InMemoryConversationFactory.kt
@@ -18,16 +18,29 @@ package com.embabel.chat.support
 import com.embabel.chat.Conversation
 import com.embabel.chat.ConversationFactory
 import com.embabel.chat.ConversationStoreType
+import org.springframework.context.ApplicationEventPublisher
 
 /**
- * Factory for creating [InMemoryConversation] instances.
+ * Factory for creating in-memory [Conversation] instances.
  *
- * Messages are stored in memory only and not persisted.
- * Suitable for testing and ephemeral sessions.
+ * Messages are stored in memory only and not persisted; suitable for testing and
+ * ephemeral sessions. When an [eventPublisher] is supplied, created conversations are
+ * wrapped in an [EventPublishingConversation] so message events are fired.
+ *
+ * @param eventPublisher optional event publisher for firing message events
  */
-class InMemoryConversationFactory : ConversationFactory {
+class InMemoryConversationFactory(
+    private val eventPublisher: ApplicationEventPublisher? = null,
+) : ConversationFactory {
 
     override val storeType: ConversationStoreType = ConversationStoreType.IN_MEMORY
 
-    override fun create(id: String): Conversation = InMemoryConversation(id = id)
+    override fun create(id: String): Conversation {
+        val conversation = InMemoryConversation(id = id)
+        return if (eventPublisher != null) {
+            EventPublishingConversation(conversation, eventPublisher)
+        } else {
+            conversation
+        }
+    }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/event/MessageEventTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/event/MessageEventTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.event
+
+import com.embabel.chat.MessageRole
+import com.embabel.chat.UserMessage
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class MessageEventTest {
+
+    @Test
+    fun `added derives status content and role from the message`() {
+        val message = UserMessage("Hello")
+
+        val event = MessageEvent.added("conv-1", message, fromUserId = "u1", toUserId = "u2")
+
+        assertEquals("conv-1", event.conversationId)
+        assertEquals(MessageStatus.ADDED, event.status)
+        assertSame(message, event.message)
+        assertEquals("Hello", event.content)
+        assertEquals(MessageRole.USER, event.role)
+        assertEquals("u1", event.fromUserId)
+        assertEquals("u2", event.toUserId)
+        assertNull(event.error)
+    }
+
+    @Test
+    fun `persisted sets PERSISTED status`() {
+        val event = MessageEvent.persisted("conv-1", UserMessage("Saved"))
+
+        assertEquals(MessageStatus.PERSISTED, event.status)
+        assertEquals("Saved", event.content)
+    }
+
+    @Test
+    fun `persistenceFailed carries the error and raw content`() {
+        val boom = IllegalStateException("db down")
+
+        val event = MessageEvent.persistenceFailed(
+            conversationId = "conv-1",
+            content = "Lost",
+            role = MessageRole.ASSISTANT,
+            error = boom,
+        )
+
+        assertEquals(MessageStatus.PERSISTENCE_FAILED, event.status)
+        assertEquals("Lost", event.content)
+        assertEquals(MessageRole.ASSISTANT, event.role)
+        assertSame(boom, event.error)
+        assertNull(event.message)
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/support/EventPublishingConversationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/support/EventPublishingConversationTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.support
+
+import com.embabel.agent.api.identity.SimpleUser
+import com.embabel.chat.AssistantMessage
+import com.embabel.chat.UserMessage
+import com.embabel.chat.event.MessageEvent
+import com.embabel.chat.event.MessageStatus
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+
+class EventPublishingConversationTest {
+
+    private class RecordingEventPublisher : ApplicationEventPublisher {
+        val events = mutableListOf<Any>()
+        override fun publishEvent(event: Any) {
+            events.add(event)
+        }
+
+        fun messageEvents(): List<MessageEvent> = events.filterIsInstance<MessageEvent>()
+    }
+
+    @Test
+    fun `addMessage delegates to the conversation and publishes an ADDED event`() {
+        val publisher = RecordingEventPublisher()
+        val delegate = InMemoryConversation(id = "c1")
+        val conversation = EventPublishingConversation(delegate, publisher)
+
+        val message = UserMessage("Hello!")
+        val returned = conversation.addMessage(message)
+
+        assertSame(message, returned)
+        assertEquals(listOf(message), delegate.messages)
+        assertEquals(listOf(message), conversation.messages)
+
+        val event = publisher.messageEvents().single()
+        assertEquals("c1", event.conversationId)
+        assertEquals(MessageStatus.ADDED, event.status)
+        assertSame(message, event.message)
+    }
+
+    @Test
+    fun `addMessageFrom publishes event with the author id as sender`() {
+        val publisher = RecordingEventPublisher()
+        val conversation = EventPublishingConversation(InMemoryConversation(id = "c2"), publisher)
+        val author = SimpleUser("u-1", "Alice", "alice", null)
+
+        conversation.addMessageFrom(UserMessage("Hi"), author)
+
+        val event = publisher.messageEvents().single()
+        assertEquals("c2", event.conversationId)
+        assertEquals(MessageStatus.ADDED, event.status)
+        assertEquals("u-1", event.fromUserId)
+    }
+
+    @Test
+    fun `addMessageFromTo publishes event with both sender and recipient ids`() {
+        val publisher = RecordingEventPublisher()
+        val conversation = EventPublishingConversation(InMemoryConversation(id = "c3"), publisher)
+        val from = SimpleUser("from-1", "Alice", "alice", null)
+        val to = SimpleUser("to-1", "Bob", "bob", null)
+
+        conversation.addMessageFromTo(AssistantMessage("Reply"), from, to)
+
+        val event = publisher.messageEvents().single()
+        assertEquals("from-1", event.fromUserId)
+        assertEquals("to-1", event.toUserId)
+    }
+
+    @Test
+    fun `default sender and recipient ids are used when a message supplies none`() {
+        val publisher = RecordingEventPublisher()
+        val conversation = EventPublishingConversation(
+            InMemoryConversation(id = "c4"),
+            publisher,
+            fromUserId = "default-from",
+            toUserId = "default-to",
+        )
+
+        conversation.addMessage(UserMessage("Hello"))
+
+        val event = publisher.messageEvents().single()
+        assertEquals("default-from", event.fromUserId)
+        assertEquals("default-to", event.toUserId)
+    }
+
+    @Test
+    fun `read-through properties reflect the delegate`() {
+        val delegate = InMemoryConversation(id = "c5")
+        val conversation = EventPublishingConversation(delegate, RecordingEventPublisher())
+
+        assertEquals(delegate.id, conversation.id)
+        assertSame(delegate.assetTracker, conversation.assetTracker)
+        assertFalse(conversation.persistent())
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/support/InMemoryConversationFactoryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/support/InMemoryConversationFactoryTest.kt
@@ -16,8 +16,11 @@
 package com.embabel.chat.support
 
 import com.embabel.chat.ConversationStoreType
+import com.embabel.chat.UserMessage
+import com.embabel.chat.event.MessageEvent
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
 
 class InMemoryConversationFactoryTest {
 
@@ -59,5 +62,27 @@ class InMemoryConversationFactoryTest {
         val conversation = factory.create("test-id")
 
         assertFalse(conversation.persistent())
+    }
+
+    @Test
+    fun `create without event publisher returns a plain InMemoryConversation`() {
+        val factory = InMemoryConversationFactory()
+
+        assertTrue(factory.create("test-id") is InMemoryConversation)
+    }
+
+    @Test
+    fun `create with event publisher wraps conversation and fires message events`() {
+        val events = mutableListOf<Any>()
+        val publisher = ApplicationEventPublisher { event -> events.add(event) }
+        val factory = InMemoryConversationFactory(publisher)
+
+        val conversation = factory.create("test-id")
+        assertTrue(conversation is EventPublishingConversation)
+
+        conversation.addMessage(UserMessage("Hello"))
+
+        val messageEvent = events.filterIsInstance<MessageEvent>().single()
+        assertEquals("test-id", messageEvent.conversationId)
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/support/InMemoryConversationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/support/InMemoryConversationTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.support
+
+import com.embabel.chat.UserMessage
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class InMemoryConversationTest {
+
+    @Test
+    fun `last returns a non-persistent conversation with the trailing messages`() {
+        val conversation = InMemoryConversation(id = "c")
+        repeat(5) { conversation.addMessage(UserMessage("m$it")) }
+
+        val tail = conversation.last(2)
+
+        assertEquals(listOf("m3", "m4"), tail.messages.map { it.content })
+        assertFalse(tail.persistent())
+    }
+
+    @Test
+    fun `concurrent addMessage from many threads keeps every message`() {
+        val conversation = InMemoryConversation(id = "concurrent")
+        val threads = 8
+        val perThread = 500
+        val pool = Executors.newFixedThreadPool(threads)
+        val start = CountDownLatch(1)
+
+        repeat(threads) {
+            pool.submit {
+                start.await()
+                repeat(perThread) { conversation.addMessage(UserMessage("m")) }
+            }
+        }
+        start.countDown()
+        pool.shutdown()
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS))
+
+        assertEquals(threads * perThread, conversation.messages.size)
+    }
+
+    @Test
+    fun `reading messages while another thread writes does not throw`() {
+        val conversation = InMemoryConversation(id = "read-write")
+        val pool = Executors.newSingleThreadExecutor()
+        val writer = pool.submit {
+            repeat(5000) { conversation.addMessage(UserMessage("m")) }
+        }
+
+        // Forces iteration of the backing list on every call; would throw
+        // ConcurrentModificationException against a non-thread-safe list.
+        while (!writer.isDone) {
+            assertTrue(conversation.messages.size >= 0)
+        }
+
+        pool.shutdown()
+        assertTrue(pool.awaitTermination(30, TimeUnit.SECONDS))
+        assertEquals(5000, conversation.messages.size)
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/chatbots/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/chatbots/page.adoc
@@ -586,6 +586,9 @@ Otherwise the actions needed to respond to chat may not be available in the sess
 By default, chatbots use **in-memory conversations** that are lost when the session ends.
 For production applications, you typically want to **persist conversations** to a backing store.
 
+NOTE: Message events (`MessageEvent`) and the in-memory conversation types live in `embabel-agent-api`, so they are available without the `embabel-chat-store` dependency.
+In-memory conversations can also publish `MessageEvent`s (status `ADDED`) by passing a Spring `ApplicationEventPublisher` to `InMemoryConversationFactory`.
+
 ===== Storage Types
 
 Embabel supports two conversation storage types via `ConversationStoreType`:
@@ -681,7 +684,7 @@ This provides:
 
 - `StoredConversationFactory` - creates conversations that persist to Neo4j
 - `StoredConversation` - conversation implementation with async persistence
-- Message lifecycle events (`MessageEvent`) for UI updates
+- Persistence lifecycle events (`MessageEvent` with `PERSISTED` / `PERSISTENCE_FAILED` status) for UI updates
 - Title generation for conversation sessions
 
 ===== Restoring Conversations


### PR DESCRIPTION
## Why

`embabel-chat-store` shipped its own `com.embabel.chat.support.InMemoryConversationFactory` — the **same fully-qualified name** as the one in `embabel-agent-api`, but divergent: the chat-store copy took an optional `ApplicationEventPublisher` and produced an event-publishing conversation, while core's took no args.

Any app that uses both jars (i.e. any embabel-agent app that adds chat-store) then has two classes with identical FQNs on the classpath. Which one wins is classpath-order dependent, and because chat-store's autoconfigure is compiled against the `(eventPublisher)` constructor, if core's version loads first the call becomes a **`NoSuchMethodError` at runtime**.

In-memory conversation and message events are core chat concerns — `AgentProcessChatbot` already defaults to an in-memory factory — so the canonical home is core, not the downstream store module.

## What

Hosts the in-memory conversation event machinery in `embabel-agent-api`:

- **`chat/event/MessageEvent.kt` + `chat/event/MessageStatus.kt`** — message lifecycle events (`ADDED` / `PERSISTED` / `PERSISTENCE_FAILED`). Moved down from chat-store, split one-type-per-file.
- **`chat/support/EventPublishingConversation.kt`** — decorator that fires `MessageEvent`s on message add. Moved down from chat-store.
- **`InMemoryConversationFactory`** — now takes an optional `ApplicationEventPublisher`; wraps the conversation in `EventPublishingConversation` when supplied. This makes it the single canonical factory (`Spring` is already on agent-api's classpath, so no new dependency).
- **`InMemoryConversation`** — made thread-safe (`CopyOnWriteArrayList`). This preserved the one real property chat-store's near-duplicate `InMemoryStorableConversation` had, so that class is dropped entirely rather than moved — core keeps a single in-memory conversation type.

All classes keep their `com.embabel.chat.*` packages, so consumers see identical FQNs — the change is transparent at the source level once this jar is on the classpath.

## Companion change

`embabel-chat-store` deletes its copies (`InMemoryConversationFactory`, `InMemoryStorableConversation`, `EventPublishingConversation`, `event/ConversationEvents.kt`), bumps its consumed `embabel-agent` to `1.0.0-RC1-SNAPSHOT`, and bumps its own version to `0.3.0-SNAPSHOT`. Its `StoredConversation` / `ChatStoreEvents` resolve `MessageEvent` from agent-api unchanged.

## Verification

- `embabel-agent-api` builds and installs.
- Core chat unit tests pass: `InMemoryConversationFactoryTest` (5), `AgentProcessChatbotTest` (13).
- `embabel-chat-store` compiles clean (main + tests) against the installed jar, with no dangling references from the deletions.
