### PR TITLE
fix(observability): use Spring Boot 4 packages in ObservabilityAutoConfiguration afterName

### DIFF
--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/pom.xml
@@ -51,6 +51,19 @@
             <optional>true</optional>
         </dependency>
 
+        <!--
+            Spring Boot 4 moved MicrometerTracingAutoConfiguration out of
+            spring-boot-actuator-autoconfigure into spring-boot-micrometer-tracing
+            (org.springframework.boot.micrometer.tracing.autoconfigure).
+            Optional here so afterName FQCN can resolve when present; the
+            observability starter brings spring-boot-micrometer-tracing-opentelemetry.
+        -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-tracing</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- AspectJ weaver for @Tracked aspect support (direct dep, not spring-boot-starter-aspectj); provides org.aspectj.lang.* -->
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfiguration.java
@@ -56,8 +56,9 @@ import org.springframework.context.annotation.Primary;
 @AutoConfiguration(
         after = MicrometerTracingAutoConfiguration.class,
         afterName = {
-                "org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration",
-                "org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration"
+                // Spring Boot 4 moved these out of spring-boot-actuator-autoconfigure
+                "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration",
+                "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration"
         }
 )
 @EnableConfigurationProperties(ObservabilityProperties.class)

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
@@ -339,12 +339,14 @@ class ObservabilityAutoConfigurationTest {
         assertThat(afterName).containsExactlyInAnyOrder(
                 "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration",
                 "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration");
-        // Boot 3 actuate paths are silently ignored under Boot 4 — must not remain
-        assertThat(afterName).noneMatch(name -> name.contains(".actuate.autoconfigure."));
 
-        // Observation auto-config is a direct optional dep; confirm the FQCN still resolves
+        // afterName FQCNs must resolve on the classpath; a wrong name is silently ignored by
+        // Spring and ordering never applies (#1808). Check both observation and tracing.
         assertThat(classExists(
                 "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration"))
+                .isTrue();
+        assertThat(classExists(
+                "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration"))
                 .isTrue();
     }
 

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
@@ -24,10 +24,14 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -321,6 +325,37 @@ class ObservabilityAutoConfigurationTest {
                 .run(context -> {
                     assertThat(context).hasSingleBean(HttpRequestObservationFilter.class);
                 });
+    }
+
+    // --- Boot 4 afterName ordering (#1808) ---
+
+    @Test
+    void autoConfiguration_afterName_shouldUseSpringBoot4MicrometerPackages() {
+        AutoConfiguration autoConfiguration =
+                ObservabilityAutoConfiguration.class.getAnnotation(AutoConfiguration.class);
+        assertThat(autoConfiguration).isNotNull();
+
+        List<String> afterName = Arrays.asList(autoConfiguration.afterName());
+        assertThat(afterName).containsExactlyInAnyOrder(
+                "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration",
+                "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration");
+        // Boot 3 actuate paths are silently ignored under Boot 4 — must not remain
+        assertThat(afterName).noneMatch(name -> name.contains(".actuate.autoconfigure."));
+
+        // Observation auto-config is a direct optional dep; confirm the FQCN still resolves
+        assertThat(classExists(
+                "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration"))
+                .isTrue();
+    }
+
+    private static boolean classExists(String name) {
+        try {
+            Class.forName(name);
+            return true;
+        }
+        catch (ClassNotFoundException ex) {
+            return false;
+        }
     }
 
     // --- Metrics listener ---

--- a/embabel-agent-starters/embabel-agent-starter-observability/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-observability/pom.xml
@@ -38,6 +38,18 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!--
+            Spring Boot 4 moved tracing auto-config out of spring-boot-actuator-autoconfigure.
+            Actuator alone no longer creates a Tracer / spans. This Boot module pulls
+            MicrometerTracingAutoConfiguration (and OTel bridge) so afterName ordering
+            and Embabel observations → spans work out of the box (#1808).
+            Version managed by spring-boot-dependencies BOM.
+        -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-tracing-opentelemetry</artifactId>
+        </dependency>
+
         <!-- AspectJ weaver for @Tracked aspect support (direct dep, not spring-boot-starter-aspectj); provides org.aspectj.lang.* -->
         <dependency>
             <groupId>org.aspectj</groupId>


### PR DESCRIPTION
## Summary

`ObservabilityAutoConfiguration` ordered itself after Spring Boot observation/tracing via `afterName` strings that still pointed at **Boot 3** `org.springframework.boot.actuate.autoconfigure.*` paths.

On Spring Boot 4 those classes live under `org.springframework.boot.micrometer.*`. Boot silently ignores unknown `afterName` entries, so the ordering guarantee against Boot's observation/tracing autoconfiguration was lost (no compile/runtime failure).

## Changes

- Update `afterName` to:
  - `org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration`
  - `org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration`
- Unit test pins the Boot 4 FQCNs and rejects leftover Boot 3 actuate paths; verifies observation class still resolves on the module classpath.

Fixes #1808

## Test plan

- [x] `mvn -pl embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure -am test -Dtest=ObservabilityAutoConfigurationTest -Dsurefire.failIfNoSpecifiedTests=false` (JDK 21) — **29/29 green**
- [x] Confirmed no open prior PR for #1808 before opening

## AI disclosure

Human-reviewed fix. Implementation assisted by AI (Grok / Cursor implementator wave). Author: arimu1.