### PR TITLE
Prepare 1.0.0 Release

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-dependencies</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
     <name>Embabel Agent BOM</name>
     <description>Embabel Agent BOM</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,7 +16,7 @@
 
     <properties>
         <argLine />
-        <embabel-common.version>1.0.0-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>1.0.0</embabel-common.version>
         <netty.version>4.2.15.Final</netty.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>


### PR DESCRIPTION
This pull request updates project versioning to move from snapshot builds to a stable release. The main changes are version bumps in the Maven configuration files.

Dependency and parent version updates:

* Updated the version in `embabel-agent-dependencies/pom.xml` from `1.0.0-SNAPSHOT` to `1.0.0` to mark a stable release.
* Updated the parent version in `pom.xml` from `1.0.0-SNAPSHOT` to `1.0.0` for `embabel-build-parent`.
* Updated the `embabel-common.version` property in `pom.xml` from `1.0.0-SNAPSHOT` to `1.0.0`.