### PR TITLE
Reduce log level / remove stacktraces from Model Loader logging

### DIFF
--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/autoconfig/AbstractModelLoader.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/autoconfig/AbstractModelLoader.kt
@@ -70,7 +70,7 @@ abstract class AbstractYamlModelLoader<T : LlmAutoConfigProvider<*>>(
                 logger.info("Loaded {} {} model definitions", it.models.size, getProviderName())
             }
         } catch (e: Exception) {
-            logger.error("Failed to load {} models from {}", getProviderName(), configPath, e)
+            logger.warn("Failed to load {} models from {}: {}", getProviderName(), configPath, e.message)
             createEmptyProvider()
         }
     }


### PR DESCRIPTION
## Overview

Closes #1809 

Reduce logging noise from Model Loader on JUnit executions 


## Sample output

WARN  OciGenAiModelLoader - Failed to load OCI GenAI models from file:/tmp/oci-genai-models10849517405125410894.yml: Temperature must be between 0 and 2 for model invalid-temperature