### PR TITLE
feat: Add Alibaba Cloud DashScope models support

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/DashScopeModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/DashScopeModels.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.models
+
+/**
+ * Provides constants for Alibaba Cloud DashScope model identifiers.
+ * DashScope offers the Qwen family of large language models via an OpenAI-compatible API,
+ * including reasoning-capable models and cost-effective lightweight variants.
+ *
+ * @see <a href="https://dashscope.console.alibabacloud.com">DashScope Model Studio</a>
+ */
+class DashScopeModels {
+
+    companion object {
+
+        const val QWEN3_7_MAX = "qwen3.7-max"
+        const val QWEN3_7_PLUS = "qwen3.7-plus"
+        const val QWEN3_7_FLASH = "qwen3.7-flash"
+
+        const val PROVIDER = "DashScope"
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-autoconfigure</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>embabel-agent-dashscope-autoconfigure</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Autoconfiguration Models DashScope</name>
+    <description>Alibaba Cloud DashScope Models Auto-Configuration for Embabel Agent API</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-openai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/dashscope/AgentDashScopeAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/dashscope/AgentDashScopeAutoConfiguration.java
@@ -13,25 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.embabel.agent.autoconfigure.models.openai.custom;
+package com.embabel.agent.autoconfigure.models.dashscope;
 
-import com.embabel.agent.config.models.openai.custom.OpenAiCustomModelsConfig;
+import com.embabel.agent.config.models.dashscope.DashScopeModelsConfig;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.context.annotation.Import;
 
 /**
- * Autoconfiguration for OpenAI Custom models in the Embabel Agent system.
+ * Autoconfiguration for Alibaba Cloud DashScope models
+ * in the Embabel Agent system.
  * <p>
  * This class serves as a Spring Boot autoconfiguration entry point that:
- * - Scans for configuration properties in the "com.embabel.agent" package
- * - Imports the {@link OpenAiCustomModelsConfig} configuration to register OpenAI model beans
+ * - Imports the {@link DashScopeModelsConfig} configuration to register DashScope model beans
  * <p>
- * The configuration is automatically activated when the OpenAI models
- * dependencies are present on the classpath.
+ * The configuration is automatically activated when the DashScope
+ * dependencies are present on the classpath and the DASHSCOPE_API_KEY
+ * environment variable is set.
  */
 @AutoConfiguration
 @AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
-@Import(OpenAiCustomModelsConfig.class)
-public class AgentOpenAiCustomAutoConfiguration {
+@Import(DashScopeModelsConfig.class)
+public class AgentDashScopeAutoConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(AgentDashScopeAutoConfiguration.class);
+
+    @PostConstruct
+    public void logEvent() {
+        logger.info("AgentDashScopeAutoConfiguration about to proceed...");
+    }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/dashscope/DashScopeModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/dashscope/DashScopeModelLoader.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.dashscope
+
+import com.embabel.agent.api.models.DashScopeModels
+import com.embabel.common.ai.autoconfig.AbstractYamlModelLoader
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadata
+import com.embabel.common.ai.autoconfig.LlmAutoConfigProvider
+import com.embabel.common.ai.model.PerTokenPricingModel
+import org.springframework.core.io.DefaultResourceLoader
+import org.springframework.core.io.ResourceLoader
+import java.time.LocalDate
+
+/**
+ * Container for Alibaba Cloud DashScope model definitions loaded from YAML.
+ *
+ * Implements [LlmAutoConfigProvider] to supply DashScope-specific model metadata
+ * for auto-configuration purposes.
+ *
+ * @property models list of DashScope Qwen model definitions
+ */
+data class DashScopeModelDefinitions(
+    override val models: List<DashScopeModelDefinition> = emptyList()
+) : LlmAutoConfigProvider<DashScopeModelDefinition>
+
+/**
+ * DashScope Qwen-specific model definition.
+ *
+ * Implements [LlmAutoConfigMetadata].
+ *
+ * @property name the unique bean name of the model
+ * @property modelId the DashScope API model identifier (e.g. "qwen-max")
+ * @property displayName optional human-readable name
+ * @property knowledgeCutoffDate optional knowledge cutoff date
+ * @property pricingModel optional per-token pricing information
+ * @property maxTokens maximum tokens for completion
+ * @property temperature default sampling temperature
+ * @property topP nucleus sampling parameter
+ */
+data class DashScopeModelDefinition(
+    override val name: String,
+    override val modelId: String,
+    override val displayName: String? = null,
+    override val knowledgeCutoffDate: LocalDate? = null,
+    override val pricingModel: PerTokenPricingModel? = null,
+    val maxTokens: Int = 8192,
+    val temperature: Double = 0.7,
+    val topP: Double? = null,
+) : LlmAutoConfigMetadata
+
+/**
+ * Loader for DashScope Qwen model definitions from YAML configuration.
+ *
+ * Reads model metadata from the configured resource path
+ * (default: `classpath:models/dashscope-models.yml`) and deserializes it into
+ * [DashScopeModelDefinitions]. Validates loaded models to ensure data integrity.
+ *
+ * @property resourceLoader Spring resource loader for accessing classpath resources
+ * @property configPath path to the YAML configuration file
+ */
+class DashScopeModelLoader(
+    resourceLoader: ResourceLoader = DefaultResourceLoader(),
+    configPath: String = DEFAULT_CONFIG_PATH
+) : AbstractYamlModelLoader<DashScopeModelDefinitions>(resourceLoader, configPath) {
+
+    override fun getProviderClass() = DashScopeModelDefinitions::class
+
+    override fun createEmptyProvider() = DashScopeModelDefinitions()
+
+    override fun getProviderName() = DashScopeModels.PROVIDER
+
+    override fun validateModels(provider: DashScopeModelDefinitions) {
+        provider.models.forEach { model ->
+            validateCommonFields(model)
+            require(model.maxTokens > 0) { "Max tokens must be positive for model ${model.name}" }
+            require(model.temperature >= 0.0 && model.temperature <= 2.0) {
+                "Temperature must be in [0.0, 2.0] for DashScope model ${model.name}"
+            }
+            model.topP?.let {
+                require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Default path to the DashScope models YAML configuration file.
+         */
+        private const val DEFAULT_CONFIG_PATH = "classpath:models/dashscope-models.yml"
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/dashscope/DashScopeModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/dashscope/DashScopeModelsConfig.kt
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.dashscope
+
+import com.embabel.agent.api.models.DashScopeModels
+import com.embabel.agent.config.models.dashscope.DashScopeProperties.Companion.PREFIX
+import com.embabel.agent.openai.OpenAiCompatibleModelFactory
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.common.RetryProperties
+import com.embabel.common.ai.autoconfig.LlmAutoConfigMetadataLoader
+import com.embabel.common.ai.autoconfig.ProviderInitialization
+import com.embabel.common.ai.autoconfig.RegisteredModel
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.OptionsConverter
+import com.embabel.common.ai.model.PerTokenPricingModel
+import com.embabel.common.ai.model.PricingModel
+import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
+import com.embabel.common.util.loggerFor
+import io.micrometer.observation.ObservationRegistry
+import org.springframework.ai.openai.OpenAiChatOptions
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * Configuration properties for Alibaba Cloud DashScope models.
+ * These properties are bound from the Spring configuration with the prefix
+ * "embabel.agent.platform.models.dashscope" and control retry behavior
+ * when calling DashScope APIs.
+ */
+@ConfigurationProperties(prefix = PREFIX)
+class DashScopeProperties : RetryProperties {
+    /**
+     * Base URL for DashScope API requests. DashScope exposes an OpenAI-compatible
+     * chat-completions endpoint, so this is the base URL for the compatible mode;
+     * the OpenAI client appends `/chat/completions` itself.
+     */
+    var baseUrl: String = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+    /**
+     * API key for authenticating with DashScope services.
+     */
+    var apiKey: String? = null
+
+    /**
+     *  Maximum number of attempts.
+     */
+    override var maxAttempts: Int = 4
+
+    /**
+     * Initial backoff interval (in milliseconds).
+     */
+    override var backoffMillis: Long = 1500L
+
+    /**
+     * Backoff interval multiplier.
+     */
+    override var backoffMultiplier: Double = 2.0
+
+    /**
+     * Maximum backoff interval (in milliseconds).
+     */
+    override var backoffMaxInterval: Long = 60000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.dashscope"
+    }
+}
+
+/**
+ * Configuration class for Alibaba Cloud DashScope Qwen models.
+ *
+ * DashScope exposes an OpenAI-compatible chat-completions API, so models are served through
+ * [OpenAiCompatibleModelFactory] pointed at DashScope's international compatible-mode endpoint.
+ * (Spring AI does not provide a dedicated DashScope module.)
+ *
+ * Model definitions are loaded from `classpath:models/dashscope-models.yml` and each is
+ * registered as a singleton [LlmService] bean via [ConfigurableBeanFactory.registerSingleton].
+ *
+ * To use, set the following environment variables:
+ * ```
+ * DASHSCOPE_API_KEY=your-api-key
+ * ```
+ *
+ * @see <a href="https://dashscope.console.alibabacloud.com">DashScope Model Studio</a>
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(DashScopeProperties::class)
+@ExcludeFromJacocoGeneratedReport(reason = "DashScope configuration can't be unit tested")
+class DashScopeModelsConfig(
+    @param:Value("\${DASHSCOPE_BASE_URL:#{null}}")
+    envBaseUrl: String?,
+    @param:Value("\${DASHSCOPE_API_KEY:#{null}}")
+    envApiKey: String?,
+    observationRegistry: ObjectProvider<ObservationRegistry>,
+    private val properties: DashScopeProperties,
+    private val configurableBeanFactory: ConfigurableBeanFactory,
+    @Qualifier("aiModelRestClientBuilder")
+    restClientBuilder: ObjectProvider<RestClient.Builder>,
+    @Qualifier("aiModelWebClientBuilder")
+    webClientBuilder: ObjectProvider<WebClient.Builder>,
+    private val modelLoader: LlmAutoConfigMetadataLoader<DashScopeModelDefinitions> = DashScopeModelLoader(),
+) : OpenAiCompatibleModelFactory(
+    baseUrl = envBaseUrl?.trim()?.takeIf { it.isNotEmpty() } ?: properties.baseUrl,
+    apiKey = envApiKey?.trim()?.takeIf { it.isNotEmpty() }
+        ?: properties.apiKey?.trim()?.takeIf { it.isNotEmpty() }
+        ?: error("DashScope API key required: set DASHSCOPE_API_KEY env var or embabel.agent.platform.models.dashscope.api-key"),
+    completionsPath = null,
+    embeddingsPath = null,
+    observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
+    restClientBuilder = restClientBuilder,
+    webClientBuilder = webClientBuilder,
+) {
+
+    init {
+        logger.info("DashScope models are available: {}", properties)
+    }
+
+    @Bean
+    fun dashScopeModelsInitializer(): ProviderInitialization {
+        val registeredLlms = buildList {
+            modelLoader.loadAutoConfigMetadata().models.forEach { modelDef ->
+                try {
+                    val llm = openAiCompatibleLlm(
+                        model = modelDef.modelId,
+                        provider = DashScopeModels.PROVIDER,
+                        knowledgeCutoffDate = modelDef.knowledgeCutoffDate,
+                        optionsConverter = DashScopeOptionsConverter,
+                        pricingModel = modelDef.pricingModel?.let {
+                            PerTokenPricingModel(
+                                usdPer1mInputTokens = it.usdPer1mInputTokens,
+                                usdPer1mOutputTokens = it.usdPer1mOutputTokens,
+                            )
+                        } ?: PricingModel.ALL_YOU_CAN_EAT,
+                        retryTemplate = properties.retryTemplate("dashscope-${modelDef.modelId}"),
+                    )
+
+                    // Register as singleton bean with the configured bean name
+                    configurableBeanFactory.registerSingleton(modelDef.name, llm)
+                    add(RegisteredModel(beanName = modelDef.name, modelId = modelDef.modelId))
+
+                    logger.info("Registered DashScope model bean: {} -> {}", modelDef.name, modelDef.modelId)
+                } catch (e: Exception) {
+                    logger.error("Failed to create model: {} ({})", modelDef.name, modelDef.modelId)
+                    throw e
+                }
+            }
+        }
+
+        return ProviderInitialization(
+            provider = DashScopeModels.PROVIDER,
+            registeredLlms = registeredLlms,
+        ).also { logger.info(it.summary()) }
+    }
+}
+
+/**
+ * Options converter for Alibaba Cloud DashScope Qwen models.
+ * DashScope supports temperature in the range [0.0, 2.0].
+ * Values outside this range are clamped accordingly.
+ */
+object DashScopeOptionsConverter : OptionsConverter<OpenAiChatOptions> {
+
+    private const val MIN_TEMPERATURE = 0.0
+    private const val MAX_TEMPERATURE = 2.0
+
+    override fun convertOptions(options: LlmOptions): OpenAiChatOptions {
+        val temperature = options.temperature?.let { temp ->
+            temp.coerceIn(MIN_TEMPERATURE, MAX_TEMPERATURE).also { clamped ->
+                if (clamped != temp) {
+                    loggerFor<DashScopeOptionsConverter>().debug(
+                        "DashScope temperature clamped from {} to {} (valid range: [{}, {}])",
+                        temp, clamped, MIN_TEMPERATURE, MAX_TEMPERATURE
+                    )
+                }
+            }
+        }
+        return OpenAiChatOptions.builder()
+            .temperature(temperature)
+            .topP(options.topP)
+            .maxTokens(options.maxTokens)
+            .presencePenalty(options.presencePenalty)
+            .frequencyPenalty(options.frequencyPenalty)
+            .build()
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2025-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.embabel.agent.autoconfigure.models.dashscope.AgentDashScopeAutoConfiguration

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/resources/models/dashscope-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/resources/models/dashscope-models.yml
@@ -1,0 +1,42 @@
+# ============================================
+# dashscope-models.yml
+# ============================================
+# Alibaba Cloud DashScope models configuration
+# Served via DashScope's OpenAI-compatible API (OpenAiCompatibleModelFactory)
+#
+# DashScope supports temperature in the range [0.0, 2.0]; the
+# DashScopeOptionsConverter clamps runtime values into that range.
+
+models:
+  # Qwen3.7-Max - flagship reasoning model
+  - name: "dashscopeQwen37Max"
+    model_id: "qwen3.7-max"
+    display_name: "Qwen3.7-Max"
+    knowledge_cutoff_date: "2025-04-01"
+    max_tokens: 64000
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 2.50
+      usd_per1m_output_tokens: 7.50
+
+  # Qwen3.7-Plus - high-performance model
+  - name: "dashscopeQwen37Plus"
+    model_id: "qwen3.7-plus"
+    display_name: "Qwen3.7-Plus"
+    knowledge_cutoff_date: "2025-04-01"
+    max_tokens: 64000
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 0.40
+      usd_per1m_output_tokens: 1.60
+
+  # Qwen3.7-Flash - fast and cost-effective model (default)
+  - name: "dashscopeQwen37Flash"
+    model_id: "qwen3.7-flash"
+    display_name: "Qwen3.7-Flash"
+    knowledge_cutoff_date: "2025-04-01"
+    max_tokens: 64000
+    temperature: 0.7
+    pricing_model:
+      usd_per1m_input_tokens: 0.03
+      usd_per1m_output_tokens: 0.13

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/dashscope/AgentDashScopeAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/dashscope/AgentDashScopeAutoConfigurationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.dashscope;
+
+import com.embabel.agent.spi.LlmService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the DashScope entrypoint auto-configuration imports the provider config
+ * and exposes the configured Qwen model beans when credentials are present.
+ */
+class AgentDashScopeAutoConfigurationTest {
+
+   /**
+    * Context runner configured with a test API key so the provider configuration can
+    * instantiate its model beans without depending on real environment variables.
+    */
+   private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+           .withConfiguration(AutoConfigurations.of(AgentDashScopeAutoConfiguration.class))
+           .withPropertyValues("embabel.agent.platform.models.dashscope.api-key=test-key");
+
+   /**
+    * Confirms that all DashScope Qwen model beans are registered and backed by the
+    * generic LLM service abstraction exposed to the rest of the platform.
+    */
+   @Test
+   void registersDashScopeModelBeans() {
+      // Act
+      contextRunner.run(context -> {
+         // Assert
+         assertThat(context).hasBean("dashscopeQwen37Max");
+         assertThat(context).hasBean("dashscopeQwen37Plus");
+         assertThat(context).hasBean("dashscopeQwen37Flash");
+         assertThat(context.getBean("dashscopeQwen37Max")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("dashscopeQwen37Plus")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("dashscopeQwen37Flash")).isInstanceOf(LlmService.class);
+      });
+   }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/dashscope/DashScopeAllModelsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/dashscope/DashScopeAllModelsIT.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.dashscope
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.models.DashScopeModels
+import com.embabel.agent.autoconfigure.models.dashscope.AgentDashScopeAutoConfiguration
+import com.embabel.agent.spi.LlmService
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.opentest4j.TestAbortedException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.test.context.ActiveProfiles
+
+/**
+ * Test-only configuration that brings up the platform beans alongside the
+ * DashScope auto-configuration.
+ */
+@Profile("dashscope-chat-test")
+@ConfigurationPropertiesScan(basePackages = ["com.embabel.agent", "com.embabel.example"])
+@ComponentScan(basePackages = ["com.embabel.agent", "com.embabel.example"])
+class DashScopeChatTestConfig
+
+/**
+ * Live smoke test that verifies all registered DashScope (Qwen) chat models work correctly
+ * against the DashScope API endpoint.
+ *
+ * Design goals:
+ *  1. **No drift.** The list of models is derived at runtime from registered [LlmService] beans.
+ *  2. **Access gaps are skips, not failures.** Missing API access aborts individual tests instead of failing.
+ *
+ * Requires `DASHSCOPE_API_KEY` to be set; otherwise the whole class is disabled.
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=qwen3.7-flash",
+        "embabel.agent.platform.models.dashscope.max-attempts=1",
+        "embabel.agent.platform.models.dashscope.api-key=\${DASHSCOPE_API_KEY:dummy-key-for-context-loading}",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("dashscope-chat-test")
+@Import(
+    DashScopeChatTestConfig::class,
+    AgentDashScopeAutoConfiguration::class,
+)
+@EnabledIfEnvironmentVariable(
+    named = "DASHSCOPE_API_KEY",
+    matches = ".+",
+    disabledReason = "Live DashScope integration test requires DASHSCOPE_API_KEY",
+)
+class DashScopeAllModelsIT(
+    @param:Autowired private val ai: Ai,
+    @param:Autowired private val llms: List<LlmService<*>>,
+) {
+
+    /**
+     * Fast, no-network guard: every chat model constant must have produced a registered [LlmService].
+     */
+    @Test
+    fun everyDeclaredChatModelIsRegistered() {
+        val registered = registeredDashScopeModelIds().toSet()
+        val missing = EXPECTED_CHAT_MODELS.filterNot { it in registered }
+        assertTrue(
+            missing.isEmpty(),
+            "Expected DashScope chat models to be registered but these are missing: $missing " +
+                "(registered: ${registered.sorted()})",
+        )
+    }
+
+    /**
+     * Live smoke test: verify that the default model (qwen3.7-flash) can complete a simple request.
+     */
+    @Test
+    fun defaultModelCompletesRoundTrip() {
+        val response = try {
+            ai.withLlm(DashScopeModels.QWEN3_7_FLASH)
+                .generateText(SMOKE_PROMPT)
+                .trim()
+        } catch (ex: Exception) {
+            if (isModelAccessError(ex)) {
+                throw TestAbortedException(
+                    "DASHSCOPE_API_KEY is set, but it does not have access to qwen3.7-flash",
+                    ex,
+                )
+            }
+            throw ex
+        }
+
+        assertNotNull(response, "Expected a response from qwen3.7-flash")
+        assertTrue(response.isNotBlank(), "Expected non-empty response from qwen3.7-flash")
+        assertTrue(
+            response.contains("READY", ignoreCase = true),
+            "Expected qwen3.7-flash to reply with READY, got: $response",
+        )
+    }
+
+    private fun registeredDashScopeModelIds(): List<String> =
+        llms.asSequence()
+            .filter { it.provider == DashScopeModels.PROVIDER }
+            .map { it.name }
+            .distinct()
+            .sorted()
+            .toList()
+
+    private fun isModelAccessError(ex: Exception): Boolean {
+        val message = generateSequence<Throwable>(ex) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString(" | ")
+        return message.contains("does not have access", ignoreCase = true) ||
+            message.contains("model_not_found", ignoreCase = true) ||
+            message.contains("permission", ignoreCase = true) ||
+            message.contains("insufficient", ignoreCase = true) ||
+            message.contains("balance", ignoreCase = true) ||
+            message.contains("404", ignoreCase = false) ||
+            message.contains("no longer available", ignoreCase = true)
+    }
+
+    companion object {
+        private const val SMOKE_PROMPT = "Reply with exactly the word READY."
+
+        /**
+         * Canonical list of chat models expected to be registered, from [DashScopeModels].
+         */
+        private val EXPECTED_CHAT_MODELS = listOf(
+            DashScopeModels.QWEN3_7_MAX,
+            DashScopeModels.QWEN3_7_PLUS,
+            DashScopeModels.QWEN3_7_FLASH,
+        )
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/dashscope/DashScopeOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/dashscope/DashScopeOptionsConverterTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.dashscope
+
+import com.embabel.agent.test.models.OptionsConverterTestSupport
+import com.embabel.common.ai.model.LlmOptions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.ai.openai.OpenAiChatOptions
+
+// Calls the deprecated 1-arg convertOptions() directly to verify field mapping in isolation.
+// Model stamping is not tested here — it is covered by OptionsConverter.convertOptions(options, model).
+class DashScopeOptionsConverterTest : OptionsConverterTestSupport<OpenAiChatOptions>(
+    optionsConverter = DashScopeOptionsConverter
+) {
+    @Test
+    fun `should set override maxTokens default`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withMaxTokens(200))
+        assertEquals(200, options.maxTokens)
+    }
+
+    @Test
+    fun `should clamp temperature below minimum to minimum`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTemperature(-0.5))
+        val temperature = requireNotNull(options.temperature) { "Temperature should not be null after clamping" }
+        assertTrue(temperature >= 0.0, "Temperature should be clamped to at least 0.0")
+    }
+
+    @Test
+    fun `should clamp temperature above maximum to maximum`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTemperature(3.0))
+        assertEquals(2.0, options.temperature)
+    }
+
+    @Test
+    fun `should preserve valid temperature`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTemperature(0.7))
+        assertEquals(0.7, options.temperature)
+    }
+
+    @Test
+    fun `should handle null temperature`() {
+        val options = optionsConverter.convertOptions(LlmOptions())
+        assertNull(options.temperature)
+    }
+
+    @Test
+    fun `should preserve topP`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTopP(0.9))
+        assertEquals(0.9, options.topP)
+    }
+}

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -40,6 +40,7 @@
         <module>models/embabel-agent-oci-genai-autoconfigure</module>
         <module>models/embabel-agent-minimax-autoconfigure</module>
         <module>models/embabel-agent-zai-autoconfigure</module>
+        <module>models/embabel-agent-dashscope-autoconfigure</module>
         <module>models/embabel-agent-mistral-ai-autoconfigure</module>
         <module>models/embabel-agent-onnx-autoconfigure</module>
     </modules>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -199,6 +199,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-dashscope-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-mistral-ai-autoconfigure</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -344,6 +350,12 @@
             <dependency>
                 <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-zai</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-dashscope</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/embabel-agent-starters/embabel-agent-starter-dashscope/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-dashscope/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>embabel-agent-starter-dashscope</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent DashScope Starter</name>
+    <description>Embabel Agent DashScope Starter</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-dashscope-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -39,6 +39,7 @@
         <module>embabel-agent-starter-oci-genai</module>
         <module>embabel-agent-starter-minimax</module>
         <module>embabel-agent-starter-zai</module>
+        <module>embabel-agent-starter-dashscope</module>
         <module>embabel-agent-starter-mistral-ai</module>
         <module>embabel-agent-starter-a2a</module>
         <module>embabel-agent-starter-webmvc</module>


### PR DESCRIPTION
# Summary

- Add `embabel-agent-dashscope-autoconfigure` module
- Add `embabel-agent-dashscope-autoconfigure` module
- Add comprehensive test coverage:
  * `AgentDashScopeAutoConfigurationTest` - validates bean registration
  * `DashScopeOptionsConverterTest` - validates parameter conversion
  * `DashScopeAllModelsIT` - integration tests with `qwen3.7-flash` as default model

# Related Issue

Closes #1842 
