### PR TITLE
Propagate tool failures as ToolExecutionException so MCP clients see isError

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringToolCallbackAdapter.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringToolCallbackAdapter.kt
@@ -23,6 +23,7 @@ import org.springframework.ai.chat.model.ToolContext
 import org.springframework.ai.tool.ToolCallback
 import org.springframework.ai.tool.definition.DefaultToolDefinition
 import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.ai.tool.execution.ToolExecutionException
 import org.springframework.ai.tool.metadata.DefaultToolMetadata
 import org.springframework.ai.tool.metadata.ToolMetadata
 
@@ -64,18 +65,26 @@ class SpringToolCallbackAdapter(
     override fun call(toolInput: String, toolContext: ToolContext?): String {
         logger.debug("Executing tool '{}' with input: {}", tool.definition.name, toolInput)
         val context = toolContext?.let { ToolCallContext.of(it.context) } ?: ToolCallContext.EMPTY
-        return try {
-            when (val result = tool.call(toolInput, context)) {
-                is Tool.Result.Text -> result.content
-                is Tool.Result.WithArtifact -> result.content
-                is Tool.Result.Error -> {
-                    logger.warn("Tool '{}' returned error: {}", tool.definition.name, result.message)
-                    "ERROR: ${result.message}"
-                }
-            }
+        // Only the tool invocation itself is guarded here, so the Result.Error
+        // branch below can throw without landing back in this same catch.
+        val result = try {
+            tool.call(toolInput, context)
+        } catch (e: ToolExecutionException) {
+            throw e
+        } catch (e: RuntimeException) {
+            logger.error("Tool '{}' threw exception: {}", tool.definition.name, e.message, e)
+            throw ToolExecutionException(toolDefinition, e)
         } catch (e: Exception) {
             logger.error("Tool '{}' threw exception: {}", tool.definition.name, e.message, e)
-            "ERROR: ${e.message ?: "Unknown error"}"
+            throw ToolExecutionException(toolDefinition, RuntimeException(e.message ?: "Unknown error", e))
+        }
+        return when (result) {
+            is Tool.Result.Text -> result.content
+            is Tool.Result.WithArtifact -> result.content
+            is Tool.Result.Error -> {
+                logger.warn("Tool '{}' returned error: {}", tool.definition.name, result.message)
+                throw ToolExecutionException(toolDefinition, RuntimeException(result.message, result.cause))
+            }
         }
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/McpToolErrorMappingTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/McpToolErrorMappingTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.springai
+
+import com.embabel.agent.api.tool.Tool
+import io.mockk.mockk
+import io.modelcontextprotocol.server.McpSyncServerExchange
+import io.modelcontextprotocol.spec.McpSchema
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.ai.mcp.McpToolUtils
+import org.springframework.ai.tool.execution.ToolExecutionException
+import java.io.IOException
+
+/**
+ * Proves that a failing Embabel tool comes out the other side of the MCP wire as
+ * `CallToolResult.isError == true`, fixing issue #1780 where every failure looked
+ * like a successful call whose text happened to start with "ERROR:".
+ *
+ * Goes through the real [McpToolUtils.toSyncToolSpecification] handler, the same
+ * code Spring AI's MCP server support uses to turn a [ToolExecutionException]
+ * into an error [McpSchema.CallToolResult].
+ */
+class McpToolErrorMappingTest {
+
+    private val exchange = mockk<McpSyncServerExchange>(relaxed = true)
+
+    private fun request(name: String) =
+        McpSchema.CallToolRequest.builder().name(name).arguments(emptyMap<String, Any>()).build()
+
+    private fun textOf(result: McpSchema.CallToolResult): String =
+        (result.content().first() as McpSchema.TextContent).text()
+
+    @Test
+    fun `tool throwing a RuntimeException surfaces as an MCP error`() {
+        val tool = Tool.of(name = "boom", description = "Throws") { _ ->
+            throw RuntimeException("access denied")
+        }
+        val spec = McpToolUtils.toSyncToolSpecification(SpringToolCallbackAdapter(tool))
+
+        val result = spec.callHandler().apply(exchange, request("boom"))
+
+        assertTrue(result.isError())
+        assertEquals("access denied", textOf(result))
+    }
+
+    @Test
+    fun `tool returning Result-Error surfaces as an MCP error`() {
+        val tool = Tool.of(name = "soft_fail", description = "Fails softly") { _ ->
+            Tool.Result.error("soft failure")
+        }
+        val spec = McpToolUtils.toSyncToolSpecification(SpringToolCallbackAdapter(tool))
+
+        val result = spec.callHandler().apply(exchange, request("soft_fail"))
+
+        assertTrue(result.isError())
+        assertEquals("soft failure", textOf(result))
+    }
+
+    @Test
+    fun `tool throwing a checked exception wraps it in a RuntimeException cause`() {
+        val tool = Tool.of(name = "io_fail", description = "Throws checked") { _ ->
+            throw IOException("disk gone")
+        }
+        val callback = SpringToolCallbackAdapter(tool)
+
+        val thrown = assertThrows<ToolExecutionException> { callback.call("{}") }
+        assertTrue(thrown.cause is RuntimeException)
+        assertEquals("disk gone", thrown.message)
+
+        val spec = McpToolUtils.toSyncToolSpecification(callback)
+        val result = spec.callHandler().apply(exchange, request("io_fail"))
+
+        assertTrue(result.isError())
+        assertEquals("disk gone", textOf(result))
+    }
+
+    @Test
+    fun `happy path is unaffected`() {
+        val tool = Tool.of(name = "ok", description = "Succeeds") { _ ->
+            Tool.Result.text("ok")
+        }
+        val spec = McpToolUtils.toSyncToolSpecification(SpringToolCallbackAdapter(tool))
+
+        val result = spec.callHandler().apply(exchange, request("ok"))
+
+        assertFalse(result.isError() == true)
+        assertEquals("ok", textOf(result))
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringToolCallbackAdapterTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringToolCallbackAdapterTest.kt
@@ -29,9 +29,11 @@ import org.springframework.ai.mcp.SyncMcpToolCallbackProvider
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.ai.model.ModelOptionsUtils
 import org.springframework.ai.tool.ToolCallback
 import org.springframework.ai.tool.definition.DefaultToolDefinition
+import org.springframework.ai.tool.execution.ToolExecutionException
 import org.springframework.ai.tool.metadata.DefaultToolMetadata
 
 class SpringToolCallbackAdapterTest {
@@ -101,10 +103,9 @@ class SpringToolCallbackAdapterTest {
             }
 
             val callback = SpringToolCallbackAdapter(tool)
-            val result = callback.call("{}")
+            val exception = assertThrows<ToolExecutionException> { callback.call("{}") }
 
-            assertTrue(result.startsWith("ERROR:"))
-            assertTrue(result.contains("Something went wrong"))
+            assertEquals("Something went wrong", exception.message)
         }
 
         @Test
@@ -132,10 +133,9 @@ class SpringToolCallbackAdapterTest {
             }
 
             val callback = SpringToolCallbackAdapter(tool)
-            val result = callback.call("{}")
+            val exception = assertThrows<ToolExecutionException> { callback.call("{}") }
 
-            assertTrue(result.startsWith("ERROR:"))
-            assertTrue(result.contains("Unexpected error"))
+            assertEquals("Unexpected error", exception.message)
         }
 
         @Test


### PR DESCRIPTION
Fixes #1780.

`SpringToolCallbackAdapter.call` swallowed both `Tool.Result.Error` and thrown exceptions into `"ERROR: ..."` string results, so MCP clients received successful `tools/call` responses with `CallToolResult.isError = false` for every tool failure — including access-control denials.

## What changed

- The adapter now throws `ToolExecutionException` for both failure kinds, always with a `RuntimeException` cause carrying the intended message:
  - `Tool.Result.Error(message, cause)` → `ToolExecutionException(definition, RuntimeException(message, cause))` — the error message survives verbatim on the wire.
  - Thrown `RuntimeException` → passed as the cause directly, preserving the concrete class (e.g. `AccessDeniedException`) for exception processors configured to rethrow specific types.
  - Checked exceptions → wrapped in `RuntimeException` first. This matters: `DefaultToolExecutionExceptionProcessor` rethrows when the cause is not a `RuntimeException`, which would break the chat tool loop.
- Success paths (`Text`, `WithArtifact`) unchanged; `SpringToolCallbackWrapper` (the reverse adapter) unchanged.

## Behavior after the change

- **MCP**: Spring AI's `McpToolUtils` handler catches the exception → `isError = true` with the message as content. `McpAwareGoalTool` already maps `AccessDeniedException` to `Tool.Result.Error`, so security denials become protocol-level errors with no further change.
- **LLM chat loop**: `DefaultToolCallingManager` catches exactly `ToolExecutionException` and its processor returns the message to the model — same visible behavior as before, minus the `"ERROR: "` prefix.

On the issue's open question (soft vs hard errors): both `Result.Error` and exceptions map to protocol errors — a tool that returns `Result.Error` failed, and clients branching on `isError` should see it. No config surface added; easy to revisit if a use case needs split behavior.

## Testing

- `SpringToolCallbackAdapterTest` updated from string-prefix assertions to `assertThrows` with message assertions.
- New `McpToolErrorMappingTest` drives the real `McpToolUtils.toSyncToolSpecification` handler end to end: `isError = true` for runtime, `Result.Error`, and checked-exception cases (asserting the `RuntimeException`-cause invariant); happy path stays non-error.
- Failure-path tests confirmed failing against the pre-fix code; full `embabel-agent-api` suite green (3907 tests, 0 failures).
