### PR TITLE
test(mcp): add in-process MCP protocol E2E coverage

### DIFF
--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/ToolFactorySpringIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/ToolFactorySpringIntegrationTest.kt
@@ -29,6 +29,7 @@ import com.embabel.agent.core.Export
 import com.embabel.agent.tools.agent.GoalTool
 import com.embabel.agent.tools.agent.PerGoalToolFactory
 import com.embabel.agent.tools.agent.PromptedTextCommunicator
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -38,7 +39,6 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 const val REMOTE_GOAL_NAME = "remotelyExportedWizardGoal"
@@ -119,6 +119,12 @@ class ToolFactorySpringIntegrationTest(
         toolFactory.goalTools(remoteOnly = true, listeners = emptyList())
             .single { it.goal.name == REMOTE_GOAL_NAME }
 
+    /**
+     * A goal tool is what the platform publishes for one exported goal: one tool per goal,
+     * per starting input type it accepts. Calling it starts an agent process whose objective
+     * is that goal, and returns whatever that process produced. This is the layer an MCP
+     * server exports, without the protocol on top.
+     */
     @Nested
     inner class GoalToolExecution {
 
@@ -126,7 +132,7 @@ class ToolFactorySpringIntegrationTest(
         fun `calling a goal tool runs an agent process and returns its result`() {
             val result = remoteWizardTool().call("""{"name": "Hamish"}""")
 
-            val text = assertNotNull(result as? Tool.Result.Text, "Expected a text result, got $result")
+            val text = assertInstanceOf(Tool.Result.Text::class.java, result)
             assertTrue(
                 text.content.contains("SnakeMeal"),
                 "Result should be the goal output SnakeMeal: ${text.content}"
@@ -138,10 +144,10 @@ class ToolFactorySpringIntegrationTest(
         }
 
         @Test
-        fun `malformed tool input is reported as an error result rather than thrown`() {
+        fun `malformed tool input is reported as an error result`() {
             val result = remoteWizardTool().call("not json at all")
 
-            val error = assertNotNull(result as? Tool.Result.Error, "Expected an error result, got $result")
+            val error = assertInstanceOf(Tool.Result.Error::class.java, result)
             assertTrue(
                 error.message.contains("BAD INPUT ERROR"),
                 "Error should tell the caller to retry with valid input: ${error.message}"
@@ -159,7 +165,7 @@ class ToolFactorySpringIntegrationTest(
 
             val result = remoteWizardTool().withListener(listener).call("""{"name": "Hamish"}""")
 
-            assertTrue(result is Tool.Result.Text, "Expected a text result, got $result")
+            assertInstanceOf(Tool.Result.Text::class.java, result)
             assertTrue(
                 processEvents.isNotEmpty(),
                 "Listener should have been propagated to the agent process started by the tool"

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/ToolFactorySpringIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/e2e/ToolFactorySpringIntegrationTest.kt
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.e2e
+
+import com.embabel.agent.api.common.autonomy.Autonomy
+import com.embabel.agent.api.dsl.MagicVictim
+import com.embabel.agent.api.dsl.SnakeMeal
+import com.embabel.agent.api.dsl.agent
+import com.embabel.agent.api.dsl.aggregate
+import com.embabel.agent.api.dsl.Frog
+import com.embabel.agent.api.event.AgenticEventListener
+import com.embabel.agent.api.event.AgentProcessEvent
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.core.Export
+import com.embabel.agent.tools.agent.GoalTool
+import com.embabel.agent.tools.agent.PerGoalToolFactory
+import com.embabel.agent.tools.agent.PromptedTextCommunicator
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+const val REMOTE_GOAL_NAME = "remotelyExportedWizardGoal"
+
+const val LOCAL_GOAL_NAME = "locallyExportedWizardGoal"
+
+/**
+ * Goal names on the platform are not qualified by agent, so these fixtures use
+ * names of their own rather than the shared `done` of the dsl test agents.
+ */
+private fun wizard(
+    agentName: String,
+    goalName: String,
+    export: Export,
+) = agent(agentName, description = "Turn a person into a frog") {
+
+    flow {
+        aggregate<MagicVictim, Frog, SnakeMeal>(
+            transforms = listOf({ Frog(it.input.name) }),
+            merge = { frogs, _ -> SnakeMeal(frogs) },
+        )
+    }
+
+    goal(
+        name = goalName,
+        description = "Turn the victim into a snake meal",
+        satisfiedBy = SnakeMeal::class,
+        export = export,
+    )
+}
+
+fun remotelyExportedWizard() = wizard(
+    agentName = "RemotelyExportedWizard",
+    goalName = REMOTE_GOAL_NAME,
+    export = Export(remote = true, startingInputTypes = setOf(MagicVictim::class.java)),
+)
+
+fun locallyExportedWizard() = wizard(
+    agentName = "LocallyExportedWizard",
+    goalName = LOCAL_GOAL_NAME,
+    export = Export(remote = false, startingInputTypes = setOf(MagicVictim::class.java)),
+)
+
+/**
+ * Integration test of the layer beneath MCP: a goal on a live platform becomes a
+ * [com.embabel.agent.api.tool.Tool], and calling that tool runs a real agent process.
+ *
+ * No MCP server, transport or protocol is involved here — tools are invoked directly.
+ * `McpServerProtocolIntegrationTest` in embabel-agent-mcpserver covers the protocol.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(
+    value = [
+        FakeConfig::class,
+    ]
+)
+class ToolFactorySpringIntegrationTest(
+    @param:Autowired
+    private val autonomy: Autonomy,
+) {
+
+    private val agentPlatform: AgentPlatform = autonomy.agentPlatform
+
+    private val toolFactory = PerGoalToolFactory(
+        autonomy = autonomy,
+        applicationName = "test-app",
+        textCommunicator = PromptedTextCommunicator,
+    )
+
+    @BeforeEach
+    fun setup() {
+        agentPlatform.deploy(remotelyExportedWizard())
+        agentPlatform.deploy(locallyExportedWizard())
+    }
+
+    private fun remoteWizardTool(): GoalTool<*> =
+        toolFactory.goalTools(remoteOnly = true, listeners = emptyList())
+            .single { it.goal.name == REMOTE_GOAL_NAME }
+
+    @Nested
+    inner class GoalToolExecution {
+
+        @Test
+        fun `calling a goal tool runs an agent process and returns its result`() {
+            val result = remoteWizardTool().call("""{"name": "Hamish"}""")
+
+            val text = assertNotNull(result as? Tool.Result.Text, "Expected a text result, got $result")
+            assertTrue(
+                text.content.contains("SnakeMeal"),
+                "Result should be the goal output SnakeMeal: ${text.content}"
+            )
+            assertTrue(
+                text.content.contains("Hamish"),
+                "Result should carry the tool input through to the output: ${text.content}"
+            )
+        }
+
+        @Test
+        fun `malformed tool input is reported as an error result rather than thrown`() {
+            val result = remoteWizardTool().call("not json at all")
+
+            val error = assertNotNull(result as? Tool.Result.Error, "Expected an error result, got $result")
+            assertTrue(
+                error.message.contains("BAD INPUT ERROR"),
+                "Error should tell the caller to retry with valid input: ${error.message}"
+            )
+        }
+
+        @Test
+        fun `listeners added to a goal tool receive events from the process it starts`() {
+            val processEvents = ConcurrentLinkedQueue<AgentProcessEvent>()
+            val listener = object : AgenticEventListener {
+                override fun onProcessEvent(event: AgentProcessEvent) {
+                    processEvents.add(event)
+                }
+            }
+
+            val result = remoteWizardTool().withListener(listener).call("""{"name": "Hamish"}""")
+
+            assertTrue(result is Tool.Result.Text, "Expected a text result, got $result")
+            assertTrue(
+                processEvents.isNotEmpty(),
+                "Listener should have been propagated to the agent process started by the tool"
+            )
+        }
+
+        @Test
+        fun `a listener is only added to the copy leaving the original tool unchanged`() {
+            val original = remoteWizardTool()
+            val listener = object : AgenticEventListener {}
+
+            val withListener = original.withListener(listener)
+
+            assertEquals(original.definition.name, withListener.definition.name)
+            assertEquals(listOf(listener), withListener.listeners)
+            assertTrue(original.listeners.isEmpty(), "Original tool should not be mutated")
+        }
+    }
+
+    @Nested
+    inner class RemoteExport {
+
+        @Test
+        fun `remote export publishes only goals marked remote`() {
+            val remoteToolGoals = toolFactory.goalTools(remoteOnly = true, listeners = emptyList())
+                .map { it.goal }
+
+            assertTrue(
+                remoteToolGoals.any { it.name == REMOTE_GOAL_NAME },
+                "Remotely exported goal should be published: ${remoteToolGoals.map { it.name }}"
+            )
+            assertTrue(
+                remoteToolGoals.none { it.name == LOCAL_GOAL_NAME },
+                "Locally exported goal should not be published remotely: ${remoteToolGoals.map { it.name }}"
+            )
+            assertTrue(
+                remoteToolGoals.all { it.export.remote },
+                "Every published tool must map to a remote goal: ${remoteToolGoals.map { it.name }}"
+            )
+        }
+
+        @Test
+        fun `local export publishes goals that remote export withholds`() {
+            val localToolGoals = toolFactory.goalTools(remoteOnly = false, listeners = emptyList())
+                .map { it.goal }
+
+            assertTrue(
+                localToolGoals.any { it.name == LOCAL_GOAL_NAME },
+                "Locally exported goal should be published locally: ${localToolGoals.map { it.name }}"
+            )
+        }
+
+        @Test
+        fun `all tools combine goal tools and platform tools`() {
+            val goalTools = toolFactory.goalTools(remoteOnly = true, listeners = emptyList())
+            val allTools = toolFactory.allTools(remoteOnly = true, listeners = emptyList())
+
+            assertEquals(
+                (goalTools + toolFactory.platformTools).map { it.definition.name }.toSet(),
+                allTools.map { it.definition.name }.toSet(),
+            )
+        }
+    }
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpClientToolGroupIntegrationTest.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpClientToolGroupIntegrationTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import com.embabel.agent.AgentTestApplication
+import com.embabel.agent.api.common.autonomy.Autonomy
+import com.embabel.agent.api.dsl.agent
+import com.embabel.agent.api.dsl.aggregate
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.core.Export
+import com.embabel.agent.core.ToolGroupDescription
+import com.embabel.agent.core.ToolGroupPermission
+import com.embabel.agent.spi.support.AgentScanningBeanPostProcessorEvent
+import com.embabel.agent.test.domain.Frog
+import com.embabel.agent.test.domain.MagicVictim
+import com.embabel.agent.test.dsl.SnakeMeal
+import com.embabel.agent.tools.mcp.McpToolGroup
+import com.embabel.common.test.ai.config.FakeAiConfiguration
+import io.modelcontextprotocol.client.McpClient
+import io.modelcontextprotocol.client.McpSyncClient
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private const val CONSUMED_GOAL_NAME = "mcpConsumedWizardGoal"
+
+private fun consumedWizard() = agent("McpConsumedWizard", description = "Turn a person into a snake meal") {
+
+    flow {
+        aggregate<MagicVictim, Frog, SnakeMeal>(
+            transforms = listOf({ Frog(it.input.name) }),
+            merge = { frogs, _ -> SnakeMeal(frogs) },
+        )
+    }
+
+    goal(
+        name = CONSUMED_GOAL_NAME,
+        description = "Turn the victim into a snake meal",
+        satisfiedBy = SnakeMeal::class,
+        export = Export(remote = true, startingInputTypes = setOf(MagicVictim::class.java)),
+    )
+}
+
+/**
+ * The client direction of MCP: [McpToolGroup] consuming a real MCP server over the wire,
+ * so that an Embabel agent can call tools that live outside the platform.
+ *
+ * [McpServerProtocolIntegrationTest] covers the opposite direction — Embabel *serving*
+ * MCP. Here the in-process server is only a stand-in for a third-party MCP server; the
+ * subject under test is [McpToolGroup] and the `ToolCallback` to [Tool] conversion
+ * beneath it, which today is exercised only against mocks.
+ *
+ * `McpToolGroupTest` already pins the swallow behaviour with a throwing mock client, so an
+ * empty tool list there is the asserted outcome. This test is the only place where an empty
+ * list means a genuine defect: everything is wired correctly against a live server, so
+ * [McpToolGroup.loadTools] returning nothing can only be a regression.
+ *
+ * TODO(#issue-mcp-client-e2e): enable once the client direction is agreed to be in scope
+ *  for this module.
+ */
+@Disabled("TODO: client-direction MCP coverage not yet part of the CI contract — see class KDoc")
+@SpringBootTest(
+    classes = [AgentTestApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "spring.ai.mcp.server.enabled=true",
+        "spring.ai.mcp.server.protocol=SSE",
+        "spring.ai.mcp.client.enabled=false",
+    ],
+)
+@ActiveProfiles("test")
+@Import(FakeAiConfiguration::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class McpClientToolGroupIntegrationTest(
+    @param:Autowired
+    private val autonomy: Autonomy,
+    @param:Autowired
+    private val applicationContext: ConfigurableApplicationContext,
+    @param:Value("\${local.server.port}")
+    private val port: Int,
+) {
+
+    private lateinit var client: McpSyncClient
+
+    @BeforeAll
+    fun exposeAServerWorthConsuming() {
+        autonomy.agentPlatform.deploy(consumedWizard())
+        applicationContext.publishEvent(AgentScanningBeanPostProcessorEvent(this))
+        client = McpClient
+            .sync(HttpClientSseClientTransport.builder("http://localhost:$port").build())
+            .requestTimeout(Duration.ofSeconds(30))
+            .build()
+        client.initialize()
+    }
+
+    @AfterAll
+    fun closeClient() {
+        client.closeGracefully()
+    }
+
+    private fun toolGroup(filter: (org.springframework.ai.tool.ToolCallback) -> Boolean = { true }) =
+        McpToolGroup(
+            description = ToolGroupDescription(description = "Tools from an external MCP server", role = "external"),
+            provider = "test",
+            name = "external-mcp",
+            permissions = setOf(ToolGroupPermission.INTERNET_ACCESS),
+            clients = listOf(client),
+            filter = filter,
+        )
+
+    private fun consumedTool(): Tool =
+        toolGroup().tools.single { it.definition.name.contains(CONSUMED_GOAL_NAME) }
+
+    @Test
+    fun `tool group exposes the remote server's tools as native Embabel tools`() {
+        val tools = toolGroup().tools
+
+        assertTrue(tools.isNotEmpty(), "loadTools swallows failures and returns empty — an empty list means broken")
+        assertTrue(
+            tools.any { it.definition.name.contains(CONSUMED_GOAL_NAME) },
+            "Remote goal tool should be visible through the tool group: ${tools.map { it.definition.name }}"
+        )
+        assertNotNull(consumedTool().definition.inputSchema, "Converted tool must keep its input schema")
+    }
+
+    @Test
+    fun `calling a tool through the tool group round trips to the remote server`() {
+        val result = consumedTool().call("""{"name": "Hamish"}""")
+
+        val text = assertNotNull(result as? Tool.Result.Text, "Expected a text result, got $result")
+        assertTrue(text.content.contains("SnakeMeal"), "Should carry the remote tool's output: ${text.content}")
+        assertTrue(text.content.contains("Hamish"), "Should carry the caller's input through: ${text.content}")
+    }
+
+    @Test
+    fun `the filter predicate is applied to the remote tool list`() {
+        val filtered = toolGroup { false }.tools
+
+        assertTrue(filtered.isEmpty(), "A reject-all filter must yield no tools, got ${filtered.map { it.definition.name }}")
+    }
+}

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpServerProtocolIntegrationTest.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpServerProtocolIntegrationTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
@@ -45,7 +46,6 @@ import org.springframework.context.annotation.Import
 import org.springframework.test.context.ActiveProfiles
 import java.time.Duration
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -90,6 +90,10 @@ private fun mcpLocallyExportedWizard() = wizard(
  * Drives a real MCP server over its wire protocol: an in-process Spring Boot server on a
  * loopback port, reached by an MCP client that performs the initialize handshake,
  * `tools/list` and `tools/call`.
+ *
+ * The server runs in-process on a port assigned by the OS (RANDOM_PORT) and is reached
+ * over loopback, so nothing leaves the machine and parallel CI jobs cannot clash on a
+ * fixed port.
  *
  * This is the only test that exercises the full export path — deployed goal to
  * [PerGoalMcpExportToolCallbackPublisher] to `McpSyncServer` registration to protocol
@@ -171,8 +175,7 @@ class McpServerProtocolIntegrationTest(
             val tool = client.listTools().named(REMOTE_GOAL_NAME)
 
             assertEquals("object", tool.inputSchema()["type"], "Input schema must be a JSON Schema object")
-            @Suppress("UNCHECKED_CAST")
-            val properties = tool.inputSchema()["properties"] as? Map<String, Any>
+            val properties = tool.inputSchema()["properties"] as? Map<*, *>
             assertNotNull(properties, "Input schema must declare properties: ${tool.inputSchema()}")
             assertTrue(
                 properties.containsKey("name"),
@@ -230,7 +233,7 @@ class McpServerProtocolIntegrationTest(
 
         @Test
         fun `calling an unknown tool is rejected as a protocol error`() {
-            val thrown = assertFailsWith<McpError> {
+            val thrown = assertThrows<McpError> {
                 client.callTool(McpSchema.CallToolRequest("no_such_tool_at_all", emptyMap()))
             }
 

--- a/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpServerProtocolIntegrationTest.kt
+++ b/embabel-agent-mcp/embabel-agent-mcpserver/src/test/kotlin/com/embabel/agent/mcpserver/McpServerProtocolIntegrationTest.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.mcpserver
+
+import com.embabel.agent.AgentTestApplication
+import com.embabel.agent.api.common.autonomy.Autonomy
+import com.embabel.agent.api.dsl.agent
+import com.embabel.agent.api.dsl.aggregate
+import com.embabel.agent.core.Export
+import com.embabel.agent.spi.support.AgentScanningBeanPostProcessorEvent
+import com.embabel.agent.test.domain.Frog
+import com.embabel.agent.test.domain.MagicVictim
+import com.embabel.agent.test.dsl.SnakeMeal
+import com.embabel.agent.tools.agent.CONFIRMATION_TOOL_NAME
+import com.embabel.agent.tools.agent.FORM_SUBMISSION_TOOL_NAME
+import com.embabel.common.test.ai.config.FakeAiConfiguration
+import io.modelcontextprotocol.client.McpClient
+import io.modelcontextprotocol.client.McpSyncClient
+import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport
+import io.modelcontextprotocol.spec.McpError
+import io.modelcontextprotocol.spec.McpSchema
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+private const val REMOTE_GOAL_NAME = "mcpRemoteWizardGoal"
+
+private const val LOCAL_GOAL_NAME = "mcpLocalWizardGoal"
+
+private fun wizard(
+    agentName: String,
+    goalName: String,
+    export: Export,
+) = agent(agentName, description = "Turn a person into a snake meal") {
+
+    flow {
+        aggregate<MagicVictim, Frog, SnakeMeal>(
+            transforms = listOf({ Frog(it.input.name) }),
+            merge = { frogs, _ -> SnakeMeal(frogs) },
+        )
+    }
+
+    goal(
+        name = goalName,
+        description = "Turn the victim into a snake meal",
+        satisfiedBy = SnakeMeal::class,
+        export = export,
+    )
+}
+
+private fun mcpRemotelyExportedWizard() = wizard(
+    agentName = "McpRemotelyExportedWizard",
+    goalName = REMOTE_GOAL_NAME,
+    export = Export(remote = true, startingInputTypes = setOf(MagicVictim::class.java)),
+)
+
+private fun mcpLocallyExportedWizard() = wizard(
+    agentName = "McpLocallyExportedWizard",
+    goalName = LOCAL_GOAL_NAME,
+    export = Export(remote = false, startingInputTypes = setOf(MagicVictim::class.java)),
+)
+
+/**
+ * Drives a real MCP server over its wire protocol: an in-process Spring Boot server on a
+ * loopback port, reached by an MCP client that performs the initialize handshake,
+ * `tools/list` and `tools/call`.
+ *
+ * This is the only test that exercises the full export path — deployed goal to
+ * [PerGoalMcpExportToolCallbackPublisher] to `McpSyncServer` registration to protocol
+ * round trip. Tests that call tools directly bypass everything below the agent.
+ */
+@SpringBootTest(
+    classes = [AgentTestApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "spring.ai.mcp.server.enabled=true",
+        "spring.ai.mcp.server.protocol=SSE",
+        "spring.ai.mcp.server.name=embabel-mcp-protocol-it",
+        "spring.ai.mcp.server.version=9.9.9",
+        "spring.ai.mcp.client.enabled=false",
+    ],
+)
+@ActiveProfiles("test")
+@Import(FakeAiConfiguration::class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class McpServerProtocolIntegrationTest(
+    @param:Autowired
+    private val autonomy: Autonomy,
+    @param:Autowired
+    private val applicationContext: ConfigurableApplicationContext,
+    @param:Value("\${local.server.port}")
+    private val port: Int,
+) {
+
+    private lateinit var client: McpSyncClient
+
+    private lateinit var handshake: McpSchema.InitializeResult
+
+    /**
+     * One deployment, one exposure and one MCP session for the whole class. Nothing here
+     * mutates server state per test, and a session per test method left SSE connections
+     * being torn down mid-response, which shows up as broken pipe noise in the build log.
+     */
+    @BeforeAll
+    fun deployAgentsAndOpenOneMcpSession() {
+        autonomy.agentPlatform.deploy(mcpRemotelyExportedWizard())
+        autonomy.agentPlatform.deploy(mcpLocallyExportedWizard())
+        // AgentScanningBeanPostProcessorEvent is published by a bean excluded under the
+        // "test" profile, so the production initialization path is triggered explicitly.
+        // Tool exposure is synchronous: SyncServerStrategy.addTool is a Mono.fromRunnable and
+        // nothing in AbstractMcpServerConfiguration schedules it elsewhere, so publishEvent
+        // returns only once every tool is registered. No polling needed.
+        applicationContext.publishEvent(AgentScanningBeanPostProcessorEvent(this))
+        client = McpClient
+            .sync(HttpClientSseClientTransport.builder("http://localhost:$port").build())
+            .requestTimeout(Duration.ofSeconds(30))
+            .build()
+        handshake = client.initialize()
+    }
+
+    @AfterAll
+    fun closeMcpSession() {
+        client.closeGracefully()
+    }
+
+    private fun McpSchema.ListToolsResult.named(goalName: String): McpSchema.Tool =
+        tools().single { it.name().contains(goalName) }
+
+    @Nested
+    inner class Handshake {
+
+        @Test
+        fun `initialize reports the configured server identity and tool capability`() {
+            assertEquals("embabel-mcp-protocol-it", handshake.serverInfo().name())
+            assertEquals("9.9.9", handshake.serverInfo().version())
+            assertNotNull(handshake.capabilities().tools(), "Server must advertise the tools capability")
+        }
+    }
+
+    @Nested
+    inner class ToolsList {
+
+        @Test
+        fun `remotely exported goal is published as a tool with a usable input schema`() {
+            val tool = client.listTools().named(REMOTE_GOAL_NAME)
+
+            assertEquals("object", tool.inputSchema()["type"], "Input schema must be a JSON Schema object")
+            @Suppress("UNCHECKED_CAST")
+            val properties = tool.inputSchema()["properties"] as? Map<String, Any>
+            assertNotNull(properties, "Input schema must declare properties: ${tool.inputSchema()}")
+            assertTrue(
+                properties.containsKey("name"),
+                "Input schema must expose the MagicVictim name property: $properties"
+            )
+            assertTrue(tool.description().isNotBlank(), "Tool must carry a description for the model")
+        }
+
+        @Test
+        fun `locally exported goal is withheld from the MCP server`() {
+            val toolNames = client.listTools().tools().map { it.name() }
+
+            assertTrue(
+                toolNames.any { it.contains(REMOTE_GOAL_NAME) },
+                "Guard against a vacuous pass: the remote goal must be listed: $toolNames"
+            )
+            assertTrue(
+                toolNames.none { it.contains(LOCAL_GOAL_NAME) },
+                "Only remotely exported goals may reach MCP clients: $toolNames"
+            )
+        }
+
+        @Test
+        fun `HITL platform tools are published alongside goal tools`() {
+            val toolNames = client.listTools().tools().map { it.name() }
+
+            assertTrue(
+                toolNames.any { it.contains(CONFIRMATION_TOOL_NAME) },
+                "Confirmation tool must be reachable over MCP for HITL: $toolNames"
+            )
+            assertTrue(
+                toolNames.any { it.contains(FORM_SUBMISSION_TOOL_NAME) },
+                "Form submission tool must be reachable over MCP for HITL: $toolNames"
+            )
+        }
+    }
+
+    @Nested
+    inner class ToolsCall {
+
+        @Test
+        fun `calling the goal tool runs the agent and returns its output over the protocol`() {
+            val result = client.callTool(
+                McpSchema.CallToolRequest(
+                    client.listTools().named(REMOTE_GOAL_NAME).name(),
+                    mapOf("name" to "Hamish"),
+                )
+            )
+
+            assertEquals(false, result.isError(), "Call should succeed: ${result.content()}")
+            val text = result.content().filterIsInstance<McpSchema.TextContent>().joinToString("\n") { it.text() }
+            assertTrue(text.contains("SnakeMeal"), "Result should be the goal output: $text")
+            assertTrue(text.contains("Hamish"), "Result should carry the caller's input through: $text")
+        }
+
+        @Test
+        fun `calling an unknown tool is rejected as a protocol error`() {
+            val thrown = assertFailsWith<McpError> {
+                client.callTool(McpSchema.CallToolRequest("no_such_tool_at_all", emptyMap()))
+            }
+
+            assertTrue(
+                thrown.message!!.contains("Unknown tool"),
+                "Server must reject an unregistered tool by name, got: ${thrown.message}"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Adds the first test that drives a real MCP server over its wire protocol: Spring Boot on a loopback port, reached by an MCP SDK client performing initialize, tools/list and tools/call. Until now MCP coverage stopped at mocked McpSyncServer, so tool registration and protocol round-trip were unverified.

- McpServerProtocolIntegrationTest: serve direction. Covers handshake, goal tool JSON Schema, remote/local export filtering over the wire, HITL tools (_confirm, submitFormAndResumeProcess), tools/call executing a real agent process, and unknown-tool rejection.
- McpClientToolGroupIntegrationTest: consume direction (McpToolGroup against a live server). Disabled pending a decision on whether the client direction is in the CI contract.
- ToolFactorySpringIntegrationTest: reworked to assert tool execution and export filtering on a Spring-wired platform. KDoc no longer claims MCP coverage and points at the protocol test instead.

One deployment, one exposure and one MCP session per class: a session per test method tore down SSE connections mid-response, producing broken-pipe noise in the build log.