### PR TITLE
Fix: separate content across streaming tool turns

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/streaming/LlmMessageStreamer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/streaming/LlmMessageStreamer.kt
@@ -27,7 +27,7 @@ import reactor.core.publisher.Flux
 /**
  * Provider-neutral events emitted by one streaming LLM inference call.
  *
- * [Content] events are forwarded as soon as they arrive. [Complete] is emitted once,
+ * [Content] and [Thinking] events are forwarded as soon as they arrive. [Complete] is emitted once,
  * after provider-specific fragments (including partial tool calls) have been assembled.
  *
  * This SPI type is deliberately distinct from
@@ -37,6 +37,9 @@ import reactor.core.publisher.Flux
  */
 sealed interface LlmInferenceStreamEvent {
     data class Content(val text: String) : LlmInferenceStreamEvent
+
+    /** Provider-identified native reasoning content. */
+    data class Thinking(val text: String) : LlmInferenceStreamEvent
 
     data class Complete(
         val message: Message,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/streaming/StreamingToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/streaming/StreamingToolLoop.kt
@@ -117,7 +117,23 @@ internal class DefaultStreamingToolLoop(
     override fun execute(
         initialMessages: List<Message>,
         initialTools: List<Tool>,
-    ): Flux<String> = Flux.defer {
+    ): Flux<String> = executeEvents(initialMessages, initialTools)
+        .map { event ->
+            when (event) {
+                is LlmInferenceStreamEvent.Content -> event.text
+                is LlmInferenceStreamEvent.Thinking -> event.text
+                is LlmInferenceStreamEvent.Complete -> error("Completion events are internal to the streaming tool loop")
+            }
+        }
+
+    /**
+     * Execute the tool loop while retaining the distinction between ordinary content
+     * and provider-identified native thinking. Completion events remain internal.
+     */
+    internal fun executeEvents(
+        initialMessages: List<Message>,
+        initialTools: List<Tool>,
+    ): Flux<LlmInferenceStreamEvent> = Flux.defer {
         streamTurn(
             State(
                 conversationHistory = initialMessages.toMutableList(),
@@ -126,11 +142,13 @@ internal class DefaultStreamingToolLoop(
         )
     }
 
-    private fun streamTurn(state: State): Flux<String> = Flux.defer {
+    private fun streamTurn(state: State): Flux<LlmInferenceStreamEvent> = Flux.defer {
         if (state.iterations >= maxIterations) {
             return@defer Flux.error(MaxIterationsExceededException(maxIterations))
         }
         state.iterations++
+        state.turnHasContent = false
+        state.turnEndsWithNewline = false
         logger.debug(
             "Streaming tool loop iteration {} with {} available tools",
             state.iterations,
@@ -142,7 +160,19 @@ internal class DefaultStreamingToolLoop(
             tools = state.availableTools.toList(),
         ).concatMap { event ->
             when (event) {
-                is LlmInferenceStreamEvent.Content -> Flux.just(event.text)
+                is LlmInferenceStreamEvent.Content,
+                is LlmInferenceStreamEvent.Thinking -> {
+                    val text = when (event) {
+                        is LlmInferenceStreamEvent.Content -> event.text
+                        is LlmInferenceStreamEvent.Thinking -> event.text
+                        is LlmInferenceStreamEvent.Complete -> error("Already handled")
+                    }
+                    if (text.isNotEmpty()) {
+                        state.turnHasContent = true
+                        state.turnEndsWithNewline = text.endsWith('\n')
+                    }
+                    Flux.just<LlmInferenceStreamEvent>(event)
+                }
                 is LlmInferenceStreamEvent.Complete -> continueFrom(event, state)
             }
         }
@@ -159,7 +189,7 @@ internal class DefaultStreamingToolLoop(
     private fun continueFrom(
         event: LlmInferenceStreamEvent.Complete,
         state: State,
-    ): Flux<String> {
+    ): Flux<LlmInferenceStreamEvent> {
         state.conversationHistory.add(event.message)
         val assistant = event.message as? AssistantMessageWithToolCalls
             ?: return Flux.empty()
@@ -167,10 +197,29 @@ internal class DefaultStreamingToolLoop(
 
         for (toolCall in assistant.toolCalls) {
             val directResult = executeToolCall(toolCall, state)
-            if (directResult != null) return Flux.just(directResult)
+            if (directResult != null) {
+                return separateFromCurrentTurn(
+                    Flux.just<LlmInferenceStreamEvent>(LlmInferenceStreamEvent.Content(directResult)),
+                    state,
+                )
+            }
         }
-        return streamTurn(state)
+        return separateFromCurrentTurn(streamTurn(state), state)
     }
+
+    /**
+     * Prevent the final unterminated line of one inference from being joined to the
+     * first chunk of the next inference after tool execution.
+     */
+    private fun separateFromCurrentTurn(
+        next: Flux<LlmInferenceStreamEvent>,
+        state: State,
+    ): Flux<LlmInferenceStreamEvent> =
+        if (state.turnHasContent && !state.turnEndsWithNewline) {
+            Flux.just<LlmInferenceStreamEvent>(LlmInferenceStreamEvent.Content("\n")).concatWith(next)
+        } else {
+            next
+        }
 
     /**
      * Executes one tool call and returns direct content when the tool short-circuits the loop.
@@ -226,5 +275,7 @@ internal class DefaultStreamingToolLoop(
         val conversationHistory: MutableList<Message>,
         val availableTools: MutableList<Tool>,
         var iterations: Int = 0,
+        var turnHasContent: Boolean = false,
+        var turnEndsWithNewline: Boolean = false,
     )
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/SpringAiLlmMessageStreamer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/streaming/SpringAiLlmMessageStreamer.kt
@@ -58,8 +58,13 @@ internal class SpringAiLlmMessageStreamer(
         tools: List<Tool>,
         toolCallInspectors: List<ToolCallInspector>,
     ): Flux<String> = streamInference(messages, tools)
-        .ofType(LlmInferenceStreamEvent.Content::class.java)
-        .map { it.text }
+        .handle { event, sink ->
+            when (event) {
+                is LlmInferenceStreamEvent.Content -> sink.next(event.text)
+                is LlmInferenceStreamEvent.Thinking -> sink.next(event.text)
+                is LlmInferenceStreamEvent.Complete -> Unit
+            }
+        }
 
     override fun streamInference(
         messages: List<Message>,
@@ -88,9 +93,15 @@ internal class SpringAiLlmMessageStreamer(
         // this adapter deliberately performs no tool execution.
         chatModel.stream(prompt).publish { responses ->
             val content = responses
-                .flatMapIterable { response -> listOfNotNull(response.result?.output?.text) }
-                .filter { it.isNotEmpty() }
-                .map<LlmInferenceStreamEvent> { LlmInferenceStreamEvent.Content(it) }
+                .flatMapIterable { response -> listOfNotNull(response.result?.output) }
+                .mapNotNull { output -> output.text?.takeIf { it.isNotEmpty() }?.let { output to it } }
+                .map<LlmInferenceStreamEvent> { (output, text) ->
+                    if (output.metadata["thinking"] == true) {
+                        LlmInferenceStreamEvent.Thinking(text)
+                    } else {
+                        LlmInferenceStreamEvent.Content(text)
+                    }
+                }
             val completion = MessageAggregator()
                 .aggregate(responses, aggregate::tryEmitValue)
                 .then(aggregate.asMono())

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/streaming/StreamingLlmOperationsImpl.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/streaming/StreamingLlmOperationsImpl.kt
@@ -23,8 +23,9 @@ import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.ToolDecorator
-import com.embabel.agent.spi.loop.streaming.LlmMessageStreamer
 import com.embabel.agent.spi.loop.streaming.DefaultStreamingToolLoop
+import com.embabel.agent.spi.loop.streaming.LlmInferenceStreamEvent
+import com.embabel.agent.spi.loop.streaming.LlmMessageStreamer
 import com.embabel.agent.spi.loop.AutoCorrectionPolicy
 import com.embabel.agent.spi.loop.ChainedToolInjectionStrategy
 import com.embabel.agent.spi.loop.ToolInjectionStrategy
@@ -235,13 +236,19 @@ internal class StreamingLlmOperationsImpl(
         val messagesWithContributions = buildMessagesWithContributions(messages, fullPromptContributions)
 
         // Step 1: Raw chunk stream from LLM
-        val rawChunkFlux: Flux<String> = streamWithToolLoop(
+        val rawChunkFlux: Flux<String> = streamEventsWithToolLoop(
             messagesWithContributions,
             tools,
             interaction,
             agentProcess,
             action,
-        )
+        ).map { event ->
+            when (event) {
+                is LlmInferenceStreamEvent.Content -> event.text
+                is LlmInferenceStreamEvent.Thinking -> "<think>${event.text}</think>\n"
+                is LlmInferenceStreamEvent.Complete -> error("Completion events are internal to the streaming tool loop")
+            }
+        }
             .filter { it.isNotEmpty() }
             .doOnNext { chunk -> logger.trace("RAW CHUNK: '${chunk.replace("\n", "\\n")}'") }
 
@@ -294,7 +301,22 @@ internal class StreamingLlmOperationsImpl(
         interaction: LlmInteraction,
         agentProcess: AgentProcess?,
         action: Action?,
-    ): Flux<String> {
+    ): Flux<String> = createStreamingToolLoop(interaction, agentProcess, action).execute(messages, tools)
+
+    private fun streamEventsWithToolLoop(
+        messages: List<Message>,
+        tools: List<Tool>,
+        interaction: LlmInteraction,
+        agentProcess: AgentProcess?,
+        action: Action?,
+    ): Flux<LlmInferenceStreamEvent> =
+        createStreamingToolLoop(interaction, agentProcess, action).executeEvents(messages, tools)
+
+    private fun createStreamingToolLoop(
+        interaction: LlmInteraction,
+        agentProcess: AgentProcess?,
+        action: Action?,
+    ): DefaultStreamingToolLoop {
         val injectionStrategy = if (interaction.additionalInjectionStrategies.isEmpty()) {
             ToolInjectionStrategy.DEFAULT
         } else {
@@ -328,7 +350,7 @@ internal class StreamingLlmOperationsImpl(
             toolCallInspectors = interaction.toolCallInspectors,
             toolCallContext = toolCallContext,
             toolNotFoundPolicy = interaction.toolNotFoundPolicy ?: AutoCorrectionPolicy(),
-        ).execute(messages, tools)
+        )
     }
 
     /**

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/streaming/StreamingToolLoopTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/streaming/StreamingToolLoopTest.kt
@@ -66,10 +66,78 @@ class StreamingToolLoopTest {
             .execute(listOf(UserMessage("question")), listOf(lookup))
 
         StepVerifier.create(result)
-            .expectNext("<think>checking</think>", "final")
+            .expectNext("<think>checking</think>", "\n", "final")
             .verifyComplete()
         assertEquals(2, histories.size)
         assertEquals("tool-result", histories[1].filterIsInstance<ToolResultMessage>().single().content)
+    }
+
+    @Test
+    fun `separates unterminated content across tool turns`() {
+        var calls = 0
+        val streamer = inferenceStreamer { _, _ ->
+            calls++
+            if (calls == 1) {
+                Flux.just(
+                    LlmInferenceStreamEvent.Content("reasoning before tool"),
+                    LlmInferenceStreamEvent.Complete(
+                        AssistantMessageWithToolCalls(
+                            content = "reasoning before tool",
+                            toolCalls = listOf(ToolCall("call-1", "lookup", "{}")),
+                        )
+                    ),
+                )
+            } else {
+                Flux.just(
+                    LlmInferenceStreamEvent.Content("<think>reasoning after tool</think>\n"),
+                    LlmInferenceStreamEvent.Complete(AssistantMessage("done")),
+                )
+            }
+        }
+        val lookup = Tool.of("lookup", "Lookup") { Tool.Result.text("tool-result") }
+
+        StepVerifier.create(
+            DefaultStreamingToolLoop(streamer, jacksonObjectMapper())
+                .execute(listOf(UserMessage("question")), listOf(lookup))
+        )
+            .expectNext("reasoning before tool", "\n", "<think>reasoning after tool</think>\n")
+            .verifyComplete()
+    }
+
+    @Test
+    fun `preserves native thinking identity across tool turns`() {
+        var calls = 0
+        val streamer = inferenceStreamer { _, _ ->
+            calls++
+            if (calls == 1) {
+                Flux.just(
+                    LlmInferenceStreamEvent.Thinking("reasoning before tool"),
+                    LlmInferenceStreamEvent.Complete(
+                        AssistantMessageWithToolCalls(
+                            content = "",
+                            toolCalls = listOf(ToolCall("call-1", "lookup", "{}")),
+                        )
+                    ),
+                )
+            } else {
+                Flux.just(
+                    LlmInferenceStreamEvent.Thinking("reasoning after tool"),
+                    LlmInferenceStreamEvent.Content("result\n"),
+                    LlmInferenceStreamEvent.Complete(AssistantMessage("result")),
+                )
+            }
+        }
+        val lookup = Tool.of("lookup", "Lookup") { Tool.Result.text("tool-result") }
+
+        StepVerifier.create(
+            DefaultStreamingToolLoop(streamer, jacksonObjectMapper())
+                .executeEvents(listOf(UserMessage("question")), listOf(lookup))
+        )
+            .expectNext(LlmInferenceStreamEvent.Thinking("reasoning before tool"))
+            .expectNext(LlmInferenceStreamEvent.Content("\n"))
+            .expectNext(LlmInferenceStreamEvent.Thinking("reasoning after tool"))
+            .expectNext(LlmInferenceStreamEvent.Content("result\n"))
+            .verifyComplete()
     }
 
     @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/SpringAiLlmMessageStreamerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/streaming/SpringAiLlmMessageStreamerTest.kt
@@ -65,6 +65,41 @@ class SpringAiLlmMessageStreamerTest {
     }
 
     @Test
+    fun `preserves provider identified native thinking`() {
+        val thinking = AssistantMessage.builder()
+            .content("native reasoning")
+            .properties(mapOf("thinking" to true))
+            .build()
+        every { chatModel.stream(capture(capturedPrompt)) } returns Flux.just(
+            ChatResponse(listOf(Generation(thinking)))
+        )
+        val streamer = SpringAiLlmMessageStreamer(chatModel, chatOptions)
+
+        StepVerifier.create(streamer.streamInference(listOf(UserMessage("Hi")), emptyList()))
+            .expectNext(LlmInferenceStreamEvent.Thinking("native reasoning"))
+            .assertNext { event ->
+                assertInstanceOf(LlmInferenceStreamEvent.Complete::class.java, event)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `preserves native thinking text through original raw signature`() {
+        val thinking = AssistantMessage.builder()
+            .content("native reasoning")
+            .properties(mapOf("thinking" to true))
+            .build()
+        every { chatModel.stream(capture(capturedPrompt)) } returns Flux.just(
+            ChatResponse(listOf(Generation(thinking)))
+        )
+        val streamer = SpringAiLlmMessageStreamer(chatModel, chatOptions)
+
+        StepVerifier.create(streamer.stream(listOf(UserMessage("Hi")), emptyList(), emptyList()))
+            .expectNext("native reasoning")
+            .verifyComplete()
+    }
+
+    @Test
     fun `preserves the original raw content streaming signature`() {
         every { chatModel.stream(capture(capturedPrompt)) } returns Flux.just(
             ChatResponse(listOf(Generation(AssistantMessage("hello"))))

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/streaming/StreamingLlmOperationsImplTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/streaming/StreamingLlmOperationsImplTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support.streaming
+
+import com.embabel.agent.api.common.InteractionId
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.support.LlmInteraction
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.ToolDecorator
+import com.embabel.agent.spi.loop.streaming.LlmInferenceStreamEvent
+import com.embabel.agent.spi.loop.streaming.LlmMessageStreamer
+import com.embabel.chat.AssistantMessage
+import com.embabel.chat.UserMessage
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.Thinking
+import com.embabel.common.core.streaming.StreamingEvent
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.test.StepVerifier
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+class StreamingLlmOperationsImplTest {
+
+    @Test
+    fun `emits provider native thinking through structured stream`() {
+        val streamer = object : LlmMessageStreamer {
+            override fun stream(
+                messages: List<com.embabel.chat.Message>,
+                tools: List<com.embabel.agent.api.tool.Tool>,
+                toolCallInspectors: List<com.embabel.agent.api.tool.callback.ToolCallInspector>,
+            ): Flux<String> = Flux.empty()
+
+            override fun streamInference(
+                messages: List<com.embabel.chat.Message>,
+                tools: List<com.embabel.agent.api.tool.Tool>,
+            ): Flux<LlmInferenceStreamEvent> = Flux.just(
+                LlmInferenceStreamEvent.Thinking("native reasoning"),
+                LlmInferenceStreamEvent.Content("{\"name\":\"result\"}\n"),
+                LlmInferenceStreamEvent.Complete(AssistantMessage("result")),
+            )
+        }
+        val llmService = mockk<LlmService<*>>()
+        every { llmService.promptContributors } returns emptyList()
+        val operations = StreamingLlmOperationsImpl(
+            messageStreamer = streamer,
+            objectMapper = jacksonObjectMapper(),
+            llmService = llmService,
+            toolDecorator = mockk<ToolDecorator>(relaxed = true),
+        )
+        val interaction = LlmInteraction(
+            id = InteractionId("native-thinking-stream"),
+            llm = LlmOptions().withThinking(Thinking.withTokenBudget(100)),
+        )
+
+        StepVerifier.create(
+            operations.createObjectStreamWithThinking(
+                messages = listOf(UserMessage("question")),
+                interaction = interaction,
+                outputClass = ResultItem::class.java,
+                agentProcess = mockk<AgentProcess>(relaxed = true),
+                action = null,
+            )
+        )
+            .expectNextMatches { event ->
+                event is StreamingEvent.Thinking && event.content == "native reasoning"
+            }
+            .expectNextMatches { event ->
+                event is StreamingEvent.Object && event.item.name == "result"
+            }
+            .verifyComplete()
+    }
+
+    data class ResultItem(
+        val name: String,
+    )
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/streaming/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/streaming/page.adoc
@@ -28,7 +28,9 @@ content chunks. Integrations that participate in Embabel's streaming tool loop o
 `streamInference` to expose the assembled assistant message and tool calls.
 
 Content from every inference turn remains in the returned stream. This includes thinking content
-emitted before or between tool calls. Because the tool set is evaluated between turns,
+emitted before or between tool calls. When a turn that requests a tool ends without a newline,
+Embabel emits a newline before the next turn so that structured streaming does not combine content
+from separate inference turns into one JSONL or thinking line. Because the tool set is evaluated between turns,
 `ToolInjectionStrategy` implementations such as `UnfoldingToolInjectionStrategy` can replace a
 facade with its child tools before the next request.
 
@@ -36,6 +38,10 @@ Provider integrations override `LlmMessageStreamer.streamInference` by emitting 
 `LlmInferenceStreamEvent.Content` events followed by one `LlmInferenceStreamEvent.Complete` event containing
 the assembled assistant message. The completed message must include provider-assigned tool-call IDs,
 names, and complete arguments. Provider adapters must not execute those calls themselves.
+
+Providers that identify native reasoning separately emit `LlmInferenceStreamEvent.Thinking` events.
+Embabel retains that distinction across tool turns while preserving the original raw-text streaming
+contract for callers of `generateStream()`.
 
 ==== Example - Simple Thinking and Object Streaming with Callbacks
 [source,java]


### PR DESCRIPTION
## Summary

Preserves native reasoning across streaming tool-call turns and prevents content from adjacent inference turns being merged into a single line.

This completes the native-thinking follow-up identified during #1826.

Fixes #1860.

## Problem

The streaming tool loop flattened content from consecutive inference turns into a single `Flux<String>`.

This caused two related problems:

1. If a tool-requesting turn ended without a newline, its final reasoning content was joined to the first chunk after tool execution:

```
reasoning before tool<think>reasoning after tool
```

2. Spring AI identifies Anthropic native-thinking chunks using `metadata["thinking"] = true`, but the adapter converted every chunk into an ordinary `LlmInferenceStreamEvent.Content`. The text remained visible, but its native-thinking identity was lost.

## Changes

- Add provider-neutral `LlmInferenceStreamEvent.Thinking`.
- Map Spring AI native-thinking metadata to the new event type.
- Preserve native-thinking identity across tool execution and subsequent inference turns.
- Emit native reasoning through the public `StreamingEvent.Thinking` stream.
- Preserve incremental delivery without buffering complete reasoning blocks.
- Insert a newline between inference turns only when the preceding turn is unterminated.
- Keep the existing raw `Flux<String>` streaming contract compatible.
- Document native-thinking and inference-turn boundary behavior.

## Testing

Added focused coverage for:

- Native-thinking metadata mapping in the Spring AI adapter.
- Original raw streaming compatibility.
- Native-thinking preservation before and after a tool call.
- Unterminated content separation across tool turns.
- Native thinking reaching the public structured-stream API.

Executed:

```
mvn -pl embabel-agent-api \
  -Dtest=StreamingToolLoopTest,SpringAiLlmMessageStreamerTest,StreamingLlmOperationsImplTest \
  test
```

Result:

```
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```