### PR TITLE
chore(deps): upgrade LangChain4j to 1.14.1

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/embabel/embabel-agent</url>
 
     <properties>
-        <langchain4j.version>1.14.0</langchain4j.version>
+        <langchain4j.version>1.14.1</langchain4j.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Summary

Upgrades the test-only LangChain4j dependencies in the Ollama autoconfiguration module from `1.14.0` to `1.14.1`.

## Motivation

LangChain4j `1.14.0` transitively depends on Apache OpenNLP `2.5.4`, which is affected by the critical XXE vulnerability [GHSA-4v8g-86x5-3vrc](https://github.com/advisories/GHSA-4v8g-86x5-3vrc) / CVE-2026-40682.

The advisory affects OpenNLP versions earlier than `2.5.9`. LangChain4j `1.14.1` upgrades OpenNLP to the patched `2.5.9` release.

The upgrade also ensures the effective dependency graph uses the currently managed Jackson versions:

- `jackson-core`: `2.21.4`
- `jackson-databind`: `2.21.4`
- `jackson-annotations`: `2.21`

`jackson-annotations` intentionally follows the `2.21` versioning scheme and is not an outdated patch release.

## Changes

- Upgraded `dev.langchain4j:langchain4j` from `1.14.0` to `1.14.1`
- Upgraded `dev.langchain4j:langchain4j-ollama` from `1.14.0` to `1.14.1`
- Removed the vulnerable transitive OpenNLP `2.5.4` dependency
- Confirmed OpenNLP now resolves to patched version `2.5.9`

## Verification

Verified the effective Maven dependency graph:

```
dev.langchain4j:langchain4j:1.14.1:test
+- com.fasterxml.jackson.core:jackson-annotations:2.21
+- com.fasterxml.jackson.core:jackson-core:2.21.4
+- com.fasterxml.jackson.core:jackson-databind:2.21.4
\- org.apache.opennlp:opennlp-tools:2.5.9:test
```

Ran the Ollama autoconfiguration module tests:

```
Tests run: 28, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

## Security impact

This removes the vulnerable OpenNLP version from the module’s test dependency graph. The affected dependency is test-scoped and is not included in the production runtime artifact.

Fixes #1862 