### PR TITLE
 fix(skills): confine script engine inputs to a root and harden both engines (#1754)

### DIFF
--- a/embabel-agent-skills/pom.xml
+++ b/embabel-agent-skills/pom.xml
@@ -82,6 +82,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- A fake secret in the test JVM env, used to assert that skill
+                         scripts do NOT inherit host environment variables. -->
+                    <environmentVariables>
+                        <EMBABEL_TEST_SECRET>s3cr3t-do-not-leak</EMBABEL_TEST_SECRET>
+                    </environmentVariables>
+                </configuration>
             </plugin>
 
         </plugins>

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ConfinedInputResolver.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ConfinedInputResolver.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills.script
+
+import com.embabel.agent.tools.file.FileTools
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Confines skill-script input files to an allowed root and stages produced artifacts so a
+ * later skill can reuse them as input.
+ *
+ * Shared by [ProcessSkillScriptExecutionEngine] and [DockerSkillScriptExecutionEngine] so
+ * the confinement + artifact-chaining behaviour lives in one place instead of being
+ * copy-pasted (and diverging) per engine.
+ *
+ * @param userRoot resolves the user's own input files, rejecting path traversal and files
+ * outside the root.
+ */
+internal class ConfinedInputResolver(
+    private val userRoot: FileTools,
+) {
+
+    /**
+     * Dedicated, engine-owned directory where produced artifacts are kept. It is a
+     * generated temp dir (never the user's working directory), and it is trusted as an
+     * input source so a previous skill's artifact can be reused by the next.
+     */
+    val artifactsRoot: Path = Files.createTempDirectory("skill-artifacts-")
+
+    private val artifactsRootTools: FileTools = FileTools.readWrite(artifactsRoot.toString())
+
+    /**
+     * Resolve an input file against the two allowed roots, in order:
+     *
+     *  1. [userRoot] — where the user's own files live;
+     *  2. the artifacts root — where outputs produced by a previous run are kept, so a
+     *     later skill can reuse them as input.
+     *
+     * Both roots reject path traversal (any path escaping the root).
+     *
+     * We fall back to root 2 ONLY when root 1 throws [SecurityException]. This relies on
+     * [FileTools.resolveAndValidateFile] reporting two failures distinctly:
+     *
+     *  - [SecurityException]        -> the path is *outside* the root. That means "not a user
+     *                                  file", so it is worth retrying against the artifacts root.
+     *  - [IllegalArgumentException] -> the path is *inside* the root but the file is missing
+     *                                  ("file not found"). That is a genuine error, NOT a
+     *                                  wrong-root signal, so we let it propagate unchanged.
+     *
+     * Consequence: a mere typo on a user-dir path stays a clear "file not found" instead of
+     * silently falling through to the artifacts root. A path outside both roots is rejected.
+     *
+     * @throws SecurityException if the path escapes both roots
+     * @throws IllegalArgumentException if the path is inside a root but the file is missing
+     */
+    fun resolve(path: Path): Path =
+        try {
+            userRoot.resolveAndValidateFile(path.toString())
+        } catch (e: SecurityException) {
+            artifactsRootTools.resolveAndValidateFile(path.toString())
+        }
+
+    /**
+     * Copy the regular files in [outputDir] into a fresh run directory under
+     * [artifactsRoot] — so they survive [outputDir]'s cleanup and can be reused as input by
+     * a subsequent skill — and return them as [ScriptArtifact]s sorted by name.
+     */
+    fun stageArtifacts(outputDir: Path): List<ScriptArtifact> {
+        if (!Files.isDirectory(outputDir)) return emptyList()
+        val files = Files.list(outputDir).use { stream ->
+            stream.filter { Files.isRegularFile(it) }.toList()
+        }
+        if (files.isEmpty()) return emptyList()
+
+        val runDir = Files.createTempDirectory(artifactsRoot, "run-")
+        return files
+            .map { file ->
+                val dest = runDir.resolve(file.fileName)
+                Files.copy(file, dest)
+                ScriptArtifact(
+                    name = file.fileName.toString(),
+                    path = dest.toAbsolutePath(),
+                    mimeType = ScriptArtifact.inferMimeType(file.fileName.toString()),
+                    sizeBytes = Files.size(dest),
+                )
+            }
+            .sortedBy { it.name }
+    }
+}

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngine.kt
@@ -17,7 +17,6 @@ package com.embabel.agent.skills.script
 
 import com.embabel.agent.tools.file.FileTools
 import org.slf4j.LoggerFactory
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
@@ -25,7 +24,7 @@ import kotlin.io.path.absolutePathString
 import kotlin.io.path.exists
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.measureTime
+import kotlin.time.measureTimedValue
 
 /**
  * Script execution engine that runs scripts inside a Docker container for sandboxed execution.
@@ -226,53 +225,19 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
             .redirectErrorStream(false)
             .start()
 
-        var stdout = ""
-        var stderr = ""
-        // Start draining stdout/stderr BEFORE writing stdin, so a script that produces
-        // output while still consuming stdin cannot deadlock on a full pipe.
-        val stdoutThread = Thread { stdout = process.inputStream.bufferedReader().readText() }
-            .apply { isDaemon = true; start() }
-        val stderrThread = Thread { stderr = process.errorStream.bufferedReader().readText() }
-            .apply { isDaemon = true; start() }
+        val (io, duration) = measureTimedValue { process.pumpIo(stdin, timeout) }
 
-        // Write stdin on its own thread so a large stdin can't block, and a container that
-        // stops reading early (broken pipe) doesn't fail the whole execution.
-        val stdinThread = Thread {
-            try {
-                if (stdin != null) {
-                    process.outputStream.bufferedWriter().use { it.write(stdin) }
-                } else {
-                    process.outputStream.close()
-                }
-            } catch (e: IOException) {
-                // The container may close its stdin / exit before consuming all input.
-            }
-        }.apply { isDaemon = true; start() }
-
-        val completed: Boolean
-        val duration = measureTime {
-            completed = process.waitFor(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-        }
-
-        if (!completed) {
-            process.destroyForcibly()
-            stdinThread.join(1_000)
-            stdoutThread.join(1_000)
-            stderrThread.join(1_000)
+        if (io.timedOut) {
             logger.warn("Script {} timed out after {}", scriptFileName, timeout)
             return ScriptExecutionResult.Failure(
                 error = "Script execution timed out after $timeout",
-                stderr = stderr.takeIf { it.isNotBlank() },
+                stderr = io.stderr.takeIf { it.isNotBlank() },
                 timedOut = true,
                 duration = duration,
             )
         }
 
-        stdinThread.join()
-        stdoutThread.join()
-        stderrThread.join()
-
-        val exitCode = process.exitValue()
+        val exitCode = io.exitCode!!
         val artifacts = collectArtifacts(outputDir)
 
         logger.debug(
@@ -281,8 +246,8 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
         )
 
         return ScriptExecutionResult.Success(
-            stdout = stdout,
-            stderr = stderr,
+            stdout = io.stdout,
+            stderr = io.stderr,
             exitCode = exitCode,
             duration = duration,
             artifacts = artifacts,

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngine.kt
@@ -65,39 +65,9 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    // Dedicated, engine-owned directory where produced artifacts are kept. It is a
-    // generated temp dir (never the user's working directory), and the engine trusts
-    // it as an input source so a previous skill's artifact can be reused by the next.
-    private val artifactsRoot: Path = Files.createTempDirectory("skill-artifacts-")
-    private val artifactsFileTools: FileTools = FileTools.readWrite(artifactsRoot.toString())
-
-    /**
-     * Resolve an input file against the two allowed roots, in order:
-     *
-     *  1. the user root ([fileTools]) — where the user's own files live;
-     *  2. the engine's artifacts root ([artifactsFileTools]) — where outputs produced by a
-     *     previous run are kept, so a later skill can reuse them as input.
-     *
-     * Both roots reject path traversal (any path escaping the root).
-     *
-     * We fall back to root 2 ONLY when root 1 throws [SecurityException]. This relies on
-     * [FileTools.resolveAndValidateFile] reporting two failures distinctly:
-     *
-     *  - [SecurityException]        -> the path is *outside* the root. That means "not a user
-     *                                  file", so it is worth retrying against the artifacts root.
-     *  - [IllegalArgumentException] -> the path is *inside* the root but the file is missing
-     *                                  ("file not found"). That is a genuine error, NOT a
-     *                                  wrong-root signal, so we let it propagate unchanged.
-     *
-     * Consequence: a mere typo on a user-dir path stays a clear "file not found" instead of
-     * silently falling through to the artifacts root. A path outside both roots is rejected.
-     */
-    private fun resolveInputFile(path: Path): Path =
-        try {
-            fileTools.resolveAndValidateFile(path.toString())
-        } catch (e: SecurityException) {
-            artifactsFileTools.resolveAndValidateFile(path.toString())
-        }
+    // Confines input files to the user root (rejecting path traversal) and stages produced
+    // artifacts so a later skill can reuse them as input.
+    private val inputs = ConfinedInputResolver(fileTools)
 
     override fun supportedLanguages(): Set<ScriptLanguage> = supportedLanguages
 
@@ -129,16 +99,14 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
     ): ScriptExecutionResult {
         validate(script)?.let { return it }
 
-        // Resolve and validate input file paths securely via FileTools
-        val resolvedInputFiles = mutableListOf<Path>()
-        for (inputFile in inputFiles) {
-            try {
-                resolvedInputFiles.add(resolveInputFile(inputFile))
-            } catch (e: SecurityException) {
-                return ScriptExecutionResult.Denied("Path traversal not allowed: $inputFile")
-            } catch (e: IllegalArgumentException) {
-                return ScriptExecutionResult.Denied("Input file error: ${e.message}")
-            }
+        // Resolve and validate input files, confining them to the user root
+        // (rejects path traversal and files outside the root).
+        val resolvedInputFiles = try {
+            inputFiles.map { inputs.resolve(it) }
+        } catch (e: SecurityException) {
+            return ScriptExecutionResult.Denied("Path traversal not allowed: ${e.message}")
+        } catch (e: IllegalArgumentException) {
+            return ScriptExecutionResult.Denied("Input file error: ${e.message}")
         }
 
         // Temp directories: script mount, input files, output artifacts
@@ -238,7 +206,7 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
         }
 
         val exitCode = io.exitCode!!
-        val artifacts = collectArtifacts(outputDir)
+        val artifacts = inputs.stageArtifacts(outputDir)
 
         logger.debug(
             "Script {} completed: exit={}, duration={}, artifacts={}",
@@ -252,31 +220,6 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
             duration = duration,
             artifacts = artifacts,
         )
-    }
-
-    // --- Artifact collection ---
-
-    private fun collectArtifacts(outputDir: Path): List<ScriptArtifact> {
-        if (!Files.isDirectory(outputDir)) return emptyList()
-        // Copy artifacts out of outputDir (before the temp tree is deleted) into the
-        // engine's artifacts root, so a subsequent skill can reuse them as input.
-        val artifactsStaging = Files.createTempDirectory(artifactsRoot, "run-")
-        return Files.list(outputDir).use { files ->
-            files
-                .filter { Files.isRegularFile(it) }
-                .map { file ->
-                    val dest = artifactsStaging.resolve(file.fileName)
-                    Files.copy(file, dest)
-                    ScriptArtifact(
-                        name = file.fileName.toString(),
-                        path = dest.toAbsolutePath(),
-                        mimeType = ScriptArtifact.inferMimeType(file.fileName.toString()),
-                        sizeBytes = Files.size(dest),
-                    )
-                }
-                .toList()
-                .sortedBy { it.name }
-        }
     }
 
     // --- Interpreter selection ---
@@ -329,9 +272,9 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
         fun confinedTo(root: String): DockerSkillScriptExecutionEngine =
             DockerSkillScriptExecutionEngine(fileTools = FileTools.readWrite(root))
 
-        /** Check if Docker is available on this system. */
-        fun isDockerAvailable(): Boolean = try {
-            val process = ProcessBuilder("docker", "version")
+        /** Run `docker <args>`, returning true if it exits 0 within 5 seconds. */
+        private fun dockerCommandSucceeds(vararg args: String): Boolean = try {
+            val process = ProcessBuilder(listOf("docker", *args))
                 .redirectErrorStream(true)
                 .start()
             process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0
@@ -339,15 +282,11 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
             false
         }
 
+        /** Check if Docker is available on this system. */
+        fun isDockerAvailable(): Boolean = dockerCommandSucceeds("version")
+
         /** Check if a Docker image exists locally. */
-        fun imageExists(image: String): Boolean = try {
-            val process = ProcessBuilder("docker", "image", "inspect", image)
-                .redirectErrorStream(true)
-                .start()
-            process.waitFor(5, TimeUnit.SECONDS) && process.exitValue() == 0
-        } catch (e: Exception) {
-            false
-        }
+        fun imageExists(image: String): Boolean = dockerCommandSucceeds("image", "inspect", image)
 
         /**
          * Ensure the default sandbox image exists, logging build instructions if not.

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngine.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.skills.script
 
 import com.embabel.agent.tools.file.FileTools
 import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
@@ -72,14 +73,25 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
     private val artifactsFileTools: FileTools = FileTools.readWrite(artifactsRoot.toString())
 
     /**
-     * Resolve an input file. Validated against the user root first.
+     * Resolve an input file against the two allowed roots, in order:
      *
-     * The fallback to the engine's artifacts root fires ONLY on [SecurityException] —
-     * i.e. the path is *outside* the user root, a definitive signal that it isn't a
-     * user file. A path that is under the user root but missing throws
-     * [IllegalArgumentException] instead ("file not found"), which is NOT caught here
-     * and stays a normal error — so an LLM fumbling a working-dir path is unaffected.
-     * Anything outside both roots is rejected.
+     *  1. the user root ([fileTools]) — where the user's own files live;
+     *  2. the engine's artifacts root ([artifactsFileTools]) — where outputs produced by a
+     *     previous run are kept, so a later skill can reuse them as input.
+     *
+     * Both roots reject path traversal (any path escaping the root).
+     *
+     * We fall back to root 2 ONLY when root 1 throws [SecurityException]. This relies on
+     * [FileTools.resolveAndValidateFile] reporting two failures distinctly:
+     *
+     *  - [SecurityException]        -> the path is *outside* the root. That means "not a user
+     *                                  file", so it is worth retrying against the artifacts root.
+     *  - [IllegalArgumentException] -> the path is *inside* the root but the file is missing
+     *                                  ("file not found"). That is a genuine error, NOT a
+     *                                  wrong-root signal, so we let it propagate unchanged.
+     *
+     * Consequence: a mere typo on a user-dir path stays a clear "file not found" instead of
+     * silently falling through to the artifacts root. A path outside both roots is rejected.
      */
     private fun resolveInputFile(path: Path): Path =
         try {
@@ -171,7 +183,9 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
         outputDir: Path,
     ): List<String> {
         return buildList {
-            add("docker"); add("run"); add("--rm")
+            // -i keeps the container's stdin open so a provided stdin is actually
+            // delivered; without it Docker attaches stdin to /dev/null and drops it.
+            add("docker"); add("run"); add("--rm"); add("-i")
 
             memoryLimit?.let { addAll(listOf("--memory", it)) }
             cpuLimit?.let { addAll(listOf("--cpus", it)) }
@@ -212,18 +226,28 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
             .redirectErrorStream(false)
             .start()
 
-        if (stdin != null) {
-            process.outputStream.bufferedWriter().use { it.write(stdin) }
-        } else {
-            process.outputStream.close()
-        }
-
         var stdout = ""
         var stderr = ""
+        // Start draining stdout/stderr BEFORE writing stdin, so a script that produces
+        // output while still consuming stdin cannot deadlock on a full pipe.
         val stdoutThread = Thread { stdout = process.inputStream.bufferedReader().readText() }
             .apply { isDaemon = true; start() }
         val stderrThread = Thread { stderr = process.errorStream.bufferedReader().readText() }
             .apply { isDaemon = true; start() }
+
+        // Write stdin on its own thread so a large stdin can't block, and a container that
+        // stops reading early (broken pipe) doesn't fail the whole execution.
+        val stdinThread = Thread {
+            try {
+                if (stdin != null) {
+                    process.outputStream.bufferedWriter().use { it.write(stdin) }
+                } else {
+                    process.outputStream.close()
+                }
+            } catch (e: IOException) {
+                // The container may close its stdin / exit before consuming all input.
+            }
+        }.apply { isDaemon = true; start() }
 
         val completed: Boolean
         val duration = measureTime {
@@ -232,6 +256,7 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
 
         if (!completed) {
             process.destroyForcibly()
+            stdinThread.join(1_000)
             stdoutThread.join(1_000)
             stderrThread.join(1_000)
             logger.warn("Script {} timed out after {}", scriptFileName, timeout)
@@ -243,6 +268,7 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
             )
         }
 
+        stdinThread.join()
         stdoutThread.join()
         stderrThread.join()
 

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngine.kt
@@ -65,6 +65,29 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    // Dedicated, engine-owned directory where produced artifacts are kept. It is a
+    // generated temp dir (never the user's working directory), and the engine trusts
+    // it as an input source so a previous skill's artifact can be reused by the next.
+    private val artifactsRoot: Path = Files.createTempDirectory("skill-artifacts-")
+    private val artifactsFileTools: FileTools = FileTools.readWrite(artifactsRoot.toString())
+
+    /**
+     * Resolve an input file. Validated against the user root first.
+     *
+     * The fallback to the engine's artifacts root fires ONLY on [SecurityException] —
+     * i.e. the path is *outside* the user root, a definitive signal that it isn't a
+     * user file. A path that is under the user root but missing throws
+     * [IllegalArgumentException] instead ("file not found"), which is NOT caught here
+     * and stays a normal error — so an LLM fumbling a working-dir path is unaffected.
+     * Anything outside both roots is rejected.
+     */
+    private fun resolveInputFile(path: Path): Path =
+        try {
+            fileTools.resolveAndValidateFile(path.toString())
+        } catch (e: SecurityException) {
+            artifactsFileTools.resolveAndValidateFile(path.toString())
+        }
+
     override fun supportedLanguages(): Set<ScriptLanguage> = supportedLanguages
 
     override fun validate(script: SkillScript): ScriptExecutionResult.Denied? {
@@ -99,7 +122,7 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
         val resolvedInputFiles = mutableListOf<Path>()
         for (inputFile in inputFiles) {
             try {
-                resolvedInputFiles.add(fileTools.resolveAndValidateFile(inputFile.toString()))
+                resolvedInputFiles.add(resolveInputFile(inputFile))
             } catch (e: SecurityException) {
                 return ScriptExecutionResult.Denied("Path traversal not allowed: $inputFile")
             } catch (e: IllegalArgumentException) {
@@ -117,9 +140,10 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
             // Stage the script file into its own mount directory
             Files.copy(script.scriptPath, scriptDir.resolve(script.fileName))
 
-            // Stage input files
+            // Stage input files (unique names so same-named inputs from different
+            // folders don't collide).
             for (inputFile in resolvedInputFiles) {
-                Files.copy(inputFile, inputDir.resolve(inputFile.fileName))
+                copyIntoUniqueName(inputFile, inputDir)
             }
 
             val interpreter = interpreterFor(script.language)
@@ -243,8 +267,9 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
 
     private fun collectArtifacts(outputDir: Path): List<ScriptArtifact> {
         if (!Files.isDirectory(outputDir)) return emptyList()
-        // Copy artifacts out of outputDir before the temp tree is deleted
-        val artifactsStaging = Files.createTempDirectory("skills-artifacts-")
+        // Copy artifacts out of outputDir (before the temp tree is deleted) into the
+        // engine's artifacts root, so a subsequent skill can reuse them as input.
+        val artifactsStaging = Files.createTempDirectory(artifactsRoot, "run-")
         return Files.list(outputDir).use { files ->
             files
                 .filter { Files.isRegularFile(it) }
@@ -299,6 +324,19 @@ class DockerSkillScriptExecutionEngine @JvmOverloads constructor(
         const val DEFAULT_IMAGE = "embabel/agent-sandbox:latest"
 
         private val logger = LoggerFactory.getLogger(DockerSkillScriptExecutionEngine::class.java)
+
+        /**
+         * Create an engine confined to [root]: input files are resolved against [root]
+         * and anything outside it (absolute paths, `..` traversal) is rejected.
+         *
+         * Java-friendly entry point. Kotlin callers can pass `fileTools` directly via the
+         * constructor's named argument; Java cannot reach it (the leading `Duration`
+         * value-class parameter makes the deeper constructor overloads synthetic), so this
+         * factory exposes the one knob a per-request/multi-tenant caller needs.
+         */
+        @JvmStatic
+        fun confinedTo(root: String): DockerSkillScriptExecutionEngine =
+            DockerSkillScriptExecutionEngine(fileTools = FileTools.readWrite(root))
 
         /** Check if Docker is available on this system. */
         fun isDockerAvailable(): Boolean = try {

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngine.kt
@@ -41,17 +41,17 @@ import kotlin.time.measureTimedValue
  * - Development and testing environments
  * - Scenarios where OS-level user permissions provide adequate isolation
  *
- * For untrusted scripts, consider using [DockerSkillScriptExecutionEngine] or
- * [GraalVMExecutionEngine] which provide stronger isolation.
+ * For untrusted scripts, consider using [DockerSkillScriptExecutionEngine], which
+ * provides stronger isolation.
  *
  * @param timeout maximum execution time before the process is killed
  * @param supportedLanguages languages this engine will execute (defaults to all)
  * @param interpreters map of language to interpreter command
  * @param environment environment variables to pass to scripts (always passed through)
  * @param inheritEnvironment whether to inherit the FULL host environment. Defaults to
- * false: only a safe allowlist ([SAFE_ENV_ALLOWLIST], e.g. PATH/HOME) is passed, so
- * scripts can find interpreters without seeing host secrets (API keys, etc.). Set true
- * to opt into full inheritance.
+ * true (scripts see the host env, including any secrets). Set false to restrict scripts
+ * to [environmentAllowlist] (a safe subset, e.g. PATH/HOME) so they can find interpreters
+ * without seeing host secrets (API keys, etc.).
  * @param environmentAllowlist host variables passed through when [inheritEnvironment] is
  * false (defaults to [SAFE_ENV_ALLOWLIST]); override to add or restrict variables
  * @param fileTools resolves and validates input file paths against a root, rejecting path
@@ -62,7 +62,7 @@ class ProcessSkillScriptExecutionEngine @JvmOverloads constructor(
     private val supportedLanguages: Set<ScriptLanguage> = ScriptLanguage.entries.toSet(),
     private val interpreters: Map<ScriptLanguage, List<String>> = defaultInterpreters,
     private val environment: Map<String, String> = emptyMap(),
-    private val inheritEnvironment: Boolean = false,
+    private val inheritEnvironment: Boolean = true,
     private val environmentAllowlist: Set<String> = SAFE_ENV_ALLOWLIST,
     private val fileTools: FileTools = FileTools.readWrite(System.getProperty("user.dir")),
 ) : SkillScriptExecutionEngine {
@@ -76,14 +76,25 @@ class ProcessSkillScriptExecutionEngine @JvmOverloads constructor(
     private val artifactsFileTools: FileTools = FileTools.readWrite(artifactsRoot.toString())
 
     /**
-     * Resolve an input file. Validated against the user root first.
+     * Resolve an input file against the two allowed roots, in order:
      *
-     * The fallback to the engine's artifacts root fires ONLY on [SecurityException] —
-     * i.e. the path is *outside* the user root, a definitive signal that it isn't a
-     * user file. A path that is under the user root but missing throws
-     * [IllegalArgumentException] instead ("file not found"), which is NOT caught here
-     * and stays a normal error — so an LLM fumbling a working-dir path is unaffected.
-     * Anything outside both roots is rejected.
+     *  1. the user root ([fileTools]) — where the user's own files live;
+     *  2. the engine's artifacts root ([artifactsFileTools]) — where outputs produced by a
+     *     previous run are kept, so a later skill can reuse them as input.
+     *
+     * Both roots reject path traversal (any path escaping the root).
+     *
+     * We fall back to root 2 ONLY when root 1 throws [SecurityException]. This relies on
+     * [FileTools.resolveAndValidateFile] reporting two failures distinctly:
+     *
+     *  - [SecurityException]        -> the path is *outside* the root. That means "not a user
+     *                                  file", so it is worth retrying against the artifacts root.
+     *  - [IllegalArgumentException] -> the path is *inside* the root but the file is missing
+     *                                  ("file not found"). That is a genuine error, NOT a
+     *                                  wrong-root signal, so we let it propagate unchanged.
+     *
+     * Consequence: a mere typo on a user-dir path stays a clear "file not found" instead of
+     * silently falling through to the artifacts root. A path outside both roots is rejected.
      */
     private fun resolveInputFile(path: Path): Path =
         try {

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngine.kt
@@ -18,10 +18,8 @@ package com.embabel.agent.skills.script
 import com.embabel.agent.tools.file.FileTools
 import org.slf4j.LoggerFactory
 import java.io.File
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTimedValue
@@ -355,57 +353,17 @@ class ProcessSkillScriptExecutionEngine @JvmOverloads constructor(
             // Add OUTPUT_DIR for scripts to write artifacts
             env["OUTPUT_DIR"] = outputDir.toAbsolutePath().toString()
 
-            val process = processBuilder.start()
+            val io = processBuilder.start().pumpIo(stdin, timeout)
 
-            var stdout = ""
-            var stderr = ""
-
-            // Start draining stdout/stderr BEFORE writing stdin, so a script that
-            // produces output while still consuming stdin cannot deadlock on a full pipe.
-            val stdoutThread = Thread {
-                stdout = process.inputStream.bufferedReader().readText()
-            }.apply { start() }
-
-            val stderrThread = Thread {
-                stderr = process.errorStream.bufferedReader().readText()
-            }.apply { start() }
-
-            // Write stdin on its own thread so a large stdin can't block, and a script
-            // that stops reading early (broken pipe) doesn't fail the whole execution.
-            val stdinThread = Thread {
-                try {
-                    if (stdin != null) {
-                        process.outputStream.bufferedWriter().use { it.write(stdin) }
-                    } else {
-                        process.outputStream.close()
-                    }
-                } catch (e: IOException) {
-                    // The process may close its stdin / exit before consuming all input.
-                }
-            }.apply { start() }
-
-            // Wait for process with timeout
-            val completed = process.waitFor(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-
-            if (!completed) {
-                process.destroyForcibly()
-                stdinThread.join(1000)
-                stdoutThread.join(1000)
-                stderrThread.join(1000)
-
-                return ProcessResult.TimedOut(stderr)
+            if (io.timedOut) {
+                ProcessResult.TimedOut(io.stderr)
+            } else {
+                ProcessResult.Completed(
+                    exitCode = io.exitCode!!,
+                    stdout = io.stdout,
+                    stderr = io.stderr,
+                )
             }
-
-            // Wait for the stdin writer and output readers to complete
-            stdinThread.join()
-            stdoutThread.join()
-            stderrThread.join()
-
-            ProcessResult.Completed(
-                exitCode = process.exitValue(),
-                stdout = stdout,
-                stderr = stderr,
-            )
         } catch (e: Exception) {
             ProcessResult.Failed(e.message ?: "Unknown error starting process")
         }

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngine.kt
@@ -67,39 +67,9 @@ class ProcessSkillScriptExecutionEngine @JvmOverloads constructor(
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
-    // Dedicated, engine-owned directory where produced artifacts are kept. It is a
-    // generated temp dir (never the user's working directory), and the engine trusts
-    // it as an input source so a previous skill's artifact can be reused by the next.
-    private val artifactsRoot: Path = Files.createTempDirectory("skill-artifacts-")
-    private val artifactsFileTools: FileTools = FileTools.readWrite(artifactsRoot.toString())
-
-    /**
-     * Resolve an input file against the two allowed roots, in order:
-     *
-     *  1. the user root ([fileTools]) — where the user's own files live;
-     *  2. the engine's artifacts root ([artifactsFileTools]) — where outputs produced by a
-     *     previous run are kept, so a later skill can reuse them as input.
-     *
-     * Both roots reject path traversal (any path escaping the root).
-     *
-     * We fall back to root 2 ONLY when root 1 throws [SecurityException]. This relies on
-     * [FileTools.resolveAndValidateFile] reporting two failures distinctly:
-     *
-     *  - [SecurityException]        -> the path is *outside* the root. That means "not a user
-     *                                  file", so it is worth retrying against the artifacts root.
-     *  - [IllegalArgumentException] -> the path is *inside* the root but the file is missing
-     *                                  ("file not found"). That is a genuine error, NOT a
-     *                                  wrong-root signal, so we let it propagate unchanged.
-     *
-     * Consequence: a mere typo on a user-dir path stays a clear "file not found" instead of
-     * silently falling through to the artifacts root. A path outside both roots is rejected.
-     */
-    private fun resolveInputFile(path: Path): Path =
-        try {
-            fileTools.resolveAndValidateFile(path.toString())
-        } catch (e: SecurityException) {
-            artifactsFileTools.resolveAndValidateFile(path.toString())
-        }
+    // Confines input files to the user root (rejecting path traversal) and stages produced
+    // artifacts so a later skill can reuse them as input.
+    private val inputs = ConfinedInputResolver(fileTools)
 
     companion object {
         /**
@@ -185,7 +155,7 @@ class ProcessSkillScriptExecutionEngine @JvmOverloads constructor(
         // Resolve and validate input files, confining them to the fileTools root
         // (rejects path traversal and files outside the root, like the Docker engine).
         val resolvedInputFiles = try {
-            inputFiles.map { resolveInputFile(it) }
+            inputFiles.map { inputs.resolve(it) }
         } catch (e: SecurityException) {
             return ScriptExecutionResult.Denied("Path traversal not allowed: ${e.message}")
         } catch (e: IllegalArgumentException) {
@@ -225,7 +195,7 @@ class ProcessSkillScriptExecutionEngine @JvmOverloads constructor(
 
             when (result) {
                 is ProcessResult.Completed -> {
-                    val artifacts = collectArtifacts(outputDir)
+                    val artifacts = inputs.stageArtifacts(outputDir)
                     logger.debug(
                         "Script {} completed with exit code {} in {}, produced {} artifacts",
                         script.fileName,
@@ -276,38 +246,6 @@ class ProcessSkillScriptExecutionEngine @JvmOverloads constructor(
                 error = "Unexpected error: ${e.message}",
             )
         }
-    }
-
-    /**
-     * Collect artifacts from the output directory.
-     */
-    private fun collectArtifacts(outputDir: Path): List<ScriptArtifact> {
-        if (!Files.isDirectory(outputDir)) {
-            return emptyList()
-        }
-
-        val files = Files.list(outputDir).use { stream ->
-            stream.filter { Files.isRegularFile(it) }.toList()
-        }
-        if (files.isEmpty()) {
-            return emptyList()
-        }
-
-        // Copy artifacts into the engine's artifacts root so a subsequent skill can
-        // reuse them as input (they would be rejected from a system temp dir).
-        val runArtifacts = Files.createTempDirectory(artifactsRoot, "run-")
-        return files
-            .map { file ->
-                val dest = runArtifacts.resolve(file.fileName)
-                Files.copy(file, dest)
-                ScriptArtifact(
-                    name = file.fileName.toString(),
-                    path = dest.toAbsolutePath(),
-                    mimeType = ScriptArtifact.inferMimeType(file.fileName.toString()),
-                    sizeBytes = Files.size(dest),
-                )
-            }
-            .sortedBy { it.name }
     }
 
     /**

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngine.kt
@@ -15,8 +15,10 @@
  */
 package com.embabel.agent.skills.script
 
+import com.embabel.agent.tools.file.FileTools
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
@@ -45,20 +47,76 @@ import kotlin.time.measureTimedValue
  * @param timeout maximum execution time before the process is killed
  * @param supportedLanguages languages this engine will execute (defaults to all)
  * @param interpreters map of language to interpreter command
- * @param environment environment variables to pass to scripts (defaults to inheriting current env)
- * @param inheritEnvironment whether to inherit the current process environment
+ * @param environment environment variables to pass to scripts (always passed through)
+ * @param inheritEnvironment whether to inherit the FULL host environment. Defaults to
+ * false: only a safe allowlist ([SAFE_ENV_ALLOWLIST], e.g. PATH/HOME) is passed, so
+ * scripts can find interpreters without seeing host secrets (API keys, etc.). Set true
+ * to opt into full inheritance.
+ * @param environmentAllowlist host variables passed through when [inheritEnvironment] is
+ * false (defaults to [SAFE_ENV_ALLOWLIST]); override to add or restrict variables
+ * @param fileTools resolves and validates input file paths against a root, rejecting path
+ * traversal and files outside the root (defaults to the current working directory)
  */
-class ProcessSkillScriptExecutionEngine(
+class ProcessSkillScriptExecutionEngine @JvmOverloads constructor(
     private val timeout: Duration = 30.seconds,
     private val supportedLanguages: Set<ScriptLanguage> = ScriptLanguage.entries.toSet(),
     private val interpreters: Map<ScriptLanguage, List<String>> = defaultInterpreters,
     private val environment: Map<String, String> = emptyMap(),
-    private val inheritEnvironment: Boolean = true,
+    private val inheritEnvironment: Boolean = false,
+    private val environmentAllowlist: Set<String> = SAFE_ENV_ALLOWLIST,
+    private val fileTools: FileTools = FileTools.readWrite(System.getProperty("user.dir")),
 ) : SkillScriptExecutionEngine {
 
     private val logger = LoggerFactory.getLogger(javaClass)
 
+    // Dedicated, engine-owned directory where produced artifacts are kept. It is a
+    // generated temp dir (never the user's working directory), and the engine trusts
+    // it as an input source so a previous skill's artifact can be reused by the next.
+    private val artifactsRoot: Path = Files.createTempDirectory("skill-artifacts-")
+    private val artifactsFileTools: FileTools = FileTools.readWrite(artifactsRoot.toString())
+
+    /**
+     * Resolve an input file. Validated against the user root first.
+     *
+     * The fallback to the engine's artifacts root fires ONLY on [SecurityException] —
+     * i.e. the path is *outside* the user root, a definitive signal that it isn't a
+     * user file. A path that is under the user root but missing throws
+     * [IllegalArgumentException] instead ("file not found"), which is NOT caught here
+     * and stays a normal error — so an LLM fumbling a working-dir path is unaffected.
+     * Anything outside both roots is rejected.
+     */
+    private fun resolveInputFile(path: Path): Path =
+        try {
+            fileTools.resolveAndValidateFile(path.toString())
+        } catch (e: SecurityException) {
+            artifactsFileTools.resolveAndValidateFile(path.toString())
+        }
+
     companion object {
+        /**
+         * Create an engine confined to [root]: input files are resolved against [root]
+         * and anything outside it (absolute paths, `..` traversal) is rejected.
+         *
+         * Java-friendly entry point. Kotlin callers can pass `fileTools` directly via the
+         * constructor's named argument; Java cannot reach it (the leading `Duration`
+         * value-class parameter makes the deeper constructor overloads synthetic), so this
+         * factory exposes the one knob a per-request/multi-tenant caller needs.
+         */
+        @JvmStatic
+        fun confinedTo(root: String): ProcessSkillScriptExecutionEngine =
+            ProcessSkillScriptExecutionEngine(fileTools = FileTools.readWrite(root))
+
+        /**
+         * Environment variables passed through to scripts when the full host environment
+         * is not inherited. Enough to locate and run interpreters, without leaking host
+         * secrets (API keys, tokens, ...).
+         */
+        val SAFE_ENV_ALLOWLIST: Set<String> = setOf(
+            "PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TMPDIR", "TERM", "TZ",
+            // Windows equivalents
+            "SystemRoot", "SystemDrive", "TEMP", "TMP", "USERPROFILE", "PATHEXT",
+        )
+
         /**
          * Default interpreters for each language.
          * The script path will be appended to this command.
@@ -115,14 +173,14 @@ class ProcessSkillScriptExecutionEngine(
         // Validate first
         validate(script)?.let { return it }
 
-        // Validate input files exist
-        for (inputFile in inputFiles) {
-            if (!Files.exists(inputFile)) {
-                return ScriptExecutionResult.Denied("Input file does not exist: $inputFile")
-            }
-            if (!Files.isRegularFile(inputFile)) {
-                return ScriptExecutionResult.Denied("Input path is not a file: $inputFile")
-            }
+        // Resolve and validate input files, confining them to the fileTools root
+        // (rejects path traversal and files outside the root, like the Docker engine).
+        val resolvedInputFiles = try {
+            inputFiles.map { resolveInputFile(it) }
+        } catch (e: SecurityException) {
+            return ScriptExecutionResult.Denied("Path traversal not allowed: ${e.message}")
+        } catch (e: IllegalArgumentException) {
+            return ScriptExecutionResult.Denied("Input file error: ${e.message}")
         }
 
         val interpreter = interpreters[script.language]!!
@@ -137,10 +195,10 @@ class ProcessSkillScriptExecutionEngine(
         logger.debug("Created output directory: {}", outputDir)
 
         return try {
-            // Copy input files to input directory
-            for (inputFile in inputFiles) {
-                val targetPath = inputDir.resolve(inputFile.fileName)
-                Files.copy(inputFile, targetPath)
+            // Copy input files to input directory (unique names so same-named inputs
+            // from different folders don't collide).
+            for (inputFile in resolvedInputFiles) {
+                val targetPath = copyIntoUniqueName(inputFile, inputDir)
                 logger.debug("Copied input file {} to {}", inputFile, targetPath)
             }
 
@@ -166,8 +224,10 @@ class ProcessSkillScriptExecutionEngine(
                         duration,
                         artifacts.size
                     )
-                    // Clean up input directory (no longer needed)
+                    // Artifacts are copied to the artifacts root, so both temp dirs
+                    // can be cleaned up now.
                     cleanupDirectory(inputDir)
+                    cleanupDirectory(outputDir)
                     ScriptExecutionResult.Success(
                         stdout = result.stdout,
                         stderr = result.stderr,
@@ -217,17 +277,27 @@ class ProcessSkillScriptExecutionEngine(
             return emptyList()
         }
 
-        return Files.list(outputDir)
-            .filter { Files.isRegularFile(it) }
+        val files = Files.list(outputDir).use { stream ->
+            stream.filter { Files.isRegularFile(it) }.toList()
+        }
+        if (files.isEmpty()) {
+            return emptyList()
+        }
+
+        // Copy artifacts into the engine's artifacts root so a subsequent skill can
+        // reuse them as input (they would be rejected from a system temp dir).
+        val runArtifacts = Files.createTempDirectory(artifactsRoot, "run-")
+        return files
             .map { file ->
+                val dest = runArtifacts.resolve(file.fileName)
+                Files.copy(file, dest)
                 ScriptArtifact(
                     name = file.fileName.toString(),
-                    path = file.toAbsolutePath(),
+                    path = dest.toAbsolutePath(),
                     mimeType = ScriptArtifact.inferMimeType(file.fileName.toString()),
-                    sizeBytes = Files.size(file),
+                    sizeBytes = Files.size(dest),
                 )
             }
-            .toList()
             .sortedBy { it.name }
     }
 
@@ -259,7 +329,12 @@ class ProcessSkillScriptExecutionEngine(
             // Set up environment
             val env = processBuilder.environment()
             if (!inheritEnvironment) {
+                // Secure default: don't hand the full host environment (API keys, other
+                // secrets) to scripts. Keep only a safe allowlist — enough to locate and
+                // run interpreters.
+                val allowed = env.filterKeys { it in environmentAllowlist }
                 env.clear()
+                env.putAll(allowed)
             }
             env.putAll(environment)
 
@@ -271,19 +346,11 @@ class ProcessSkillScriptExecutionEngine(
 
             val process = processBuilder.start()
 
-            // Write stdin if provided
-            if (stdin != null) {
-                process.outputStream.bufferedWriter().use { writer ->
-                    writer.write(stdin)
-                }
-            } else {
-                process.outputStream.close()
-            }
-
-            // Read stdout and stderr concurrently to avoid blocking
             var stdout = ""
             var stderr = ""
 
+            // Start draining stdout/stderr BEFORE writing stdin, so a script that
+            // produces output while still consuming stdin cannot deadlock on a full pipe.
             val stdoutThread = Thread {
                 stdout = process.inputStream.bufferedReader().readText()
             }.apply { start() }
@@ -292,18 +359,34 @@ class ProcessSkillScriptExecutionEngine(
                 stderr = process.errorStream.bufferedReader().readText()
             }.apply { start() }
 
+            // Write stdin on its own thread so a large stdin can't block, and a script
+            // that stops reading early (broken pipe) doesn't fail the whole execution.
+            val stdinThread = Thread {
+                try {
+                    if (stdin != null) {
+                        process.outputStream.bufferedWriter().use { it.write(stdin) }
+                    } else {
+                        process.outputStream.close()
+                    }
+                } catch (e: IOException) {
+                    // The process may close its stdin / exit before consuming all input.
+                }
+            }.apply { start() }
+
             // Wait for process with timeout
             val completed = process.waitFor(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
 
             if (!completed) {
                 process.destroyForcibly()
+                stdinThread.join(1000)
                 stdoutThread.join(1000)
                 stderrThread.join(1000)
 
                 return ProcessResult.TimedOut(stderr)
             }
 
-            // Wait for output readers to complete
+            // Wait for the stdin writer and output readers to complete
+            stdinThread.join()
             stdoutThread.join()
             stderrThread.join()
 

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/SkillScriptExecutionEngine.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/SkillScriptExecutionEngine.kt
@@ -30,10 +30,9 @@ import java.nio.file.Path
  * ## Sandboxing Strategies
  *
  * Different implementations may provide varying levels of isolation:
- * - **NoOpExecutionEngine**: Denies all execution (safe default)
- * - **ProcessExecutionEngine**: Runs scripts as subprocesses with OS-level isolation
- * - **DockerExecutionEngine**: Runs scripts in ephemeral containers (strongest isolation)
- * - **GraalVMExecutionEngine**: Uses GraalVM polyglot sandboxing for JS/Python
+ * - [NoOpExecutionEngine]: Denies all execution (safe default)
+ * - [ProcessSkillScriptExecutionEngine]: Runs scripts as subprocesses with OS-level isolation
+ * - [DockerSkillScriptExecutionEngine]: Runs scripts in ephemeral containers (strongest isolation)
  *
  * @see ScriptExecutionResult
  * @see SkillScript

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/inputStaging.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/inputStaging.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills.script
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Copy [source] into [dir] under its file name, disambiguating with a numeric suffix
+ * (e.g. `report.csv` -> `report-1.csv`) when that name is already taken. This lets
+ * several input files that share a base name (from different folders) coexist in a flat
+ * input directory instead of colliding on the same target.
+ *
+ * @return the path the file was copied to
+ */
+internal fun copyIntoUniqueName(source: Path, dir: Path): Path {
+    val name = source.fileName.toString()
+    var target = dir.resolve(name)
+    if (Files.exists(target)) {
+        val dot = name.lastIndexOf('.')
+        val base = if (dot > 0) name.substring(0, dot) else name
+        val ext = if (dot > 0) name.substring(dot) else ""
+        var i = 1
+        do {
+            target = dir.resolve("$base-$i$ext")
+            i++
+        } while (Files.exists(target))
+    }
+    Files.copy(source, target)
+    return target
+}

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/processIo.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/processIo.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills.script
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+
+/**
+ * Outcome of running a process with deadlock-safe I/O pumping.
+ *
+ * [exitCode] is null exactly when the process timed out ([timedOut] is true).
+ */
+internal data class ProcessIoResult(
+    val exitCode: Int?,
+    val stdout: String,
+    val stderr: String,
+    val timedOut: Boolean,
+)
+
+/**
+ * Run a started [Process] to completion (or [timeout]) without deadlocking.
+ *
+ * stdout and stderr are drained on their own threads STARTED BEFORE stdin is written, so
+ * a process that produces output while still consuming stdin cannot deadlock on a full
+ * pipe. stdin is written on a third thread, and an [IOException] (the process closed its
+ * stdin / exited early) is swallowed rather than failing the whole execution. On timeout
+ * the process is force-killed. All three threads are daemon so they never block JVM exit.
+ *
+ * Both script engines share this so the deadlock-safe pattern lives in one place instead
+ * of being copy-pasted (and diverging) per engine.
+ */
+internal fun Process.pumpIo(stdin: String?, timeout: Duration): ProcessIoResult {
+    var stdout = ""
+    var stderr = ""
+    val stdoutThread = Thread { stdout = inputStream.bufferedReader().readText() }
+        .apply { isDaemon = true; start() }
+    val stderrThread = Thread { stderr = errorStream.bufferedReader().readText() }
+        .apply { isDaemon = true; start() }
+    val stdinThread = Thread {
+        try {
+            if (stdin != null) {
+                outputStream.bufferedWriter().use { it.write(stdin) }
+            } else {
+                outputStream.close()
+            }
+        } catch (e: IOException) {
+            // The process may close its stdin / exit before consuming all input.
+        }
+    }.apply { isDaemon = true; start() }
+
+    val completed = waitFor(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+    if (!completed) {
+        destroyForcibly()
+        stdinThread.join(1_000)
+        stdoutThread.join(1_000)
+        stderrThread.join(1_000)
+        return ProcessIoResult(exitCode = null, stdout = stdout, stderr = stderr, timedOut = true)
+    }
+
+    stdinThread.join()
+    stdoutThread.join()
+    stderrThread.join()
+    return ProcessIoResult(exitCode = exitValue(), stdout = stdout, stderr = stderr, timedOut = false)
+}

--- a/embabel-agent-skills/src/test/java/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngineJavaTest.java
+++ b/embabel-agent-skills/src/test/java/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngineJavaTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills.script;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Verifies that {@link DockerSkillScriptExecutionEngine} is constructable from Java,
+ * including via the {@code confinedTo(root)} factory.
+ *
+ * <p>Constructing the engine and reading {@code supportedLanguages()} does not require
+ * Docker (only {@code execute()} does), so these tests run without a Docker daemon.
+ */
+class DockerSkillScriptExecutionEngineJavaTest {
+
+    @Test
+    void constructableFromJavaWithDefaults() {
+        DockerSkillScriptExecutionEngine engine = new DockerSkillScriptExecutionEngine();
+
+        assertNotNull(engine);
+        // A real engine (unlike NoOpExecutionEngine) supports at least one language.
+        assertFalse(engine.supportedLanguages().isEmpty());
+    }
+
+    /**
+     * The {@code confinedTo(root)} factory lets a Java caller set the confinement root
+     * per request; this test would not compile if it were not Java-callable.
+     *
+     * <p>Scope: Java-callability only — driving confinement end-to-end needs a Docker
+     * daemon, and the confinement itself goes through the same
+     * {@code resolveInputFile} / {@code resolveAndValidateFile} path as the process
+     * engine, whose behaviour is covered in {@code ProcessSkillScriptExecutionEngineJavaTest}.
+     */
+    @Test
+    void confinedToFactoryIsCallableFromJava(@TempDir Path root) {
+        DockerSkillScriptExecutionEngine engine =
+                DockerSkillScriptExecutionEngine.confinedTo(root.toString());
+
+        assertNotNull(engine);
+        assertFalse(engine.supportedLanguages().isEmpty());
+    }
+}

--- a/embabel-agent-skills/src/test/java/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngineJavaTest.java
+++ b/embabel-agent-skills/src/test/java/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngineJavaTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills.script;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies {@link ProcessSkillScriptExecutionEngine} from Java.
+ *
+ * <p>The engine's primary constructor takes a {@code kotlin.time.Duration} (an inline
+ * value class), so without {@code @JvmOverloads} the only public constructors are
+ * name-mangled synthetic ones that {@code javac} refuses — this class would not compile.
+ */
+class ProcessSkillScriptExecutionEngineJavaTest {
+
+    @Test
+    void constructableFromJavaWithDefaults() {
+        ProcessSkillScriptExecutionEngine engine = new ProcessSkillScriptExecutionEngine();
+
+        assertNotNull(engine);
+        // A real engine (unlike NoOpExecutionEngine) supports at least one language.
+        assertFalse(engine.supportedLanguages().isEmpty());
+    }
+
+    /**
+     * The point of {@code confinedTo(root)} is to let a Java caller choose the
+     * confinement root per request. This drives the engine end-to-end to prove the root
+     * is actually honoured — not merely that the factory returns an engine: an input
+     * <em>under</em> the given root is accepted, an input <em>outside</em> it is denied.
+     *
+     * <p>The accepted-input assertion is what makes this discriminating: both files live
+     * under JUnit temp dirs, i.e. outside the engine's default root ({@code user.dir}).
+     * If {@code confinedTo} ignored our root, the in-root input would be denied too and
+     * this test would fail.
+     */
+    @Test
+    @EnabledOnOs({OS.MAC, OS.LINUX})
+    void confinedToHonoursTheGivenRoot(@TempDir Path root, @TempDir Path outsideRoot) throws IOException {
+        // A skill script that echoes whatever is staged into INPUT_DIR.
+        Path scriptsDir = root.resolve("scripts");
+        Files.createDirectories(scriptsDir);
+        Path scriptFile = scriptsDir.resolve("cat.sh");
+        Files.writeString(scriptFile, "#!/bin/bash\ncat \"$INPUT_DIR\"/*\n");
+        scriptFile.toFile().setExecutable(true);
+        SkillScript script = new SkillScript("test-skill", "cat.sh", ScriptLanguage.BASH, root);
+
+        ProcessSkillScriptExecutionEngine engine =
+                ProcessSkillScriptExecutionEngine.confinedTo(root.toString());
+
+        // Input INSIDE the configured root -> accepted.
+        Path inside = root.resolve("inside.txt");
+        Files.writeString(inside, "OK");
+        ScriptExecutionResult allowed = engine.execute(script, List.of(), null, List.of(inside));
+        assertTrue(allowed instanceof ScriptExecutionResult.Success,
+                "in-root input must be allowed, got: " + allowed);
+
+        // Input OUTSIDE the configured root (a sibling @TempDir) -> denied.
+        Path secret = outsideRoot.resolve("secret.txt");
+        Files.writeString(secret, "TOP_SECRET");
+        ScriptExecutionResult denied = engine.execute(script, List.of(), null, List.of(secret));
+        assertTrue(denied instanceof ScriptExecutionResult.Denied,
+                "out-of-root input must be denied, got: " + denied);
+    }
+}

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/ConfinedInputResolverTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/ConfinedInputResolverTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills.script
+
+import com.embabel.agent.tools.file.FileTools
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ConfinedInputResolverTest {
+
+    @TempDir
+    lateinit var userRoot: Path
+
+    private fun resolver() = ConfinedInputResolver(FileTools.readWrite(userRoot.toString()))
+
+    @Test
+    fun `resolves a file inside the user root`() {
+        val file = Files.writeString(userRoot.resolve("data.txt"), "x")
+        assertEquals(file, resolver().resolve(userRoot.resolve("data.txt")))
+    }
+
+    @Test
+    fun `a missing file inside the user root propagates IllegalArgumentException (not found)`() {
+        val e = assertThrows(IllegalArgumentException::class.java) {
+            resolver().resolve(userRoot.resolve("nope.txt"))
+        }
+        assertTrue(e.message!!.contains("does not exist"), "message was: ${e.message}")
+    }
+
+    @Test
+    fun `a file outside both roots is rejected as path traversal`(@TempDir outside: Path) {
+        val secret = Files.writeString(outside.resolve("secret.txt"), "TOP_SECRET")
+        assertThrows(SecurityException::class.java) {
+            resolver().resolve(secret)
+        }
+    }
+
+    @Test
+    fun `an artifact staged from a previous run is resolvable as input (chaining)`() {
+        val resolver = resolver()
+
+        // Produce an artifact from a fake output dir, then feed its path back as input.
+        val outputDir = Files.createTempDirectory("out-")
+        Files.writeString(outputDir.resolve("result.pdf"), "PDF")
+        val artifact = resolver.stageArtifacts(outputDir).single()
+
+        assertTrue(artifact.path.startsWith(resolver.artifactsRoot))
+        assertEquals(artifact.path, resolver.resolve(artifact.path))
+    }
+
+    @Test
+    fun `stageArtifacts returns empty and creates no run dir when there is nothing to stage`() {
+        val resolver = resolver()
+        val emptyOutput = Files.createTempDirectory("out-empty-")
+
+        assertTrue(resolver.stageArtifacts(emptyOutput).isEmpty())
+        Files.list(resolver.artifactsRoot).use { runs ->
+            assertEquals(0, runs.count(), "no run-* dir should be created for an empty output")
+        }
+    }
+}

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngineTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngineTest.kt
@@ -382,6 +382,31 @@ cat "${'$'}INPUT_DIR/data.txt"
         assertNotNull(engine)
     }
 
+    @Test
+    @EnabledIf("isDockerAvailable")
+    fun `a text-transform skill must not deadlock and must process all of a large input`() {
+        // Same scenario as the process engine: a streaming filter (tr) that reads stdin
+        // and writes stdout. If the engine writes ALL of stdin before draining the
+        // container's stdout, the stdout pipe fills, tr stops reading stdin, and the stdin
+        // write blocks forever -> deadlock (before waitFor(timeout) is ever reached).
+        // assertTimeoutPreemptively turns that hang into a failure; the content assertions
+        // prove the full 1MB round-tripped, not just that the call returned.
+        val engine = DockerSkillScriptExecutionEngine(image = TEST_IMAGE, user = null)
+        val script = createScript("upper.sh", ScriptLanguage.BASH, "#!/bin/bash\ntr 'a-z' 'A-Z'\n")
+
+        val bigInput = "y".repeat(1048576) // ~1MB, all lowercase
+
+        var result: ScriptExecutionResult? = null
+        assertTimeoutPreemptively(java.time.Duration.ofSeconds(60)) {
+            result = engine.execute(script, stdin = bigInput)
+        }
+
+        assertTrue(result is ScriptExecutionResult.Success, "Expected success but got: $result")
+        val success = result as ScriptExecutionResult.Success
+        assertEquals(bigInput.length, success.stdout.length, "The whole input must be transformed")
+        assertTrue(success.stdout.all { it == 'Y' }, "Every character must be uppercased")
+    }
+
     private fun createScript(
         fileName: String,
         language: ScriptLanguage,

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngineTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/DockerSkillScriptExecutionEngineTest.kt
@@ -228,6 +228,105 @@ echo "Done"
 
     @Test
     @EnabledIf("isDockerAvailable")
+    fun `an artifact produced by one skill must be usable as input to the next skill`() {
+        // Chaining scenario: skill A produces a file (e.g. a PDF), skill B takes it as
+        // input (e.g. to email it). The engine must keep A's artifact reachable by its
+        // confined file access so B can consume it. Guards against artifacts landing in
+        // a temp dir outside any trusted root.
+        val engine = DockerSkillScriptExecutionEngine(
+            image = TEST_IMAGE,
+            user = null,
+            fileTools = FileTools.readWrite(tempDir.toString()),
+        )
+
+        // Skill A: produce an artifact.
+        val producer = createScript(
+            "produce.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\necho \"PDF_CONTENT\" > \"${'$'}OUTPUT_DIR/result.pdf\"\n",
+        )
+        val produced = engine.execute(producer)
+        assertTrue(produced is ScriptExecutionResult.Success, "Producer failed: $produced")
+        val artifact = (produced as ScriptExecutionResult.Success).artifacts.single()
+
+        // Skill B: consume A's artifact as an input file and echo its content.
+        val consumer = createScript(
+            "consume.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\ncat \"${'$'}INPUT_DIR/result.pdf\"\n",
+        )
+        val consumed = engine.execute(consumer, inputFiles = listOf(artifact.path))
+
+        assertTrue(
+            consumed is ScriptExecutionResult.Success,
+            "The next skill must be able to consume the produced artifact, but got: $consumed",
+        )
+        assertTrue(
+            (consumed as ScriptExecutionResult.Success).stdout.contains("PDF_CONTENT"),
+            "The next skill should read the artifact content, but stdout was: ${consumed.stdout}",
+        )
+    }
+
+    @Test
+    @EnabledIf("isDockerAvailable")
+    fun `a container must not inherit host environment secrets`() {
+        // EMBABEL_TEST_SECRET is set in the test JVM env (surefire config), standing in for
+        // a real secret like an API key. The container must not receive host env vars.
+        // Docker isolates the container env, so this passes.
+        val engine = DockerSkillScriptExecutionEngine(image = TEST_IMAGE, user = null)
+        val script = createScript(
+            "leak.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\nprintenv EMBABEL_TEST_SECRET || true\n",
+        )
+
+        val result = engine.execute(script)
+
+        assertTrue(result is ScriptExecutionResult.Success, "got: $result")
+        assertFalse(
+            (result as ScriptExecutionResult.Success).stdout.contains("s3cr3t-do-not-leak"),
+            "Host secret leaked into the container: ${result.stdout}",
+        )
+    }
+
+    @Test
+    @EnabledIf("isDockerAvailable")
+    fun `two input files with the same name from different folders are both made available`() {
+        // Realistic scenario: "merge the monthly report.csv from January and February".
+        // Both files are named report.csv but live in different folders; the LLM passes
+        // both. They must both reach the script; today the second copy collides on the
+        // same target name and the run fails with a confusing "Unexpected error".
+        val engine = DockerSkillScriptExecutionEngine(
+            image = TEST_IMAGE,
+            user = null,
+            fileTools = FileTools.readWrite(tempDir.toString()),
+        )
+
+        val jan = tempDir.resolve("jan").resolve("report.csv")
+        val feb = tempDir.resolve("feb").resolve("report.csv")
+        Files.createDirectories(jan.parent)
+        Files.createDirectories(feb.parent)
+        Files.writeString(jan, "month,total\njan,100\n")
+        Files.writeString(feb, "month,total\nfeb,200\n")
+
+        val script = createScript(
+            "merge.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\nls -1 \"${'$'}INPUT_DIR\" | wc -l | tr -d ' '\n",
+        )
+
+        val result = engine.execute(script, inputFiles = listOf(jan, feb))
+
+        assertTrue(result is ScriptExecutionResult.Success, "Run failed on duplicate input names: $result")
+        assertEquals(
+            "2",
+            (result as ScriptExecutionResult.Success).stdout.trim(),
+            "Both report.csv files must reach the script",
+        )
+    }
+
+    @Test
+    @EnabledIf("isDockerAvailable")
     fun `execute makes input files available in INPUT_DIR`() {
         val engine = DockerSkillScriptExecutionEngine(
             image = TEST_IMAGE,

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngineTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngineTest.kt
@@ -462,16 +462,13 @@ ls -1 "${'$'}INPUT_DIR" | wc -l | tr -d ' '
     @EnabledOnOs(OS.MAC, OS.LINUX)
     fun `a script must not inherit host environment secrets`() {
         // EMBABEL_TEST_SECRET is set in the test JVM env (surefire config), standing in
-        // for a real secret like an API key. A skill script must NOT be able to read it.
-        //
-        // EXPECTED (after fix): the script sees nothing (only a safe allowlist is passed).
-        // CURRENT (buggy): the engine inherits the full host env, so the script prints the
-        // secret -> this FAILS.
+        // for a real secret like an API key. With inheritEnvironment = false a skill script
+        // must NOT be able to read it: only the safe allowlist is passed through.
         assertNotNull(
             System.getenv("EMBABEL_TEST_SECRET"),
             "EMBABEL_TEST_SECRET must be set in the test JVM env (surefire)",
         )
-        val engine = ProcessSkillScriptExecutionEngine()
+        val engine = ProcessSkillScriptExecutionEngine(inheritEnvironment = false)
         val script = createScript(
             "leak.sh",
             ScriptLanguage.BASH,
@@ -496,6 +493,7 @@ ls -1 "${'$'}INPUT_DIR" | wc -l | tr -d ' '
         // with a built-in default.)
         val engine = ProcessSkillScriptExecutionEngine(
             interpreters = mapOf(ScriptLanguage.BASH to listOf("/bin/bash")),
+            inheritEnvironment = false,
             environmentAllowlist = emptySet(),
         )
         val script = createScript(
@@ -523,6 +521,7 @@ ls -1 "${'$'}INPUT_DIR" | wc -l | tr -d ' '
         // EMBABEL_TEST_SECRET — while HOME (which IS in the default allowlist) is dropped
         // because it is not listed here.
         val engine = ProcessSkillScriptExecutionEngine(
+            inheritEnvironment = false,
             environmentAllowlist = setOf("PATH", "EMBABEL_TEST_SECRET"),
         )
         val script = createScript(

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngineTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/ProcessSkillScriptExecutionEngineTest.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.skills.script
 
+import com.embabel.agent.tools.file.FileTools
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.condition.EnabledOnOs
@@ -294,7 +295,7 @@ echo "Some content here" > "${'$'}OUTPUT_DIR/output.txt"
     @Test
     @EnabledOnOs(OS.MAC, OS.LINUX)
     fun `execute makes input files available in INPUT_DIR`() {
-        val engine = ProcessSkillScriptExecutionEngine()
+        val engine = ProcessSkillScriptExecutionEngine(fileTools = FileTools.readWrite(tempDir.toString()))
         val script = createScript(
             "test.sh",
             ScriptLanguage.BASH,
@@ -325,7 +326,7 @@ cat "${'$'}INPUT_DIR/input.txt" > "${'$'}OUTPUT_DIR/output.txt"
     @Test
     @EnabledOnOs(OS.MAC, OS.LINUX)
     fun `execute handles multiple input files`() {
-        val engine = ProcessSkillScriptExecutionEngine()
+        val engine = ProcessSkillScriptExecutionEngine(fileTools = FileTools.readWrite(tempDir.toString()))
         val script = createScript(
             "test.sh",
             ScriptLanguage.BASH,
@@ -352,7 +353,7 @@ ls -1 "${'$'}INPUT_DIR" | wc -l | tr -d ' '
 
     @Test
     fun `execute returns Denied for non-existent input file`() {
-        val engine = ProcessSkillScriptExecutionEngine()
+        val engine = ProcessSkillScriptExecutionEngine(fileTools = FileTools.readWrite(tempDir.toString()))
         val script = createScript("test.sh", ScriptLanguage.BASH, "#!/bin/bash\necho ok")
 
         val nonExistentFile = tempDir.resolve("does-not-exist.txt")
@@ -360,6 +361,250 @@ ls -1 "${'$'}INPUT_DIR" | wc -l | tr -d ' '
 
         assertTrue(result is ScriptExecutionResult.Denied)
         assertTrue((result as ScriptExecutionResult.Denied).reason.contains("does not exist"))
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC, OS.LINUX)
+    fun `execute must deny input files located outside the confinement root`() {
+        // Regression test for the input-path-confinement gap (issue #1754).
+        //
+        // The engine should confine input files to a configured root - as
+        // DockerSkillScriptExecutionEngine already does via
+        // FileTools.resolveAndValidateFile(...) - and deny anything outside it.
+        //
+        // The input below lives under the JUnit @TempDir, i.e. under the system
+        // temp dir, which is OUTSIDE the process working directory that the
+        // engine's default root should be.
+        //
+        // EXPECTED (after fix): Denied.
+        // CURRENT (buggy): the engine copies the out-of-root file into INPUT_DIR and
+        // runs the script over it, returning Success - so this assertion FAILS, which
+        // is exactly what confirms the vulnerability.
+        val engine = ProcessSkillScriptExecutionEngine()
+        val script = createScript(
+            "leak.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\ncat \"${'$'}INPUT_DIR\"/*",
+        )
+
+        val outsideRoot = tempDir.resolve("secret.txt")
+        Files.writeString(outsideRoot, "TOP_SECRET")
+
+        val result = engine.execute(script, inputFiles = listOf(outsideRoot))
+
+        assertTrue(
+            result is ScriptExecutionResult.Denied,
+            "Input file outside the confinement root must be denied, but got: $result",
+        )
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC, OS.LINUX)
+    fun `a text-transform skill must not deadlock and must process all of a large input`() {
+        // Realistic scenario: a "transform this text" skill (read stdin -> write stdout),
+        // e.g. uppercasing a large pasted document. `tr` streams (reads a block -> writes
+        // a block), so read and write interleave, like any Unix filter.
+        //
+        // The engine used to write ALL of stdin before starting the stdout readers, so
+        // once the filter's stdout pipe filled it blocked (parent not draining), stopped
+        // reading stdin, and the parent blocked writing stdin -> deadlock, before
+        // waitFor(timeout).
+        //
+        // assertTimeoutPreemptively turns a deadlock into a failure instead of hanging the
+        // suite; the content assertions prove the full 1MB round-tripped (not just that
+        // the call returned).
+        val engine = ProcessSkillScriptExecutionEngine()
+        val script = createScript("upper.sh", ScriptLanguage.BASH, "#!/bin/bash\ntr 'a-z' 'A-Z'\n")
+
+        val bigInput = "y".repeat(1048576) // ~1MB, all lowercase
+
+        var result: ScriptExecutionResult? = null
+        assertTimeoutPreemptively(java.time.Duration.ofSeconds(10)) {
+            result = engine.execute(script, stdin = bigInput)
+        }
+
+        assertTrue(result is ScriptExecutionResult.Success, "Expected success but got: $result")
+        val success = result as ScriptExecutionResult.Success
+        assertEquals(bigInput.length, success.stdout.length, "The whole input must be transformed")
+        assertTrue(success.stdout.all { it == 'Y' }, "Every character must be uppercased")
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC, OS.LINUX)
+    fun `an artifact produced by one skill can be reused as input to the next skill`() {
+        // A produces a file; B must be able to take it as input (chaining).
+        val engine = ProcessSkillScriptExecutionEngine(fileTools = FileTools.readWrite(tempDir.toString()))
+
+        val producer = createScript(
+            "produce.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\necho \"PDF_CONTENT\" > \"${'$'}OUTPUT_DIR/result.pdf\"\n",
+        )
+        val produced = engine.execute(producer)
+        assertTrue(produced is ScriptExecutionResult.Success, "Producer failed: $produced")
+        val artifact = (produced as ScriptExecutionResult.Success).artifacts.single()
+
+        val consumer = createScript(
+            "consume.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\ncat \"${'$'}INPUT_DIR/result.pdf\"\n",
+        )
+        val consumed = engine.execute(consumer, inputFiles = listOf(artifact.path))
+
+        assertTrue(consumed is ScriptExecutionResult.Success, "Consumer failed: $consumed")
+        assertTrue(
+            (consumed as ScriptExecutionResult.Success).stdout.contains("PDF_CONTENT"),
+            "The next skill should read the artifact content, but stdout was: ${consumed.stdout}",
+        )
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC, OS.LINUX)
+    fun `a script must not inherit host environment secrets`() {
+        // EMBABEL_TEST_SECRET is set in the test JVM env (surefire config), standing in
+        // for a real secret like an API key. A skill script must NOT be able to read it.
+        //
+        // EXPECTED (after fix): the script sees nothing (only a safe allowlist is passed).
+        // CURRENT (buggy): the engine inherits the full host env, so the script prints the
+        // secret -> this FAILS.
+        assertNotNull(
+            System.getenv("EMBABEL_TEST_SECRET"),
+            "EMBABEL_TEST_SECRET must be set in the test JVM env (surefire)",
+        )
+        val engine = ProcessSkillScriptExecutionEngine()
+        val script = createScript(
+            "leak.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\nprintenv EMBABEL_TEST_SECRET || true\n",
+        )
+
+        val result = engine.execute(script)
+
+        assertTrue(result is ScriptExecutionResult.Success, "got: $result")
+        assertFalse(
+            (result as ScriptExecutionResult.Success).stdout.contains("s3cr3t-do-not-leak"),
+            "Host secret leaked into the script: ${result.stdout}",
+        )
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC, OS.LINUX)
+    fun `an empty allowlist passes no host variables - not even PATH`() {
+        // Max-lockdown posture: environmentAllowlist = emptySet() drops every host var,
+        // including PATH. An absolute interpreter path lets the process still start.
+        // (printenv reads the real environment, unlike echo ${'$'}PATH which bash fills
+        // with a built-in default.)
+        val engine = ProcessSkillScriptExecutionEngine(
+            interpreters = mapOf(ScriptLanguage.BASH to listOf("/bin/bash")),
+            environmentAllowlist = emptySet(),
+        )
+        val script = createScript(
+            "env.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\n" +
+                "echo \"PATH=[\$(printenv PATH)]\"\n" +
+                "echo \"HOME=[\$(printenv HOME)]\"\n" +
+                "printenv EMBABEL_TEST_SECRET || true\n",
+        )
+
+        val result = engine.execute(script)
+
+        assertTrue(result is ScriptExecutionResult.Success, "got: $result")
+        val stdout = (result as ScriptExecutionResult.Success).stdout
+        assertTrue(stdout.contains("PATH=[]"), "PATH must be empty, stdout: $stdout")
+        assertTrue(stdout.contains("HOME=[]"), "HOME must be empty, stdout: $stdout")
+        assertFalse(stdout.contains("s3cr3t-do-not-leak"), "secret leaked: $stdout")
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC, OS.LINUX)
+    fun `a custom allowlist passes exactly the listed host variables`() {
+        // Custom posture: pass PATH (so the script runs) and, deliberately,
+        // EMBABEL_TEST_SECRET — while HOME (which IS in the default allowlist) is dropped
+        // because it is not listed here.
+        val engine = ProcessSkillScriptExecutionEngine(
+            environmentAllowlist = setOf("PATH", "EMBABEL_TEST_SECRET"),
+        )
+        val script = createScript(
+            "env.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\n" +
+                "echo \"SECRET=[\$(printenv EMBABEL_TEST_SECRET)]\"\n" +
+                "echo \"HOME=[\$(printenv HOME)]\"\n",
+        )
+
+        val result = engine.execute(script)
+
+        assertTrue(result is ScriptExecutionResult.Success, "got: $result")
+        val stdout = (result as ScriptExecutionResult.Success).stdout
+        assertTrue(stdout.contains("SECRET=[s3cr3t-do-not-leak]"), "listed var must pass, stdout: $stdout")
+        assertTrue(stdout.contains("HOME=[]"), "unlisted var must be dropped, stdout: $stdout")
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC, OS.LINUX)
+    fun `two input files with the same name from different folders are both made available`() {
+        // Realistic scenario: "merge the monthly report.csv from January and February".
+        // Both files are named report.csv but live in different folders — the LLM passes
+        // both. They must both reach the script; today the second copy collides on the
+        // same target name and the run fails with a confusing "Unexpected error".
+        // EXPECTED (after fix): Success, the script sees 2 files.
+        val engine = ProcessSkillScriptExecutionEngine(fileTools = FileTools.readWrite(tempDir.toString()))
+
+        val jan = tempDir.resolve("jan").resolve("report.csv")
+        val feb = tempDir.resolve("feb").resolve("report.csv")
+        Files.createDirectories(jan.parent)
+        Files.createDirectories(feb.parent)
+        Files.writeString(jan, "month,total\njan,100\n")
+        Files.writeString(feb, "month,total\nfeb,200\n")
+
+        // A "merge reports" script: count how many input files it received.
+        val script = createScript(
+            "merge.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\nls -1 \"${'$'}INPUT_DIR\" | wc -l | tr -d ' '\n",
+        )
+
+        val result = engine.execute(script, inputFiles = listOf(jan, feb))
+
+        assertTrue(result is ScriptExecutionResult.Success, "Run failed on duplicate input names: $result")
+        assertEquals(
+            "2",
+            (result as ScriptExecutionResult.Success).stdout.trim(),
+            "Both report.csv files must reach the script",
+        )
+    }
+
+    @Test
+    @EnabledOnOs(OS.MAC, OS.LINUX)
+    fun `same-name inputs are disambiguated even when the suffixed name is also taken`() {
+        // Two files named report.csv AND one already named report-1.csv: the suffix loop
+        // must keep incrementing (report.csv, report-1.csv, report-1-1.csv) — never
+        // crash, never overwrite.
+        val engine = ProcessSkillScriptExecutionEngine(fileTools = FileTools.readWrite(tempDir.toString()))
+
+        val a = tempDir.resolve("a").resolve("report.csv")
+        val b = tempDir.resolve("b").resolve("report.csv")
+        val c = tempDir.resolve("c").resolve("report-1.csv")
+        listOf(a, b, c).forEach {
+            Files.createDirectories(it.parent)
+            Files.writeString(it, "x")
+        }
+
+        val script = createScript(
+            "count.sh",
+            ScriptLanguage.BASH,
+            "#!/bin/bash\nls -1 \"${'$'}INPUT_DIR\" | wc -l | tr -d ' '\n",
+        )
+
+        val result = engine.execute(script, inputFiles = listOf(a, b, c))
+
+        assertTrue(result is ScriptExecutionResult.Success, "got: $result")
+        assertEquals(
+            "3",
+            (result as ScriptExecutionResult.Success).stdout.trim(),
+            "All three inputs must be present with distinct names",
+        )
     }
 
     private fun createScript(


### PR DESCRIPTION
# Harden the skill script execution engines (Process & Docker)

Follow-up to #1754. This branch hardens both `ProcessSkillScriptExecutionEngine` and `DockerSkillScriptExecutionEngine` across four areas:

1. **Security** - confine inputs to a root, give operators a way to stop leaking host secrets.
2. **Correctness** - fix stdin/stdout deadlocks and Docker's dropped stdin.
3. **Usability** - support same-name inputs and artifact chaining between skills.
4. **Java interop** - make the engines constructable and configurable from Java.

All changes apply to **both** engines unless noted. Every fix ships with a test that is
red before the change and green after.

---

## 1. Security

### 1.1 Confine input files to a root (path traversal) - core of #1754

**Problem.** `ProcessSkillScriptExecutionEngine` used LLM-supplied `inputFiles` paths raw (`Files.exists` / `Files.copy` directly), with no root resolution and no traversal check.
Relative paths resolved against the JVM cwd, and **any absolute or `../` path was accepted**, copied into `INPUT_DIR`, and exposed to the script. The Docker engine already confined inputs via `fileTools.resolveAndValidateFile(...)`.

**Fix.** Give the process engine the same treatment:
- Add `fileTools: FileTools = FileTools.readWrite(System.getProperty("user.dir"))`.
- Resolve every input through a shared `ConfinedInputResolver` (new `ConfinedInputResolver.kt`), now used by **both** engines so the confinement logic lives in one place instead of being copy-pasted. It resolves against two allowed roots, in order:
  1. the **user root** (`fileTools`), where the user's own files live;
  2. the **artifacts root**, where a previous run's outputs are kept (see §3.2).

  Both roots enforce `resolvedPath.startsWith(root)`. The fallback to root 2 happens **only** on `SecurityException` (path outside the root, so "not a user file", worth retrying), never on `IllegalArgumentException` (path inside the root but file missing). A typo on a user-dir path therefore stays a clear "file not found" instead of silently falling through to the artifacts root. The engines turn both exceptions into `Denied`.

**Compatibility.** The default root (`user.dir`) matches `findFiles`' root, so the normal flow (LLM to `findFiles` to absolute path under the project) still passes. Only out-of-root paths are now rejected.

**Verification.** Before: `["/tmp/demo/secret.csv"]` runs the script over it. After: same input gives `Denied("Path traversal not allowed")`; in-root inputs still work. `ConfinedInputResolverTest` covers rejection outside both roots and resolution of a staged artifact.

**Known limitation / follow-up (not fixed here)** - symlink escape. The §1.1 check is lexical: it verifies the path string stays under the root, but never resolves symlinks. So a link that sits in the root but points outside it passes,   and Files.copy (which follows links) pulls the outside file into INPUT_DIR.                                                                                                                                          - Vector: a cloned git repo - git versions symlinks, so a malicious repo can ship innocent.txt -> /etc/passwd. The LLM can't create the link itself (no file tool does); it must already exist in the root.

### 1.2 Give operators a way to stop leaking the host environment (secrets) to scripts

**Problem.** The process engine runs scripts on the host and passes the **full JVM environment** to them, including host secrets (`GEMINI_*`, `OPENAI_*`, ...). An LLM-directed (possibly prompt-injected) script can exfiltrate them (`printenv | grep -i key`). Before this branch there was no way to prevent it short of clearing the env entirely, which also drops `PATH` and breaks interpreter lookup. The Docker engine is unaffected: a container never inherits the host env.

**Fix.** Add a configurable allowlist, so restricting the env no longer means losing `PATH`:

```kotlin
inheritEnvironment: Boolean = true,                      // unchanged default: full host env
environmentAllowlist: Set<String> = SAFE_ENV_ALLOWLIST,  // PATH, HOME, LANG, ... - override to add/restrict
```

`inheritEnvironment` **still defaults to `true`**, so this branch changes no existing behaviour: opting into confinement is a deliberate act by the caller. Setting `inheritEnvironment = false` passes only `environmentAllowlist` instead of clearing everything. The explicit `environment` map is always passed through in every posture.

| Posture | Config |
|---|---|
| Full host env (default, current behaviour) | leave defaults |
| Balanced - no secrets, interpreters still resolvable | `inheritEnvironment = false` (uses `SAFE_ENV_ALLOWLIST`) |
| Custom | `inheritEnvironment = false, environmentAllowlist = setOf("PATH", "MY_VAR")` |
| Lock down everything | `inheritEnvironment = false, environmentAllowlist = emptySet()` - drops even PATH |

> **Open question for review:** should `inheritEnvironment` default to `false` (secure by default)? It is the safer posture, but it is a behavioural break for any caller relying on a host variable outside the allowlist, so it is left as opt-in here.

**Tests** (a fake `EMBABEL_TEST_SECRET` is injected into the test JVM via surefire, so they are deterministic):
- `a script must not inherit host environment secrets` (Process) - with `inheritEnvironment = false`, secret hidden, `PATH` still present.
- `a container must not inherit host environment secrets` (Docker).
- `an empty allowlist passes no host variables - not even PATH`.
- `a custom allowlist passes exactly the listed host variables`.

---

## 2. Correctness

### 2.1 stdin/stdout deadlock in the process engine

**Problem.** `executeProcess` wrote the **entire stdin before** starting the stdout/stderr readers. If a script produced more output than the OS pipe buffer (~64 KB) while still consuming stdin, it blocked writing stdout (nobody draining), stopped reading stdin, and the engine blocked writing stdin, a mutual deadlock. It happened **before** `waitFor(timeout)`,
so the timeout never fired and the call hung forever. Hits any filter skill (read stdin, write stdout) on large data.

**Fix.** Start the stdout/stderr reader threads **before** writing stdin, so output drains concurrently. Additionally: write stdin on its own daemon thread with `IOException` swallowed, and join it alongside the readers (including on the timeout path), the canonical in/out/err pattern, and a script that stops reading stdin early is no longer reported as a failure.

**Test.** `a text-transform skill must not deadlock and must process all of a large input` - a `tr 'a-z' 'A-Z'` filter given ~1 MB via stdin. `assertTimeoutPreemptively` turns a deadlock into a failure; assertions verify the full 1 MB round-tripped. Red (10 s hang) without the fix, green (immediate) with it.

### 2.2 Docker: missing `-i` flag + the same deadlock

**Problem.** `docker run` was invoked without `-i`, so Docker attached the container's stdin to `/dev/null` and the `stdin` parameter was **silently dropped**. Combined with the write-stdin-first ordering, a filter skill deadlocked and, with stdin unattached, failed with `Broken pipe`.

**Fix.** Add `-i` to `docker run`, and apply the same in/out/err thread pattern as the process engine.

**Test.** `a text-transform skill must not deadlock and must process all of a large input` mirrored in the Docker suite. Red without the fix (`Broken pipe` in ~0.3 s), green with it.

> Both engines now share the deadlock-safe I/O logic via a single `Process.pumpIo(...)`
> helper (`processIo.kt`), so the pattern lives in one place instead of being copy-pasted.

---

## 3. Usability

### 3.1 Input files that share a name no longer crash the run

**Problem.** Each input was staged into the flat input dir under its base name (`inputDir.resolve(inputFile.fileName)`), with no collision handling. Two `inputFiles` sharing a base name (from different folders) hit the same target: the second `Files.copy` threw `FileAlreadyExistsException`, surfaced as a confusing `Failure("Unexpected error")` in the process engine, and propagated **uncaught** in the Docker engine. Breaks legitimate requests like "merge the monthly `report.csv` from January and February".

**Fix.** A shared helper `copyIntoUniqueName(source, dir)` (new `inputStaging.kt`), used by both engines:
- name free, keep the original name (common case unchanged);
- collision, append a numeric suffix, preserving the extension: `report.csv` gives `report-1.csv`, `report-2.csv`.

The input dir stays flat and no file is lost.

**Test.** `two input files with the same name from different folders are both made available` on **both** engines, asserts the script receives 2 files.

### 3.2 Artifact chaining: outputs land in a trusted dir, not a system temp dir

**Problem.** Both engines wrote a script's output files (artifacts) into a **system temp dir**, outside the `fileTools` root. Since inputs are confined to that root (§1.1), an artifact produced by skill A was **rejected** when passed as input to skill B:

```
Denied(reason=Path traversal not allowed: /var/folders/.../T/skills-artifacts-.../result.pdf)
```

So file chaining (A produces a PDF, B emails it) didn't work.

**Fix.** `ConfinedInputResolver` owns an artifacts root (a generated temp dir, never the user's working directory) and both engines stage their outputs into a fresh `run-*` dir under it via `stageArtifacts(outputDir)`. That root is the second root the resolver trusts as an input source (§1.1), so a subsequent skill can consume the artifact while arbitrary host files stay blocked.

**Tests.**
- `an artifact produced by one skill can be reused as input to the next skill` (Process) and `an artifact produced by one skill must be usable as input to the next skill` (Docker): A produces `result.pdf`, B consumes it via `inputFiles` and reads its content.
- `an artifact staged from a previous run is resolvable as input (chaining)` and `stageArtifacts returns empty and creates no run dir when there is nothing to stage` (`ConfinedInputResolverTest`).

**Known limitation / follow-up (not fixed here).** Artifacts must outlive `execute()` so a following skill can consume them, so they can't be deleted at end of run. As a result the artifacts root accumulates one `run-*` subdir per execution and is never cleaned up (it lives under the system temp dir, which the OS eventually reclaims). The per-run input/output sandboxes *are* cleaned up. Follow-up: add lifecycle cleanup for the artifacts directory (JVM shutdown hook and/or keep the last N runs).

---

## 4. Java interop

### 4.1 Make `ProcessSkillScriptExecutionEngine` constructable from Java

**Problem.** The primary constructor's first parameter is `timeout: kotlin.time.Duration` (an inline value class), so Kotlin emitted only name-mangled **synthetic** public constructors (the non-synthetic one is `private`). `javac` refuses synthetic constructors, so `new ProcessSkillScriptExecutionEngine()` did not compile, even though the docs advertise
a Java API and the Docker engine is already Java-constructable.

**Fix.** Add `@JvmOverloads` to the constructor (as the Docker engine already has), generating a non-synthetic no-arg `public ProcessSkillScriptExecutionEngine()`.

**Test.** `ProcessSkillScriptExecutionEngineJavaTest.java`, the file wouldn't compile without the fix; asserts `supportedLanguages()` is non-empty.

### 4.2 A Java-callable `confinedTo(root)` factory on both engines

**Problem.** The engine confines inputs to its `fileTools` root, but Java couldn't set it:
`fileTools` sits behind the `Duration` value-class parameter, so every `@JvmOverloads` overload reaching it is synthetic and rejected by `javac`. Only the no-arg constructor compiles, pinning the root to `user.dir` (the JVM cwd #1754 flagged). Java consumers couldn't give each request its own root (per-request / multi-tenant).

**Fix.** Add a `@JvmStatic` factory with a plain `String` signature (Java-callable) on both
engines:

```kotlin
@JvmStatic
fun confinedTo(root: String) =
    ProcessSkillScriptExecutionEngine(fileTools = FileTools.readWrite(root))
```

A factory rather than `constructor(String)` because the Docker engine's first param is already `String image` (would collide).

**Notes.**
- Security unchanged: only sets the root; traversal checks still reject `..` / out-of-root.
- Complements §4.1: `@JvmOverloads` unblocks the default engine from Java; this exposes the
  root knob. Per-parameter customization beyond the root would need further factories (like Docker's `pythonOnly` / `isolated`), out of scope here.

**Verification.** `mvn compile` OK; `javap` confirms `public static final ... confinedTo(java.lang.String)` on both engines.

---

## Verification summary

- `mvn -pl embabel-agent-skills test` - **230 tests green**, of which 55 in the script-engine suites: Process 28, Docker 18, `ConfinedInputResolver` 5, Java 2 + 2.
- Each behavioural fix has a test verified red before the change and green after.
