### PR TITLE
test: add unit coverage for uncovered utilities

### DIFF
--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/reference/EagerSearchTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/reference/EagerSearchTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.reference
+
+import com.embabel.common.core.types.TextSimilaritySearchRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/** Verifies the [EagerSearch] text overload, including request defaults and forwarded inputs. */
+class EagerSearchTest {
+
+    private fun mockEagerSearch(): TestEagerSearch {
+        val search = mockk<TestEagerSearch>()
+        every { search.withEagerSearchAbout(any<TextSimilaritySearchRequest>()) } returns search
+        every { search.withEagerSearchAbout(any<String>(), any()) } answers { callOriginal() }
+        return search
+    }
+
+    @Nested
+    inner class DefaultWithEagerSearchAbout {
+
+        @Test
+        fun `string overload builds request with zero threshold and given topK`() {
+            val capturedRequest = slot<TextSimilaritySearchRequest>()
+            val search = mockEagerSearch()
+
+            val result = search.withEagerSearchAbout("find related APIs", limit = 5)
+
+            assertSame(search, result)
+            verify(exactly = 1) { search.withEagerSearchAbout(capture(capturedRequest)) }
+            assertEquals("find related APIs", capturedRequest.captured.query)
+            assertEquals(0.0, capturedRequest.captured.similarityThreshold)
+            assertEquals(5, capturedRequest.captured.topK)
+        }
+
+        @Test
+        fun `string overload forwards empty query and zero limit`() {
+            val capturedRequest = slot<TextSimilaritySearchRequest>()
+            val search = mockEagerSearch()
+
+            search.withEagerSearchAbout("", limit = 0)
+
+            verify(exactly = 1) { search.withEagerSearchAbout(capture(capturedRequest)) }
+            assertEquals("", capturedRequest.captured.query)
+            assertEquals(0.0, capturedRequest.captured.similarityThreshold)
+            assertEquals(0, capturedRequest.captured.topK)
+        }
+    }
+
+    private interface TestEagerSearch : EagerSearch<TestEagerSearch>
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/CommunicateToolTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/tool/CommunicateToolTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.tool
+
+import com.embabel.agent.api.channel.MessageOutputChannelEvent
+import com.embabel.agent.api.channel.OutputChannel
+import com.embabel.agent.api.channel.OutputChannelEvent
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.AgentProcess.Companion.withCurrent
+import com.embabel.agent.core.ProcessOptions
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/** Verifies [CommunicateTool] definition, delivery, and failure handling with and without an active process. */
+class CommunicateToolTest {
+
+    private fun mockAgentProcess(outputChannel: OutputChannel): AgentProcess =
+        mockk {
+            every { id } returns "communicate-test"
+            every { processOptions } returns ProcessOptions(outputChannel = outputChannel)
+        }
+
+    @Nested
+    inner class ToolDefinition {
+
+        @Test
+        fun `create returns communicate tool with message parameter`() {
+            val tool = CommunicateTool.create()
+
+            assertEquals(CommunicateTool.NAME, tool.definition.name)
+            assertEquals(
+                "Send a permanent message to the user. " +
+                    "Use this to report results, share links (e.g., PR URLs), " +
+                    "or inform the user of important outcomes. " +
+                    "Unlike progress, this creates a visible chat message.",
+                tool.definition.description,
+            )
+            assertEquals(1, tool.definition.inputSchema.parameters.size)
+            val parameter = tool.definition.inputSchema.parameters.single()
+            assertEquals("message", parameter.name)
+            assertEquals(Tool.ParameterType.STRING, parameter.type)
+            assertEquals("The message to send to the user", parameter.description)
+            assertTrue(parameter.required)
+        }
+    }
+
+    @Nested
+    inner class WithoutActiveProcess {
+
+        @Test
+        fun `missing message parameter returns error`() {
+            val result = CommunicateTool.create().call("""{"other":"x"}""")
+
+            val error = assertIs<Tool.Result.Error>(result)
+            assertEquals("Missing 'message' parameter", error.message)
+        }
+
+        @Test
+        fun `notes message when no agent process is bound`() {
+            val result = CommunicateTool.create().call("""{"message":"hello user"}""")
+
+            val text = assertIs<Tool.Result.Text>(result)
+            assertEquals(
+                "Message noted (no active process to deliver it).",
+                text.content,
+            )
+        }
+    }
+
+    @Nested
+    inner class WithActiveProcess {
+
+        @Test
+        fun `sends assistant message on output channel`() {
+            val channel = mockk<OutputChannel>(relaxed = true)
+            val event = slot<OutputChannelEvent>()
+            val process = mockAgentProcess(outputChannel = channel)
+
+            process.withCurrent {
+                val result = CommunicateTool.create().call("""{"message":"PR ready at https://example.com"}""")
+
+                val text = assertIs<Tool.Result.Text>(result)
+                assertEquals("Message sent to user.", text.content)
+            }
+
+            verify(exactly = 1) { channel.send(capture(event)) }
+            val messageEvent = assertIs<MessageOutputChannelEvent>(event.captured)
+            assertEquals(process.id, messageEvent.processId)
+            assertEquals("PR ready at https://example.com", messageEvent.message.content)
+        }
+
+        @Test
+        fun `rejects empty message content when process is active`() {
+            val channel = mockk<OutputChannel>(relaxed = true)
+            val process = mockAgentProcess(outputChannel = channel)
+
+            process.withCurrent {
+                assertFailsWith<IllegalArgumentException> {
+                    CommunicateTool.create().call("""{"message":""}""")
+                }
+            }
+
+            verify(exactly = 0) { channel.send(any()) }
+        }
+
+        @Test
+        fun `propagates output channel failure instead of reporting success`() {
+            val channel = mockk<OutputChannel>()
+            every { channel.send(any()) } throws IllegalStateException("channel unavailable")
+            val process = mockAgentProcess(outputChannel = channel)
+
+            val failure = assertFailsWith<IllegalStateException> {
+                process.withCurrent {
+                    CommunicateTool.create().call("""{"message":"important update"}""")
+                }
+            }
+
+            assertEquals("channel unavailable", failure.message)
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/logging/personality/FormatUtilsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/logging/personality/FormatUtilsTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.logging.personality
+
+import com.embabel.common.util.bold
+import com.embabel.common.util.color
+import com.embabel.common.util.italic
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/** Verifies [character] styling for named, unnamed, and empty text. */
+class FormatUtilsTest {
+
+    @Nested
+    inner class CharacterFormatting {
+
+        @Test
+        fun `formats nonblank name and text exactly`() {
+            val color = 0xbeb780
+
+            val result = character(name = "Kier", text = "hello", color = color)
+
+            assertEquals("${"Kier".bold()}: ${"hello".italic().color(color)}", result)
+        }
+
+        @Test
+        fun `omits name prefix when name is blank`() {
+            val color = 0xbeb780
+
+            val result = character(name = "", text = "hello", color = color)
+
+            assertEquals("hello".italic().color(color), result)
+        }
+
+        @Test
+        fun `omits name prefix when name is whitespace only`() {
+            val color = 0x00ff66
+
+            val result = character(name = "   ", text = "whisper", color = color)
+
+            assertEquals("whisper".italic().color(color), result)
+        }
+
+        @Test
+        fun `preserves empty text body`() {
+            val color = 0x00ff66
+
+            val result = character(name = "Guide", text = "", color = color)
+
+            assertEquals("${"Guide".bold()}: ${"".italic().color(color)}", result)
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/logging/personality/hitchhiker/HitchhikerUtilsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/logging/personality/hitchhiker/HitchhikerUtilsTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.logging.personality.hitchhiker
+
+import com.embabel.common.util.bold
+import com.embabel.common.util.color
+import com.embabel.common.util.italic
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/** Verifies [guide] styling, including empty text. */
+class HitchhikerUtilsTest {
+
+    @Nested
+    inner class GuideSaying {
+
+        @Test
+        fun `formats Guide saying exactly`() {
+            val result = guide("Don't Panic")
+
+            assertEquals(
+                "📕 ${"Guide".bold()} ${"Don't Panic".italic().color(HitchhikerColorPalette.BABEL_GREEN)}",
+                result,
+            )
+        }
+
+        @Test
+        fun `handles empty text`() {
+            val result = guide("")
+
+            assertEquals(
+                "📕 ${"Guide".bold()} ${"".italic().color(HitchhikerColorPalette.BABEL_GREEN)}",
+                result,
+            )
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/logging/personality/severance/SeveranceUtilsTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/logging/personality/severance/SeveranceUtilsTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.logging.personality.severance
+
+import com.embabel.common.util.bold
+import com.embabel.common.util.color
+import com.embabel.common.util.italic
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/** Verifies [kier] styling, including empty text. */
+class SeveranceUtilsTest {
+
+    @Nested
+    inner class KierSaying {
+
+        @Test
+        fun `formats Kier saying exactly`() {
+            val result = kier("Praise Kier")
+
+            assertEquals(
+                "👔 ${"Kier".bold()} ${"Praise Kier".italic().color(LumonColorPalette.MEMBRANE)}",
+                result,
+            )
+        }
+
+        @Test
+        fun `handles empty text`() {
+            val result = kier("")
+
+            assertEquals(
+                "👔 ${"Kier".bold()} ${"".italic().color(LumonColorPalette.MEMBRANE)}",
+                result,
+            )
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/filter/EntityFilterTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/filter/EntityFilterTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.filter
+
+import com.embabel.agent.filter.PropertyFilter
+import com.embabel.agent.rag.model.SimpleNamedEntityData
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Verifies [EntityFilter] construction and entity matching by labels and properties. */
+class EntityFilterTest {
+
+    private fun entity(vararg labels: String) = SimpleNamedEntityData(
+        id = "e1",
+        name = "Entity",
+        description = "desc",
+        labels = labels.toSet(),
+        properties = emptyMap(),
+    )
+
+    @Nested
+    inner class FactoryMethods {
+
+        @Test
+        fun `secondary vararg constructor creates HasAnyLabel`() {
+            val filter = EntityFilter.HasAnyLabel("Person", "Organization", "Person")
+
+            assertEquals(setOf("Person", "Organization"), filter.labels)
+        }
+
+        @Test
+        fun `vararg factory creates HasAnyLabel`() {
+            val filter = EntityFilter.hasAnyLabel("Person", "Organization")
+
+            assertEquals(setOf("Person", "Organization"), filter.labels)
+        }
+
+        @Test
+        fun `set factory creates HasAnyLabel`() {
+            val filter = EntityFilter.hasAnyLabel(setOf("Person"))
+
+            assertEquals(setOf("Person"), filter.labels)
+        }
+
+        @Test
+        fun `collection factory creates HasAnyLabel`() {
+            val filter = EntityFilter.hasAnyLabel(listOf("Person", "Person", "Org"))
+
+            assertEquals(setOf("Person", "Org"), filter.labels)
+        }
+
+        @Test
+        fun `empty labels are rejected`() {
+            assertFailsWith<IllegalArgumentException> {
+                EntityFilter.hasAnyLabel()
+            }
+            assertFailsWith<IllegalArgumentException> {
+                EntityFilter.hasAnyLabel(emptySet())
+            }
+            assertFailsWith<IllegalArgumentException> {
+                EntityFilter.hasAnyLabel(emptyList())
+            }
+            assertFailsWith<IllegalArgumentException> {
+                EntityFilter.HasAnyLabel(emptySet())
+            }
+        }
+    }
+
+    @Nested
+    inner class MatchesEntityFilterExtension {
+
+        @Test
+        fun `null filter always matches`() {
+            assertTrue(entity("Person").matchesEntityFilter(null))
+        }
+
+        @Test
+        fun `matches when entity has overlapping label`() {
+            val filter = EntityFilter.hasAnyLabel("Person", "Organization")
+
+            assertTrue(entity("Person", "Employee").matchesEntityFilter(filter))
+        }
+
+        @Test
+        fun `does not match when labels are disjoint`() {
+            val filter = EntityFilter.hasAnyLabel("Organization")
+
+            assertFalse(entity("Person").matchesEntityFilter(filter))
+        }
+
+        @Test
+        fun `label matching is case sensitive`() {
+            val filter = EntityFilter.hasAnyLabel("person")
+
+            assertFalse(entity("Person").matchesEntityFilter(filter))
+        }
+
+        @Test
+        fun `property eq filter matches entity properties`() {
+            val entity = SimpleNamedEntityData(
+                id = "e1",
+                name = "Alice",
+                description = "desc",
+                labels = setOf("Person"),
+                properties = mapOf("role" to "admin"),
+            )
+
+            assertTrue(entity.matchesEntityFilter(PropertyFilter.Eq(key = "role", value = "admin")))
+            assertFalse(entity.matchesEntityFilter(PropertyFilter.Eq(key = "role", value = "guest")))
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/pipeline/AdaptivePipelineRagResponseEnhancerTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/pipeline/AdaptivePipelineRagResponseEnhancerTest.kt
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.pipeline
+
+import com.embabel.agent.event.RagEvent
+import com.embabel.agent.event.RagEventListener
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.pipeline.event.EnhancementCompletedRagPipelineEvent
+import com.embabel.agent.rag.pipeline.event.EnhancementStartingRagPipelineEvent
+import com.embabel.agent.rag.service.DesiredMaxLatency
+import com.embabel.agent.rag.service.EnhancementEstimate
+import com.embabel.agent.rag.service.EnhancementRecommendation
+import com.embabel.agent.rag.service.EnhancementType
+import com.embabel.agent.rag.service.QualityMetrics
+import com.embabel.agent.rag.service.RagRequest
+import com.embabel.agent.rag.service.RagResponse
+import com.embabel.agent.rag.service.RagResponseEnhancer
+import com.embabel.common.core.types.SimpleSimilaritySearchResult
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/** Verifies adaptive and sequential enhancer execution, including skips, failures, and lifecycle events. */
+class AdaptivePipelineRagResponseEnhancerTest {
+
+    private fun response(
+        results: List<SimpleSimilaritySearchResult<Chunk>> = emptyList(),
+        request: RagRequest = RagRequest("q"),
+        quality: QualityMetrics? = null,
+    ) = RagResponse(
+        request = request,
+        service = "test",
+        results = results,
+        qualityMetrics = quality,
+    )
+
+    private fun chunk(id: String) = SimpleSimilaritySearchResult(
+        match = Chunk(id = id, text = id, parentId = "doc", metadata = emptyMap()),
+        score = 0.9,
+    )
+
+    @Nested
+    inner class NameAndType {
+
+        @Test
+        fun `name joins enhancer names`() {
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(FixedEnhancer("a"), FixedEnhancer("b")),
+                listener = RecordingRagListener(),
+            )
+
+            assertEquals("a->b", pipeline.name)
+            assertEquals(EnhancementType.CUSTOM, pipeline.enhancementType)
+        }
+
+        @Test
+        fun `empty pipeline has empty name and custom type`() {
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = emptyList(),
+                listener = RecordingRagListener(),
+            )
+
+            assertEquals("", pipeline.name)
+            assertEquals(EnhancementType.CUSTOM, pipeline.enhancementType)
+        }
+    }
+
+    @Nested
+    inner class NonAdaptiveExecution {
+
+        @Test
+        fun `applies enhancers in order when adaptiveExecution is false`() {
+            val listener = RecordingRagListener()
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(AppendingEnhancer("x"), AppendingEnhancer("y")),
+                adaptiveExecution = false,
+                listener = listener,
+            )
+
+            val original = response(listOf(chunk("base")))
+
+            val enhanced = pipeline.enhance(original)
+
+            assertEquals(listOf("base", "x", "y"), enhanced.results.map { it.match.id })
+            assertEquals(listOf("x", "y"), listener.starting.map { it.enhancerName })
+            assertEquals(listOf("x", "y"), listener.completed.map { it.enhancerName })
+            val enhancement = assertNotNull(enhanced.enhancement)
+            assertEquals("y", enhancement.enhancer.name)
+            assertEquals(listOf("base", "x"), enhancement.basis.results.map { it.match.id })
+            assertEquals(EnhancementType.CUSTOM, enhancement.enhancementType)
+            assertTrue(enhancement.processingTimeMs >= 0)
+        }
+
+        @Test
+        fun `non adaptive execution ignores skip recommendation`() {
+            val listener = RecordingRagListener()
+            val enhancer = FixedEnhancer(
+                name = "forced",
+                estimate = EnhancementEstimate(0.0, 0, 0, EnhancementRecommendation.SKIP),
+            )
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(enhancer),
+                adaptiveExecution = false,
+                listener = listener,
+            )
+
+            pipeline.enhance(response())
+
+            assertEquals(1, enhancer.enhancementCalls)
+            assertEquals(listOf("forced"), listener.starting.map { it.enhancerName })
+            assertEquals(listOf("forced"), listener.completed.map { it.enhancerName })
+        }
+
+        @Test
+        fun `empty pipeline returns original response without events`() {
+            val listener = RecordingRagListener()
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = emptyList(),
+                adaptiveExecution = false,
+                listener = listener,
+            )
+            val original = response(listOf(chunk("base")))
+
+            val enhanced = pipeline.enhance(original)
+
+            assertSame(original, enhanced)
+            assertTrue(listener.starting.isEmpty())
+            assertTrue(listener.completed.isEmpty())
+        }
+    }
+
+    @Nested
+    inner class AdaptiveSkipping {
+
+        @Test
+        fun `skips enhancer that recommends SKIP`() {
+            val skipper = FixedEnhancer(
+                name = "skip-me",
+                estimate = EnhancementEstimate(
+                    expectedQualityGain = 0.0,
+                    estimatedLatencyMs = 10,
+                    estimatedTokenCost = 0,
+                    recommendation = EnhancementRecommendation.SKIP,
+                ),
+            )
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(skipper, AppendingEnhancer("kept")),
+                adaptiveExecution = true,
+                listener = RecordingRagListener(),
+            )
+
+            val enhanced = pipeline.enhance(response(listOf(chunk("base"))))
+
+            assertEquals(listOf("base", "kept"), enhanced.results.map { it.match.id })
+            assertEquals(0, skipper.enhancementCalls)
+        }
+
+        @Test
+        fun `skips expensive enhancer when quality already high`() {
+            val expensive = FixedEnhancer(
+                name = "expensive",
+                estimate = EnhancementEstimate(
+                    expectedQualityGain = 0.1,
+                    estimatedLatencyMs = 1500,
+                    estimatedTokenCost = 0,
+                    recommendation = EnhancementRecommendation.APPLY,
+                ),
+            )
+            val highQuality = QualityMetrics(
+                faithfulness = 0.9,
+                answerRelevancy = 0.9,
+                contextPrecision = 0.9,
+                contextRecall = 0.9,
+                contextRelevancy = 0.9,
+                overallScore = 0.95,
+            )
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(expensive, AppendingEnhancer("cheap")),
+                adaptiveExecution = true,
+                qualityThreshold = 0.7,
+                listener = RecordingRagListener(),
+            )
+
+            val enhanced = pipeline.enhance(
+                response(listOf(chunk("base")), quality = highQuality),
+            )
+
+            assertEquals(listOf("base", "cheap"), enhanced.results.map { it.match.id })
+            assertEquals(0, expensive.enhancementCalls)
+        }
+
+        @Test
+        fun `applies enhancer with absent impact estimate even when quality is high`() {
+            val enhancer = FixedEnhancer(name = "unknown", estimate = null)
+            val listener = RecordingRagListener()
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(enhancer),
+                adaptiveExecution = true,
+                qualityThreshold = 0.7,
+                listener = listener,
+            )
+            val highQuality = QualityMetrics(
+                faithfulness = 0.9,
+                answerRelevancy = 0.9,
+                contextPrecision = 0.9,
+                contextRecall = 0.9,
+                contextRelevancy = 0.9,
+                overallScore = 0.95,
+            )
+
+            pipeline.enhance(response(quality = highQuality))
+
+            assertEquals(1, enhancer.enhancementCalls)
+            assertEquals(listOf("unknown"), listener.completed.map { it.enhancerName })
+        }
+
+        @Test
+        fun `quality and expensive latency thresholds remain inclusive`() {
+            val qualityBoundary = FixedEnhancer(
+                name = "quality-boundary",
+                estimate = EnhancementEstimate(0.1, 1501, 0, EnhancementRecommendation.APPLY),
+            )
+            val expensiveLatencyBoundary = FixedEnhancer(
+                name = "latency-boundary",
+                estimate = EnhancementEstimate(0.1, 1000, 0, EnhancementRecommendation.APPLY),
+            )
+            val qualityAtThreshold = QualityMetrics(
+                faithfulness = 0.7,
+                answerRelevancy = 0.7,
+                contextPrecision = 0.7,
+                contextRecall = 0.7,
+                contextRelevancy = 0.7,
+                overallScore = 0.7,
+            )
+            val highQuality = qualityAtThreshold.copy(overallScore = 0.95)
+
+            AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(qualityBoundary),
+                adaptiveExecution = true,
+                qualityThreshold = 0.7,
+                listener = RecordingRagListener(),
+            ).enhance(response(quality = qualityAtThreshold))
+            AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(expensiveLatencyBoundary),
+                adaptiveExecution = true,
+                qualityThreshold = 0.7,
+                listener = RecordingRagListener(),
+            ).enhance(response(quality = highQuality))
+
+            assertEquals(1, qualityBoundary.enhancementCalls)
+            assertEquals(1, expensiveLatencyBoundary.enhancementCalls)
+        }
+
+        @Test
+        fun `skips enhancers when latency budget is exhausted`() {
+            val listener = RecordingRagListener()
+            val skipped = FixedEnhancer(name = "never")
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(skipped),
+                adaptiveExecution = true,
+                listener = listener,
+            )
+            val exhaustedLatencyBudget = DesiredMaxLatency(duration = Duration.ofMillis(-1))
+            val request = RagRequest("q").withHint(exhaustedLatencyBudget)
+            val original = response(results = listOf(chunk("base")), request = request)
+
+            val enhanced = pipeline.enhance(original)
+
+            assertSame(original, enhanced)
+            assertEquals(0, skipped.enhancementCalls)
+            assertTrue(listener.starting.isEmpty())
+            assertTrue(listener.completed.isEmpty())
+        }
+
+        @Test
+        fun `enhancer failure propagates after starting event without completed event`() {
+            val listener = RecordingRagListener()
+            val pipeline = AdaptivePipelineRagResponseEnhancer(
+                enhancers = listOf(ThrowingEnhancer),
+                adaptiveExecution = true,
+                listener = listener,
+            )
+
+            val failure = assertFailsWith<IllegalStateException> {
+                pipeline.enhance(response())
+            }
+
+            assertEquals("enhancement failed", failure.message)
+            assertEquals(listOf("throwing"), listener.starting.map { it.enhancerName })
+            assertTrue(listener.completed.isEmpty())
+        }
+    }
+
+    private class RecordingRagListener : RagEventListener {
+        val starting = CopyOnWriteArrayList<EnhancementStartingRagPipelineEvent>()
+        val completed = CopyOnWriteArrayList<EnhancementCompletedRagPipelineEvent>()
+
+        override fun onRagEvent(event: RagEvent) {
+            when (event) {
+                is EnhancementStartingRagPipelineEvent -> starting += event
+                is EnhancementCompletedRagPipelineEvent -> completed += event
+            }
+        }
+    }
+
+    private class FixedEnhancer(
+        override val name: String,
+        private val estimate: EnhancementEstimate? = EnhancementEstimate(
+            expectedQualityGain = 0.1,
+            estimatedLatencyMs = 0,
+            estimatedTokenCost = 0,
+            recommendation = EnhancementRecommendation.APPLY,
+        ),
+    ) : RagResponseEnhancer {
+        var enhancementCalls: Int = 0
+            private set
+
+        override val enhancementType: EnhancementType = EnhancementType.CUSTOM
+        override fun enhance(response: RagResponse): RagResponse {
+            enhancementCalls++
+            return response
+        }
+
+        override fun estimateImpact(response: RagResponse): EnhancementEstimate? = estimate
+    }
+
+    private class AppendingEnhancer(private val id: String) : RagResponseEnhancer {
+        override val name: String = id
+        override val enhancementType: EnhancementType = EnhancementType.CUSTOM
+        override fun enhance(response: RagResponse): RagResponse =
+            response.copy(
+                results = response.results + SimpleSimilaritySearchResult(
+                    match = Chunk(id = id, text = id, parentId = "doc", metadata = emptyMap()),
+                    score = 0.5,
+                ),
+            )
+
+        override fun estimateImpact(response: RagResponse): EnhancementEstimate =
+            EnhancementEstimate(0.1, 0, 0, EnhancementRecommendation.APPLY)
+    }
+
+    private object ThrowingEnhancer : RagResponseEnhancer {
+        override val name: String = "throwing"
+        override val enhancementType: EnhancementType = EnhancementType.CUSTOM
+
+        override fun enhance(response: RagResponse): RagResponse =
+            throw IllegalStateException("enhancement failed")
+
+        override fun estimateImpact(response: RagResponse): EnhancementEstimate =
+            EnhancementEstimate(0.0, 0, 0, EnhancementRecommendation.APPLY)
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/pipeline/DeduplicatingEnhancerTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/pipeline/DeduplicatingEnhancerTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.pipeline
+
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.service.EnhancementRecommendation
+import com.embabel.agent.rag.service.EnhancementType
+import com.embabel.agent.rag.service.RagRequest
+import com.embabel.agent.rag.service.RagResponse
+import com.embabel.common.core.types.SimpleSimilaritySearchResult
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+/** Verifies [DeduplicatingEnhancer] metadata and first-occurrence ordering by chunk ID. */
+class DeduplicatingEnhancerTest {
+
+    private fun chunk(id: String, score: Double = 0.9) = SimpleSimilaritySearchResult(
+        match = Chunk(id = id, text = "text-$id", parentId = "doc", metadata = emptyMap()),
+        score = score,
+    )
+
+    @Nested
+    inner class Metadata {
+
+        @Test
+        fun `reports deduplication enhancement type`() {
+            assertEquals("dedupe", DeduplicatingEnhancer.name)
+            assertEquals(EnhancementType.DEDUPLICATION, DeduplicatingEnhancer.enhancementType)
+        }
+
+        @Test
+        fun `estimateImpact always recommends apply`() {
+            val response = RagResponse(request = RagRequest("q"), service = "test", results = emptyList())
+            val estimate = DeduplicatingEnhancer.estimateImpact(response)
+
+            assertEquals(1.0, estimate.expectedQualityGain)
+            assertEquals(EnhancementRecommendation.APPLY, estimate.recommendation)
+            assertEquals(0L, estimate.estimatedLatencyMs)
+            assertEquals(0, estimate.estimatedTokenCost)
+        }
+    }
+
+    @Nested
+    inner class Enhance {
+
+        @Test
+        fun `returns same instance when all ids are unique`() {
+            val response = RagResponse(
+                request = RagRequest("q"),
+                service = "test",
+                results = listOf(chunk("a"), chunk("b")),
+            )
+
+            assertSame(response, DeduplicatingEnhancer.enhance(response))
+        }
+
+        @Test
+        fun `keeps first occurrence and encounter order for duplicate ids`() {
+            val response = RagResponse(
+                request = RagRequest("q"),
+                service = "test",
+                results = listOf(
+                    chunk("a", 0.9),
+                    chunk("b", 0.8),
+                    chunk("a", 0.5),
+                    chunk("b", 0.4),
+                    chunk("c", 0.7),
+                ),
+            )
+
+            val enhanced = DeduplicatingEnhancer.enhance(response)
+
+            assertNotSame(response, enhanced)
+            assertEquals(listOf("a", "b", "c"), enhanced.results.map { it.match.id })
+            assertEquals(listOf(0.9, 0.8, 0.7), enhanced.results.map { it.score })
+        }
+
+        @Test
+        fun `empty results stay empty`() {
+            val response = RagResponse(request = RagRequest("q"), service = "test", results = emptyList())
+
+            assertSame(response, DeduplicatingEnhancer.enhance(response))
+        }
+    }
+}

--- a/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/FormatProcessOutputTest.kt
+++ b/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/FormatProcessOutputTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.shell
+
+import com.embabel.agent.api.common.autonomy.AgentProcessExecution
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.domain.library.HasContent
+import com.embabel.agent.domain.library.InternetResource
+import com.embabel.agent.domain.library.InternetResources
+import com.embabel.agent.spi.logging.DefaultColorPalette
+import com.embabel.common.util.color
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Verifies [formatProcessOutput] formatting for JSON, text, Markdown, links, and line wrapping. */
+class FormatProcessOutputTest {
+
+    private val palette = DefaultColorPalette()
+
+    private fun execution(output: Any, basis: Any = "user question"): AgentProcessExecution {
+        val process = mockk<AgentProcess>(relaxed = true)
+        every { process.infoString(verbose = true) } returns "process-info"
+        every { process.costInfoString(verbose = true) } returns "cost-info"
+        every { process.toolsStats.infoString(verbose = true) } returns "tools-info"
+
+        val execution = mockk<AgentProcessExecution>()
+        every { execution.output } returns output
+        every { execution.basis } returns basis
+        every { execution.agentProcess } returns process
+        return execution
+    }
+
+    @Nested
+    inner class NonContentOutput {
+
+        @Test
+        fun `pretty prints arbitrary output as json`() {
+            val result = formatProcessOutput(
+                result = execution(mapOf("answer" to 42)),
+                colorPalette = palette,
+                objectMapper = jacksonObjectMapper(),
+                lineLength = 80,
+            )
+            val prettyJson = """
+                {
+                  "answer" : 42
+                }
+            """.trimIndent()
+            val expectedFragments = listOf(
+                "process-info",
+                "user question",
+                prettyJson,
+                "cost-info",
+                "tools-info",
+            )
+            val fragmentIndexes = expectedFragments.map(result::indexOf)
+
+            assertTrue(fragmentIndexes.all { it >= 0 }, "Missing expected fragment")
+            assertTrue(
+                fragmentIndexes.zipWithNext().all { (first, second) -> first < second },
+                "Fragments are out of order",
+            )
+        }
+    }
+
+    @Nested
+    inner class HasContentOutput {
+
+        @Test
+        fun `formats plain content`() {
+            val output = object : HasContent {
+                override val content: String = "plain text answer without heading"
+            }
+
+            val result = formatProcessOutput(
+                result = execution(output),
+                colorPalette = palette,
+                objectMapper = jacksonObjectMapper(),
+                lineLength = 40,
+            )
+
+            assertTrue(result.contains("plain text answer without heading"))
+            assertFalse(result.contains("\u001B[36m\u001B[1m"))
+        }
+
+        @Test
+        fun `converts markdown heading to ANSI styling`() {
+            val output = object : HasContent {
+                override val content: String = "# Title\nBody text"
+            }
+
+            val result = formatProcessOutput(
+                result = execution(output),
+                colorPalette = palette,
+                objectMapper = jacksonObjectMapper(),
+                lineLength = 80,
+            )
+
+            assertTrue(result.contains("\u001B[36m\u001B[1m# Title\u001B[22m\u001B[0m\nBody text"))
+        }
+
+        @Test
+        fun `appends internet resource links when output implements InternetResources`() {
+            data class ContentWithLinks(
+                override val content: String,
+                override val links: List<InternetResource>,
+            ) : HasContent, InternetResources
+
+            val output = ContentWithLinks(
+                content = "see links",
+                links = listOf(
+                    InternetResource(url = "https://example.com", summary = "Example"),
+                    InternetResource(url = "https://example.org", summary = "Second"),
+                ),
+            )
+
+            val result = formatProcessOutput(
+                result = execution(output),
+                colorPalette = palette,
+                objectMapper = jacksonObjectMapper(),
+                lineLength = 80,
+            )
+            val expectedLinks = """
+                - https://example.com: ${"Example".color(palette.color2)}
+                - https://example.org: ${"Second".color(palette.color2)}
+            """.trimIndent()
+
+            assertTrue(result.contains(expectedLinks))
+        }
+
+        @Test
+        fun `wraps long plain content at configured line length`() {
+            val output = object : HasContent {
+                override val content: String = "alpha beta gamma delta"
+            }
+
+            val result = formatProcessOutput(
+                result = execution(output),
+                colorPalette = palette,
+                objectMapper = jacksonObjectMapper(),
+                lineLength = 10,
+            )
+
+            assertTrue(result.contains("alpha beta\ngamma\ndelta"))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add focused unit coverage for nine previously uncovered utility and pipeline components
- align the tests with current Kotlin, MockK, KDoc, deterministic-test, and Jackson 3 conventions
- keep the contribution test-only

## Context

Supersedes #1806, which was closed because its branch history was rebased incorrectly.
This PR reapplies the final reviewed test changes as a single clean commit on the current `main`.

Ref #29.

## Verification

- 47 focused tests passed on Java 21
- JaCoCo: 119/119 executable lines and 48/48 branches across the nine target production files
- Spotless and `git diff --check` passed
