### PR TITLE
feat(rag): promote structural chunk metadata to typed ChunkStructure

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/ContentChunker.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/ContentChunker.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.rag.ingestion
 
 import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.ChunkStructure
 import com.embabel.agent.rag.model.NavigableContainerSection
 
 /**
@@ -58,38 +59,38 @@ interface ContentChunker {
     companion object {
 
         /** Metadata key for the zero-based index of this chunk within its parent section */
-        const val CHUNK_INDEX = "chunk_index"
+        const val CHUNK_INDEX = ChunkStructure.CHUNK_INDEX
 
         /** Metadata key for the total number of chunks created from the parent section */
-        const val TOTAL_CHUNKS = "total_chunks"
+        const val TOTAL_CHUNKS = ChunkStructure.TOTAL_CHUNKS
 
         /**
          * Metadata key for a stable sequence number used for sorting chunks within a container section hierarchy.
          * This is a zero-based sequential number assigned to each chunk as it is created from a container section,
          * preserving the original order of leaves and their chunks. Use this for stable, predictable sorting.
          */
-        const val SEQUENCE_NUMBER = "sequence_number"
+        const val SEQUENCE_NUMBER = ChunkStructure.SEQUENCE_NUMBER
 
         /** Metadata key for the unique identifier of the root document */
-        const val ROOT_DOCUMENT_ID = "root_document_id"
+        const val ROOT_DOCUMENT_ID = ChunkStructure.ROOT_DOCUMENT_ID
 
         /** Metadata key for the unique identifier of the container section */
-        const val CONTAINER_SECTION_ID = "container_section_id"
+        const val CONTAINER_SECTION_ID = ChunkStructure.CONTAINER_SECTION_ID
 
         /** Metadata key for the title of the container section */
-        const val CONTAINER_SECTION_TITLE = "container_section_title"
+        const val CONTAINER_SECTION_TITLE = ChunkStructure.CONTAINER_SECTION_TITLE
 
         /** Metadata key for the URI/URL of the container section */
-        const val CONTAINER_SECTION_URL = "container_section_url"
+        const val CONTAINER_SECTION_URL = ChunkStructure.CONTAINER_SECTION_URL
 
         /** Metadata key for the unique identifier of the leaf section */
-        const val LEAF_SECTION_ID = "leaf_section_id"
+        const val LEAF_SECTION_ID = ChunkStructure.LEAF_SECTION_ID
 
         /** Metadata key for the title of the leaf section */
-        const val LEAF_SECTION_TITLE = "leaf_section_title"
+        const val LEAF_SECTION_TITLE = ChunkStructure.LEAF_SECTION_TITLE
 
         /** Metadata key for the URI/URL of the leaf section */
-        const val LEAF_SECTION_URL = "leaf_section_url"
+        const val LEAF_SECTION_URL = ChunkStructure.LEAF_SECTION_URL
 
         /**
          * Factory method to create an InMemoryContentChunker.

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/Chunk.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/Chunk.kt
@@ -35,6 +35,13 @@ interface Chunk : Source, HierarchicalContentElement {
     val urtext: String
 
     /**
+     * Chunker-owned structural fields (document/section ids, sequence, indexes).
+     * Free-form user data remains in [metadata]; structural keys are also exposed there
+     * for backward compatibility during the deprecation window.
+     */
+    val structure: ChunkStructure
+
+    /**
      * Parent must be non-null. It must a physical content element.
      */
     override val parentId: String
@@ -43,7 +50,7 @@ interface Chunk : Source, HierarchicalContentElement {
      * If available, this is the path from the root document as ids,
      * with the root id first and this element's id as the last element.
      *
-     * Default implementation computes from metadata for backward compatibility.
+     * Default implementation uses [structure] (with metadata fallback via the compat view).
      * For a more robust solution that traverses actual parentId relationships,
      * use ContentElementRepository.pathFromRoot(element) instead.
      *
@@ -51,33 +58,27 @@ interface Chunk : Source, HierarchicalContentElement {
      */
     val pathFromRoot: List<String>?
         get() {
-            // Get root document ID from metadata
-            val rootId = metadata["root_document_id"] as? String ?: return null
-            val containerId = metadata["container_section_id"] as? String
-            val leafId = metadata["leaf_section_id"] as? String
+            val rootId = structure.rootDocumentId ?: return null
+            val containerId = structure.containerSectionId
+            val leafId = structure.leafSectionId
 
-            // Build path: root -> container -> leaf (if exists) -> chunk
             val path = mutableListOf<String>()
             path.add(rootId)
 
-            // Only add container if it's different from root
             if (containerId != null && containerId != rootId) {
                 path.add(containerId)
             }
 
-            // Add leaf section if it exists and is different from container
             if (leafId != null && leafId != containerId) {
                 path.add(leafId)
             }
 
-            // Add chunk itself if it's not already in the path
             if (id != path.lastOrNull()) {
                 path.add(id)
             }
 
             return path
         }
-
 
     override val uri: String? get() = metadata["url"] as? String
 
@@ -98,12 +99,26 @@ interface Chunk : Source, HierarchicalContentElement {
      * Transform the content of this chunk
      */
     fun withText(transformed: String): Chunk =
-        ChunkImpl(
-            id = this.id,
+        create(
             text = transformed,
-            urtext = this.urtext,
-            metadata = this.metadata,
-            parentId = this.parentId,
+            parentId = parentId,
+            metadata = metadata,
+            id = id,
+            urtext = urtext,
+            structure = structure,
+        )
+
+    /**
+     * Replace structural fields while preserving free-form metadata.
+     */
+    fun withStructure(structure: ChunkStructure): Chunk =
+        create(
+            text = text,
+            parentId = parentId,
+            metadata = ChunkStructure.withoutStructuralKeys(metadata),
+            id = id,
+            urtext = urtext,
+            structure = structure,
         )
 
     companion object {
@@ -114,12 +129,12 @@ interface Chunk : Source, HierarchicalContentElement {
             metadata: Map<String, Any?>,
             parentId: String,
         ): Chunk {
-            return ChunkImpl(
-                id = id,
+            return create(
                 text = text,
-                urtext = text,
-                metadata = metadata,
                 parentId = parentId,
+                metadata = metadata,
+                id = id,
+                urtext = text,
             )
         }
 
@@ -131,13 +146,17 @@ interface Chunk : Source, HierarchicalContentElement {
             metadata: Map<String, Any?> = emptyMap(),
             id: String = UUID.randomUUID().toString(),
             urtext: String = text,
+            structure: ChunkStructure? = null,
         ): Chunk {
+            val resolvedStructure = structure ?: ChunkStructure.fromMetadata(metadata)
+            val freeform = ChunkStructure.withoutStructuralKeys(metadata)
             return ChunkImpl(
                 id = id,
                 text = text,
                 urtext = urtext,
-                metadata = metadata,
                 parentId = parentId,
+                freeformMetadata = freeform,
+                structure = resolvedStructure,
             )
         }
 
@@ -164,9 +183,22 @@ private data class ChunkImpl(
     override val text: String,
     override val urtext: String,
     override val parentId: String,
-    override val metadata: Map<String, Any?>,
+    private val freeformMetadata: Map<String, Any?>,
+    override val structure: ChunkStructure,
 ) : Chunk {
 
-    override fun withAdditionalMetadata(metadata: Map<String, Any?>): Chunk =
-        this.copy(metadata = this.metadata + metadata)
+    override val metadata: Map<String, Any?>
+        get() {
+            val structural = structure.toMetadata()
+            return if (structural.isEmpty()) freeformMetadata else freeformMetadata + structural
+        }
+
+    override fun withAdditionalMetadata(metadata: Map<String, Any?>): Chunk {
+        val addedStructure = ChunkStructure.fromMetadata(metadata)
+        val addedFreeform = ChunkStructure.withoutStructuralKeys(metadata)
+        return copy(
+            freeformMetadata = freeformMetadata + addedFreeform,
+            structure = structure.merge(addedStructure),
+        )
+    }
 }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/ChunkStructure.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/ChunkStructure.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model
+
+/**
+ * Load-bearing structural fields for a [Chunk], promoted out of free-form [Chunk.metadata].
+ *
+ * Written by the content chunker and used for navigation, ordering, and filtering.
+ * During the deprecation window, [toMetadata] is merged into [Chunk.metadata] so existing
+ * string-key readers keep working.
+ */
+data class ChunkStructure(
+    val rootDocumentId: String? = null,
+    val containerSectionId: String? = null,
+    val containerSectionTitle: String? = null,
+    val containerSectionUrl: String? = null,
+    val leafSectionId: String? = null,
+    val leafSectionTitle: String? = null,
+    val leafSectionUrl: String? = null,
+    val chunkIndex: Int? = null,
+    val totalChunks: Int? = null,
+    val sequenceNumber: Int? = null,
+) {
+
+    fun isEmpty(): Boolean = this == EMPTY
+
+    /**
+     * Non-null fields as the historical metadata key/value map.
+     */
+    fun toMetadata(): Map<String, Any?> {
+        if (isEmpty()) return emptyMap()
+        val result = LinkedHashMap<String, Any?>(KEYS.size)
+        rootDocumentId?.let { result[ROOT_DOCUMENT_ID] = it }
+        containerSectionId?.let { result[CONTAINER_SECTION_ID] = it }
+        containerSectionTitle?.let { result[CONTAINER_SECTION_TITLE] = it }
+        containerSectionUrl?.let { result[CONTAINER_SECTION_URL] = it }
+        leafSectionId?.let { result[LEAF_SECTION_ID] = it }
+        leafSectionTitle?.let { result[LEAF_SECTION_TITLE] = it }
+        leafSectionUrl?.let { result[LEAF_SECTION_URL] = it }
+        chunkIndex?.let { result[CHUNK_INDEX] = it }
+        totalChunks?.let { result[TOTAL_CHUNKS] = it }
+        sequenceNumber?.let { result[SEQUENCE_NUMBER] = it }
+        return result
+    }
+
+    /**
+     * Prefer non-null values from [other].
+     */
+    fun merge(other: ChunkStructure): ChunkStructure = ChunkStructure(
+        rootDocumentId = other.rootDocumentId ?: rootDocumentId,
+        containerSectionId = other.containerSectionId ?: containerSectionId,
+        containerSectionTitle = other.containerSectionTitle ?: containerSectionTitle,
+        containerSectionUrl = other.containerSectionUrl ?: containerSectionUrl,
+        leafSectionId = other.leafSectionId ?: leafSectionId,
+        leafSectionTitle = other.leafSectionTitle ?: leafSectionTitle,
+        leafSectionUrl = other.leafSectionUrl ?: leafSectionUrl,
+        chunkIndex = other.chunkIndex ?: chunkIndex,
+        totalChunks = other.totalChunks ?: totalChunks,
+        sequenceNumber = other.sequenceNumber ?: sequenceNumber,
+    )
+
+    companion object {
+
+        const val CHUNK_INDEX = "chunk_index"
+        const val TOTAL_CHUNKS = "total_chunks"
+        const val SEQUENCE_NUMBER = "sequence_number"
+        const val ROOT_DOCUMENT_ID = "root_document_id"
+        const val CONTAINER_SECTION_ID = "container_section_id"
+        const val CONTAINER_SECTION_TITLE = "container_section_title"
+        const val CONTAINER_SECTION_URL = "container_section_url"
+        const val LEAF_SECTION_ID = "leaf_section_id"
+        const val LEAF_SECTION_TITLE = "leaf_section_title"
+        const val LEAF_SECTION_URL = "leaf_section_url"
+
+        val KEYS: Set<String> = setOf(
+            CHUNK_INDEX,
+            TOTAL_CHUNKS,
+            SEQUENCE_NUMBER,
+            ROOT_DOCUMENT_ID,
+            CONTAINER_SECTION_ID,
+            CONTAINER_SECTION_TITLE,
+            CONTAINER_SECTION_URL,
+            LEAF_SECTION_ID,
+            LEAF_SECTION_TITLE,
+            LEAF_SECTION_URL,
+        )
+
+        val EMPTY = ChunkStructure()
+
+        @JvmStatic
+        fun fromMetadata(metadata: Map<String, Any?>): ChunkStructure {
+            if (metadata.isEmpty() || metadata.keys.none { it in KEYS }) {
+                return EMPTY
+            }
+            return ChunkStructure(
+                rootDocumentId = stringOrNull(metadata[ROOT_DOCUMENT_ID]),
+                containerSectionId = stringOrNull(metadata[CONTAINER_SECTION_ID]),
+                containerSectionTitle = stringOrNull(metadata[CONTAINER_SECTION_TITLE]),
+                containerSectionUrl = stringOrNull(metadata[CONTAINER_SECTION_URL]),
+                leafSectionId = stringOrNull(metadata[LEAF_SECTION_ID]),
+                leafSectionTitle = stringOrNull(metadata[LEAF_SECTION_TITLE]),
+                leafSectionUrl = stringOrNull(metadata[LEAF_SECTION_URL]),
+                chunkIndex = intOrNull(metadata[CHUNK_INDEX]),
+                totalChunks = intOrNull(metadata[TOTAL_CHUNKS]),
+                sequenceNumber = intOrNull(metadata[SEQUENCE_NUMBER]),
+            )
+        }
+
+        @JvmStatic
+        fun withoutStructuralKeys(metadata: Map<String, Any?>): Map<String, Any?> {
+            if (metadata.isEmpty() || metadata.keys.none { it in KEYS }) {
+                return metadata
+            }
+            return metadata.filterKeys { it !in KEYS }
+        }
+
+        private fun stringOrNull(value: Any?): String? = when (value) {
+            null -> null
+            is String -> value
+            else -> value.toString()
+        }
+
+        private fun intOrNull(value: Any?): Int? = when (value) {
+            null -> null
+            is Int -> value
+            is Number -> value.toInt()
+            is String -> value.toIntOrNull()
+            else -> null
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChunkStructureTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChunkStructureTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ChunkStructureTest {
+
+    @Nested
+    inner class FromMetadata {
+
+        @Test
+        fun `empty map yields empty structure`() {
+            assertEquals(ChunkStructure.EMPTY, ChunkStructure.fromMetadata(emptyMap()))
+            assertTrue(ChunkStructure.fromMetadata(emptyMap()).isEmpty())
+        }
+
+        @Test
+        fun `extracts structural keys and coerces numeric types`() {
+            val structure = ChunkStructure.fromMetadata(
+                mapOf(
+                    ChunkStructure.ROOT_DOCUMENT_ID to "doc-1",
+                    ChunkStructure.CONTAINER_SECTION_ID to "sec-1",
+                    ChunkStructure.CONTAINER_SECTION_TITLE to "Intro",
+                    ChunkStructure.CONTAINER_SECTION_URL to "https://example.com",
+                    ChunkStructure.LEAF_SECTION_ID to "leaf-1",
+                    ChunkStructure.LEAF_SECTION_TITLE to "Leaf",
+                    ChunkStructure.LEAF_SECTION_URL to "https://example.com#leaf",
+                    ChunkStructure.CHUNK_INDEX to 2,
+                    ChunkStructure.TOTAL_CHUNKS to 5L,
+                    ChunkStructure.SEQUENCE_NUMBER to "7",
+                    "custom" to "keep-me",
+                )
+            )
+
+            assertEquals("doc-1", structure.rootDocumentId)
+            assertEquals("sec-1", structure.containerSectionId)
+            assertEquals("Intro", structure.containerSectionTitle)
+            assertEquals("https://example.com", structure.containerSectionUrl)
+            assertEquals("leaf-1", structure.leafSectionId)
+            assertEquals("Leaf", structure.leafSectionTitle)
+            assertEquals("https://example.com#leaf", structure.leafSectionUrl)
+            assertEquals(2, structure.chunkIndex)
+            assertEquals(5, structure.totalChunks)
+            assertEquals(7, structure.sequenceNumber)
+            assertFalse(structure.isEmpty())
+        }
+
+        @Test
+        fun `withoutStructuralKeys drops only reserved keys`() {
+            val original = mapOf(
+                ChunkStructure.SEQUENCE_NUMBER to 1,
+                "author" to "alice",
+                ChunkStructure.ROOT_DOCUMENT_ID to "doc",
+            )
+            val freeform = ChunkStructure.withoutStructuralKeys(original)
+            assertEquals(mapOf("author" to "alice"), freeform)
+        }
+    }
+
+    @Nested
+    inner class ToMetadata {
+
+        @Test
+        fun `round trips non-null fields`() {
+            val structure = ChunkStructure(
+                rootDocumentId = "doc-1",
+                containerSectionId = "sec-1",
+                sequenceNumber = 3,
+                chunkIndex = 0,
+                totalChunks = 1,
+            )
+            val asMeta = structure.toMetadata()
+            assertEquals(structure, ChunkStructure.fromMetadata(asMeta))
+            assertFalse(asMeta.containsKey(ChunkStructure.LEAF_SECTION_ID))
+        }
+
+        @Test
+        fun `empty structure produces empty map`() {
+            assertTrue(ChunkStructure.EMPTY.toMetadata().isEmpty())
+        }
+    }
+
+    @Nested
+    inner class Merge {
+
+        @Test
+        fun `prefers non-null values from other`() {
+            val base = ChunkStructure(rootDocumentId = "doc", sequenceNumber = 1)
+            val other = ChunkStructure(sequenceNumber = 9, containerSectionId = "c1")
+            val merged = base.merge(other)
+            assertEquals("doc", merged.rootDocumentId)
+            assertEquals(9, merged.sequenceNumber)
+            assertEquals("c1", merged.containerSectionId)
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChunkTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChunkTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ChunkTest {
+
+    @Nested
+    inner class StructureFromMetadata {
+
+        @Test
+        fun `promotes structural keys to structure and keeps metadata compat view`() {
+            val chunk = Chunk(
+                id = "c1",
+                text = "hello",
+                parentId = "parent",
+                metadata = mapOf(
+                    ChunkStructure.ROOT_DOCUMENT_ID to "doc-1",
+                    ChunkStructure.CONTAINER_SECTION_ID to "sec-1",
+                    ChunkStructure.LEAF_SECTION_ID to "leaf-1",
+                    ChunkStructure.SEQUENCE_NUMBER to 2,
+                    ChunkStructure.CHUNK_INDEX to 1,
+                    ChunkStructure.TOTAL_CHUNKS to 4,
+                    "author" to "alice",
+                ),
+            )
+
+            assertEquals("doc-1", chunk.structure.rootDocumentId)
+            assertEquals("sec-1", chunk.structure.containerSectionId)
+            assertEquals("leaf-1", chunk.structure.leafSectionId)
+            assertEquals(2, chunk.structure.sequenceNumber)
+            assertEquals(1, chunk.structure.chunkIndex)
+            assertEquals(4, chunk.structure.totalChunks)
+
+            // Compat: historical string keys still resolve on metadata
+            assertEquals("doc-1", chunk.metadata[ChunkStructure.ROOT_DOCUMENT_ID])
+            assertEquals(2, chunk.metadata[ChunkStructure.SEQUENCE_NUMBER])
+            assertEquals("alice", chunk.metadata["author"])
+        }
+
+        @Test
+        fun `create factory accepts explicit structure`() {
+            val structure = ChunkStructure(
+                rootDocumentId = "doc",
+                sequenceNumber = 5,
+            )
+            val chunk = Chunk.create(
+                text = "body",
+                parentId = "p",
+                metadata = mapOf("tag" to "x"),
+                structure = structure,
+            )
+            assertEquals(structure, chunk.structure)
+            assertEquals("doc", chunk.metadata[ChunkStructure.ROOT_DOCUMENT_ID])
+            assertEquals(5, chunk.metadata[ChunkStructure.SEQUENCE_NUMBER])
+            assertEquals("x", chunk.metadata["tag"])
+        }
+
+        @Test
+        fun `pathFromRoot uses structure fields`() {
+            val chunk = Chunk(
+                id = "chunk-id",
+                text = "t",
+                parentId = "leaf-1",
+                metadata = mapOf(
+                    ChunkStructure.ROOT_DOCUMENT_ID to "root",
+                    ChunkStructure.CONTAINER_SECTION_ID to "container",
+                    ChunkStructure.LEAF_SECTION_ID to "leaf-1",
+                ),
+            )
+            assertEquals(listOf("root", "container", "leaf-1", "chunk-id"), chunk.pathFromRoot)
+        }
+    }
+
+    @Nested
+    inner class Withers {
+
+        @Test
+        fun `withText preserves structure`() {
+            val chunk = Chunk(
+                id = "c1",
+                text = "old",
+                parentId = "p",
+                metadata = mapOf(ChunkStructure.SEQUENCE_NUMBER to 3),
+            )
+            val transformed = chunk.withText("new")
+            assertEquals("new", transformed.text)
+            assertEquals("old", transformed.urtext)
+            assertEquals(3, transformed.structure.sequenceNumber)
+        }
+
+        @Test
+        fun `withAdditionalMetadata merges freeform and structure`() {
+            val chunk = Chunk(
+                id = "c1",
+                text = "t",
+                parentId = "p",
+                metadata = mapOf(
+                    ChunkStructure.ROOT_DOCUMENT_ID to "doc",
+                    "a" to 1,
+                ),
+            )
+            val updated = chunk.withAdditionalMetadata(
+                mapOf(
+                    ChunkStructure.SEQUENCE_NUMBER to 9,
+                    "b" to 2,
+                )
+            )
+            assertEquals("doc", updated.structure.rootDocumentId)
+            assertEquals(9, updated.structure.sequenceNumber)
+            assertEquals(1, updated.metadata["a"])
+            assertEquals(2, updated.metadata["b"])
+        }
+
+        @Test
+        fun `withStructure replaces structure`() {
+            val chunk = Chunk.create(
+                text = "t",
+                parentId = "p",
+                metadata = mapOf(ChunkStructure.SEQUENCE_NUMBER to 1),
+            )
+            val updated = chunk.withStructure(ChunkStructure(sequenceNumber = 42, rootDocumentId = "d"))
+            assertEquals(42, updated.structure.sequenceNumber)
+            assertEquals("d", updated.structure.rootDocumentId)
+            assertEquals(42, updated.metadata[ChunkStructure.SEQUENCE_NUMBER])
+        }
+    }
+
+    @Nested
+    inner class PropertiesToPersist {
+
+        @Test
+        fun `includes structural keys via metadata compat view`() {
+            val chunk = Chunk(
+                id = "chunk-1",
+                text = "body",
+                parentId = "section-1",
+                metadata = mapOf(
+                    "url" to "http://example.com",
+                    ChunkStructure.CHUNK_INDEX to 0,
+                    ChunkStructure.TOTAL_CHUNKS to 5,
+                ),
+            )
+            val properties = chunk.propertiesToPersist()
+            assertEquals(0, properties[ChunkStructure.CHUNK_INDEX])
+            assertEquals(5, properties[ChunkStructure.TOTAL_CHUNKS])
+            assertEquals("body", properties["text"])
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-lucene/src/main/kotlin/com/embabel/agent/rag/lucene/LuceneSearchOperations.kt
+++ b/embabel-agent-rag/embabel-agent-rag-lucene/src/main/kotlin/com/embabel/agent/rag/lucene/LuceneSearchOperations.kt
@@ -543,8 +543,10 @@ class LuceneSearchOperations @JvmOverloads constructor(
         chunk: Chunk,
         chunksToAdd: Int,
     ): List<Chunk> {
-        val containerSectionId = chunk.metadata[CONTAINER_SECTION_ID]?.toString()
-        val sequenceNumber = chunk.metadata[SEQUENCE_NUMBER]?.toString()?.toIntOrNull()
+        val containerSectionId = chunk.structure.containerSectionId
+            ?: chunk.metadata[CONTAINER_SECTION_ID]?.toString()
+        val sequenceNumber = chunk.structure.sequenceNumber
+            ?: chunk.metadata[SEQUENCE_NUMBER]?.toString()?.toIntOrNull()
 
         if (containerSectionId == null || sequenceNumber == null) {
             logger.warn(
@@ -559,9 +561,12 @@ class LuceneSearchOperations @JvmOverloads constructor(
         // Find all chunks in the same container section
         val chunksInSection = contentElementStorage.values
             .filterIsInstance<Chunk>()
-            .filter { it.metadata[CONTAINER_SECTION_ID]?.toString() == containerSectionId }
             .mapNotNull { c ->
-                val seqNum = c.metadata[SEQUENCE_NUMBER]?.toString()?.toIntOrNull()
+                val sectionId = c.structure.containerSectionId
+                    ?: c.metadata[CONTAINER_SECTION_ID]?.toString()
+                if (sectionId != containerSectionId) return@mapNotNull null
+                val seqNum = c.structure.sequenceNumber
+                    ?: c.metadata[SEQUENCE_NUMBER]?.toString()?.toIntOrNull()
                 if (seqNum != null) c to seqNum else null
             }
             .sortedBy { it.second }
@@ -589,8 +594,10 @@ class LuceneSearchOperations @JvmOverloads constructor(
             chunk.id,
             sequenceNumber,
             expandedChunks.size,
-            expandedChunks.firstOrNull()?.metadata?.get(SEQUENCE_NUMBER),
-            expandedChunks.lastOrNull()?.metadata?.get(SEQUENCE_NUMBER)
+            expandedChunks.firstOrNull()?.structure?.sequenceNumber
+                ?: expandedChunks.firstOrNull()?.metadata?.get(SEQUENCE_NUMBER),
+            expandedChunks.lastOrNull()?.structure?.sequenceNumber
+                ?: expandedChunks.lastOrNull()?.metadata?.get(SEQUENCE_NUMBER)
         )
 
         return expandedChunks

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/main/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancer.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/main/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancer.kt
@@ -16,9 +16,8 @@
 package com.embabel.agent.rag.pipeline
 
 import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.ChunkStructure
 import com.embabel.agent.rag.model.Retrievable
-import com.embabel.agent.rag.ingestion.ContentChunker.Companion.ROOT_DOCUMENT_ID
-import com.embabel.agent.rag.ingestion.ContentChunker.Companion.SEQUENCE_NUMBER
 import com.embabel.agent.rag.service.*
 import com.embabel.common.core.types.SimilarityResult
 import org.slf4j.Logger
@@ -69,12 +68,26 @@ object ChunkMergingEnhancer : RagResponseEnhancer {
         first: SimilarityResult<out Retrievable>,
         second: SimilarityResult<out Retrievable>,
     ): Boolean {
-        val firstRootId = first.match.metadata[ROOT_DOCUMENT_ID] as? String ?: return false
-        val secondRootId = second.match.metadata[ROOT_DOCUMENT_ID] as? String ?: return false
-        val firstSeq = first.match.metadata[SEQUENCE_NUMBER] as? Int ?: return false
-        val secondSeq = second.match.metadata[SEQUENCE_NUMBER] as? Int ?: return false
+        val firstRootId = rootDocumentId(first.match) ?: return false
+        val secondRootId = rootDocumentId(second.match) ?: return false
+        val firstSeq = sequenceNumber(first.match) ?: return false
+        val secondSeq = sequenceNumber(second.match) ?: return false
 
         return firstRootId == secondRootId && secondSeq == firstSeq + 1
+    }
+
+    private fun rootDocumentId(match: Retrievable): String? =
+        (match as? Chunk)?.structure?.rootDocumentId
+            ?: match.metadata[ChunkStructure.ROOT_DOCUMENT_ID] as? String
+
+    private fun sequenceNumber(match: Retrievable): Int? {
+        (match as? Chunk)?.structure?.sequenceNumber?.let { return it }
+        return when (val value = match.metadata[ChunkStructure.SEQUENCE_NUMBER]) {
+            is Int -> value
+            is Number -> value.toInt()
+            is String -> value.toIntOrNull()
+            else -> null
+        }
     }
 
     private fun mergeChunks(
@@ -84,7 +97,7 @@ object ChunkMergingEnhancer : RagResponseEnhancer {
             return chunks[0]
         }
 
-        logger.info("Merging {} chunks from document {}", chunks.size, chunks[0].match.metadata["root_document_id"])
+        logger.info("Merging {} chunks from document {}", chunks.size, rootDocumentId(chunks[0].match))
 
         val firstChunk = chunks[0].match as Chunk
         val mergedText = chunks.joinToString(" ") { (it.match as Chunk).text }


### PR DESCRIPTION
## Summary

Fixes #1829 by promoting load-bearing structural chunk metadata keys to a typed `ChunkStructure` value object on `Chunk`, while keeping a **metadata compatibility view** so existing string-key readers keep working during the deprecation window.

### Shape
- New `ChunkStructure` (`rag-core`) with the 10 chunker-owned fields (`rootDocumentId`, `containerSection*`, `leafSection*`, `chunkIndex`, `totalChunks`, `sequenceNumber` as `Int?`)
- Single source of key constants on `ChunkStructure`; `ContentChunker` companion re-exports the same strings
- `Chunk.structure` is first-class; factories extract structure from metadata when not supplied
- Free-form user data stays in `metadata`; structural keys are re-merged into `metadata` via `toMetadata()` for backward compatibility
- Numeric coercion accepts `Int`/`Number`/`String` (helps Lucene round-trips that store strings)

### In-repo readers
- `Chunk.pathFromRoot` uses structure fields
- `ChunkMergingEnhancer` prefers typed structure (with metadata fallback)
- Lucene `expandBySequence` prefers typed structure

### Out of scope (per issue)
- `rag-graph` / `ChunkNode.STRUCTURAL_KEYS` migration left for a follow-up as offered on the issue

## Testing

```bash
mvn -pl embabel-agent-rag/embabel-agent-rag-core,embabel-agent-rag/embabel-agent-rag-pipeline,embabel-agent-rag/embabel-agent-rag-lucene -am test \
  -Dtest=ChunkStructureTest,ChunkTest,ChunkMergingEnhancerTest,ContentChunkerTest,ContentElementPropertiesToPersistTest,LuceneExpandChunkTest,ContentChunkerPathFromRootTest \
  -Dsurefire.failIfNoSpecifiedTests=false
```

All listed tests green (JDK 21).