### PR TITLE
docs: update emabel docs to match current codebase

### DIFF
--- a/embabel-agent-api/src/test/resources/application.properties
+++ b/embabel-agent-api/src/test/resources/application.properties
@@ -27,7 +27,7 @@ embabel.process-id-generation.include-agent-name=false
 embabel.process-id-generation.include-version=false
 
 # LLM Operations
-embabel.llm-operations.prompts.generate-examples-by-default=true
+embabel.agent.platform.llm-operations.prompts.generate-examples-by-default=true
 
 # Tool Loop Configuration
 embabel.agent.platform.toolloop.type=default

--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
@@ -815,17 +815,17 @@ From `LlmOperationsPromptsProperties` - properties for ChatClientLlmOperations o
 |===
 |Property |Type |Default |Description
 
-|`embabel.llm-operations.prompts.maybe-prompt-template`
+|`embabel.agent.platform.llm-operations.prompts.maybe-prompt-template`
 |String
 |`maybe_prompt_contribution`
 |Template to use for the "maybe" prompt, which can enable a failure result if the LLM does not have enough information to create the desired output structure
 
-|`embabel.llm-operations.prompts.generate-examples-by-default`
+|`embabel.agent.platform.llm-operations.prompts.generate-examples-by-default`
 |Boolean
 |`true`
 |Whether to generate examples by default
 
-|`embabel.llm-operations.prompts.default-timeout`
+|`embabel.agent.platform.llm-operations.prompts.default-timeout`
 |Duration
 |`60s`
 |Default timeout for operations


### PR DESCRIPTION
<details>
<summary>Original description</summary>
* aligns docs with current codebase of `LlmOperationsPromptsProperties`

refs https://github.com/embabel/embabel-agent/issues/1805
</details>

# :ghost: :package: description
## Namespace LLM operations prompts under embabel.agent.platform and update docs
**Type:** Enhancement, Documentation

### Summary
- Namespace LLM prompt properties under agent.platform
- Update test application.properties key accordingly
- Sync configuration docs with renamed properties

### Overview
```mermaid
flowchart LR
A["Old key prefix: embabel.llm-operations.prompts.*"]
B["New key prefix: embabel.agent.platform.llm-operations.prompts.*"]
C["Test properties updated"]
D["Docs property names updated"]
A -- "renamed to" --> B
B -- "applied in" --> C
B -- "reflected in" --> D
```

### Files
<details>
<summary>documentation (1)</summary>

| filename | summary | details |
| -------- | ------- | ------- |
| embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc | Align docs with new property namespace | <ul><li>Update three property names to new prefix</li><li>Reflect maybe, examples, timeout property renames</li></ul> |
</details>

<details>
<summary>configuration changes (1)</summary>

| filename | summary | details |
| -------- | ------- | ------- |
| embabel-agent-api/src/test/resources/application.properties | Update test property key namespace | <ul><li>Replace deprecated property key with new namespace</li></ul> |
</details>

