### PR TITLE
Add Alibaba Cloud DashScope models User Guide and enhance parameter clamping

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/DashScopeModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/DashScopeModels.kt
@@ -20,7 +20,8 @@ package com.embabel.agent.api.models
  * DashScope offers the Qwen family of large language models via an OpenAI-compatible API,
  * including reasoning-capable models and cost-effective lightweight variants.
  *
- * @see <a href="https://dashscope.console.alibabacloud.com">DashScope Model Studio</a>
+ * @see <a href="https://modelstudio.console.alibabacloud.com">DashScope Model Studio</a>
+ * @since 1.5.0
  */
 class DashScopeModels {
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/dashscope/AgentDashScopeAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/dashscope/AgentDashScopeAutoConfiguration.java
@@ -33,6 +33,8 @@ import org.springframework.context.annotation.Import;
  * The configuration is automatically activated when the DashScope
  * dependencies are present on the classpath and the DASHSCOPE_API_KEY
  * environment variable is set.
+ *
+ * @since 1.5.0
  */
 @AutoConfiguration
 @AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/dashscope/DashScopeModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/dashscope/DashScopeModelLoader.kt
@@ -31,6 +31,7 @@ import java.time.LocalDate
  * for auto-configuration purposes.
  *
  * @property models list of DashScope Qwen model definitions
+ * @since 1.5.0
  */
 data class DashScopeModelDefinitions(
     override val models: List<DashScopeModelDefinition> = emptyList()
@@ -49,6 +50,7 @@ data class DashScopeModelDefinitions(
  * @property maxTokens maximum tokens for completion
  * @property temperature default sampling temperature
  * @property topP nucleus sampling parameter
+ * @since 1.5.0
  */
 data class DashScopeModelDefinition(
     override val name: String,
@@ -70,6 +72,7 @@ data class DashScopeModelDefinition(
  *
  * @property resourceLoader Spring resource loader for accessing classpath resources
  * @property configPath path to the YAML configuration file
+ * @since 1.5.0
  */
 class DashScopeModelLoader(
     resourceLoader: ResourceLoader = DefaultResourceLoader(),
@@ -86,8 +89,8 @@ class DashScopeModelLoader(
         provider.models.forEach { model ->
             validateCommonFields(model)
             require(model.maxTokens > 0) { "Max tokens must be positive for model ${model.name}" }
-            require(model.temperature >= 0.0 && model.temperature <= 2.0) {
-                "Temperature must be in [0.0, 2.0] for DashScope model ${model.name}"
+            require(model.temperature >= 0.0 && model.temperature < 2.0) {
+                "Temperature must be in [0.0, 2.0) for DashScope model ${model.name}"
             }
             model.topP?.let {
                 require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/dashscope/DashScopeModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/dashscope/DashScopeModelsConfig.kt
@@ -47,6 +47,8 @@ import org.springframework.web.reactive.function.client.WebClient
  * These properties are bound from the Spring configuration with the prefix
  * "embabel.agent.platform.models.dashscope" and control retry behavior
  * when calling DashScope APIs.
+ *
+ * @since 1.5.0
  */
 @ConfigurationProperties(prefix = PREFIX)
 class DashScopeProperties : RetryProperties {
@@ -103,7 +105,8 @@ class DashScopeProperties : RetryProperties {
  * DASHSCOPE_API_KEY=your-api-key
  * ```
  *
- * @see <a href="https://dashscope.console.alibabacloud.com">DashScope Model Studio</a>
+ * @see <a href="https://modelstudio.console.alibabacloud.com">DashScope Model Studio</a>
+ * @since 1.5.0
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(DashScopeProperties::class)
@@ -177,13 +180,19 @@ class DashScopeModelsConfig(
 
 /**
  * Options converter for Alibaba Cloud DashScope Qwen models.
- * DashScope supports temperature in the range [0.0, 2.0].
- * Values outside this range are clamped accordingly.
+ * DashScope supports temperature in the range [0.0, 2.0) and top_p in the range (0, 1.0].
+ * Values outside these ranges are clamped accordingly:
+ * - Temperature: values are clamped to [0.0, 1.99]
+ * - Top P: values <= 0 are raised to 0.01, values > 1.0 are lowered to 1.0
+ *
+ * @since 1.5.0
  */
 object DashScopeOptionsConverter : OptionsConverter<OpenAiChatOptions> {
 
     private const val MIN_TEMPERATURE = 0.0
-    private const val MAX_TEMPERATURE = 2.0
+    private const val MAX_TEMPERATURE = 1.99
+    private const val MIN_TOP_P = 0.01
+    private const val MAX_TOP_P = 1.0
 
     override fun convertOptions(options: LlmOptions): OpenAiChatOptions {
         val temperature = options.temperature?.let { temp ->
@@ -196,9 +205,21 @@ object DashScopeOptionsConverter : OptionsConverter<OpenAiChatOptions> {
                 }
             }
         }
+
+        val topP = options.topP?.let { p ->
+            p.coerceIn(MIN_TOP_P, MAX_TOP_P).also { clamped ->
+                if (clamped != p) {
+                    loggerFor<DashScopeOptionsConverter>().debug(
+                        "DashScope topP clamped from {} to {} (valid range: ({}, {}])",
+                        p, clamped, MIN_TOP_P, MAX_TOP_P
+                    )
+                }
+            }
+        }
+
         return OpenAiChatOptions.builder()
             .temperature(temperature)
-            .topP(options.topP)
+            .topP(topP)
             .maxTokens(options.maxTokens)
             .presencePenalty(options.presencePenalty)
             .frequencyPenalty(options.frequencyPenalty)

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/resources/models/dashscope-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/main/resources/models/dashscope-models.yml
@@ -4,7 +4,7 @@
 # Alibaba Cloud DashScope models configuration
 # Served via DashScope's OpenAI-compatible API (OpenAiCompatibleModelFactory)
 #
-# DashScope supports temperature in the range [0.0, 2.0]; the
+# DashScope supports temperature in the range [0.0, 2.0); the
 # DashScopeOptionsConverter clamps runtime values into that range.
 
 models:

--- a/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/dashscope/DashScopeOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-dashscope-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/dashscope/DashScopeOptionsConverterTest.kt
@@ -42,9 +42,15 @@ class DashScopeOptionsConverterTest : OptionsConverterTestSupport<OpenAiChatOpti
     }
 
     @Test
-    fun `should clamp temperature above maximum to maximum`() {
+    fun `should clamp temperature at exactly 2_0 to 1_99`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTemperature(2.0))
+        assertEquals(1.99, options.temperature)
+    }
+
+    @Test
+    fun `should clamp temperature above maximum to 1_99`() {
         val options = optionsConverter.convertOptions(LlmOptions().withTemperature(3.0))
-        assertEquals(2.0, options.temperature)
+        assertEquals(1.99, options.temperature)
     }
 
     @Test
@@ -60,8 +66,38 @@ class DashScopeOptionsConverterTest : OptionsConverterTestSupport<OpenAiChatOpti
     }
 
     @Test
-    fun `should preserve topP`() {
+    fun `should clamp topP at zero to 0_01`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTopP(0.0))
+        assertEquals(0.01, options.topP)
+    }
+
+    @Test
+    fun `should clamp topP below zero to 0_01`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTopP(-0.5))
+        assertEquals(0.01, options.topP)
+    }
+
+    @Test
+    fun `should clamp topP above 1_0 to 1_0`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTopP(1.5))
+        assertEquals(1.0, options.topP)
+    }
+
+    @Test
+    fun `should preserve valid topP`() {
         val options = optionsConverter.convertOptions(LlmOptions().withTopP(0.9))
         assertEquals(0.9, options.topP)
+    }
+
+    @Test
+    fun `should preserve topP at exactly 1_0`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTopP(1.0))
+        assertEquals(1.0, options.topP)
+    }
+
+    @Test
+    fun `should handle null topP`() {
+        val options = optionsConverter.convertOptions(LlmOptions())
+        assertNull(options.topP)
     }
 }

--- a/embabel-agent-docs/src/main/asciidoc/reference/dashscope/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/dashscope/page.adoc
@@ -1,0 +1,271 @@
+[[reference.dashscope]]
+=== DashScope Integration
+
+https://modelstudio.console.alibabacloud.com/[Alibaba Cloud DashScope] is Alibaba Cloud's AI model platform offering the Qwen family of high-performance LLMs via an OpenAI-compatible API.
+Embabel integrates DashScope as a first-class provider using the same `OpenAiCompatibleModelFactory` pattern as other OpenAI-compatible providers.
+
+Model definitions (ids, pricing, knowledge cutoff) are loaded from `classpath:models/dashscope-models.yml` and each is registered as an `LlmService` bean.
+
+==== Add the Dependency
+
+[tabs]
+====
+Maven::
++
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-dashscope</artifactId>
+</dependency>
+----
+
+Gradle (Kotlin)::
++
+[source,kotlin]
+----
+implementation("com.embabel.agent:embabel-agent-starter-dashscope")
+----
+
+Gradle (Groovy)::
++
+[source,groovy]
+----
+implementation 'com.embabel.agent:embabel-agent-starter-dashscope'
+----
+====
+
+==== API Key Configuration
+
+Set your DashScope API key via environment variable (recommended) or Spring property:
+
+[source,bash]
+----
+export DASHSCOPE_API_KEY=your-api-key
+----
+
+Or in `application.yml`:
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        dashscope:
+          api-key: your-api-key
+----
+
+TIP: The environment variable `DASHSCOPE_API_KEY` takes precedence over the property value.
+Use the property for local development and the environment variable in production deployments.
+
+==== Available Models
+
+[cols="2,3,1,1",options="header"]
+|===
+|Model Name |Model ID |Input (per 1M tokens) |Output (per 1M tokens)
+
+|`Qwen3.7-Max`
+|`qwen3.7-max`
+|$2.50
+|$7.50
+
+|`Qwen3.7-Plus`
+|`qwen3.7-plus`
+|$0.40
+|$1.60
+
+|`Qwen3.7-Flash`
+|`qwen3.7-flash`
+|$0.03
+|$0.13
+
+|===
+
+`qwen3.7-max` is the flagship reasoning model — the best choice for demanding tasks requiring deep reasoning and complex problem-solving.
+`qwen3.7-plus` is a high-performance general-purpose model with strong capabilities at a moderate price point.
+`qwen3.7-flash` is the fastest and most cost-effective model — the *default model* — well-suited to high-volume extraction, classification, and intermediate steps in a multi-action agent flow.
+
+TIP: Embabel's per-step LLM selection makes DashScope models particularly well-suited to mixed strategies: use `qwen3.7-flash` for extraction and classification steps, and reserve `qwen3.7-max` (or a premium model from another provider) only for the final reasoning step.
+
+==== Using DashScope Models
+
+Reference models by name in `@LlmCall` or programmatically via `ai.withLlm()`:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+// Declarative
+@LlmCall(llm = "qwen3.7-max")
+fun summarize(article: Article): Summary
+
+// Programmatic
+ai.withLlm("qwen3.7-flash")
+    .create<Classification>("Classify this input")
+----
+
+Java::
++
+[source,java]
+----
+// Declarative
+@LlmCall(llm = "qwen3.7-max")
+Summary summarize(Article article);
+
+// Programmatic
+ai.withLlm("qwen3.7-flash")
+    .create("Classify this input", Classification.class);
+----
+====
+
+Or use the constants defined in `DashScopeModels`:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+import com.embabel.agent.api.models.DashScopeModels
+
+@LlmCall(llm = DashScopeModels.QWEN3_7_MAX)
+fun reason(complex: ComplexProblem): Solution
+----
+
+Java::
++
+[source,java]
+----
+import com.embabel.agent.api.models.DashScopeModels;
+
+@LlmCall(llm = DashScopeModels.QWEN3_7_MAX)
+Solution reason(ComplexProblem complex);
+----
+====
+
+Or map DashScope models to roles in your configuration:
+
+[source,yaml]
+----
+embabel:
+  models:
+    llms:
+      cheapest: qwen3.7-flash
+      best: qwen3.7-max
+----
+
+Then reference by role with the `#` prefix:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+@LlmCall(llm = "#cheapest")
+fun extractEntities(text: String): EntityList
+----
+
+Java::
++
+[source,java]
+----
+@LlmCall(llm = "#cheapest")
+EntityList extractEntities(String text);
+----
+====
+
+==== Parameter Clamping
+
+DashScope models have specific parameter ranges:
+
+* **temperature**: range `[0.0, 2.0)` — a value of exactly `0.0` *is* permitted.
+* **top_p**: range `(0, 1.0]` — a value of exactly `0.0` is *not* permitted.
+
+Embabel's `DashScopeOptionsConverter` clamps these values automatically:
+
+**temperature:**
+
+* Values `< 0.0` are raised to `0.0`
+* Values `>= 2.0` are lowered to `1.99`
+
+**top_p:**
+
+* Values `\<= 0.0` are raised to `0.01`
+* Values `> 1.0` are lowered to `1.0`
+
+A `DEBUG` log message is emitted whenever clamping occurs.
+No action is required on your part — this is handled transparently.
+
+==== Regional Endpoints
+
+DashScope provides different OpenAI-compatible API endpoints based on region:
+
+[cols="2,5",options="header"]
+|===
+|Region |Base URL
+
+|China (Beijing) *(default)*
+|`https://dashscope.aliyuncs.com/compatible-mode/v1`
+
+|Singapore
+|`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
+
+|US (Virginia)
+|`https://dashscope-us.aliyuncs.com/compatible-mode/v1`
+
+|China (Hong Kong)
+|`https://cn-hongkong.dashscope.aliyuncs.com/compatible-mode/v1`
+|===
+
+To use a different region, configure the `base-url` property or set the `DASHSCOPE_BASE_URL` environment variable:
+
+[tabs]
+====
+Environment Variable::
++
+[source,bash]
+----
+# Example: Singapore region
+export DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+----
+
+application.yml::
++
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        dashscope:
+          api-key: your-api-key
+          base-url: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+----
+====
+
+==== Configuration Reference
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        dashscope:
+          api-key: your-api-key                                        # Alternative to DASHSCOPE_API_KEY env var
+          base-url: https://dashscope.aliyuncs.com/compatible-mode/v1  # Default; see Regional Endpoints above
+          max-attempts: 4                                              # Retry attempts (default: 4)
+          backoff-millis: 1500                                         # Initial backoff ms (default: 1500)
+          backoff-multiplier: 2.0                                      # Backoff multiplier (default: 2.0)
+          backoff-max-interval: 60000                                  # Max backoff ms (default: 60000)
+----
+
+==== See Also
+
+* <<reference.llms,Working with LLMs>>
+* <<reference.configuration,Configuration Reference>>
+* https://modelstudio.console.alibabacloud.com[DashScope Model Studio]

--- a/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
@@ -37,6 +37,8 @@ include::minimax/page.adoc[]
 
 include::zai/page.adoc[]
 
+include::dashscope/page.adoc[]
+
 include::streaming/page.adoc[]
 
 include::thinking/page.adoc[]


### PR DESCRIPTION
# Sumarry

- Add DashScope Integration document
- Enhance DashScopeOptionsConverter parameter clamping:
  * Temperature: [0.0, 2.0) range, clamp >=2.0 to 1.99
  * Top P: (0, 1.0] range, clamp <=0.0 to 0.01, >1.0 to 1.0

# Related Issue

Closes: #1848 