### PR TITLE
feat: add TemplatedPromptRunnerBuilder to render system prompts from templates

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/template/TemplatedPromptRunnerBuilder.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/template/TemplatedPromptRunnerBuilder.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.template
+
+import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.api.common.PromptRunner
+
+/**
+ * Wrapper builder that renders a loaded template into a system prompt for a [PromptRunner],
+ * using the platform [com.embabel.common.textio.template.TemplateRenderer] available from
+ * the [OperationContext]. Keeps template handling out of the PromptRunner sub-interfaces,
+ * following the same pattern as [com.embabel.agent.api.streaming.StreamingPromptRunnerBuilder].
+ */
+data class TemplatedPromptRunnerBuilder(
+    val context: OperationContext,
+    val runner: PromptRunner,
+) {
+
+    /**
+     * Render the named template with the given model and return a runner
+     * carrying the rendered text as its system prompt.
+     *
+     * @param templateName the name of the template to load and render
+     * @param model the model data to use for template rendering.
+     *        Defaults to the empty map (which is appropriate for static templates)
+     * @return a runner with the rendered system prompt applied
+     */
+    @JvmOverloads
+    fun withSystemPromptTemplate(
+        templateName: String,
+        model: Map<String, Any> = emptyMap(),
+    ): PromptRunner {
+        val renderer = context.agentPlatform().platformServices.templateRenderer
+        return runner.withSystemPrompt(renderer.renderLoadedTemplate(templateName, model))
+    }
+}

--- a/embabel-agent-api/src/test/java/com/embabel/agent/api/template/TemplatedPromptRunnerBuilderJavaTest.java
+++ b/embabel-agent-api/src/test/java/com/embabel/agent/api/template/TemplatedPromptRunnerBuilderJavaTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.template;
+
+import com.embabel.agent.api.common.OperationContext;
+import com.embabel.agent.api.common.PlatformServices;
+import com.embabel.agent.api.common.PromptRunner;
+import com.embabel.agent.core.AgentPlatform;
+import com.embabel.common.textio.template.NoSuchTemplateException;
+import com.embabel.common.textio.template.TemplateRenderer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Java-idiom tests for {@link TemplatedPromptRunnerBuilder}.
+ */
+@ExtendWith(MockitoExtension.class)
+class TemplatedPromptRunnerBuilderJavaTest {
+
+    @Mock
+    private OperationContext mockContext;
+
+    @Mock
+    private AgentPlatform mockPlatform;
+
+    @Mock
+    private PlatformServices mockPlatformServices;
+
+    @Mock
+    private TemplateRenderer mockRenderer;
+
+    @Mock
+    private PromptRunner mockRunner;
+
+    @Mock
+    private PromptRunner mockRunnerWithSystemPrompt;
+
+    @Test
+    @DisplayName("Should expose context and runner")
+    void exposesContextAndRunner() {
+        // Arrange & Act
+        var builder = new TemplatedPromptRunnerBuilder(mockContext, mockRunner);
+
+        // Assert
+        assertEquals(mockContext, builder.getContext());
+        assertEquals(mockRunner, builder.getRunner());
+    }
+
+    @Test
+    @DisplayName("Should render template via platform renderer and pass result as system prompt")
+    void rendersTemplateAndDelegatesToWithSystemPrompt() {
+        // Arrange
+        var model = Map.<String, Object>of("company", "Acme");
+        stubPlatformRenderer();
+        when(mockRenderer.renderLoadedTemplate("greeting", model)).thenReturn("You are the Acme assistant");
+        when(mockRunner.withSystemPrompt("You are the Acme assistant")).thenReturn(mockRunnerWithSystemPrompt);
+        var builder = new TemplatedPromptRunnerBuilder(mockContext, mockRunner);
+
+        // Act
+        var result = builder.withSystemPromptTemplate("greeting", model);
+
+        // Assert
+        assertEquals(mockRunnerWithSystemPrompt, result);
+        verify(mockRunner).withSystemPrompt("You are the Acme assistant");
+    }
+
+    @Test
+    @DisplayName("Should default to an empty model for static templates")
+    void rendersStaticTemplateWithoutModel() {
+        // Arrange
+        stubPlatformRenderer();
+        when(mockRenderer.renderLoadedTemplate("static", Map.of())).thenReturn("You are a helpful assistant");
+        when(mockRunner.withSystemPrompt("You are a helpful assistant")).thenReturn(mockRunnerWithSystemPrompt);
+        var builder = new TemplatedPromptRunnerBuilder(mockContext, mockRunner);
+
+        // Act
+        var result = builder.withSystemPromptTemplate("static");
+
+        // Assert
+        assertEquals(mockRunnerWithSystemPrompt, result);
+    }
+
+    @Test
+    @DisplayName("Should propagate NoSuchTemplateException for an unknown template")
+    void propagatesNoSuchTemplateException() {
+        // Arrange
+        var model = Map.<String, Object>of();
+        stubPlatformRenderer();
+        when(mockRenderer.renderLoadedTemplate("missing", model))
+                .thenThrow(new NoSuchTemplateException("missing"));
+        var builder = new TemplatedPromptRunnerBuilder(mockContext, mockRunner);
+
+        // Act & Assert
+        assertThrows(NoSuchTemplateException.class,
+                () -> builder.withSystemPromptTemplate("missing", model));
+    }
+
+    private void stubPlatformRenderer() {
+        when(mockContext.agentPlatform()).thenReturn(mockPlatform);
+        when(mockPlatform.getPlatformServices()).thenReturn(mockPlatformServices);
+        when(mockPlatformServices.getTemplateRenderer()).thenReturn(mockRenderer);
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/template/TemplatedPromptRunnerBuilderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/template/TemplatedPromptRunnerBuilderTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.template
+
+import com.embabel.agent.api.common.OperationContext
+import com.embabel.agent.api.common.PlatformServices
+import com.embabel.agent.api.common.PromptRunner
+import com.embabel.agent.core.AgentPlatform
+import com.embabel.common.textio.template.NoSuchTemplateException
+import com.embabel.common.textio.template.TemplateRenderer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class TemplatedPromptRunnerBuilderTest {
+
+    private val context = mockk<OperationContext>()
+    private val platform = mockk<AgentPlatform>()
+    private val platformServices = mockk<PlatformServices>()
+    private val renderer = mockk<TemplateRenderer>()
+    private val runner = mockk<PromptRunner>()
+    private val runnerWithSystemPrompt = mockk<PromptRunner>()
+
+    private fun stubPlatformRenderer() {
+        every { context.agentPlatform() } returns platform
+        every { platform.platformServices } returns platformServices
+        every { platformServices.templateRenderer } returns renderer
+    }
+
+    @Test
+    fun `renders template via platform renderer and passes result as system prompt`() {
+        stubPlatformRenderer()
+        val model = mapOf<String, Any>("company" to "Acme")
+        every { renderer.renderLoadedTemplate("greeting", model) } returns "You are the Acme assistant"
+        every { runner.withSystemPrompt("You are the Acme assistant") } returns runnerWithSystemPrompt
+
+        val result = TemplatedPromptRunnerBuilder(context, runner).withSystemPromptTemplate("greeting", model)
+
+        assertEquals(runnerWithSystemPrompt, result)
+        verify { runner.withSystemPrompt("You are the Acme assistant") }
+    }
+
+    @Test
+    fun `defaults to an empty model for static templates`() {
+        stubPlatformRenderer()
+        every { renderer.renderLoadedTemplate("static", emptyMap()) } returns "You are a helpful assistant"
+        every { runner.withSystemPrompt("You are a helpful assistant") } returns runnerWithSystemPrompt
+
+        val result = TemplatedPromptRunnerBuilder(context, runner).withSystemPromptTemplate("static")
+
+        assertEquals(runnerWithSystemPrompt, result)
+    }
+
+    @Test
+    fun `propagates NoSuchTemplateException for an unknown template`() {
+        stubPlatformRenderer()
+        every { renderer.renderLoadedTemplate("missing", emptyMap()) } throws NoSuchTemplateException("missing")
+
+        assertThrows<NoSuchTemplateException> {
+            TemplatedPromptRunnerBuilder(context, runner).withSystemPromptTemplate("missing")
+        }
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/templates/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/templates/page.adoc
@@ -51,6 +51,40 @@ val distinctFactualAssertions = context.ai()
 ----
 ====
 
+==== System Prompts from Templates
+
+To render a template into the _system_ prompt of a regular `PromptRunner` chain, wrap the runner in a `TemplatedPromptRunnerBuilder`.
+It renders the template with the platform's `TemplateRenderer` and returns a runner with the result applied via `withSystemPrompt()`, leaving all downstream operations unchanged.
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+PromptRunner runner = new TemplatedPromptRunnerBuilder(context, context.ai().withLlm(llm))
+    .withSystemPromptTemplate(
+            "support/system_prompt",
+            Map.of("company", companyName)
+    );
+
+Answer answer = runner.createObject(question, Answer.class);
+----
+
+Kotlin::
++
+[source,kotlin]
+----
+val runner = TemplatedPromptRunnerBuilder(context, context.ai().withLlm(llm))
+    .withSystemPromptTemplate(
+            "support/system_prompt",
+            mapOf("company" to companyName)
+    )
+
+val answer = runner.createObject(question, Answer::class.java)
+----
+====
+
 ==== Custom Template Renderer
 
 By default, `rendering()` uses the platform's `TemplateRenderer` (a Jinja-based renderer that loads templates from the classpath).


### PR DESCRIPTION
## Summary

- Add `TemplatedPromptRunnerBuilder(context, runner)` in `com.embabel.agent.api.template`: renders a loaded template with the platform `TemplateRenderer` (publicly reachable from the `OperationContext`) and hands back `runner.withSystemPrompt(rendered)`.
- No changes to `PromptRunner` or its sub-interfaces - the rendering/creating boundary stays intact, same pattern as `StreamingPromptRunnerBuilder`.
- Implemented in Kotlin and exposed idiomatically to Java; `@JvmOverloads` gives a one-arg form for static templates (model defaults to the empty map, mirroring `Rendering.respondWithSystemPrompt`).
- New "System Prompts from Templates" section in the templates reference docs.

## Context

- `withSystemPrompt` takes a ready string only, so a templated system prompt forced injecting a `TemplateRenderer` and rendering by hand before entering the chain. `Rendering` covers template-as-system-prompt only in the `Conversation` respond flow, while the reported case ends in `createObject`.
- Shape agreed with @igordayen in the issue: wrapper builder per the `StreamingPromptRunnerBuilder` precedent, Kotlin-first with the same exposure for Java.

## Validation

- Kotlin mockk test (3 cases) plus `TemplatedPromptRunnerBuilderJavaTest` (4 cases, Mockito) proving idiomatic Java use including the one-arg overload; tests written first and verified to fail without the implementation.
- Full `embabel-agent-api` module: 3957 tests, 0 failures, Java 21.

Fixes #1729
