### PR TITLE
Never sever a markdown table row from its header when chunking

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/InMemoryContentChunker.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/InMemoryContentChunker.kt
@@ -293,7 +293,16 @@ class InMemoryContentChunker(
         val chunks = mutableListOf<String>()
         var currentChunk = StringBuilder()
 
-        for (paragraph in paragraphs) {
+        // An oversized paragraph MIXING table lines with prose (single newlines — no
+        // blank line isolating the table) would fall through to sentence splitting,
+        // whose fake boundaries ("excl.") cut inside rows and even inside numeric
+        // tokens. Split such paragraphs into runs of table lines vs prose lines
+        // first, so each run takes its proper path below.
+        val blocks = paragraphs.flatMap { p ->
+            if (p.length > config.maxChunkSize) splitTableProseBlocks(p) else listOf(p)
+        }
+
+        for (paragraph in blocks) {
             // A table paragraph too long for one chunk splits by ROWS with the header
             // repeated in every piece — "sentences" have no meaning inside a table, and
             // a row severed from its header row is retrieved next to the wrong label.
@@ -365,14 +374,7 @@ class InMemoryContentChunker(
         }
 
         // Safety check: ensure no chunk exceeds max size and filter out empty chunks
-        val finalChunks = chunks.flatMap { chunk ->
-            if (chunk.length <= config.maxChunkSize) {
-                listOf(chunk)
-            } else {
-                // Emergency fallback: split oversized chunk by character count
-                chunk.chunked(config.maxChunkSize).filter { it.trim().isNotEmpty() }
-            }
-        }.filter { it.trim().isNotEmpty() }
+        val finalChunks = enforceMaxSize(chunks)
 
         return finalChunks.ifEmpty {
             if (text.trim().isNotEmpty()) listOf(text.trim()) else emptyList()
@@ -415,14 +417,7 @@ class InMemoryContentChunker(
         }
 
         // Safety check: ensure no chunk exceeds max size and filter out empty chunks
-        val finalChunks = chunks.flatMap { chunk ->
-            if (chunk.length <= config.maxChunkSize) {
-                listOf(chunk)
-            } else {
-                // Emergency fallback: split oversized chunk by character count
-                chunk.chunked(config.maxChunkSize).filter { it.trim().isNotEmpty() }
-            }
-        }.filter { it.trim().isNotEmpty() }
+        val finalChunks = enforceMaxSize(chunks)
 
         return finalChunks.ifEmpty {
             if (text.trim().isNotEmpty()) listOf(text.trim()) else emptyList()
@@ -487,6 +482,47 @@ class InMemoryContentChunker(
         val header = tableHeaderOf(prevLines.subList(blockStart, prevLines.size))
         return (header + prevLines.subList(idx, prevLines.size)).joinToString("\n").trim()
     }
+
+
+    /**
+     * Split a paragraph into runs of consecutive table lines and non-table lines.
+     * Returns the paragraph unchanged when it holds no table lines at all.
+     */
+    private fun splitTableProseBlocks(paragraph: String): List<String> {
+        val lines = paragraph.lines()
+        if (lines.none { isTableLine(it) }) return listOf(paragraph)
+        val blocks = mutableListOf<String>()
+        val current = mutableListOf<String>()
+        var inTable = false
+        for (line in lines) {
+            val table = isTableLine(line)
+            if (current.isNotEmpty() && table != inTable) {
+                blocks.add(current.joinToString("\n").trim())
+                current.clear()
+            }
+            inTable = table
+            current.add(line)
+        }
+        if (current.isNotEmpty()) blocks.add(current.joinToString("\n").trim())
+        return blocks.filter { it.isNotBlank() }
+    }
+
+    /**
+     * Bound every chunk to maxChunkSize by character-splitting oversized ones — EXCEPT
+     * table content. A piece from [splitTableByRows] is row-atomic by construction and
+     * legitimately exceeds the budget when its header plus a SINGLE row does; a blind
+     * character cut severs the row from its header (retrieved next to the wrong label)
+     * and can split a numeric token in half, making the value unfindable. An oversized
+     * table piece is the lesser harm, so it passes through whole.
+     */
+    private fun enforceMaxSize(chunks: List<String>): List<String> =
+        chunks.flatMap { chunk ->
+            when {
+                chunk.length <= config.maxChunkSize -> listOf(chunk)
+                isTableParagraph(chunk) -> listOf(chunk)
+                else -> chunk.chunked(config.maxChunkSize).filter { it.trim().isNotEmpty() }
+            }
+        }.filter { it.trim().isNotEmpty() }
 
     /**
      * Split an oversized markdown table into pieces of complete rows, each carrying the table's

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/ingestion/TableAwareChunkingTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/ingestion/TableAwareChunkingTest.kt
@@ -112,6 +112,82 @@ class TableAwareChunkingTest {
     }
 
     @Test
+    fun `a row wider than maxChunkSize survives WHOLE as an oversized chunk — never a character cut`() {
+        // Observed with real financial registers (wide tables, verbose headers): the
+        // header plus a SINGLE row exceeds the budget. The emergency character cut
+        // then severed rows from headers and even split numeric tokens in half,
+        // leaving values retrievable next to the wrong label or not at all.
+        val wideChunker = ContentChunker(
+            ContentChunker.Config(maxChunkSize = 800, overlapSize = 100),
+            ChunkTransformer.NO_OP,
+        )
+        val headerCells = (1..11).joinToString(" | ") { "Reporting column heading number $it" }
+        val header = "| $headerCells |\n|${"---------------------------------|".repeat(11)}"
+        val rows = (1..5).joinToString("\n") { i ->
+            val cells = (1..10).joinToString(" | ") { c -> "value ${i * 100 + c}".padEnd(30) }
+            "| Facility register row $i | $cells | ${i},200,00$i |"
+        }
+        val leaf = LeafSection(id = "leaf-1", title = "", text = "Intro prose.\n\n$header\n$rows\n\nClosing prose.")
+        val container = MaterializedDocument(
+            id = "doc-1", title = "Register", children = listOf(leaf), metadata = emptyMap(), uri = "test://register",
+        )
+        val texts = wideChunker.chunk(container).map { it.text }
+
+        (1..5).forEach { i ->
+            val carrying = texts.filter { it.contains("${i},200,00$i") }
+            assertTrue(carrying.isNotEmpty()) { "row $i's value must survive chunking INTACT" }
+            carrying.forEach { text ->
+                assertTrue(text.contains("Facility register row $i")) {
+                    "value severed from its row label:\n$text"
+                }
+                assertTrue(text.contains("Reporting column heading number 1")) {
+                    "row emitted without its table header:\n$text"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `a heading glued to a table by single newlines still splits by rows — never by fake sentences`() {
+        // Observed with a real quarterly report: the section parser serialized
+        // "Appendix" and its reconciliation table into ONE paragraph (single
+        // newlines). The whole block fell through to sentence splitting, which cut
+        // at "excl." and even INSIDE the numeric token "5,120" — the value became
+        // unfindable by exact match in every chunk.
+        val tightChunker = ContentChunker(
+            ContentChunker.Config(maxChunkSize = 800, overlapSize = 100),
+            ChunkTransformer.NO_OP,
+        )
+        val header = "| Key financials reconciliation                            | 2H25 | Qtr avg | vs 1Q25 | vs 2H25 |\n" +
+            "|----------------------------------------------------------|------|---------|---------|---------|"
+        val rows = listOf(
+            "| Total operating income                                   | 14,368 | 7,184 | 6% | 3% |",
+            "| Operating expenses excl. restructuring and notable items | (6,494) | (3,247) | 7% | 4% |",
+            "| Restructuring and notable items                          | (130) | (65) | n/a | 88% |",
+            "| Total operating expenses                                 | (6,624) | (3,312) | 11% | 5% |",
+            "| Operating performance                                    | 7,744 | 3,872 | 2% | 1% |",
+            "| Loan impairment expense                                  | (406) | (203) | 38% | 8% |",
+            "| Cash NPAT from continuing operations                     | 5,120 | 2,560 | 2% | 1% |",
+        ).joinToString("\n")
+        val leaf = LeafSection(id = "leaf-1", title = "", text = "Appendix\n$header\n$rows\nFootnotes follow.")
+        val container = MaterializedDocument(
+            id = "doc-1", title = "Update", children = listOf(leaf), metadata = emptyMap(), uri = "test://update",
+        )
+        val texts = tightChunker.chunk(container).map { it.text }
+
+        val carrying = texts.filter { it.contains("5,120") }
+        assertTrue(carrying.isNotEmpty()) { "the value must survive INTACT (not cut into '5' + ',120')" }
+        carrying.forEach { text ->
+            assertTrue(text.contains("Cash NPAT from continuing operations")) {
+                "value severed from its row label:\n$text"
+            }
+            assertTrue(text.contains("Key financials reconciliation")) {
+                "row emitted without its table header:\n$text"
+            }
+        }
+    }
+
+    @Test
     fun `a table that fits is left intact — no header duplication, no re-slicing`() {
         val table = """
             | Metric | Value |


### PR DESCRIPTION
## Problem

Two paths still violated the table-aware chunking contract introduced in 528e7a56 ("never sever a markdown table row from its header"), observed by ingesting real bank disclosure documents (Basel Pillar 3, green-funding asset registers, quarterly reconciliation tables) through docling at `maxChunkSize` 800:

1. **Emergency character cut.** The final safety check ran `chunk.chunked(maxChunkSize)` on any oversized chunk. When a table's header plus a *single* row exceeds the budget (real registers: ~660-char header + ~360-char rows), the row-atomic pieces built by `splitTableByRows` were re-cut mid-row — and even mid-token: `5,120` became `5` + `,120`, so the value was unfindable by exact match in any chunk, and tail cells like `| 2,200,000 | 105,636 | 44,767 |` floated free of their row label.

2. **Mixed prose+table paragraphs.** A heading glued to a table by single newlines ("Appendix\n| Key financials reconciliation |…", as section parsers emit) fails `isTableParagraph`, so the whole block fell through to *sentence* splitting, which cuts at fake boundaries ("excl.").

## Fix

- `enforceMaxSize` (extracted from the two duplicated safety-check sites) passes table paragraphs through whole: an oversized row-atomic piece is the lesser harm compared to a value retrieved next to the wrong label.
- `splitTableProseBlocks` splits an oversized paragraph into runs of consecutive table lines vs prose lines before processing, so table runs split by rows (header repeated) and prose runs split by sentences.

## Tests

Two new regression tests in `TableAwareChunkingTest` pin the contracts (a row wider than `maxChunkSize` survives whole with its header; a heading-glued table splits by rows, never by fake sentences). All 36 chunker/repository tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWLCsrVSJHggsSMf6XJZHC