### PR TITLE
Prepare for 1.0.0-GA Dev Cycle

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>0.1.15</version>
+        <version>1.0.0-SNAPSHOT</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>0.1.15</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,7 +16,7 @@
 
     <properties>
         <argLine />
-        <embabel-common.version>0.1.14</embabel-common.version>
+        <embabel-common.version>1.0.0-SNAPSHOT</embabel-common.version>
         <netty.version>4.2.15.Final</netty.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>


### PR DESCRIPTION
This pull request updates the project to use new snapshot versions for parent and dependency artifacts. The main focus is on aligning the build and common dependency versions to `1.0.0-SNAPSHOT` across the project.

**Dependency and version updates:**

* Updated parent version in `pom.xml` to `1.0.0-SNAPSHOT` for the main project build parent.
* Updated `embabel-common.version` property in `pom.xml` to `1.0.0-SNAPSHOT`.
* Updated parent version in `embabel-agent-dependencies/pom.xml` to `1.0.0-SNAPSHOT`.