### PR TITLE
fix(rag): close ChunkMergingEnhancer crash path, complete typed ChunkStructure migration

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
@@ -186,7 +186,7 @@ Each chunk:
 - Contains a `text` field with the content
 - Has a `parentId` linking to its source section
 - Carries a typed `structure` (`ChunkStructure`) describing its origin (root document, container section, leaf section) and position (chunk index, sequence number)
-- Includes `metadata` for user-supplied data; during a deprecation window the structural fields also remain readable there under their legacy keys such as `sequence_number`
+- Includes `metadata` for user-supplied data; during a deprecation window the structural fields also remain readable there under their legacy keys such as `sequence_number`. Numeric structural values are re-emitted as `Int` regardless of the type originally written, so stores that persisted them as `Long` should assert on `structure` rather than on the metadata view
 - Can compute its `pathFromRoot` through the document hierarchy
 
 This hierarchical model enables advanced RAG capabilities like "zoom out" to parent sections or expansion to adjacent chunks.

--- a/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
@@ -185,7 +185,8 @@ Each chunk:
 
 - Contains a `text` field with the content
 - Has a `parentId` linking to its source section
-- Includes `metadata` with information about its origin (root document, container section, leaf section)
+- Carries a typed `structure` (`ChunkStructure`) describing its origin (root document, container section, leaf section) and position (chunk index, sequence number)
+- Includes `metadata` for user-supplied data; during a deprecation window the structural fields also remain readable there under their legacy keys such as `sequence_number`
 - Can compute its `pathFromRoot` through the document hierarchy
 
 This hierarchical model enables advanced RAG capabilities like "zoom out" to parent sections or expansion to adjacent chunks.

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearch.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/DirectoryTextSearch.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.rag.service.support
 
 import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.ChunkStructure
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.RegexSearchOperations
 import com.embabel.agent.rag.service.TextSearch
@@ -286,11 +287,12 @@ class DirectoryTextSearch @JvmOverloads constructor(
         // Return whole file if chunking disabled or file is small
         if (config.chunkSize <= 0 || content.length <= config.chunkSize) {
             return listOf(
-                Chunk(
+                Chunk.create(
                     id = relativePath,
                     text = content,
                     parentId = directory,
-                    metadata = baseMetadata + ("chunk_index" to 0) + ("total_chunks" to 1),
+                    metadata = baseMetadata,
+                    structure = ChunkStructure(chunkIndex = 0, totalChunks = 1),
                 )
             )
         }
@@ -308,16 +310,15 @@ class DirectoryTextSearch @JvmOverloads constructor(
 
         // Create chunks from merged ranges
         return mergedRanges.mapIndexed { index, (start, end) ->
-            Chunk(
+            Chunk.create(
                 id = if (mergedRanges.size == 1) relativePath else "$relativePath#$index",
                 text = content.substring(start, end),
                 parentId = if (mergedRanges.size == 1) directory else relativePath,
                 metadata = baseMetadata + mapOf(
-                    "chunk_index" to index,
                     "chunk_start" to start,
                     "chunk_end" to end,
-                    "total_chunks" to mergedRanges.size,
                 ),
+                structure = ChunkStructure(chunkIndex = index, totalChunks = mergedRanges.size),
             )
         }
     }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaChunkApiTest.java
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/java/com/embabel/agent/rag/model/JavaChunkApiTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JavaChunkApiTest {
+
+    @Test
+    void typedStructureIsUsableFromJava() {
+        var structure = ChunkStructure.fromMetadata(Map.of(
+                "root_document_id", "root-1",
+                "container_section_id", "container-1",
+                "sequence_number", 3));
+        var chunk = Chunk.create("text", "container-1", Map.of("context", "user1"), "c-1", "text", structure);
+        assertEquals("root-1", chunk.getStructure().getRootDocumentId());
+        assertEquals(Integer.valueOf(3), chunk.getStructure().getSequenceNumber());
+        assertEquals(3, chunk.getMetadata().get("sequence_number"));
+        assertEquals("user1", chunk.getMetadata().get("context"));
+    }
+
+    @Test
+    void legacyMetadataConstructionLiftsToTypedStructure() {
+        var chunk = Chunk.create("text", "parent", Map.of("sequence_number", "3", "root_document_id", "root-1"));
+        assertEquals(Integer.valueOf(3), chunk.getStructure().getSequenceNumber());
+        assertEquals("root-1", chunk.getStructure().getRootDocumentId());
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/main/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancer.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/main/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancer.kt
@@ -16,7 +16,6 @@
 package com.embabel.agent.rag.pipeline
 
 import com.embabel.agent.rag.model.Chunk
-import com.embabel.agent.rag.model.ChunkStructure
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.*
 import com.embabel.common.core.types.SimilarityResult
@@ -68,26 +67,16 @@ object ChunkMergingEnhancer : RagResponseEnhancer {
         first: SimilarityResult<out Retrievable>,
         second: SimilarityResult<out Retrievable>,
     ): Boolean {
-        val firstRootId = rootDocumentId(first.match) ?: return false
-        val secondRootId = rootDocumentId(second.match) ?: return false
-        val firstSeq = sequenceNumber(first.match) ?: return false
-        val secondSeq = sequenceNumber(second.match) ?: return false
+        // Only chunks can merge: mergeChunks casts to Chunk, so a metadata-only
+        // match here would fail there with a ClassCastException.
+        val firstStructure = (first.match as? Chunk)?.structure ?: return false
+        val secondStructure = (second.match as? Chunk)?.structure ?: return false
+        val firstRootId = firstStructure.rootDocumentId ?: return false
+        val secondRootId = secondStructure.rootDocumentId ?: return false
+        val firstSeq = firstStructure.sequenceNumber ?: return false
+        val secondSeq = secondStructure.sequenceNumber ?: return false
 
         return firstRootId == secondRootId && secondSeq == firstSeq + 1
-    }
-
-    private fun rootDocumentId(match: Retrievable): String? =
-        (match as? Chunk)?.structure?.rootDocumentId
-            ?: match.metadata[ChunkStructure.ROOT_DOCUMENT_ID] as? String
-
-    private fun sequenceNumber(match: Retrievable): Int? {
-        (match as? Chunk)?.structure?.sequenceNumber?.let { return it }
-        return when (val value = match.metadata[ChunkStructure.SEQUENCE_NUMBER]) {
-            is Int -> value
-            is Number -> value.toInt()
-            is String -> value.toIntOrNull()
-            else -> null
-        }
     }
 
     private fun mergeChunks(
@@ -97,9 +86,8 @@ object ChunkMergingEnhancer : RagResponseEnhancer {
             return chunks[0]
         }
 
-        logger.info("Merging {} chunks from document {}", chunks.size, rootDocumentId(chunks[0].match))
-
         val firstChunk = chunks[0].match as Chunk
+        logger.info("Merging {} chunks from document {}", chunks.size, firstChunk.structure.rootDocumentId)
         val mergedText = chunks.joinToString(" ") { (it.match as Chunk).text }
         val highestScore = chunks.maxOf { it.score }
 

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/main/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancer.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/main/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancer.kt
@@ -91,11 +91,12 @@ object ChunkMergingEnhancer : RagResponseEnhancer {
         val mergedText = chunks.joinToString(" ") { (it.match as Chunk).text }
         val highestScore = chunks.maxOf { it.score }
 
-        val mergedChunk = Chunk(
+        val mergedChunk = Chunk.create(
             id = "${firstChunk.id}-merged",
             text = mergedText,
             metadata = firstChunk.metadata,
-            parentId = firstChunk.parentId
+            parentId = firstChunk.parentId,
+            structure = firstChunk.structure,
         )
 
         return object : SimilarityResult<Chunk> {

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancerTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancerTest.kt
@@ -16,9 +16,11 @@
 package com.embabel.agent.rag.pipeline
 
 import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.RagRequest
 import com.embabel.agent.rag.service.RagResponse
 import com.embabel.common.core.types.SimpleSimilaritySearchResult
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Nested
@@ -216,6 +218,58 @@ class ChunkMergingEnhancerTest {
                         ),
                         score = 0.85
                     )
+                )
+            )
+
+            val enhanced = ChunkMergingEnhancer.enhance(response)
+            assertEquals(2, enhanced.results.size)
+        }
+
+        @Test
+        fun `test merge chunks whose sequence numbers were stored as strings`() {
+            val response = RagResponse(
+                request = RagRequest("test query"),
+                service = "test",
+                results = listOf(
+                    SimpleSimilaritySearchResult(
+                        match = Chunk(
+                            id = "chunk1",
+                            text = "First chunk",
+                            metadata = mapOf("root_document_id" to "doc1", "sequence_number" to "1"),
+                            parentId = "doc1"
+                        ),
+                        score = 0.9
+                    ),
+                    SimpleSimilaritySearchResult(
+                        match = Chunk(
+                            id = "chunk2",
+                            text = "Second chunk",
+                            metadata = mapOf("root_document_id" to "doc1", "sequence_number" to "2"),
+                            parentId = "doc1"
+                        ),
+                        score = 0.85
+                    )
+                )
+            )
+
+            val enhanced = ChunkMergingEnhancer.enhance(response)
+            assertEquals(1, enhanced.results.size)
+            val mergedChunk = enhanced.results[0].match as Chunk
+            assertEquals("First chunk Second chunk", mergedChunk.text)
+        }
+
+        @Test
+        fun `test non-chunk retrievables are not merged`() {
+            val first = mockk<Retrievable>(relaxed = true)
+            every { first.metadata } returns mapOf("root_document_id" to "doc1", "sequence_number" to 1)
+            val second = mockk<Retrievable>(relaxed = true)
+            every { second.metadata } returns mapOf("root_document_id" to "doc1", "sequence_number" to 2)
+            val response = RagResponse(
+                request = RagRequest("test query"),
+                service = "test",
+                results = listOf(
+                    SimpleSimilaritySearchResult(match = first, score = 0.9),
+                    SimpleSimilaritySearchResult(match = second, score = 0.85)
                 )
             )
 

--- a/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancerTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-pipeline/src/test/kotlin/com/embabel/agent/rag/pipeline/ChunkMergingEnhancerTest.kt
@@ -96,6 +96,8 @@ class ChunkMergingEnhancerTest {
             val mergedChunk = enhanced.results[0].match as Chunk
             assertEquals("First chunk Second chunk", mergedChunk.text)
             assertEquals(0.9, enhanced.results[0].score)
+            assertEquals("doc1", mergedChunk.structure.rootDocumentId)
+            assertEquals(1, mergedChunk.structure.sequenceNumber)
         }
 
         @Test


### PR DESCRIPTION
## Summary

- fix a `ClassCastException` path in `ChunkMergingEnhancer`: `canMerge` accepted any `Retrievable` whose metadata carried `root_document_id` and `sequence_number`, but `mergeChunks` casts group members to `Chunk`, so a non-chunk match crashed the merge; merging is now typed-only via `chunk.structure`
- migrate `DirectoryTextSearch` off string-literal `chunk_index`/`total_chunks` metadata keys to a typed `ChunkStructure`
- add Java interop coverage for the typed API and describe `structure` vs `metadata` in the RAG reference docs

## Context

Follow-up to #1851, covering the remaining in-repo spots of the #1829 migration. The crash path predates #1851: the old metadata-based `canMerge` had the same hole, and the metadata fallback kept it reachable.

## Validation

- the new regression test fails on current main with the `ClassCastException` above; a second test pins merging of chunks whose sequence numbers were stored as strings
- clean reactor run on Java 21: rag-core 658, rag-pipeline 219, rag-lucene 90, rag-tika 74 tests, 0 failures
- `mvn spotless:check` and `git diff --check` passed
