### PR TITLE
Include authors page on hub

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/overview/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/overview/page.adoc
@@ -3,6 +3,15 @@
 :sectids:
 :sectanchors:
 
+// The book carries the authors in its front matter, from index.adoc.
+// Hub has no front matter, so it gets them here, as a byline under the title.
+// asciidoctor always defines `backend`; downdoc never does, so this is hub-only.
+ifndef::backend[]
+
+include::../authors.adoc[]
+
+endif::[]
+
 Agentic AI is the use of large language (and other multi-modal) models not just to generate text, but to act as
 reasoning, goal-driven agents that can plan, call tools, and adapt their actions to deliver outcomes.
 


### PR DESCRIPTION
# Docs: show author credits on hub.embabel.com

## Problem

`convert-docs.sh` only copies `page.mdx` files generated from `page.adoc`. `authors.adoc` is a root fragment included by `index.adoc`, which converts to `index.mdx` and is never copied. So the credits rendered in the book but not on hub.

## Change

One file: `embabel-agent-docs/src/main/asciidoc/overview/page.adoc`, guarded include under the chapter title.

```asciidoc
ifndef::backend[]

include::../authors.adoc[]

endif::[]
```

`authors.adoc` and `index.adoc` unchanged. Name list keeps one home.

## Why the guard

Book takes the names from `index.adoc` as front matter. Hub has no front matter, so it takes them from Overview. Unguarded, asciidoctor would render them twice with a duplicate `authors` anchor. asciidoctor always defines `backend`; downdoc never does.

## Result

Book unchanged: names once, `<div id="authors" class="paragraph">` in front matter, `#authors` anchor intact.

Hub `/overview` gains an unlabelled byline under the title:

```
# Overview

Rod Johnson, Alex Hein-Heifetz, Dr. Igor Dayen, Arjen Poutsma, Jasper Blues {{ className: 'lead' }}
```

No heading, so no TOC or sidebar entry. Matches the book, where the names are also unlabelled.

## Verification

- `mvn generate-resources` passes; names appear once in `target/generated-docs/index.html`.
- `downdoc overview/page.adoc` emits the byline.
- Docs source only, no code touched.

