### PR TITLE
Log an existing SearchTools at debug, like every branch beside it

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -133,7 +133,7 @@ data class ToolishRag @JvmOverloads constructor(
         val tools = buildList {
             // If the search operations already implement SearchTools, use them directly
             if (searchOperations is SearchTools) {
-                logger.info("Adding existing SearchTools to ToolishRag '{}'", name)
+                logger.debug("Adding existing SearchTools to ToolishRag '{}'", name)
                 add(searchOperations)
             }
             // This can confuse guide. Let's skip it for now.


### PR DESCRIPTION
## What

One word: `ToolishRag.kt` logs `Adding existing SearchTools to ToolishRag '{}'` at INFO. Its five sibling branches in the same `buildList` — `FinderTools`, `VectorSearchTools`, `TextSearchTools`, `ResultExpanderTools`, `RegexSearchTools` — all log at `debug`. This moves the odd one out to match.

## Why it shows up as noise rather than a one-off line

`ToolishRag` is a `data class`, so `withMetadataFilter` / `withHint` / `withGoal` / `withListener` each return a `copy()` with a **fresh `by lazy initState`**. Any host that builds its RAG **per request** re-derives the tool objects on each one and logs again.

Per-request construction is not a misuse — it is what you must do when the metadata filter is the thing scoping private data to the acting user. In the app where this surfaced, the RAG's chunks carry a `userId` and its vector/text path bypasses the Cypher scope rewriter, so a singleton filtered only by source once leaked every user's data to every other user. The fix was to build the tool per request with a `userId`-pinned filter — and the reward was an INFO line per request.

Measured: **207 identical lines in one session**, all for a single RAG, on `tomcat-handler-*` and `cron-*` threads. Any request that touches the tool surface — including something as incidental as refreshing a generated app — emits one. The five `debug` branches beside it stayed silent throughout.

## Why the level, and not the call site

Nothing is wrong at the call site and nothing expensive repeats: what gets re-derived is a handful of wrappers around the same `SearchOperations` — no store round-trip, no model call. So this is not a caching bug to fix; the line simply describes a routine internal derivation, which is what `debug` is for. Left at INFO it penalises precisely the hosts that scope their RAG correctly.

Whether the *marker* branch should also short-circuit the others is a separate question and deliberately untouched here.

## Testing

`mvn -pl embabel-agent-rag/embabel-agent-rag-core test` — **656 tests, 0 failures, 0 errors**. No test asserted on this level (none should).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155K32rNK2wtGPWxYFVJWTG