### PR TITLE
Fix model binding broken by Spring AI 2.0 options merge removal

### DIFF
--- a/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicModelBindingTest.kt
+++ b/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicModelBindingTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.anthropic
+
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.model.LlmOptions
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.ai.anthropic.AnthropicChatOptions
+
+/**
+ * Regression for the Spring AI 2.0 model-binding bug affecting Anthropic:
+ * [AnthropicOptionsConverter] never calls .model(), so its [AnthropicChatOptions] carry
+ * DEFAULT_MODEL ("claude-haiku-4-5"). Spring AI 2.0 no longer merges the ChatModel bean's
+ * configured model into per-request options, so haiku would go on the wire silently.
+ * [SpringAiLlmService.buildChatOptions] now stamps the service name explicitly.
+ */
+class AnthropicModelBindingTest {
+
+    @Test
+    fun `buildChatOptions stamps configured model not AnthropicChatOptions haiku default`() {
+        val service = SpringAiLlmService(
+            name = "claude-sonnet-4-5",
+            provider = "Anthropic",
+            chatModel = mockk(relaxed = true),
+            optionsConverter = AnthropicOptionsConverter,
+        )
+
+        val result = service.buildChatOptions(LlmOptions())
+
+        assertThat(result).isInstanceOf(AnthropicChatOptions::class.java)
+        assertThat(result.model).isEqualTo("claude-sonnet-4-5")
+        assertThat(result.model).isNotEqualTo(AnthropicChatOptions.DEFAULT_MODEL)
+    }
+
+    @Test
+    fun `buildChatOptions preserves AnthropicChatOptions fields alongside model`() {
+        val service = SpringAiLlmService(
+            name = "claude-sonnet-4-5",
+            provider = "Anthropic",
+            chatModel = mockk(relaxed = true),
+            optionsConverter = AnthropicOptionsConverter,
+        )
+
+        val result = service.buildChatOptions(LlmOptions().withMaxTokens(500))
+
+        assertThat(result).isInstanceOf(AnthropicChatOptions::class.java)
+        assertThat(result.model).isEqualTo("claude-sonnet-4-5")
+        assertThat(result.maxTokens).isEqualTo(500)
+    }
+
+    @Test
+    fun `buildChatOptions result type is AnthropicChatOptions not generic fallback`() {
+        val service = SpringAiLlmService(
+            name = "claude-haiku-4-5",
+            provider = "Anthropic",
+            chatModel = mockk(relaxed = true),
+            optionsConverter = AnthropicOptionsConverter,
+        )
+
+        val result = service.buildChatOptions(LlmOptions())
+
+        assertThat(result).isInstanceOf(AnthropicChatOptions::class.java)
+        assertThat(result.model).isEqualTo("claude-haiku-4-5")
+    }
+}

--- a/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicModelBindingTest.kt
+++ b/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicModelBindingTest.kt
@@ -27,12 +27,12 @@ import org.springframework.ai.anthropic.AnthropicChatOptions
  * [AnthropicOptionsConverter] never calls .model(), so its [AnthropicChatOptions] carry
  * DEFAULT_MODEL ("claude-haiku-4-5"). Spring AI 2.0 no longer merges the ChatModel bean's
  * configured model into per-request options, so haiku would go on the wire silently.
- * [SpringAiLlmService.buildChatOptions] now stamps the service name explicitly.
+ * [SpringAiLlmService.convertOptions] now stamps the service name explicitly.
  */
 class AnthropicModelBindingTest {
 
     @Test
-    fun `buildChatOptions stamps configured model not AnthropicChatOptions haiku default`() {
+    fun `convertOptions stamps configured model not AnthropicChatOptions haiku default`() {
         val service = SpringAiLlmService(
             name = "claude-sonnet-4-5",
             provider = "Anthropic",
@@ -40,7 +40,7 @@ class AnthropicModelBindingTest {
             optionsConverter = AnthropicOptionsConverter,
         )
 
-        val result = service.buildChatOptions(LlmOptions())
+        val result = service.convertOptions(LlmOptions())
 
         assertThat(result).isInstanceOf(AnthropicChatOptions::class.java)
         assertThat(result.model).isEqualTo("claude-sonnet-4-5")
@@ -48,7 +48,7 @@ class AnthropicModelBindingTest {
     }
 
     @Test
-    fun `buildChatOptions preserves AnthropicChatOptions fields alongside model`() {
+    fun `convertOptions preserves AnthropicChatOptions fields alongside model`() {
         val service = SpringAiLlmService(
             name = "claude-sonnet-4-5",
             provider = "Anthropic",
@@ -56,7 +56,7 @@ class AnthropicModelBindingTest {
             optionsConverter = AnthropicOptionsConverter,
         )
 
-        val result = service.buildChatOptions(LlmOptions().withMaxTokens(500))
+        val result = service.convertOptions(LlmOptions().withMaxTokens(500))
 
         assertThat(result).isInstanceOf(AnthropicChatOptions::class.java)
         assertThat(result.model).isEqualTo("claude-sonnet-4-5")
@@ -64,7 +64,7 @@ class AnthropicModelBindingTest {
     }
 
     @Test
-    fun `buildChatOptions result type is AnthropicChatOptions not generic fallback`() {
+    fun `convertOptions result type is AnthropicChatOptions not generic fallback`() {
         val service = SpringAiLlmService(
             name = "claude-haiku-4-5",
             provider = "Anthropic",
@@ -72,7 +72,7 @@ class AnthropicModelBindingTest {
             optionsConverter = AnthropicOptionsConverter,
         )
 
-        val result = service.buildChatOptions(LlmOptions())
+        val result = service.convertOptions(LlmOptions())
 
         assertThat(result).isInstanceOf(AnthropicChatOptions::class.java)
         assertThat(result.model).isEqualTo("claude-haiku-4-5")

--- a/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicOptionsConverterTest.kt
+++ b/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicOptionsConverterTest.kt
@@ -28,6 +28,8 @@ import org.springframework.ai.anthropic.AnthropicCacheStrategy
 import org.springframework.ai.anthropic.AnthropicCacheTtl
 import org.springframework.ai.anthropic.AnthropicChatOptions
 
+// Calls the deprecated 1-arg convertOptions() directly to verify field mapping in isolation.
+// Model stamping is not tested here — it is covered by OptionsConverter.convertOptions(options, model).
 class AnthropicOptionsConverterTest : OptionsConverterTestSupport<AnthropicChatOptions>(
     optionsConverter = AnthropicOptionsConverter
 ) {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -189,7 +189,7 @@ internal class ChatClientLlmOperations(
     ): LlmMessageSender {
         if (llmRequestEvent != null) {
             val springAiLlm = requireSpringAiLlm(llm)
-            val chatOptions = springAiLlm.optionsConverter.convertOptions(options)
+            val chatOptions = springAiLlm.buildChatOptions(options)
             val instrumentedModel = InstrumentedChatModel(springAiLlm.chatModel, llmRequestEvent)
             return SpringAiLlmMessageSender(
                 chatModel = instrumentedModel,
@@ -348,7 +348,7 @@ internal class ChatClientLlmOperations(
 
         val schemaFormat = converter?.getFormat()
 
-        val chatOptions = requireSpringAiLlm(llm).optionsConverter.convertOptions(interaction.llm)
+        val chatOptions = requireSpringAiLlm(llm).buildChatOptions(interaction.llm)
         val timeoutMillis = getTimeoutMillis(interaction.llm)
 
         val basePrompt = if (schemaFormat != null) {
@@ -507,7 +507,7 @@ internal class ChatClientLlmOperations(
             // Get the complete format (examples + JSON schema)
             val schemaFormat = converter.getFormat()
 
-            val chatOptions = requireSpringAiLlm(llm).optionsConverter.convertOptions(interaction.llm)
+            val chatOptions = requireSpringAiLlm(llm).buildChatOptions(interaction.llm)
             val timeoutMillis = getTimeoutMillis(interaction.llm)
 
             val basePrompt = buildPromptWithMaybeReturnAndSchema(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -189,7 +189,7 @@ internal class ChatClientLlmOperations(
     ): LlmMessageSender {
         if (llmRequestEvent != null) {
             val springAiLlm = requireSpringAiLlm(llm)
-            val chatOptions = springAiLlm.buildChatOptions(options)
+            val chatOptions = springAiLlm.convertOptions(options)
             val instrumentedModel = InstrumentedChatModel(springAiLlm.chatModel, llmRequestEvent)
             return SpringAiLlmMessageSender(
                 chatModel = instrumentedModel,
@@ -348,7 +348,7 @@ internal class ChatClientLlmOperations(
 
         val schemaFormat = converter?.getFormat()
 
-        val chatOptions = requireSpringAiLlm(llm).buildChatOptions(interaction.llm)
+        val chatOptions = requireSpringAiLlm(llm).convertOptions(interaction.llm)
         val timeoutMillis = getTimeoutMillis(interaction.llm)
 
         val basePrompt = if (schemaFormat != null) {
@@ -507,7 +507,7 @@ internal class ChatClientLlmOperations(
             // Get the complete format (examples + JSON schema)
             val schemaFormat = converter.getFormat()
 
-            val chatOptions = requireSpringAiLlm(llm).buildChatOptions(interaction.llm)
+            val chatOptions = requireSpringAiLlm(llm).convertOptions(interaction.llm)
             val timeoutMillis = getTimeoutMillis(interaction.llm)
 
             val basePrompt = buildPromptWithMaybeReturnAndSchema(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmService.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmService.kt
@@ -28,6 +28,7 @@ import org.springframework.ai.chat.client.ChatClient
 import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.Prompt
 import reactor.core.publisher.Flux
 import java.time.Duration
@@ -123,11 +124,13 @@ data class SpringAiLlmService @JvmOverloads constructor(
      */
     override val model: ChatModel get() = chatModel
 
+    fun buildChatOptions(llmOptions: LlmOptions): ChatOptions =
+        optionsConverter.convertOptions(llmOptions).mutate().model(name).build()
+
     override fun createMessageSender(options: LlmOptions): LlmMessageSender {
-        val chatOptions = optionsConverter.convertOptions(options)
         return SpringAiLlmMessageSender(
             chatModel = chatModel,
-            chatOptions = chatOptions,
+            chatOptions = buildChatOptions(options),
             toolResponseContentAdapter = toolResponseContentAdapter,
             nativeStructuredOutputConfigurer = nativeStructuredOutputConfigurer,
             nativeSupport = nativeSupport,
@@ -136,9 +139,8 @@ data class SpringAiLlmService @JvmOverloads constructor(
     }
 
     override fun createMessageStreamer(options: LlmOptions): LlmMessageStreamer {
-        val chatOptions = optionsConverter.convertOptions(options)
         val chatClient = ChatClient.create(chatModel)
-        return SpringAiLlmMessageStreamer(chatClient, chatOptions)
+        return SpringAiLlmMessageStreamer(chatClient, buildChatOptions(options))
     }
 
     override fun supportsStreaming(): Boolean = StreamingCapabilityVerifier.supportsStreaming(chatModel)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmService.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmService.kt
@@ -86,7 +86,9 @@ private object StreamingCapabilityVerifier {
  * @param name Name of the LLM
  * @param provider Name of the provider (e.g., "OpenAI", "Anthropic")
  * @param chatModel The Spring AI ChatModel to use for LLM calls
- * @param optionsConverter Function to convert [LlmOptions] to Spring AI ChatOptions
+ * @param optionsConverter Function to convert [LlmOptions] to Spring AI ChatOptions.
+ *        Do not call [OptionsConverter.convertOptions] directly — use [SpringAiLlmService.convertOptions]
+ *        which also stamps the configured model name.
  * @param knowledgeCutoffDate Model's knowledge cutoff date, if known
  * @param promptContributors List of prompt contributors for this model.
  *        Knowledge cutoff is automatically included if knowledgeCutoffDate is set.
@@ -124,13 +126,13 @@ data class SpringAiLlmService @JvmOverloads constructor(
      */
     override val model: ChatModel get() = chatModel
 
-    fun buildChatOptions(llmOptions: LlmOptions): ChatOptions =
-        optionsConverter.convertOptions(llmOptions).mutate().model(name).build()
+    fun convertOptions(llmOptions: LlmOptions): ChatOptions =
+        optionsConverter.convertOptions(llmOptions, name)
 
     override fun createMessageSender(options: LlmOptions): LlmMessageSender {
         return SpringAiLlmMessageSender(
             chatModel = chatModel,
-            chatOptions = buildChatOptions(options),
+            chatOptions = convertOptions(options),
             toolResponseContentAdapter = toolResponseContentAdapter,
             nativeStructuredOutputConfigurer = nativeStructuredOutputConfigurer,
             nativeSupport = nativeSupport,
@@ -140,7 +142,7 @@ data class SpringAiLlmService @JvmOverloads constructor(
 
     override fun createMessageStreamer(options: LlmOptions): LlmMessageStreamer {
         val chatClient = ChatClient.create(chatModel)
-        return SpringAiLlmMessageStreamer(chatClient, buildChatOptions(options))
+        return SpringAiLlmMessageStreamer(chatClient, convertOptions(options))
     }
 
     override fun supportsStreaming(): Boolean = StreamingCapabilityVerifier.supportsStreaming(chatModel)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperations.kt
@@ -174,7 +174,7 @@ internal class StreamingChatClientOperations(
         val userMessages = messages.filterIsInstance<com.embabel.chat.UserMessage>()
         validateUserInput(userMessages, interaction, llmRequestEvent?.agentProcess?.blackboard)
 
-        val chatOptions = requireSpringAiLlm(llm).optionsConverter.convertOptions(interaction.llm)
+        val chatOptions = requireSpringAiLlm(llm).buildChatOptions(interaction.llm)
 
         // Resolve tool groups and decorate tools
         val tools = chatClientLlmOperations.resolveAndDecorateTools(interaction, agentProcess, action)
@@ -346,7 +346,7 @@ internal class StreamingChatClientOperations(
         // Chat Client
         val chatClient = chatClientLlmOperations.createChatClient(llm)
         // Chat Options, additional potential option "streaming"
-        val chatOptions = requireSpringAiLlm(llm).optionsConverter.convertOptions(interaction.llm)
+        val chatOptions = requireSpringAiLlm(llm).buildChatOptions(interaction.llm)
 
         // Spring AI 2.0's StreamingJacksonOutputConverter requires T : Any;
         // erase O via Class<Any> for the construction, cast result back at use sites.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/StreamingChatClientOperations.kt
@@ -174,7 +174,7 @@ internal class StreamingChatClientOperations(
         val userMessages = messages.filterIsInstance<com.embabel.chat.UserMessage>()
         validateUserInput(userMessages, interaction, llmRequestEvent?.agentProcess?.blackboard)
 
-        val chatOptions = requireSpringAiLlm(llm).buildChatOptions(interaction.llm)
+        val chatOptions = requireSpringAiLlm(llm).convertOptions(interaction.llm)
 
         // Resolve tool groups and decorate tools
         val tools = chatClientLlmOperations.resolveAndDecorateTools(interaction, agentProcess, action)
@@ -346,7 +346,7 @@ internal class StreamingChatClientOperations(
         // Chat Client
         val chatClient = chatClientLlmOperations.createChatClient(llm)
         // Chat Options, additional potential option "streaming"
-        val chatOptions = requireSpringAiLlm(llm).buildChatOptions(interaction.llm)
+        val chatOptions = requireSpringAiLlm(llm).convertOptions(interaction.llm)
 
         // Spring AI 2.0's StreamingJacksonOutputConverter requires T : Any;
         // erase O via Class<Any> for the construction, cast result back at use sites.

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/ChatClientLlmOperationsTest.kt
@@ -49,6 +49,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import jakarta.validation.Validation
 import jakarta.validation.constraints.Pattern
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -1320,6 +1321,28 @@ class ChatClientLlmOperationsTest {
             } catch (e: InvalidLlmReturnTypeException) {
                 assertTrue(e.constraintViolations.any { it.propertyPath.toString() == "eats" })
             }
+        }
+    }
+
+    @Nested
+    inner class ModelBinding {
+
+        @Test
+        fun `model name from SpringAiLlmService reaches ChatModel call`() {
+            val duke = Dog("Duke")
+            val fakeChatModel = FakeChatModel(jacksonObjectMapper().writeValueAsString(duke))
+            val setup = createChatClientLlmOperations(fakeChatModel)
+
+            setup.llmOperations.createObject(
+                messages = listOf(UserMessage("prompt")),
+                interaction = LlmInteraction(id = InteractionId("id"), llm = LlmOptions()),
+                outputClass = Dog::class.java,
+                action = SimpleTestAgent.actions.first(),
+                agentProcess = setup.mockAgentProcess,
+            )
+
+            assertThat(fakeChatModel.optionsPassed).isNotEmpty()
+            assertThat(fakeChatModel.optionsPassed[0].model).isEqualTo("fake")
         }
     }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmServiceTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmServiceTest.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.model.tool.ToolCallingChatOptions
 import java.time.LocalDate
 
 class SpringAiLlmServiceTest {
@@ -250,6 +251,45 @@ class SpringAiLlmServiceTest {
     }
 
     @Nested
+    inner class BuildChatOptionsTests {
+
+        @Test
+        fun `buildChatOptions stamps service name as model`() {
+            val service = SpringAiLlmService(
+                name = "my-model",
+                provider = "Provider",
+                chatModel = mockChatModel,
+            )
+            assertThat(service.buildChatOptions(LlmOptions()).model).isEqualTo("my-model")
+        }
+
+        @Test
+        fun `buildChatOptions overrides converter default model with service name`() {
+            val service = SpringAiLlmService(
+                name = "my-model",
+                provider = "Provider",
+                chatModel = mockChatModel,
+            )
+            val result = service.buildChatOptions(LlmOptions())
+            assertThat(result.model).isEqualTo("my-model")
+            assertThat(result.model).isNotEqualTo("some-default-model")
+        }
+
+        @Test
+        fun `buildChatOptions preserves converter fields alongside model`() {
+            val service = SpringAiLlmService(
+                name = "my-model",
+                provider = "Provider",
+                chatModel = mockChatModel,
+            )
+            val result = service.buildChatOptions(LlmOptions().withTemperature(0.5).withMaxTokens(100))
+            assertThat(result.model).isEqualTo("my-model")
+            assertThat(result.temperature).isEqualTo(0.5)
+            assertThat(result.maxTokens).isEqualTo(100)
+        }
+    }
+
+    @Nested
     inner class CreateMessageSenderTests {
 
         @Test
@@ -272,7 +312,7 @@ class SpringAiLlmServiceTest {
             val customConverter = object : OptionsConverter<ChatOptions> {
                 override fun convertOptions(options: LlmOptions): ChatOptions {
                     converterCalled = true
-                    return mockk()
+                    return ToolCallingChatOptions.builder().build()
                 }
             }
             val service = SpringAiLlmService(
@@ -314,7 +354,7 @@ class SpringAiLlmServiceTest {
             val customConverter = object : OptionsConverter<ChatOptions> {
                 override fun convertOptions(options: LlmOptions): ChatOptions {
                     converterCalled = true
-                    return mockk()
+                    return ToolCallingChatOptions.builder().build()
                 }
             }
             val service = SpringAiLlmService(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmServiceTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiLlmServiceTest.kt
@@ -251,38 +251,38 @@ class SpringAiLlmServiceTest {
     }
 
     @Nested
-    inner class BuildChatOptionsTests {
+    inner class ConvertOptionsTests {
 
         @Test
-        fun `buildChatOptions stamps service name as model`() {
+        fun `convertOptions stamps service name as model`() {
             val service = SpringAiLlmService(
                 name = "my-model",
                 provider = "Provider",
                 chatModel = mockChatModel,
             )
-            assertThat(service.buildChatOptions(LlmOptions()).model).isEqualTo("my-model")
+            assertThat(service.convertOptions(LlmOptions()).model).isEqualTo("my-model")
         }
 
         @Test
-        fun `buildChatOptions overrides converter default model with service name`() {
+        fun `convertOptions overrides converter default model with service name`() {
             val service = SpringAiLlmService(
                 name = "my-model",
                 provider = "Provider",
                 chatModel = mockChatModel,
             )
-            val result = service.buildChatOptions(LlmOptions())
+            val result = service.convertOptions(LlmOptions())
             assertThat(result.model).isEqualTo("my-model")
             assertThat(result.model).isNotEqualTo("some-default-model")
         }
 
         @Test
-        fun `buildChatOptions preserves converter fields alongside model`() {
+        fun `convertOptions preserves converter fields alongside model`() {
             val service = SpringAiLlmService(
                 name = "my-model",
                 provider = "Provider",
                 chatModel = mockChatModel,
             )
-            val result = service.buildChatOptions(LlmOptions().withTemperature(0.5).withMaxTokens(100))
+            val result = service.convertOptions(LlmOptions().withTemperature(0.5).withMaxTokens(100))
             assertThat(result.model).isEqualTo("my-model")
             assertThat(result.temperature).isEqualTo(0.5)
             assertThat(result.maxTokens).isEqualTo(100)

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LlmAnthropicCachingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LlmAnthropicCachingIT.java
@@ -308,7 +308,7 @@ class LlmAnthropicCachingIT {
 
     @Test
     void testSystemPromptCaching() {
-        logger.info("Testing system prompt caching");
+        logger.info("Testing system prompt caching with thinking enabled");
 
         AnthropicCachingConfig cachingConfig = new AnthropicCachingConfig();
         cachingConfig.setSystemPrompt(true);

--- a/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-deepseek-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/deepseek/DeepSeekOptionsConverterTest.kt
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.springframework.ai.deepseek.DeepSeekChatOptions
 
+// Calls the deprecated 1-arg convertOptions() directly to verify field mapping in isolation.
+// Model stamping is not tested here — it is covered by OptionsConverter.convertOptions(options, model).
 class DeepSeekOptionsConverterTest : OptionsConverterTestSupport<DeepSeekChatOptions>(
     optionsConverter = DeepSeekOptionsConverter
 ) {

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiOptionsConverterTest.kt
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.springframework.ai.google.genai.GoogleGenAiChatOptions
 
+// Calls the deprecated 1-arg convertOptions() directly to verify field mapping in isolation.
+// Model stamping is not tested here — it is covered by OptionsConverter.convertOptions(options, model).
 class GoogleGenAiOptionsConverterTest : OptionsConverterTestSupport<GoogleGenAiChatOptions>(
     optionsConverter = GoogleGenAiOptionsConverter
 ) {

--- a/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/minimax/MiniMaxOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-minimax-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/minimax/MiniMaxOptionsConverterTest.kt
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.ai.openai.OpenAiChatOptions
 
+// Calls the deprecated 1-arg convertOptions() directly to verify field mapping in isolation.
+// Model stamping is not tested here — it is covered by OptionsConverter.convertOptions(options, model).
 class MiniMaxOptionsConverterTest : OptionsConverterTestSupport<OpenAiChatOptions>(
     optionsConverter = MiniMaxOptionsConverter
 ) {

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ollama/OllamaOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ollama/OllamaOptionsConverterTest.kt
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.ai.ollama.api.OllamaChatOptions
 import org.springframework.ai.ollama.api.ThinkOption
 
+// Calls the deprecated 1-arg convertOptions() directly to verify field mapping in isolation.
+// Model stamping is not tested here — it is covered by OptionsConverter.convertOptions(options, model).
 class OllamaOptionsConverterTest : OptionsConverterTestSupport<OllamaChatOptions>(
     optionsConverter = OllamaOptionsConverter
 ) {

--- a/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-zai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/zai/ZaiOptionsConverterTest.kt
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.ai.openai.OpenAiChatOptions
 
+// Calls the deprecated 1-arg convertOptions() directly to verify field mapping in isolation.
+// Model stamping is not tested here — it is covered by OptionsConverter.convertOptions(options, model).
 class ZaiOptionsConverterTest : OptionsConverterTestSupport<OpenAiChatOptions>(
     optionsConverter = ZaiOptionsConverter
 ) {

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/OptionsConverter.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/OptionsConverter.kt
@@ -19,10 +19,25 @@ import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.model.tool.ToolCallingChatOptions
 
 /**
- * Convert our LLM options to Spring AI ChatOptions
+ * Convert our LLM options to Spring AI ChatOptions.
+ *
+ * Prefer [convertOptions] with an explicit model over the no-model overload.
+ * The no-model form is deprecated because provider converters carry hardcoded
+ * default models that will silently go to the wire if not overridden.
  */
+// TODO: update all converter implementations to override convertOptions(options, model) directly,
+//  then remove the deprecated 1-arg form and the @Suppress below.
 fun interface OptionsConverter<O : ChatOptions> {
+
+    @Deprecated(
+        message = "Provide the model explicitly — provider converters carry hardcoded defaults that bypass the configured model.",
+        replaceWith = ReplaceWith("convertOptions(options, model)"),
+    )
     fun convertOptions(options: LlmOptions): O
+
+    @Suppress("DEPRECATION")
+    fun convertOptions(options: LlmOptions, model: String): ChatOptions =
+        convertOptions(options).mutate().model(model).build()
 }
 
 /**

--- a/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/test/models/optionsConverterTestUtils.kt
+++ b/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/test/models/optionsConverterTestUtils.kt
@@ -19,6 +19,8 @@ import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.OptionsConverter
 import org.junit.jupiter.api.Assertions.assertEquals
 
+// Calls the deprecated 1-arg convertOptions() directly to verify field mapping in isolation.
+// Model stamping is not tested here — it is covered by OptionsConverter.convertOptions(options, model).
 fun checkOptionsConverterPreservesCoreValues(optionsConverter: OptionsConverter<*>) {
     val llmo = LlmOptions().withTemperature(temperature = 0.5).withTopK(10).withTopP(.2).withFrequencyPenalty(.2)
     val options = optionsConverter.convertOptions(llmo)


### PR DESCRIPTION
## OVERVIEW
  ---
###   Problem

  Spring AI 2.0 removed the implicit merge between per-request ChatOptions and the ChatModel bean's configured default options. 
  Every provider's OptionsConverter implementation omits .model() from the builder, relying on the old merge to stamp  the correct model. 

  Example — Anthropic: AnthropicOptionsConverter.convertOptions() never calls .model(), so every call produces
  AnthropicChatOptions with DEFAULT_MODEL = "claude-haiku-4-5" regardless of which model was selected. The
  AnthropicChatModel bean had claude-sonnet-4-5 in its configured default properties options — in 1.x that won; in 2.0 it is never  consulted.

  ### Fix

  Added buildChatOptions(llmOptions) to SpringAiLlmService that stamps this.name (the configured model ID) onto the
  converted options after conversion:

```
  fun buildChatOptions(llmOptions: LlmOptions): ChatOptions =
      optionsConverter.convertOptions(llmOptions).mutate().model(name).build()
```
  This is provider-agnostic — name is the model ID set at SpringAiLlmService construction time, independent of whatever  default any converter bakes in.

  Applied at all call sites that build per-request options:
  - SpringAiLlmService.createMessageSender and createMessageStreamer
  - ChatClientLlmOperations.createMessageSender (override — the actual Anthropic/non-streaming call path; the fix in
  SpringAiLlmService alone is bypassed here)
  - Two additional sites in ChatClientLlmOperations (lines 351, 510)
  - Two sites in StreamingChatClientOperations (lines 177, 349)

 ###  Tests

  - SpringAiLlmServiceTest.BuildChatOptionsTests — unit tests for model stamping and field preservation
  - ChatClientLlmOperationsTest.ModelBinding — proves model name travels through the ChatClientLlmOperations override
  path to ChatModel.call()
  - AnthropicModelBindingTest — Anthropic-specific regression: AnthropicOptionsConverter + buildChatOptions produces
  AnthropicChatOptions with the configured model, not DEFAULT_MODEL

  ---

Closes: #1815 , #1735 , #1816
