### PR TITLE
bug: JacksonOutputConverter breaks valid LLM response containing mermaid diagram

### DIFF
--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt
@@ -149,6 +149,17 @@ open class JacksonOutputConverter<T> protected constructor(
             return lenientMapper.readValue<Any?>(unwrapped, lenientMapper.constructType(this.type)) as T?
         } catch (e: JsonProcessingException) {
             logger.warn(
+                "Could not parse the given text to the desired target type. Don't panic: will try to fix it for you",
+                e
+            )
+        }
+        // Fix malformed escaped quotes - this is the one issue Jackson can't handle
+        // because `"key": \"value\"` is fundamentally broken syntax
+        val fixed = fixMalformedEscapedQuotes(unwrapped)
+        try {
+            return lenientMapper.readValue<Any?>(fixed, lenientMapper.constructType(this.type)) as T?
+        } catch (e: JsonProcessingException) {
+            logger.warn(
                 LoggingMarkers.SENSITIVE_DATA_MARKER,
                 "Could not parse the given text to the desired target type: \"{}\" into {}", unwrapped, this.type
             )
@@ -166,10 +177,6 @@ open class JacksonOutputConverter<T> protected constructor(
                 .removeSuffix("```")
                 .trim()
         }
-
-        // Fix malformed escaped quotes - this is the one issue Jackson can't handle
-        // because `"key": \"value\"` is fundamentally broken syntax
-        result = fixMalformedEscapedQuotes(result)
 
         return result
     }

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/converters/JacksonOutputConverterTest.kt
@@ -294,6 +294,22 @@ class JacksonOutputConverterTest {
         }
 
         @Test
+        fun `preserves valid escaped quotes inside mermaid diagram`() {
+            val converter = JacksonOutputConverter(SimpleObject::class.java, objectMapper)
+            val validJson = """{
+                    "name": "flowchart LR\n  a[\"A\"]\n  b[\"B\"]\n  a --> b",
+                    "value": 42
+                }""".trimIndent()
+
+            // Jackson can handle the valid JSON without any changes
+            val actual = objectMapper.readValue(validJson, SimpleObject::class.java)
+            assertThat(actual.name).isEqualTo("flowchart LR\n  a[\"A\"]\n  b[\"B\"]\n  a --> b")
+
+            val result = converter.convert(validJson)
+            assertThat(result?.name).isEqualTo("flowchart LR\n  a[\"A\"]\n  b[\"B\"]\n  a --> b")
+        }
+
+        @Test
         fun `handles mixed valid and malformed escapes`() {
             val converter = JacksonOutputConverter(Proposition::class.java, objectMapper)
             // Mix of valid escaped quotes inside string and malformed at delimiters


### PR DESCRIPTION
# Description

This PR introduces test for `JacksonOutputConverter` for issue breaking valid LLM response containing mermaid diagram.

Review showed that logic in `fixMalformedEscapedQuotes()` causes the issue.

This PR suggest to fix malformed escape chars only if parsing JSON fails.

# Implications
- breaking valid LLM response (e.g from GPT-5) leads to unnecessary retries/cost
- agent goal failes because valid LLM JSON response could not be read

# Background

I am developing MR agent based on embabel inspired by `The PR-Agent` that summarizes PR changes with an overview mermaid diagram (among other things).

# Expected behaviour
- `JacksonOutputConverter` reads JSON

# Actual behaviour
- `JacksonOutputConverter` throws exception

# Resources
- [JacksonOutputConverter](https://github.com/embabel/embabel-agent/blob/a46ec3784baa2a6a42daec15089d82cbd907326d/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/converters/JacksonOutputConverter.kt#L188)