### PR TITLE
Prepare 1.0.0 Release

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>


### PR DESCRIPTION
This pull request makes a small update to the `embabel-agent-dependencies/pom.xml` file, changing the parent project version from a snapshot to a stable release.

* Updated the parent dependency version from `1.0.0-SNAPSHOT` to `1.0.0` in `pom.xml`, ensuring the project now depends on the stable parent release.