### PR TITLE
Resolve target class for CGLIB-proxied beans in @LlmTool discovery

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodToolFactory.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/tool/MethodToolFactory.kt
@@ -21,8 +21,12 @@ import com.embabel.agent.api.tool.progressive.UnfoldingTool
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.slf4j.LoggerFactory
+import org.springframework.aop.framework.AopProxyUtils
+import org.springframework.cglib.proxy.Enhancer
 import org.springframework.core.KotlinDetector
+import org.springframework.util.ClassUtils
 import java.lang.reflect.Method
+import java.lang.reflect.Proxy
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
@@ -104,23 +108,32 @@ interface MethodToolFactory {
         instance: Any,
         objectMapper: ObjectMapper = jacksonObjectMapper(),
     ): List<Tool> {
-        if (instance::class.hasAnnotation<UnfoldingTools>()) {
+        // A CGLIB proxy's own class never carries the @LlmTool annotations -- they're on the
+        // class it subclasses. Reflect over that target class, but still invoke on the proxy
+        // instance (below, via fromMethod) so any AOP advice on the proxy actually runs.
+        val targetClass: Class<*> = if (Enhancer.isEnhanced(instance.javaClass)) {
+            ClassUtils.getUserClass(instance.javaClass)
+        } else {
+            instance.javaClass
+        }
+
+        if (targetClass.kotlin.hasAnnotation<UnfoldingTools>()) {
             return listOf(UnfoldingTool.fromInstance(instance, objectMapper))
         }
 
-        val tools = if (KotlinDetector.isKotlinReflectPresent() && KotlinDetector.isKotlinType(instance.javaClass)) {
-            instance::class.functions
+        val tools = if (KotlinDetector.isKotlinReflectPresent() && KotlinDetector.isKotlinType(targetClass)) {
+            targetClass.kotlin.functions
                 .filter { it.hasAnnotation<LlmTool>() }
                 .map { fromMethod(instance, it, objectMapper) }
         } else {
-            instance.javaClass.declaredMethods
+            targetClass.declaredMethods
                 .filter { it.isAnnotationPresent(LlmTool::class.java) }
                 .map { fromMethod(instance, it, objectMapper) }
         }
 
         if (tools.isEmpty()) {
             throw IllegalArgumentException(
-                "No methods annotated with @LlmTool found on ${instance::class.simpleName}"
+                "No methods annotated with @LlmTool found on ${targetClass.simpleName}"
             )
         }
 
@@ -142,6 +155,7 @@ interface MethodToolFactory {
         return try {
             fromInstance(instance, objectMapper)
         } catch (e: IllegalArgumentException) {
+            warnIfLlmToolsHiddenBehindJdkProxy(instance)
             logger.debug("No @LlmTool annotations found on {}: {}", instance::class.simpleName, e.message)
             emptyList()
         } catch (e: Throwable) {
@@ -152,6 +166,30 @@ interface MethodToolFactory {
                 e.message,
             )
             emptyList()
+        }
+    }
+
+    /**
+     * JDK dynamic proxies can't be unwrapped for discovery -- a method taken from the target
+     * class can't be invoked on an interface proxy. So if a JDK proxy's target class does have
+     * @LlmTool methods, warn that they're invisible instead of just quietly finding nothing.
+     */
+    private fun warnIfLlmToolsHiddenBehindJdkProxy(instance: Any) {
+        if (!Proxy.isProxyClass(instance.javaClass)) {
+            return
+        }
+        val targetClass = AopProxyUtils.ultimateTargetClass(instance)
+        val hasLlmToolMethods = if (KotlinDetector.isKotlinReflectPresent() && KotlinDetector.isKotlinType(targetClass)) {
+            targetClass.kotlin.functions.any { it.hasAnnotation<LlmTool>() }
+        } else {
+            targetClass.declaredMethods.any { it.isAnnotationPresent(LlmTool::class.java) }
+        }
+        if (hasLlmToolMethods) {
+            logger.warn(
+                "{} has @LlmTool methods but is only reachable through a JDK dynamic proxy, so they " +
+                    "can't be discovered. Use class-based (CGLIB) proxying instead, e.g. spring.aop.proxy-target-class=true.",
+                targetClass.name,
+            )
         }
     }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/ProxiedToolDiscoveryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/ProxiedToolDiscoveryTest.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.tool
+
+import com.embabel.agent.api.annotation.LlmTool
+import org.aopalliance.intercept.MethodInterceptor
+import org.aopalliance.intercept.MethodInvocation
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.aop.framework.ProxyFactory
+
+/**
+ * Covers issue #1779: tools on Spring-proxied beans must still be discoverable.
+ *
+ * A CGLIB proxy (class-based, `isProxyTargetClass = true`) subclasses the target,
+ * so its own class never carries the `@LlmTool` annotations -- they live on the
+ * original target class. Discovery has to reflect on that target class, but
+ * invocation still has to go through the proxy instance so AOP advice actually
+ * runs. A JDK dynamic proxy (interface-based) can't do that at all: a method
+ * pulled off the target class can't be invoked on an interface proxy, so those
+ * stay undiscovered, just with a WARN instead of a silent DEBUG.
+ */
+class ProxiedToolDiscoveryTest {
+
+    open class GreetingTools {
+        @LlmTool(name = "greet", description = "Greets someone")
+        open fun greet(name: String): String = "Hello, $name"
+    }
+
+    open class NoToolsHere {
+        fun notATool(): String = "nothing to see here"
+    }
+
+    interface Greeter {
+        fun greet(name: String): String
+    }
+
+    class GreeterImpl : Greeter {
+        @LlmTool(name = "greet", description = "Greets someone")
+        override fun greet(name: String): String = "Hello, $name"
+    }
+
+    private class CountingInterceptor : MethodInterceptor {
+        var invocationCount = 0
+            private set
+
+        override fun invoke(invocation: MethodInvocation): Any? {
+            invocationCount++
+            return invocation.proceed()
+        }
+    }
+
+    @Test
+    fun `discovers tool on a plain instance`() {
+        val tools = Tool.safelyFromInstance(GreetingTools())
+
+        assertEquals(listOf("greet"), tools.map { it.definition.name })
+    }
+
+    @Test
+    fun `discovers tool on a CGLIB-proxied instance`() {
+        val proxyFactory = ProxyFactory(GreetingTools())
+        proxyFactory.isProxyTargetClass = true
+        val proxy = proxyFactory.proxy as GreetingTools
+
+        val tools = Tool.safelyFromInstance(proxy)
+
+        assertEquals(listOf("greet"), tools.map { it.definition.name })
+    }
+
+    @Test
+    fun `invoking a tool discovered on a CGLIB proxy goes through the proxy`() {
+        val interceptor = CountingInterceptor()
+        val proxyFactory = ProxyFactory(GreetingTools())
+        proxyFactory.isProxyTargetClass = true
+        proxyFactory.addAdvice(interceptor)
+        val proxy = proxyFactory.proxy as GreetingTools
+
+        val tools = Tool.safelyFromInstance(proxy)
+        val greet = tools.single { it.definition.name == "greet" }
+
+        val result = greet.call("""{"name": "World"}""") as Tool.Result.Text
+
+        assertEquals("Hello, World", result.content)
+        assertEquals(1, interceptor.invocationCount)
+    }
+
+    @Test
+    fun `CGLIB proxy of a class with no LlmTool methods yields empty list`() {
+        val proxyFactory = ProxyFactory(NoToolsHere())
+        proxyFactory.isProxyTargetClass = true
+        val proxy = proxyFactory.proxy
+
+        val tools = Tool.safelyFromInstance(proxy)
+
+        assertTrue(tools.isEmpty())
+    }
+
+    @Test
+    fun `JDK dynamic proxy yields empty list without throwing`() {
+        val proxyFactory = ProxyFactory(GreeterImpl())
+        val proxy = proxyFactory.proxy
+
+        val tools = Tool.safelyFromInstance(proxy)
+
+        assertTrue(tools.isEmpty())
+    }
+}

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/pom.xml
@@ -45,5 +45,12 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/test/kotlin/com/embabel/agent/mcpserver/security/SecureLlmToolDiscoveryIntegrationTest.kt
+++ b/embabel-agent-autoconfigure/embabel-agent-mcpserver-security-autoconfigure/src/test/kotlin/com/embabel/agent/mcpserver/security/SecureLlmToolDiscoveryIntegrationTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver.security
+
+import com.embabel.agent.api.annotation.LlmTool
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.config.mcpserver.security.SecureAgentToolConfiguration
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.aop.framework.AopProxyUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.context.annotation.Import
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+
+/**
+ * Proves that a bean carrying both [SecureAgentTool] and [LlmTool] on the same method survives
+ * CGLIB proxying end to end: the tool is still discoverable via [Tool.safelyFromInstance] after
+ * proxying, and the security aspect still enforces access when the discovered tool is called.
+ *
+ * This is the sharpest edge from GitHub issue #1779: discovery (`embabel-agent-api`) and
+ * enforcement (`SecureAgentToolAspect`, this module) are two independent mechanisms that both
+ * have to see through the same CGLIB proxy. Either one regressing on its own would be silent
+ * unless something exercises them together, which is what this test does.
+ */
+@SpringJUnitConfig
+@DisplayName("SecureAgentTool + LlmTool discovery - Integration")
+class SecureLlmToolDiscoveryIntegrationTest {
+
+    @Autowired
+    lateinit var agent: SecuredToolAgent
+
+    @Configuration
+    @Import(SecureAgentToolConfiguration::class)
+    @EnableAspectJAutoProxy
+    open class TestConfig {
+
+        @Bean
+        open fun securedToolAgent(): SecuredToolAgent = SecuredToolAgent()
+    }
+
+    @BeforeEach
+    fun clearContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @AfterEach
+    fun resetContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun authenticateWith(vararg authorities: String) {
+        val auth = TestingAuthenticationToken(
+            "integration-user",
+            "credentials",
+            authorities.map { SimpleGrantedAuthority(it) },
+        )
+        auth.isAuthenticated = true
+        SecurityContextHolder.getContext().authentication = auth
+    }
+
+    private fun discoveredTool(name: String): Tool =
+        Tool.safelyFromInstance(agent).first { it.definition.name == name }
+
+    @Test
+    fun `agent bean is a Spring AOP proxy, not a plain instance`() {
+        val targetClass = AopProxyUtils.ultimateTargetClass(agent)
+        Assertions.assertThat(agent.javaClass).isNotEqualTo(targetClass)
+    }
+
+    @Test
+    fun `secured_greet is discovered as a tool after proxying`() {
+        val tools = Tool.safelyFromInstance(agent)
+        Assertions.assertThat(tools.map { it.definition.name }).contains("secured_greet")
+    }
+
+    @Test
+    fun `unauthenticated invocation does not return the success payload and surfaces AccessDeniedException`() {
+        val tool = discoveredTool("secured_greet")
+
+        // The aspect's AccessDeniedException may come out as a thrown exception or as a
+        // returned Tool.Result.Error, depending on how far the invocation unwinds before the
+        // tool wrapper's own try/catch gets it. Either is an acceptable denial shape here.
+        val outcome: Any = try {
+            tool.call("""{"name": "World"}""")
+        } catch (e: Throwable) {
+            e
+        }
+
+        Assertions.assertThat(outcome).isNotInstanceOf(Tool.Result.Text::class.java)
+
+        val deniedSomewhereInChain = when (outcome) {
+            is Throwable -> generateSequence(outcome) { it.cause }.any { it is AccessDeniedException }
+            is Tool.Result.Error -> generateSequence(outcome.cause as Throwable?) { it.cause }
+                .any { it is AccessDeniedException } ||
+                outcome.message.contains("AccessDeniedException") ||
+                outcome.message.contains("Access is denied")
+
+            else -> false
+        }
+        Assertions.assertThat(deniedSomewhereInChain)
+            .withFailMessage("expected AccessDeniedException somewhere in the denial, got: %s", outcome)
+            .isTrue()
+    }
+
+    @Test
+    fun `authorized invocation returns the tool's real result`() {
+        authenticateWith("tools:use")
+        val tool = discoveredTool("secured_greet")
+
+        val result = tool.call("""{"name": "World"}""")
+
+        Assertions.assertThat(result).isInstanceOf(Tool.Result.Text::class.java)
+        Assertions.assertThat((result as Tool.Result.Text).content).contains("Hello")
+    }
+}
+
+/**
+ * Test fixture where one method carries both defense-in-depth annotations: [SecureAgentTool]
+ * guards it via the aspect, [LlmTool] makes it discoverable as a tool. Must be `open` for CGLIB
+ * subclassing.
+ */
+open class SecuredToolAgent {
+
+    @SecureAgentTool("hasAuthority('tools:use')")
+    @LlmTool(name = "secured_greet", description = "Greets, if you're allowed")
+    open fun securedGreet(name: String): String = "Hello, $name"
+}


### PR DESCRIPTION
Fixes #1779.

`MethodToolFactory.fromInstance` reflected over the instance's runtime class, so any Spring AOP (CGLIB) proxied bean — including beans proxied by the framework's own `SecureAgentToolAspect` — silently lost all its `@LlmTool` tools: the CGLIB subclass carries no method annotations, discovery found nothing, and `safelyFromInstance` logged it away at DEBUG.

## What changed

- `fromInstance` now resolves the CGLIB target class (`Enhancer.isEnhanced` → `ClassUtils.getUserClass`, mirroring the `AgenticInfo` precedent from #841) at every reflection site — the `@UnfoldingTools` check, the Kotlin-type detection, function/method enumeration, and the error message — while still binding tools to the original proxy instance, so AOP advice fires on invocation.
- JDK dynamic proxies are deliberately NOT unwrapped: a target-class `Method`/`KFunction` can't be invoked on an interface proxy, so unwrapping would trade "silently missing" for a runtime failure at call time. Instead `safelyFromInstance` now logs a WARN when discovery comes up empty on a JDK proxy whose target class has `@LlmTool` methods, pointing at class-based proxying.

## Testing

- New `ProxiedToolDiscoveryTest`: plain-instance regression, CGLIB discovery, invocation-through-proxy proven with a counting `MethodInterceptor` (guards against "fixing" discovery by unwrapping the invocation target), no-tool proxy, and the JDK-proxy WARN path. The proxy tests were confirmed failing against the pre-fix code.
- New `SecureLlmToolDiscoveryIntegrationTest` in the MCP security autoconfigure module (which gains a test-scoped dependency on `embabel-agent-api`): boots the real `@EnableAspectJAutoProxy` + `SecureAgentToolConfiguration` context and proves the issue's sharpest edge both ways — a bean with `@SecureAgentTool` + `@LlmTool` on the same method is discovered post-proxying, unauthenticated calls surface `AccessDeniedException` (as `Tool.Result.Error`), and authorized calls return the real result.
- Full test suites of both touched modules pass.

Noticed while fixing, left alone: `UnfoldingTool.Factory` has the same runtime-class reflection pattern, so a proxied `@UnfoldingTools` class likely has the same problem — worth its own issue if confirmed.
