### PR TITLE
Netty Upgrade to 4.2.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <argLine />
         <embabel-common.version>2.0.0-SNAPSHOT</embabel-common.version>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>
     </properties>


### PR DESCRIPTION
# OVERVIEW

Netty upgrade from
4.2.13
to
4.2.15

due to a HIGH Vulnerability

