### PR TITLE
fix: widen DefaultAgentPlatform.platformServices type (#1793)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/DefaultAgentPlatform.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.core.support
 
 import com.embabel.agent.api.channel.OutputChannel
 import com.embabel.agent.api.common.Asyncer
+import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.event.AgentDeploymentEvent
 import com.embabel.agent.api.event.AgentProcessCreationEvent
 import com.embabel.agent.api.event.AgenticEventListener
@@ -73,7 +74,7 @@ open class DefaultAgentPlatform(
 
     private val agents: MutableMap<String, Agent> = ConcurrentHashMap()
 
-    override val platformServices = SpringContextPlatformServices(
+    override val platformServices: PlatformServices = SpringContextPlatformServices(
         llmOperations = llmOperations,
         agentPlatform = this,
         eventListener = eventListener,

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/DefaultAgentPlatformTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/DefaultAgentPlatformTest.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.core.support
 
 import com.embabel.agent.api.channel.DevNullOutputChannel
+import com.embabel.agent.api.common.PlatformServices
 import com.embabel.agent.api.dsl.evenMoreEvilWizard
 import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.AgentPlatform
@@ -30,6 +31,8 @@ import com.embabel.agent.support.Dog
 import com.embabel.agent.test.common.EventSavingAgenticEventListener
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -97,4 +100,37 @@ class DefaultAgentPlatformTest {
 
     }
 
+    @Nested
+    inner class PlatformServicesOverride {
+
+        @Test
+        fun `subclass can override platformServices with a different implementation`() {
+            val base = raw()
+            val custom = CustomPlatformServices(base.platformServices)
+            val subclassed: AgentPlatform = SubclassedAgentPlatform(custom)
+
+            assertNotNull(subclassed.platformServices)
+            assertInstanceOf(CustomPlatformServices::class.java, subclassed.platformServices)
+        }
+    }
+
+}
+
+private class CustomPlatformServices(delegate: PlatformServices) : PlatformServices by delegate
+
+private class SubclassedAgentPlatform(
+    customServices: PlatformServices,
+) : DefaultAgentPlatform(
+    name = "subclassed",
+    description = "subclassed platform",
+    processType = ProcessType.SIMPLE,
+    llmOperations = mockk(),
+    toolGroupResolver = mockk(relaxed = true),
+    eventListener = EventSavingAgenticEventListener(),
+    asyncer = mockk(),
+    objectMapper = mockk(),
+    outputChannel = DevNullOutputChannel,
+    templateRenderer = mockk(),
+) {
+    override val platformServices: PlatformServices = customServices
 }


### PR DESCRIPTION
DefaultAgentPlatform.platformServices: add explicit `: PlatformServices` type annotation so the compiled getter returns the interface, not the final SpringContextPlatformServices data class. This unblocks subclass overrides.

Fixes #1793 