### PR TITLE
Document a remote Streamable HTTP MCP connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,25 @@ spring:
 This configuration sets up an MCP client that connects to a Docker-based MCP server. The connection uses STDIO transport
 through Docker's socat utility to connect to a TCP endpoint.
 
+### Remote Streamable HTTP MCP Connection
+
+Embabel applications can also connect directly to remote Streamable HTTP MCP servers. For example, Parallel Search MCP
+provides `web_search` and `web_fetch` without requiring an account or API key:
+
+```yaml
+spring:
+  ai:
+    mcp:
+      client:
+        streamable-http:
+          connections:
+            parallel:
+              url: https://search.parallel.ai
+```
+
+Spring AI appends the default `/mcp` endpoint, so this configuration connects to
+`https://search.parallel.ai/mcp`.
+
 ### Docker Desktop MCP Integration
 
 Docker has embraced MCP with their Docker MCP Catalog and Toolkit, which provides:


### PR DESCRIPTION
Embabel's MCP client docs currently show a Docker/STDIO connection. This adds a second, opt-in Streamable HTTP example for applications that want search and URL-fetching tools without running a local MCP process or configuring a credential.

## What changed

- Added the native Spring AI `streamable-http.connections` configuration for Parallel Search MCP.
- Clarified that Spring AI appends its default `/mcp` endpoint and named the available `web_search` and `web_fetch` tools.

The existing Docker/STDIO example and setup guidance are unchanged.

## Validation

- Parsed the YAML and asserted the exact nested configuration value.
- Verified a credential-free MCP initialize response from the assembled endpoint.
- Ran `git diff --check` and audited the complete one-file diff.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.