### PR TITLE
Update build parent 0.1.15 and common 0.1.14

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.15-SNAPSHOT</version>
+        <version>0.1.15</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.15-SNAPSHOT</version>
+        <version>0.1.15</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,7 +16,7 @@
 
     <properties>
         <argLine />
-        <embabel-common.version>0.1.14-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>0.1.14</embabel-common.version>
         <netty.version>4.2.15.Final</netty.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>


### PR DESCRIPTION
This pull request updates Maven project configuration files to use stable release versions instead of snapshot versions for both parent and dependency versions. This ensures better build stability and consistency across the project.

**Dependency and parent version updates:**

* Updated the parent version in `pom.xml` from `0.1.15-SNAPSHOT` to the stable release `0.1.15`.
* Updated the `embabel-common.version` property in `pom.xml` from `0.1.14-SNAPSHOT` to `0.1.14`.
* Updated the parent version in `embabel-agent-dependencies/pom.xml` from `0.1.15-SNAPSHOT` to `0.1.15`.