### PR TITLE
Fix 1774: Have Subagent to inherit Verbosity Settings of a parent process

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/Subagent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/Subagent.kt
@@ -244,7 +244,7 @@ class Subagent private constructor(
             parentAgentProcess.id
         )
         return ProcessOptions(
-            verbosity = Verbosity(showPrompts = true),
+            verbosity = parentAgentProcess.processOptions.verbosity,
             blackboard = blackboard,
             outputChannel = parentOutputChannel,
             identities = parentAgentProcess.processOptions.identities,

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/SubagentTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/SubagentTest.kt
@@ -19,8 +19,14 @@ import com.embabel.agent.api.annotation.Action
 import com.embabel.agent.api.annotation.AchievesGoal
 import com.embabel.agent.api.annotation.Agent
 import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.Blackboard
+import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.Verbosity
 import io.mockk.every
 import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -299,6 +305,51 @@ class SubagentTest {
             // The schema should contain the TestInput structure
             assertTrue(schemaJson.isNotBlank())
             assertTrue(schemaJson.contains("message"))
+        }
+    }
+
+    @Nested
+    inner class VerbosityTests {
+
+        @Test
+        fun `createProcessOptions inherits verbosity from parent process`() {
+            val parentVerbosity = Verbosity(showPrompts = true, showLlmResponses = true)
+            val mockParentProcess = mockk<AgentProcess>(relaxed = true)
+            val mockContext = mockk<ProcessContext>(relaxed = true)
+            val mockBlackboard = mockk<Blackboard>(relaxed = true)
+
+            every { mockParentProcess.processContext } returns mockContext
+            every { mockContext.blackboard } returns mockBlackboard
+            every { mockBlackboard.spawn() } returns mockk(relaxed = true)
+            every { mockParentProcess.processOptions } returns ProcessOptions(verbosity = parentVerbosity)
+
+            val subagent = Subagent.ofClass(TestAgent::class.java).consuming(TestInput::class.java)
+            val method = Subagent::class.java.getDeclaredMethod("createProcessOptions", AgentProcess::class.java)
+            method.isAccessible = true
+
+            val result = method.invoke(subagent, mockParentProcess) as ProcessOptions
+
+            assertThat(result.verbosity).isEqualTo(parentVerbosity)
+        }
+
+        @Test
+        fun `createProcessOptions with DEFAULT parent verbosity produces quiet process options`() {
+            val mockParentProcess = mockk<AgentProcess>(relaxed = true)
+            val mockContext = mockk<ProcessContext>(relaxed = true)
+            val mockBlackboard = mockk<Blackboard>(relaxed = true)
+
+            every { mockParentProcess.processContext } returns mockContext
+            every { mockContext.blackboard } returns mockBlackboard
+            every { mockBlackboard.spawn() } returns mockk(relaxed = true)
+            every { mockParentProcess.processOptions } returns ProcessOptions(verbosity = Verbosity.DEFAULT)
+
+            val subagent = Subagent.ofClass(TestAgent::class.java).consuming(TestInput::class.java)
+            val method = Subagent::class.java.getDeclaredMethod("createProcessOptions", AgentProcess::class.java)
+            method.isAccessible = true
+
+            val result = method.invoke(subagent, mockParentProcess) as ProcessOptions
+
+            assertThat(result.verbosity).isEqualTo(Verbosity.DEFAULT)
         }
     }
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/invoking/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/invoking/page.adoc
@@ -190,6 +190,10 @@ val plan = invocation.invoke(travelRequest)
 ----
 ====
 
+NOTE: Verbosity set on `ProcessOptions` is inherited by `Subagent` invocations.
+A subagent runs with the same `Verbosity` as the process that triggered it - set it once at the top level and it flows through the entire call tree.
+`GoalTool` and `AgentTool` are entry points and default to `showPrompts = true` regardless of any parent context.
+
 ===== Passing Tool Call Context at Invocation Time
 
 Use `ProcessOptions.withToolCallContext()` to attach out-of-band metadata that flows through the entire agent run to every tool invoked — including remote MCP tools, where it becomes MCP `_meta` on the wire.

--- a/embabel-agent-docs/src/main/asciidoc/reference/tools/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/tools/page.adoc
@@ -1730,6 +1730,45 @@ This means:
 * Objects added by the subagent are available to the parent after the subagent completes
 * The subagent operates in its own process context but shares state appropriately
 
+===== Verbosity Inheritance
+
+A `Subagent` automatically inherits the verbosity settings from its parent `AgentProcess`.
+If the parent runs with `showPrompts = true`, the subagent shows prompts too.
+If the parent runs quietly, the subagent is quiet.
+
+There is no separate verbosity setting on `Subagent` - it mirrors the parent's `ProcessOptions.verbosity` exactly.
+To control subagent verbosity, set it once on the top-level `ProcessOptions`:
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+// Quiet parent = quiet subagent
+var processOptions = new ProcessOptions()
+    .withVerbosity(new Verbosity());
+
+// Verbose parent = verbose subagent (prompts visible in both)
+var processOptions = new ProcessOptions()
+    .withVerbosity(new Verbosity().withShowPrompts(true));
+----
+
+Kotlin::
++
+[source,kotlin]
+----
+// Quiet parent = quiet subagent
+val processOptions = ProcessOptions(verbosity = Verbosity())
+
+// Verbose parent = verbose subagent (prompts visible in both)
+val processOptions = ProcessOptions(verbosity = Verbosity(showPrompts = true))
+----
+====
+
+NOTE: `GoalTool` and `AgentTool` are entry points - they default to `showPrompts = true` and do not inherit from any parent.
+To override their verbosity, pass a custom `Verbosity` via `GoalTool.withVerbosity()` or via the `processOptionsCreator` lambda on `AgentTool`.
+
 ===== When to Use Subagent
 
 |===


### PR DESCRIPTION
# Overview
Closes: #1774 

Make Subagent inherit verbosity settings from the parent Agent.