### PR TITLE
Log improvement: locale format millisecond timings

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/DefaultPlanLister.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/autonomy/DefaultPlanLister.kt
@@ -59,7 +59,7 @@ internal class DefaultPlanLister(
             "Achievable plans given {} actions and {} goals in {}ms from bindings {} : {}\n{}",
             planningSystem.actions.size,
             planningSystem.goals.size,
-            ms,
+            "%,d".format(ms),
             bindings,
             plans.joinToString("\n") { it.infoString(verbose = true, indent = 1) },
             planningSystem.infoString(verbose = true, indent = 1),

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/LoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/LoggingAgenticEventListener.kt
@@ -227,13 +227,13 @@ open class LoggingAgenticEventListener(
         e: ToolCallResponseEvent,
         resultToShow: String,
     ): String =
-        "[${e.processId}]${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} returned $resultToShow in ${e.runningTime.toMillis()}ms with payload ${e.request.toolInput}"
+        "[${e.processId}]${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} returned $resultToShow in ${"%,d".format(e.runningTime.toMillis())}ms with payload ${e.request.toolInput}"
 
     protected open fun getToolCallFailureResponseEventMessage(
         e: ToolCallResponseEvent,
         throwable: Throwable?,
     ): String =
-        "[${e.processId}]${e.request.action?.let { " (${it.shortName()})" } ?: ""} failed tool ${e.request.tool} -> $throwable in ${e.runningTime.toMillis()}ms with payload ${e.request.toolInput}"
+        "[${e.processId}]${e.request.action?.let { " (${it.shortName()})" } ?: ""} failed tool ${e.request.tool} -> $throwable in ${"%,d".format(e.runningTime.toMillis())}ms with payload ${e.request.toolInput}"
 
     protected open fun getProcessCompletionMessage(e: AgentProcessFinishedEvent): String =
         "[${e.processId}] completed in ${e.agentProcess.runningTime}"
@@ -304,7 +304,7 @@ open class LoggingAgenticEventListener(
         "[${e.processId}] (${e.action?.shortName() ?: e.outputClass.simpleName.ifEmpty { e.outputClass.name }}) starting tool loop [${e.toolNames.joinToString(", ")}] max=${e.maxIterations}"
 
     protected open fun getToolLoopCompletedMessage(e: ToolLoopCompletedEvent): String =
-        "[${e.processId}] (${e.action?.shortName() ?: e.outputClass.simpleName.ifEmpty { e.outputClass.name }}) tool loop completed in ${e.runningTime.toMillis()}ms iterations=${e.totalIterations} replan=${e.replanRequested}"
+        "[${e.processId}] (${e.action?.shortName() ?: e.outputClass.simpleName.ifEmpty { e.outputClass.name }}) tool loop completed in ${"%,d".format(e.runningTime.toMillis())}ms iterations=${e.totalIterations} replan=${e.replanRequested}"
 
     protected open fun getProgressUpdateEventMessage(e: ProgressUpdateEvent): String =
         "[${e.processId}] progress: ${e.createProgressBar(length = 50).color(LumonColorPalette.MEMBRANE)}"

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/hitchhiker/HitchhikerLoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/hitchhiker/HitchhikerLoggingAgenticEventListener.kt
@@ -151,13 +151,13 @@ The standard repository for all knowledge and wisdom in the universe
         e: ToolCallResponseEvent,
         resultToShow: String,
     ): String =
-        "[${e.processId}] ${highlight("HEART OF GOLD")}:${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} returned $resultToShow in ${e.runningTime.toMillis()}ms with payload ${e.request.toolInput}"
+        "[${e.processId}] ${highlight("HEART OF GOLD")}:${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} returned $resultToShow in ${"%,d".format(e.runningTime.toMillis())}ms with payload ${e.request.toolInput}"
 
     override fun getToolCallFailureResponseEventMessage(
         e: ToolCallResponseEvent,
         throwable: Throwable?,
     ): String =
-        "[${e.processId}] ${highlight("DISASTER AREA")}:${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} failed $throwable in ${e.runningTime.toMillis()}ms with payload ${e.request.toolInput}"
+        "[${e.processId}] ${highlight("DISASTER AREA")}:${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} failed $throwable in ${"%,d".format(e.runningTime.toMillis())}ms with payload ${e.request.toolInput}"
 
     override fun getLlmRequestEventMessage(e: LlmRequestEvent<*>): String =
         "[${e.processId}] 🧠 DEEP THOUGHT: calculating LLM ${e.llmMetadata.name} to transform ${e.interaction.id.value} from ${e.outputClass.simpleName} -> ${e.interaction.llm} using ${e.interaction.tools.joinToString { it.definition.name }}"

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/severance/SeveranceLoggingAgenticEventListener.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/logging/personality/severance/SeveranceLoggingAgenticEventListener.kt
@@ -172,13 +172,13 @@ class SeveranceLoggingAgenticEventListener : LoggingAgenticEventListener(
         e: ToolCallResponseEvent,
         resultToShow: String,
     ): String =
-        "[${e.processId}] ${highlight("VISION")}:${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} returned $resultToShow in ${e.runningTime.toMillis()}ms with payload ${e.request.toolInput}"
+        "[${e.processId}] ${highlight("VISION")}:${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} returned $resultToShow in ${"%,d".format(e.runningTime.toMillis())}ms with payload ${e.request.toolInput}"
 
     override fun getToolCallFailureResponseEventMessage(
         e: ToolCallResponseEvent,
         throwable: Throwable?,
     ): String =
-        "[${e.processId}] ${highlight("WOE")}:${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} failed $throwable in ${e.runningTime.toMillis()}ms with payload ${e.request.toolInput}"
+        "[${e.processId}] ${highlight("WOE")}:${e.request.action?.let { " (${it.shortName()})" } ?: ""} tool ${e.request.tool} failed $throwable in ${"%,d".format(e.runningTime.toMillis())}ms with payload ${e.request.toolInput}"
 
     override fun getLlmRequestEventMessage(e: LlmRequestEvent<*>): String =
         "[${e.processId}] (${e.interaction.id.value}) \uD83D\uDDA5\uFE0F MACRODATA REFINEMENT using LLM ${e.llmMetadata.name}, creating ${e.outputClass.simpleName}: ${e.interaction.llm} with tools ${e.interaction.tools.joinToString { it.definition.name }}"

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoop.kt
@@ -127,7 +127,7 @@ internal class ParallelToolLoop(
                 .exceptionally { e ->
                     when (val cause = e.cause ?: e) {
                         is TimeoutException -> {
-                            logger.warn("Tool '{}' timed out after {}ms", toolCall.name, perToolTimeoutMs)
+                            logger.warn("Tool '{}' timed out after {}ms", toolCall.name, "%,d".format(perToolTimeoutMs))
                             ParallelToolResult.Timeout(toolCall)
                         }
                         // Termination signals - capture for processing after all tools complete
@@ -163,7 +163,7 @@ internal class ParallelToolLoop(
         }
 
         val duration = System.currentTimeMillis() - startTime
-        logger.debug("All {} tools completed in {}ms", toolCalls.size, duration)
+        logger.debug("All {} tools completed in {}ms", toolCalls.size, "%,d".format(duration))
 
         // 3. Check for control flow signals (priority: agent > action > unhandled > replan)
         propagateControlFlowSignals(results)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/ParallelToolLoop.kt
@@ -36,6 +36,7 @@ import com.embabel.agent.spi.loop.ToolNotFoundAction
 import com.embabel.agent.spi.loop.ToolNotFoundPolicy
 import com.embabel.chat.ToolCall
 import com.fasterxml.jackson.databind.ObjectMapper
+import java.util.Locale
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -127,7 +128,7 @@ internal class ParallelToolLoop(
                 .exceptionally { e ->
                     when (val cause = e.cause ?: e) {
                         is TimeoutException -> {
-                            logger.warn("Tool '{}' timed out after {}ms", toolCall.name, "%,d".format(perToolTimeoutMs))
+                            logger.warn("Tool '{}' timed out after {}ms", toolCall.name, "%,d".format(Locale.ROOT, perToolTimeoutMs))
                             ParallelToolResult.Timeout(toolCall)
                         }
                         // Termination signals - capture for processing after all tools complete

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
@@ -107,9 +107,9 @@ abstract class AbstractLlmOperations(
             future.get(timeoutMillis, TimeUnit.MILLISECONDS)
         } catch (e: TimeoutException) {
             future.cancel(true)
-            logger.warn(LLM_TIMEOUT_MESSAGE, interactionId, attempt, timeoutMillis)
+            logger.warn(LLM_TIMEOUT_MESSAGE, interactionId, attempt, "%,d".format(timeoutMillis))
             throw RuntimeException(
-                "LLM call for interaction $interactionId timed out after ${timeoutMillis}ms",
+                "LLM call for interaction $interactionId timed out after ${"%,d".format(timeoutMillis)}ms",
                 e
             )
         } catch (e: InterruptedException) {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
@@ -45,6 +45,7 @@ import jakarta.validation.ConstraintViolation
 import jakarta.validation.Validator
 import java.lang.reflect.Field
 import java.time.Duration
+import java.util.Locale
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -107,9 +108,9 @@ abstract class AbstractLlmOperations(
             future.get(timeoutMillis, TimeUnit.MILLISECONDS)
         } catch (e: TimeoutException) {
             future.cancel(true)
-            logger.warn(LLM_TIMEOUT_MESSAGE, interactionId, attempt, "%,d".format(timeoutMillis))
+            logger.warn(LLM_TIMEOUT_MESSAGE, interactionId, attempt, "%,d".format(Locale.ROOT, timeoutMillis))
             throw RuntimeException(
-                "LLM call for interaction $interactionId timed out after ${"%,d".format(timeoutMillis)}ms",
+                "LLM call for interaction $interactionId timed out after ${"%,d".format(Locale.ROOT, timeoutMillis)}ms",
                 e
             )
         } catch (e: InterruptedException) {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -172,7 +172,7 @@ internal class ChatClientLlmOperations(
         logger.info(
             "Current LLM settings: maxAttempts={}, fixedBackoffMillis={}ms, timeout={}s",
             dataBindingProperties.maxAttempts,
-            dataBindingProperties.fixedBackoffMillis,
+            "%,d".format(dataBindingProperties.fixedBackoffMillis),
             promptsProperties.defaultTimeout.seconds,
         )
     }
@@ -796,9 +796,9 @@ internal class ChatClientLlmOperations(
         when (e) {
             is TimeoutException -> {
                 future.cancel(true)
-                logger.warn(LLM_TIMEOUT_MESSAGE, interaction.id.value, attempt, timeoutMillis)
+                logger.warn(LLM_TIMEOUT_MESSAGE, interaction.id.value, attempt, "%,d".format(timeoutMillis))
                 throw RuntimeException(
-                    "ChatClient call for interaction ${interaction.id.value} timed out after ${timeoutMillis}ms",
+                    "ChatClient call for interaction ${interaction.id.value} timed out after ${"%,d".format(timeoutMillis)}ms",
                     e
                 )
             }
@@ -849,10 +849,10 @@ internal class ChatClientLlmOperations(
         return when (e) {
             is TimeoutException -> {
                 future.cancel(true)
-                logger.warn(LLM_TIMEOUT_MESSAGE, interaction.id.value, attempt, timeoutMillis)
+                logger.warn(LLM_TIMEOUT_MESSAGE, interaction.id.value, attempt, "%,d".format(timeoutMillis))
                 Result.failure(
                     ThinkingException(
-                        message = "ChatClient call for interaction ${interaction.id.value} timed out after ${timeoutMillis}ms",
+                        message = "ChatClient call for interaction ${interaction.id.value} timed out after ${"%,d".format(timeoutMillis)}ms",
                         thinkingBlocks = emptyList()
                     )
                 )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -68,6 +68,7 @@ import jakarta.annotation.PostConstruct
 import jakarta.validation.Validator
 import org.springframework.beans.factory.annotation.Value
 import java.lang.reflect.ParameterizedType
+import java.util.Locale
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -796,9 +797,9 @@ internal class ChatClientLlmOperations(
         when (e) {
             is TimeoutException -> {
                 future.cancel(true)
-                logger.warn(LLM_TIMEOUT_MESSAGE, interaction.id.value, attempt, "%,d".format(timeoutMillis))
+                logger.warn(LLM_TIMEOUT_MESSAGE, interaction.id.value, attempt, "%,d".format(Locale.ROOT, timeoutMillis))
                 throw RuntimeException(
-                    "ChatClient call for interaction ${interaction.id.value} timed out after ${"%,d".format(timeoutMillis)}ms",
+                    "ChatClient call for interaction ${interaction.id.value} timed out after ${"%,d".format(Locale.ROOT, timeoutMillis)}ms",
                     e
                 )
             }
@@ -849,10 +850,10 @@ internal class ChatClientLlmOperations(
         return when (e) {
             is TimeoutException -> {
                 future.cancel(true)
-                logger.warn(LLM_TIMEOUT_MESSAGE, interaction.id.value, attempt, "%,d".format(timeoutMillis))
+                logger.warn(LLM_TIMEOUT_MESSAGE, interaction.id.value, attempt, "%,d".format(Locale.ROOT, timeoutMillis))
                 Result.failure(
                     ThinkingException(
-                        message = "ChatClient call for interaction ${interaction.id.value} timed out after ${"%,d".format(timeoutMillis)}ms",
+                        message = "ChatClient call for interaction ${interaction.id.value} timed out after ${"%,d".format(Locale.ROOT, timeoutMillis)}ms",
                         thinkingBlocks = emptyList()
                     )
                 )

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsThinkingTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsThinkingTest.kt
@@ -717,7 +717,7 @@ class ChatClientLlmOperationsThinkingTest {
         testHandleFutureException(
             exception = TimeoutException("Test timeout"),
             interactionId = "timeout-test",
-            expectedMessageContains = "timed out after 5000ms"
+            expectedMessageContains = "timed out after 5,000ms"
         )
     }
 


### PR DESCRIPTION
Log output rendered millisecond values without , separators.

This PR makes such values more readable.