### PR TITLE
Fix/1758 OpenAI pro responses api

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/OpenAiModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/OpenAiModels.kt
@@ -18,7 +18,8 @@ package com.embabel.agent.api.models
 
 /**
  * Well-known models from OpenAI.
- * Model IDs verified against GET /v1/models on 2026-03-29.
+ * Model IDs verified against GET /v1/models on 2026-03-29; GPT-5.5 and GPT-5.6
+ * against developers.openai.com/api/docs/models on 2026-08-04.
  * Undated aliases (e.g. GPT_54) always resolve to the latest pinned version.
  * Use dated constants (e.g. GPT_54_2026_03_05) for reproducible behaviour.
  */
@@ -27,7 +28,28 @@ class OpenAiModels {
     companion object {
 
         // =====================================================================
-        // GPT-5.4 FAMILY (Current Flagship - March 2026)
+        // GPT-5.6 FAMILY (Current Flagship - July 2026)
+        // Tiers are Luna/Terra/Sol; "pro" is now a Responses-only reasoning
+        // mode rather than a model.
+        // =====================================================================
+
+        /** Alias for [GPT_56_SOL]. The shipped catalog registers the tiers, not this. */
+        const val GPT_56 = "gpt-5.6"
+
+        const val GPT_56_SOL = "gpt-5.6-sol"
+        const val GPT_56_TERRA = "gpt-5.6-terra"
+        const val GPT_56_LUNA = "gpt-5.6-luna"
+
+        // =====================================================================
+        // GPT-5.5 FAMILY (June 2026)
+        // =====================================================================
+
+        const val GPT_55 = "gpt-5.5"
+
+        const val GPT_55_PRO = "gpt-5.5-pro"
+
+        // =====================================================================
+        // GPT-5.4 FAMILY (March 2026)
         // =====================================================================
 
         const val GPT_54 = "gpt-5.4"

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/pom.xml
@@ -36,13 +36,12 @@
             <artifactId>spring-ai-openai</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>com.openai</groupId>
-            <artifactId>openai-java</artifactId>
-            <version>4.16.1</version>
-            <scope>test</scope><!-- Use the latest version -->
-        </dependency>
-
+        <!--
+          openai-java is not declared here: it arrives at compile scope via
+          embabel-agent-openai, which pins it in step with spring-ai-openai. Declaring
+          it locally would override that version and put a second SDK release on the
+          test classpath.
+        -->
 
         <dependency>
             <groupId>com.embabel.agent</groupId>

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoader.kt
@@ -75,9 +75,27 @@ data class OpenAiModelDefinition(
     val temperature: Double = 1.0,
     val topP: Double? = null,
     val specialHandling: SpecialHandlingConfiguration? = null,
+    val apiFormat: OpenAiApiFormat = OpenAiApiFormat.CHAT_COMPLETIONS,
     @param:JsonAlias("native-support")
     override val nativeSupport: NativeSupport? = null,
 ) : LlmAutoConfigMetadata
+
+/**
+ * Wire format an OpenAI model is served over.
+ *
+ * OpenAI exposes text models over two mutually incompatible APIs. Almost all are served over
+ * `/v1/chat/completions`, but the `*-pro` models are served *only* over `/v1/responses` and
+ * reject Chat Completions requests outright.
+ *
+ * Declared per model rather than inferred from the model id: OpenAI decides which models are
+ * Responses-only, and a naming convention is not a contract.
+ *
+ * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
+ */
+enum class OpenAiApiFormat {
+    CHAT_COMPLETIONS,
+    RESPONSES,
+}
 
 /**
  * Special handling configuration for models with unique requirements.

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoader.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoader.kt
@@ -100,7 +100,9 @@ enum class OpenAiApiFormat {
 /**
  * Special handling configuration for models with unique requirements.
  *
- * @property supportsTemperature whether the model supports temperature adjustment
+ * @property supportsTemperature whether the model supports temperature adjustment. A model that
+ * does not is served by `Gpt5ChatOptionsConverter`, which sends no sampling parameter at all —
+ * the GPT-5 models that refuse `temperature` refuse `top_p` and both penalties with it.
  */
 data class SpecialHandlingConfiguration(
     val supportsTemperature: Boolean = true
@@ -162,6 +164,11 @@ class OpenAiModelLoader(
             }
             model.topP?.let {
                 require(it in 0.0..1.0) { "Top P must be between 0 and 1 for model ${model.name}" }
+            }
+            model.pricingModel?.let {
+                require(it.usdPer1mInputTokens >= 0 && it.usdPer1mOutputTokens >= 0) {
+                    "Pricing must be non-negative for model ${model.name}"
+                }
             }
         }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -33,6 +33,7 @@ import com.embabel.common.ai.model.PerTokenPricingModel
 import com.embabel.common.ai.model.PricingModel
 import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
 import io.micrometer.observation.ObservationRegistry
+import org.springframework.ai.openai.OpenAiChatOptions
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
@@ -137,6 +138,13 @@ class OpenAiModelsConfig(
     webClientBuilder = webClientBuilder,
 ) {
 
+    /**
+     * Resolved the same way as the one handed to the superclass, which keeps it private. Only the
+     * Responses adapter needs it here — Spring AI's own chat model is given it by the factory.
+     */
+    private val resolvedObservationRegistry: ObservationRegistry =
+        observationRegistry.getIfUnique { ObservationRegistry.NOOP }
+
     init {
         logger.info("OpenAI models are available: {}", properties)
     }
@@ -203,9 +211,19 @@ class OpenAiModelsConfig(
             StandardOpenAiOptionsConverter
         }
 
-        val chatModel = chatModelOf(
-            model = modelDef.modelId, retryTemplate = properties.retryTemplate(modelDef.modelId)
-        )
+        // Transport is declared per model, like the converter above: most models speak Chat
+        // Completions, the *-pro family is served only over the Responses API.
+        val chatModel = when (modelDef.apiFormat) {
+            OpenAiApiFormat.CHAT_COMPLETIONS -> chatModelOf(
+                model = modelDef.modelId, retryTemplate = properties.retryTemplate(modelDef.modelId)
+            )
+
+            OpenAiApiFormat.RESPONSES -> OpenAiResponsesChatModel(
+                client = openAiClient,
+                defaultOptions = OpenAiChatOptions.builder().model(modelDef.modelId).build(),
+                observationRegistry = resolvedObservationRegistry,
+            )
+        }
 
         // Create pricing model if present
         val pricingModel = modelDef.pricingModel?.let {

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.models.OpenAiModels
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.openai.client.OpenAIClient
+import com.openai.core.JsonValue
+import com.openai.models.ResponsesModel
+import com.openai.models.responses.EasyInputMessage
+import com.openai.models.responses.FunctionTool
+import com.openai.models.responses.ResponseCreateParams
+import com.openai.models.responses.ResponseFormatTextJsonSchemaConfig
+import com.openai.models.responses.ResponseFunctionToolCall
+import com.openai.models.responses.ResponseInputItem
+import com.openai.models.responses.ResponseTextConfig
+import com.openai.models.responses.Tool
+import io.micrometer.observation.ObservationRegistry
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.Message
+import org.springframework.ai.chat.messages.MessageType
+import org.springframework.ai.chat.messages.ToolResponseMessage
+import org.springframework.ai.chat.metadata.ChatResponseMetadata
+import org.springframework.ai.chat.metadata.DefaultUsage
+import org.springframework.ai.chat.model.ChatModel
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.model.Generation
+import org.springframework.ai.chat.observation.ChatModelObservationContext
+import org.springframework.ai.chat.observation.ChatModelObservationDocumentation
+import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention
+import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.model.tool.ToolCallingChatOptions
+import org.springframework.ai.openai.OpenAiChatModel
+import org.springframework.ai.openai.OpenAiChatOptions
+import reactor.core.publisher.Flux
+import java.util.function.Supplier
+import com.openai.models.responses.Response as OpenAiResponse
+
+/**
+ * Spring AI [ChatModel] backed by the OpenAI Responses API, which serves the `*-pro` models.
+ *
+ * Spring AI has no client for that endpoint — native support is milestoned for 2.1
+ * (spring-ai#2962) — so this adapts the official OpenAI SDK, as
+ * [com.embabel.agent.config.models.ocigenai.OciGenAiChatModel] adapts the OCI SDK.
+ *
+ * Only the single request/response exchange is mapped. Embabel drives its own tool loop, so the
+ * stateful half of the Responses API — background mode, server-side conversation state, remote
+ * MCP — is deliberately unused, and requests are non-streaming.
+ *
+ * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
+ * @see <a href="https://github.com/spring-projects/spring-ai/issues/2962">spring-ai#2962</a>
+ */
+class OpenAiResponsesChatModel(
+    private val client: OpenAIClient,
+    private val defaultOptions: OpenAiChatOptions,
+    private val observationRegistry: ObservationRegistry = ObservationRegistry.NOOP,
+    private val objectMapper: ObjectMapper = ObjectMapper(),
+) : ChatModel {
+
+    /**
+     * Observed under the same convention as Spring AI's own chat models. Embabel's `embabel.llm`
+     * and `embabel.tool_loop` spans are deliberately thin because they expect the generation
+     * content — prompt, completion, token counts — on this nested observation; without it, calls
+     * to these models would drop out of every trace.
+     */
+    override fun call(prompt: Prompt): ChatResponse {
+        val context = ChatModelObservationContext.builder()
+            .prompt(prompt)
+            .provider(OpenAiModels.PROVIDER)
+            .build()
+
+        return ChatModelObservationDocumentation.CHAT_MODEL_OPERATION
+            .observation(null, OBSERVATION_CONVENTION, { context }, observationRegistry)
+            .observe(
+                Supplier {
+                    toChatResponse(client.responses().create(createParams(prompt)))
+                        .also { context.response = it }
+                }
+            )!!
+    }
+
+    /** Defensive copy: Spring AI hands these to callers that may mutate them. */
+    override fun getDefaultOptions(): ChatOptions = defaultOptions.mutate().build()
+
+    /**
+     * Throwing is load-bearing: `SpringAiLlmService.StreamingCapabilityVerifier` probes streaming
+     * support by catching exactly this type. Any other exception would propagate to the caller
+     * instead of reporting that the model does not stream.
+     */
+    override fun stream(prompt: Prompt): Flux<ChatResponse> =
+        throw UnsupportedOperationException(
+            "Streaming is not supported for OpenAI models served over the Responses API"
+        )
+
+    internal fun createParams(prompt: Prompt): ResponseCreateParams {
+        val options = prompt.options
+        val builder = ResponseCreateParams.builder()
+            .model(modelOf(options))
+            .inputOfResponse(
+                prompt.instructions
+                    .filterNot { it.messageType == MessageType.SYSTEM }
+                    .flatMap(::toInputItems)
+            )
+        instructionsOf(prompt)?.let(builder::instructions)
+        maxOutputTokensOf(options)?.let { builder.maxOutputTokens(it.toLong()) }
+        toolsOf(options).takeIf { it.isNotEmpty() }?.let(builder::tools)
+        textConfigOf(options)?.let(builder::text)
+        // Temperature is never sent: the pro models accept only the default, and the catalog
+        // already marks them supports_temperature: false.
+        return builder.build()
+    }
+
+    /**
+     * `SpringAiLlmService.convertOptions` stamps the configured model onto every request, but the
+     * provider converters it delegates to set none of their own, so the default holds the floor.
+     */
+    private fun modelOf(options: ChatOptions?): String =
+        options?.model
+            ?: defaultOptions.model
+            ?: error("No model configured for a Responses API call")
+
+    /**
+     * The models reached over this transport are served by
+     * [com.embabel.agent.openai.Gpt5ChatOptionsConverter], which carries the caller's limit on
+     * `maxCompletionTokens` because the GPT-5 family rejects `max_tokens`. Both fields are read so
+     * that options built elsewhere still get their limit through.
+     */
+    private fun maxOutputTokensOf(options: ChatOptions?): Int? {
+        val openAiOptions = options as? OpenAiChatOptions
+        return openAiOptions?.maxCompletionTokens
+            ?: openAiOptions?.maxTokens
+            ?: defaultOptions.maxCompletionTokens
+            ?: defaultOptions.maxTokens
+    }
+
+    /** The Responses API has no system role; system prompts are carried as `instructions`. */
+    private fun instructionsOf(prompt: Prompt): String? =
+        prompt.instructions
+            .filter { it.messageType == MessageType.SYSTEM }
+            .mapNotNull { it.text }
+            .joinToString("\n")
+            .takeIf { it.isNotBlank() }
+
+    private fun toInputItems(message: Message): List<ResponseInputItem> = when (message) {
+        is ToolResponseMessage -> message.responses.map(::toFunctionCallOutput)
+        is AssistantMessage -> buildList {
+            message.text?.takeIf { it.isNotBlank() }?.let {
+                add(toEasyInputMessage(EasyInputMessage.Role.ASSISTANT, it))
+            }
+            message.toolCalls.orEmpty().forEach { add(toFunctionCall(it)) }
+        }
+
+        else -> listOf(toEasyInputMessage(EasyInputMessage.Role.USER, message.text.orEmpty()))
+    }
+
+    private fun toEasyInputMessage(role: EasyInputMessage.Role, content: String): ResponseInputItem =
+        ResponseInputItem.ofEasyInputMessage(
+            EasyInputMessage.builder().role(role).content(content).build()
+        )
+
+    /**
+     * Embabel replays the assistant's tool calls and their results on the next turn; the Responses
+     * API pairs the two by `call_id`, so the id has to survive both directions unchanged.
+     */
+    private fun toFunctionCall(toolCall: AssistantMessage.ToolCall): ResponseInputItem =
+        ResponseInputItem.ofFunctionCall(
+            ResponseFunctionToolCall.builder()
+                .callId(toolCall.id)
+                .name(toolCall.name)
+                .arguments(toolCall.arguments)
+                .build()
+        )
+
+    private fun toFunctionCallOutput(response: ToolResponseMessage.ToolResponse): ResponseInputItem =
+        ResponseInputItem.ofFunctionCallOutput(
+            ResponseInputItem.FunctionCallOutput.builder()
+                .callId(response.id())
+                .output(response.responseData())
+                .build()
+        )
+
+    private fun toolsOf(options: ChatOptions?): List<Tool> =
+        (options as? ToolCallingChatOptions)?.toolCallbacks.orEmpty().map { callback ->
+            val definition = callback.toolDefinition
+            Tool.ofFunction(
+                FunctionTool.builder()
+                    .name(definition.name())
+                    .description(definition.description())
+                    .parameters(toParameters(definition.inputSchema()))
+                    .strict(false)
+                    .build()
+            )
+        }
+
+    /**
+     * Native structured output reaches us as a Chat Completions `response_format`, set by
+     * [OpenAiNativeStructuredOutputConfigurer]. The Responses API carries the same schema under
+     * `text.format`, and — unlike Chat Completions — requires it to be named, so a name is derived
+     * from the schema's own title where it has one.
+     */
+    private fun textConfigOf(options: ChatOptions?): ResponseTextConfig? {
+        val responseFormat = (options as? OpenAiChatOptions)?.responseFormat ?: return null
+        if (responseFormat.type != OpenAiChatModel.ResponseFormat.Type.JSON_SCHEMA) {
+            return null
+        }
+        val schema = responseFormat.jsonSchema?.let(::readSchema) ?: return null
+        return ResponseTextConfig.builder()
+            .format(
+                ResponseFormatTextJsonSchemaConfig.builder()
+                    .name(schemaNameOf(schema))
+                    .schema(toSchema(schema))
+                    // Strict mode rejects schemas Embabel routinely produces (open objects,
+                    // optional fields), and the catalog already declares strict: false.
+                    .strict(false)
+                    .build()
+            )
+            .build()
+    }
+
+    private fun readSchema(json: String): Map<String, Any?>? =
+        runCatching {
+            objectMapper.readValue(json, object : TypeReference<Map<String, Any?>>() {})
+        }.getOrNull()
+
+    /** OpenAI accepts only `[a-zA-Z0-9_-]` here, so anything else is folded to an underscore. */
+    private fun schemaNameOf(schema: Map<String, Any?>): String =
+        (schema["title"] as? String)
+            ?.replace(Regex("[^a-zA-Z0-9_-]"), "_")
+            ?.takeIf { it.isNotBlank() }
+            ?: DEFAULT_SCHEMA_NAME
+
+    private fun toSchema(schema: Map<String, Any?>): ResponseFormatTextJsonSchemaConfig.Schema {
+        val builder = ResponseFormatTextJsonSchemaConfig.Schema.builder()
+        schema.forEach { (key, value) -> builder.putAdditionalProperty(key, JsonValue.from(value)) }
+        return builder.build()
+    }
+
+    private fun toParameters(inputSchema: String): FunctionTool.Parameters {
+        val builder = FunctionTool.Parameters.builder()
+        readSchema(inputSchema).orEmpty()
+            .forEach { (key, value) -> builder.putAdditionalProperty(key, JsonValue.from(value)) }
+        return builder.build()
+    }
+
+    private fun toChatResponse(response: OpenAiResponse): ChatResponse {
+        val text = response.output()
+            .mapNotNull { it.message().orElse(null) }
+            .flatMap { it.content() }
+            .mapNotNull { it.outputText().orElse(null)?.text() }
+            .joinToString("\n")
+        val toolCalls = response.output()
+            .filter { it.isFunctionCall() }
+            .map { it.asFunctionCall() }
+            .map { AssistantMessage.ToolCall(it.callId(), FUNCTION_CALL_TYPE, it.name(), it.arguments()) }
+
+        val usage = response.usage().orElse(null)?.let {
+            DefaultUsage(it.inputTokens().toInt(), it.outputTokens().toInt(), it.totalTokens().toInt(), it)
+        }
+        val metadata = ChatResponseMetadata.builder()
+            .model(modelNameOf(response.model()))
+            .usage(usage)
+            .build()
+
+        // Always one generation, even when the model returned nothing usable: a reasoning model can
+        // answer with reasoning items alone, and SpringAiLlmMessageSender dereferences the first
+        // result without a null check.
+        val assistantMessage = AssistantMessage.builder()
+            .content(text)
+            .toolCalls(toolCalls)
+            .build()
+        return ChatResponse(listOf(Generation(assistantMessage)), metadata)
+    }
+
+    /**
+     * [ResponsesModel] is a union and each accessor throws unless it holds that variant: OpenAI's
+     * own model ids deserialize to [ResponsesModel.chat], not to a plain string.
+     */
+    private fun modelNameOf(model: ResponsesModel): String = when {
+        model.isString() -> model.asString()
+        model.isChat() -> model.chat().get().asString()
+        model.isOnly() -> model.only().get().asString()
+        else -> model.toString()
+    }
+
+    private companion object {
+        /** The type Spring AI expects on an [AssistantMessage.ToolCall]. */
+        const val FUNCTION_CALL_TYPE = "function"
+
+        /** Used when the schema carries no usable title. */
+        const val DEFAULT_SCHEMA_NAME = "response"
+
+        val OBSERVATION_CONVENTION = DefaultChatModelObservationConvention()
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
@@ -123,9 +123,9 @@ class OpenAiResponsesChatModel(
         maxOutputTokensOf(options)?.let { builder.maxOutputTokens(it.toLong()) }
         toolsOf(options).takeIf { it.isNotEmpty() }?.let(builder::tools)
         textConfigOf(options)?.let(builder::text)
-        // No sampling parameters: the pro models accept only the default temperature and top_p, and
-        // the Responses API has no presence/frequency penalty at all. Whatever
-        // Gpt5ChatOptionsConverter set on those fields is dropped here rather than refused there.
+        // No sampling parameters. Gpt5ChatOptionsConverter stopped setting them, and the Responses
+        // API has no presence/frequency penalty to carry them anyway; options built elsewhere are
+        // dropped here rather than refused by the endpoint.
         return builder.build()
     }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
@@ -27,6 +27,7 @@ import com.openai.models.responses.ResponseCreateParams
 import com.openai.models.responses.ResponseFormatTextJsonSchemaConfig
 import com.openai.models.responses.ResponseFunctionToolCall
 import com.openai.models.responses.ResponseInputItem
+import com.openai.models.responses.ResponseOutputMessage
 import com.openai.models.responses.ResponseStatus
 import com.openai.models.responses.ResponseTextConfig
 import com.openai.models.responses.Tool
@@ -103,11 +104,7 @@ class OpenAiResponsesChatModel(
     /** Defensive copy: Spring AI hands these to callers that may mutate them. */
     override fun getDefaultOptions(): ChatOptions = defaultOptions.mutate().build()
 
-    /**
-     * Throwing is load-bearing: `SpringAiLlmService.StreamingCapabilityVerifier` probes streaming
-     * support by catching exactly this type. Any other exception would propagate to the caller
-     * instead of reporting that the model does not stream.
-     */
+    /** Throwing is how `SpringAiLlmService.StreamingCapabilityVerifier` learns this model has no stream. */
     override fun stream(prompt: Prompt): Flux<ChatResponse> =
         throw UnsupportedOperationException(
             "Streaming is not supported for OpenAI models served over the Responses API"
@@ -290,11 +287,12 @@ class OpenAiResponsesChatModel(
     private fun toChatResponse(response: OpenAiResponse): ChatResponse {
         raiseIfFailed(response)
 
-        val text = response.output()
+        val content = response.output()
             .mapNotNull { it.message().orElse(null) }
             .flatMap { it.content() }
-            .mapNotNull { it.outputText().orElse(null)?.text() }
-            .joinToString("\n")
+        raiseIfRefused(content)
+
+        val text = content.mapNotNull { it.outputText().orElse(null)?.text() }.joinToString("\n")
         val toolCalls = response.output()
             .filter { it.isFunctionCall() }
             .map { it.asFunctionCall() }
@@ -322,16 +320,23 @@ class OpenAiResponsesChatModel(
     }
 
     /**
-     * A refusal arrives inside a `200` here — `status: "failed"`, reason in the body — so nothing
-     * throws on its own, and left alone it reads as a call that produced no output.
-     * [NonTransientAiException] is what `SpringAiRetryPolicy` reads to decide against a retry.
+     * A call that produced no answer still arrives inside a `200`, so nothing throws on its own and
+     * left alone it reads as a model with nothing to say. [NonTransientAiException] is what
+     * `SpringAiRetryPolicy` reads to decide against a retry.
      */
     private fun raiseIfFailed(response: OpenAiResponse) {
-        if (response.status().orElse(null) != ResponseStatus.FAILED) return
+        val status = response.status().orElse(null) ?: return
+        if (status !in ANSWERLESS_STATUSES) return
         val error = response.error().orElse(null)
         throw NonTransientAiException(
-            "OpenAI Responses API call failed: ${error?.message() ?: "no reason given"}"
+            "OpenAI Responses API call ${status.asString()}: ${error?.message() ?: "no reason given"}"
         )
+    }
+
+    /** A refusal is `completed` with no output text — the same silence, from a different cause. */
+    private fun raiseIfRefused(content: List<ResponseOutputMessage.Content>) {
+        val refusal = content.firstNotNullOfOrNull { it.refusal().orElse(null)?.refusal() } ?: return
+        throw NonTransientAiException("OpenAI Responses API call refused: $refusal")
     }
 
     /**
@@ -370,6 +375,9 @@ class OpenAiResponsesChatModel(
 
         /** Used when the schema carries no usable title. */
         const val DEFAULT_SCHEMA_NAME = "response"
+
+        /** Terminal statuses that carry no answer at all. */
+        val ANSWERLESS_STATUSES = setOf(ResponseStatus.FAILED, ResponseStatus.CANCELLED)
 
         val OBSERVATION_CONVENTION = DefaultChatModelObservationConvention()
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
@@ -27,13 +27,17 @@ import com.openai.models.responses.ResponseCreateParams
 import com.openai.models.responses.ResponseFormatTextJsonSchemaConfig
 import com.openai.models.responses.ResponseFunctionToolCall
 import com.openai.models.responses.ResponseInputItem
+import com.openai.models.responses.ResponseStatus
 import com.openai.models.responses.ResponseTextConfig
 import com.openai.models.responses.Tool
 import io.micrometer.observation.ObservationRegistry
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.ai.chat.messages.AssistantMessage
 import org.springframework.ai.chat.messages.Message
 import org.springframework.ai.chat.messages.MessageType
 import org.springframework.ai.chat.messages.ToolResponseMessage
+import org.springframework.ai.chat.metadata.ChatGenerationMetadata
 import org.springframework.ai.chat.metadata.ChatResponseMetadata
 import org.springframework.ai.chat.metadata.DefaultUsage
 import org.springframework.ai.chat.model.ChatModel
@@ -44,9 +48,11 @@ import org.springframework.ai.chat.observation.ChatModelObservationDocumentation
 import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention
 import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.content.MediaContent
 import org.springframework.ai.model.tool.ToolCallingChatOptions
 import org.springframework.ai.openai.OpenAiChatModel
 import org.springframework.ai.openai.OpenAiChatOptions
+import org.springframework.ai.retry.NonTransientAiException
 import reactor.core.publisher.Flux
 import java.util.function.Supplier
 import com.openai.models.responses.Response as OpenAiResponse
@@ -120,8 +126,9 @@ class OpenAiResponsesChatModel(
         maxOutputTokensOf(options)?.let { builder.maxOutputTokens(it.toLong()) }
         toolsOf(options).takeIf { it.isNotEmpty() }?.let(builder::tools)
         textConfigOf(options)?.let(builder::text)
-        // Temperature is never sent: the pro models accept only the default, and the catalog
-        // already marks them supports_temperature: false.
+        // No sampling parameters: the pro models accept only the default temperature and top_p, and
+        // the Responses API has no presence/frequency penalty at all. Whatever
+        // Gpt5ChatOptionsConverter set on those fields is dropped here rather than refused there.
         return builder.build()
     }
 
@@ -139,6 +146,9 @@ class OpenAiResponsesChatModel(
      * [com.embabel.agent.openai.Gpt5ChatOptionsConverter], which carries the caller's limit on
      * `maxCompletionTokens` because the GPT-5 family rejects `max_tokens`. Both fields are read so
      * that options built elsewhere still get their limit through.
+     *
+     * `max_output_tokens` covers reasoning tokens as well as visible output, so a limit sized for
+     * the answer alone comes back truncated — see the `length` finish reason in [finishReasonOf].
      */
     private fun maxOutputTokensOf(options: ChatOptions?): Int? {
         val openAiOptions = options as? OpenAiChatOptions
@@ -165,7 +175,20 @@ class OpenAiResponsesChatModel(
             message.toolCalls.orEmpty().forEach { add(toFunctionCall(it)) }
         }
 
-        else -> listOf(toEasyInputMessage(EasyInputMessage.Role.USER, message.text.orEmpty()))
+        else -> listOf(toEasyInputMessage(EasyInputMessage.Role.USER, textOf(message)))
+    }
+
+    /**
+     * Only text is mapped. Refused rather than dropped: a prompt stripped of its image still gets a
+     * confident answer, about something the model never saw.
+     */
+    private fun textOf(message: Message): String {
+        if ((message as? MediaContent)?.media.orEmpty().isNotEmpty()) {
+            throw UnsupportedOperationException(
+                "Media is not supported for OpenAI models served over the Responses API"
+            )
+        }
+        return message.text.orEmpty()
     }
 
     private fun toEasyInputMessage(role: EasyInputMessage.Role, content: String): ResponseInputItem =
@@ -201,7 +224,7 @@ class OpenAiResponsesChatModel(
                 FunctionTool.builder()
                     .name(definition.name())
                     .description(definition.description())
-                    .parameters(toParameters(definition.inputSchema()))
+                    .parameters(toParameters(definition.inputSchema(), definition.name()))
                     .strict(false)
                     .build()
             )
@@ -218,7 +241,8 @@ class OpenAiResponsesChatModel(
         if (responseFormat.type != OpenAiChatModel.ResponseFormat.Type.JSON_SCHEMA) {
             return null
         }
-        val schema = responseFormat.jsonSchema?.let(::readSchema) ?: return null
+        val schema = responseFormat.jsonSchema?.let { readSchema(it, "response format schema") }
+            ?: return null
         return ResponseTextConfig.builder()
             .format(
                 ResponseFormatTextJsonSchemaConfig.builder()
@@ -232,10 +256,16 @@ class OpenAiResponsesChatModel(
             .build()
     }
 
-    private fun readSchema(json: String): Map<String, Any?>? =
-        runCatching {
+    /**
+     * Fails loudly: a dropped response format leaves the model answering in free text, and dropped
+     * tool parameters tell it the tool takes none — both fail later, pointing at the wrong thing.
+     */
+    private fun readSchema(json: String, what: String): Map<String, Any?> =
+        try {
             objectMapper.readValue(json, object : TypeReference<Map<String, Any?>>() {})
-        }.getOrNull()
+        } catch (e: Exception) {
+            throw IllegalArgumentException("Cannot read $what as JSON: ${e.message}", e)
+        }
 
     /** OpenAI accepts only `[a-zA-Z0-9_-]` here, so anything else is folded to an underscore. */
     private fun schemaNameOf(schema: Map<String, Any?>): String =
@@ -250,14 +280,16 @@ class OpenAiResponsesChatModel(
         return builder.build()
     }
 
-    private fun toParameters(inputSchema: String): FunctionTool.Parameters {
+    private fun toParameters(inputSchema: String, toolName: String): FunctionTool.Parameters {
         val builder = FunctionTool.Parameters.builder()
-        readSchema(inputSchema).orEmpty()
+        readSchema(inputSchema, "input schema of tool '$toolName'")
             .forEach { (key, value) -> builder.putAdditionalProperty(key, JsonValue.from(value)) }
         return builder.build()
     }
 
     private fun toChatResponse(response: OpenAiResponse): ChatResponse {
+        raiseIfFailed(response)
+
         val text = response.output()
             .mapNotNull { it.message().orElse(null) }
             .flatMap { it.content() }
@@ -283,8 +315,43 @@ class OpenAiResponsesChatModel(
             .content(text)
             .toolCalls(toolCalls)
             .build()
-        return ChatResponse(listOf(Generation(assistantMessage)), metadata)
+        val generationMetadata = ChatGenerationMetadata.builder()
+            .finishReason(finishReasonOf(response, toolCalls.isNotEmpty()))
+            .build()
+        return ChatResponse(listOf(Generation(assistantMessage, generationMetadata)), metadata)
     }
+
+    /**
+     * A refusal arrives inside a `200` here — `status: "failed"`, reason in the body — so nothing
+     * throws on its own, and left alone it reads as a call that produced no output.
+     * [NonTransientAiException] is what `SpringAiRetryPolicy` reads to decide against a retry.
+     */
+    private fun raiseIfFailed(response: OpenAiResponse) {
+        if (response.status().orElse(null) != ResponseStatus.FAILED) return
+        val error = response.error().orElse(null)
+        throw NonTransientAiException(
+            "OpenAI Responses API call failed: ${error?.message() ?: "no reason given"}"
+        )
+    }
+
+    /**
+     * In the Chat Completions vocabulary the rest of Spring AI speaks. Earns its keep on
+     * `incomplete`, routine here because `max_output_tokens` is spent on reasoning too: the partial
+     * answer is worth returning, but silently it reads as a complete one.
+     */
+    private fun finishReasonOf(response: OpenAiResponse, hasToolCalls: Boolean): String =
+        when (response.status().orElse(null)) {
+            null, ResponseStatus.COMPLETED -> if (hasToolCalls) "tool_calls" else "stop"
+
+            ResponseStatus.INCOMPLETE ->
+                when (response.incompleteDetails().orElse(null)?.reason()?.orElse(null)) {
+                    OpenAiResponse.IncompleteDetails.Reason.MAX_OUTPUT_TOKENS -> "length"
+                    OpenAiResponse.IncompleteDetails.Reason.CONTENT_FILTER -> "content_filter"
+                    else -> "incomplete"
+                }.also { logger.warn("Incomplete response from {}: {}", modelNameOf(response.model()), it) }
+
+            else -> response.status().get().asString()
+        }
 
     /**
      * [ResponsesModel] is a union and each accessor throws unless it holds that variant: OpenAI's
@@ -305,5 +372,7 @@ class OpenAiResponsesChatModel(
         const val DEFAULT_SCHEMA_NAME = "response"
 
         val OBSERVATION_CONVENTION = DefaultChatModelObservationConvention()
+
+        val logger: Logger = LoggerFactory.getLogger(OpenAiResponsesChatModel::class.java)
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
@@ -110,7 +110,7 @@ class OpenAiResponsesChatModel(
             "Streaming is not supported for OpenAI models served over the Responses API"
         )
 
-    internal fun createParams(prompt: Prompt): ResponseCreateParams {
+    private fun createParams(prompt: Prompt): ResponseCreateParams {
         val options = prompt.options
         val builder = ResponseCreateParams.builder()
             .model(modelOf(options))
@@ -264,7 +264,21 @@ class OpenAiResponsesChatModel(
             throw IllegalArgumentException("Cannot read $what as JSON: ${e.message}", e)
         }
 
-    /** OpenAI accepts only `[a-zA-Z0-9_-]` here, so anything else is folded to an underscore. */
+    /**
+     * The Responses API requires the schema to be named and accepts only `[a-zA-Z0-9_-]` in that
+     * name, so every other character is folded to an underscore, one for one:
+     *
+     * - `Answer` stays `Answer`
+     * - `com.example.Answer` becomes `com_example_Answer`
+     * - `List<Answer>` becomes `List_Answer_`
+     *
+     * The name comes from the schema's own `title` because that is all this adapter is given:
+     * [OpenAiNativeStructuredOutputConfigurer] writes the schema into `responseFormat`, but
+     * `StructuredOutputRequest.name` does not survive into [OpenAiChatOptions].
+     *
+     * An absent or empty title falls back to [DEFAULT_SCHEMA_NAME]. The name is a label OpenAI
+     * echoes back, not something the model reasons over, so it is never worth failing a call for.
+     */
     private fun schemaNameOf(schema: Map<String, Any?>): String =
         (schema["title"] as? String)
             ?.replace(Regex("[^a-zA-Z0-9_-]"), "_")

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
@@ -78,6 +78,7 @@ models:
 
   - name: "gpt54pro"
     model_id: "gpt-5.4-pro"
+    api_format: "RESPONSES"
     display_name: "GPT-5.4 Pro"
     max_tokens: 16384
     temperature: 1.0
@@ -121,6 +122,7 @@ models:
 
   - name: "gpt52pro"
     model_id: "gpt-5.2-pro"
+    api_format: "RESPONSES"
     display_name: "GPT-5.2 Pro"
     max_tokens: 16384
     temperature: 1.0
@@ -184,6 +186,7 @@ models:
 
   - name: "gpt5pro"
     model_id: "gpt-5-pro"
+    api_format: "RESPONSES"
     display_name: "GPT-5 Pro"
     max_tokens: 16384
     temperature: 1.0

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
@@ -2,9 +2,10 @@
 # openai-models.yml
 # ============================================
 # OpenAI and compatible models configuration
-# Model IDs verified against GET /v1/models on 2026-03-29
+# Model IDs verified against GET /v1/models on 2026-03-29; the GPT-5.5 and
+# GPT-5.6 families against developers.openai.com/api/docs/models on 2026-08-04.
 # Pricing verified against official OpenAI model pages and openai.com/api/pricing
-# on 2026-04-02.
+# on 2026-04-02, and for GPT-5.5/5.6 on 2026-08-04.
 # Note: undated aliases (e.g. "gpt-5.4") resolve to OpenAI's current recommended
 #       pinned version and may change over time. Use dated model IDs in the
 #       OpenAiModels constants if reproducibility is required.
@@ -38,7 +39,78 @@ native_support_defaults:
 
 models:
   # ========================================
-  # GPT-5.4 FAMILY (Current Flagship - March 2026)
+  # GPT-5.6 FAMILY (Current Flagship - July 2026)
+  # Model pages and pricing verified: developers.openai.com 2026-08-04
+  # Tiers are Luna/Terra/Sol, not nano/mini/pro: "pro" became a Responses-only
+  # reasoning MODE (reasoning.mode) rather than a model. All three tiers are
+  # served over both Chat Completions and Responses.
+  # The "gpt-5.6" alias routes to Sol; the tiers are registered by their own ids.
+  # Prices are the short-context tier (<272K); long context is billed higher.
+  # ========================================
+
+  - name: "gpt56sol"
+    model_id: "gpt-5.6-sol"
+    display_name: "GPT-5.6 Sol"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 5.00
+      usd_per1m_output_tokens: 30.00
+    special_handling:
+      supports_temperature: false
+
+  - name: "gpt56terra"
+    model_id: "gpt-5.6-terra"
+    display_name: "GPT-5.6 Terra"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 2.00
+      usd_per1m_output_tokens: 12.00
+    special_handling:
+      supports_temperature: false
+
+  - name: "gpt56luna"
+    model_id: "gpt-5.6-luna"
+    display_name: "GPT-5.6 Luna"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 0.20
+      usd_per1m_output_tokens: 1.20
+    special_handling:
+      supports_temperature: false
+
+  # ========================================
+  # GPT-5.5 FAMILY (June 2026)
+  # Model pages and pricing verified: developers.openai.com 2026-08-04
+  # ========================================
+
+  - name: "gpt55"
+    model_id: "gpt-5.5"
+    display_name: "GPT-5.5"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 5.00
+      usd_per1m_output_tokens: 30.00
+    special_handling:
+      supports_temperature: false
+
+  - name: "gpt55pro"
+    model_id: "gpt-5.5-pro"
+    api_format: "RESPONSES"
+    display_name: "GPT-5.5 Pro"
+    max_tokens: 16384
+    temperature: 1.0
+    pricing_model:
+      usd_per1m_input_tokens: 30.0
+      usd_per1m_output_tokens: 180.0
+    special_handling:
+      supports_temperature: false
+
+  # ========================================
+  # GPT-5.4 FAMILY (March 2026)
   # Pricing verified: openai.com/api/pricing 2026-03-29
   # Cached input (not stored): gpt54=$0.25, gpt54mini=$0.075, gpt54nano=$0.02
   # ========================================

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt53ChatIntegrationIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt53ChatIntegrationIT.kt
@@ -18,12 +18,12 @@ package com.embabel.agent.config.models.openai
 import com.embabel.agent.api.common.Ai
 import com.embabel.agent.api.models.OpenAiModels
 import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.sayReady
 import com.embabel.agent.spi.LlmService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
-import org.opentest4j.TestAbortedException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.test.context.SpringBootTest
@@ -82,16 +82,7 @@ class Gpt53ChatIntegrationIT(
         val llm = findLlm()
 
         // Verify against OpenAI API
-        val response = try {
-
-            ai.withLlm(OpenAiModels.GPT_53_CHAT_LATEST).generateText("Reply with exactly the word READY.").trim()
-        } catch (ex: Exception) {
-
-            if (isModelAccessError(ex)) {
-                throw TestAbortedException("OPENAI_API_KEY is set, but the configured OpenAI project does not have access to ${OpenAiModels.GPT_53_CHAT_LATEST}", ex)
-            }
-            throw ex
-        }
+        val response = sayReady(ai, OpenAiModels.GPT_53_CHAT_LATEST)
 
         assertTrue(response.isNotBlank(), "Expected non-empty response from GPT-5.3 Chat")
         assertTrue(response.contains("READY", ignoreCase = true), "Expected GPT-5.3 Chat to reply with READY, got: $response")
@@ -101,12 +92,6 @@ class Gpt53ChatIntegrationIT(
     private fun findLlm(): LlmService<*>? {
 
         return llms.find { it.name == OpenAiModels.GPT_53_CHAT_LATEST }
-    }
-
-    private fun isModelAccessError(ex: Exception): Boolean {
-        val message = generateSequence<Throwable>(ex) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
-
-        return message.contains("does not have access to model", ignoreCase = true) || message.contains("model_not_found", ignoreCase = true)
     }
 
     override fun toString(): String {

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5MaxTokensIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5MaxTokensIT.kt
@@ -69,14 +69,27 @@ class Gpt5MaxTokensIT(
 
     @Test
     fun `a GPT-5 model accepts a token limit over Chat Completions`() {
-        assertTrue(replyWithLimit(OpenAiModels.GPT_54).isNotBlank())
+        val response = replyWithLimit(OpenAiModels.GPT_54)
+
+        assertTrue(response.contains("READY", ignoreCase = true), "Got: $response")
     }
 
     @Test
     fun `a GPT-5 model accepts a token limit over the Responses API`() {
-        assertTrue(replyWithLimit(OpenAiModels.GPT_5_PRO).isNotBlank())
+        val response = replyWithLimit(OpenAiModels.GPT_5_PRO)
+
+        assertTrue(response.contains("READY", ignoreCase = true), "Got: $response")
     }
 
     private fun replyWithLimit(model: String): String =
-        sayReady(ai, model, LlmOptions.withModel(model).withMaxTokens(2048))
+        sayReady(ai, model, LlmOptions.withModel(model).withMaxTokens(TOKEN_LIMIT))
+
+    private companion object {
+        /**
+         * Generous on purpose: `max_output_tokens` is spent on reasoning too, so a budget sized for
+         * the answer alone comes back truncated — an empty text that reads as a dropped parameter
+         * rather than as the limit doing its job.
+         */
+        const val TOKEN_LIMIT = 8192
+    }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5MaxTokensIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5MaxTokensIT.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.common.ai.model.LlmOptions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.test.context.ActiveProfiles
+
+@Profile("gpt5-max-tokens-test")
+@ConfigurationPropertiesScan(basePackages = ["com.embabel.agent"])
+@ComponentScan(basePackages = ["com.embabel.agent"])
+class Gpt5MaxTokensTestConfig
+
+/**
+ * Exercises a GPT-5 model with a token limit set, against the real API.
+ *
+ * This is the test that was missing. Nothing ever called a GPT-5 model *with* a limit, so nothing
+ * noticed that [com.embabel.agent.openai.Gpt5ChatOptionsConverter] was sending `max_tokens`, which
+ * the whole family refuses:
+ *
+ * `400 Unsupported parameter: 'max_tokens' is not supported with this model.
+ *  Use 'max_completion_tokens' instead.`
+ *
+ * Both transports are covered, because they read the limit from different option fields: gpt-5.4
+ * over Chat Completions, gpt-5-pro over the Responses API.
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=gpt-4o-mini",
+        "embabel.agent.platform.models.openai.max-attempts=1",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("gpt5-max-tokens-test")
+@Import(Gpt5MaxTokensTestConfig::class, AgentOpenAiAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(
+    named = "OPENAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires OPENAI_API_KEY",
+)
+class Gpt5MaxTokensIT(
+    @param:Autowired private val ai: Ai,
+) {
+
+    @Test
+    fun `a GPT-5 model accepts a token limit over Chat Completions`() {
+        assertTrue(replyWithLimit(OpenAiModels.GPT_54).isNotBlank())
+    }
+
+    @Test
+    fun `a GPT-5 model accepts a token limit over the Responses API`() {
+        assertTrue(replyWithLimit(OpenAiModels.GPT_5_PRO).isNotBlank())
+    }
+
+    private fun replyWithLimit(model: String): String =
+        ai.withLlm(LlmOptions.withModel(model).withMaxTokens(2048))
+            .generateText("Reply with exactly the word READY.")
+            .trim()
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5MaxTokensIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5MaxTokensIT.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.config.models.openai
 import com.embabel.agent.api.common.Ai
 import com.embabel.agent.api.models.OpenAiModels
 import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.sayReady
 import com.embabel.common.ai.model.LlmOptions
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -77,7 +78,5 @@ class Gpt5MaxTokensIT(
     }
 
     private fun replyWithLimit(model: String): String =
-        ai.withLlm(LlmOptions.withModel(model).withMaxTokens(2048))
-            .generateText("Reply with exactly the word READY.")
-            .trim()
+        sayReady(ai, model, LlmOptions.withModel(model).withMaxTokens(2048))
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ProResponsesApiIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ProResponsesApiIT.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.spi.LlmService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.opentest4j.TestAbortedException
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.test.context.ActiveProfiles
+
+@Profile("gpt5-pro-test")
+@ConfigurationPropertiesScan(
+    basePackages = [
+        "com.embabel.agent",
+        "com.embabel.example",
+    ]
+)
+@ComponentScan(
+    basePackages = [
+        "com.embabel.agent",
+        "com.embabel.example",
+    ]
+)
+class Gpt5ProTestConfig
+
+/**
+ * Exercises a model that OpenAI serves only over the Responses API, against the real endpoint.
+ *
+ * This is the test that was missing: the `*-pro` models were declared in the catalog and the build
+ * stayed green, because nothing ever called them. Every real call returned HTTP 400 until
+ * [com.embabel.agent.openai.OpenAiResponsesChatModel] was routed in.
+ *
+ * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=gpt-5-pro",
+        "embabel.agent.platform.models.openai.max-attempts=1",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("gpt5-pro-test")
+@Import(Gpt5ProTestConfig::class, AgentOpenAiAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+", disabledReason = "Integration test requires OPENAI_API_KEY")
+class Gpt5ProResponsesApiIT(
+    @param:Autowired private val ai: Ai,
+    @param:Autowired private val llms: List<LlmService<*>>,
+    @param:Autowired private val applicationContext: ApplicationContext,
+) {
+
+    @Test
+    fun `registers gpt5pro bean`() {
+        assertTrue(applicationContext.containsBean("gpt5pro"), "Expected gpt5pro bean to be registered")
+        assertTrue(findLlm() != null, "Expected GPT-5 Pro LLM service to be registered")
+    }
+
+    @Test
+    fun `calls the real Responses API`() {
+        val response = try {
+            ai.withLlm(OpenAiModels.GPT_5_PRO).generateText("Reply with exactly the word READY.").trim()
+        } catch (ex: Exception) {
+            if (isModelAccessError(ex)) {
+                throw TestAbortedException(
+                    "OPENAI_API_KEY is set, but the configured OpenAI project does not have access to " +
+                        OpenAiModels.GPT_5_PRO,
+                    ex,
+                )
+            }
+            throw ex
+        }
+
+        assertTrue(response.isNotBlank(), "Expected non-empty response from GPT-5 Pro")
+        assertTrue(response.contains("READY", ignoreCase = true), "Expected GPT-5 Pro to reply with READY, got: $response")
+        assertEquals(OpenAiModels.GPT_5_PRO, findLlm()?.name)
+    }
+
+    private fun findLlm(): LlmService<*>? = llms.find { it.name == OpenAiModels.GPT_5_PRO }
+
+    private fun isModelAccessError(ex: Exception): Boolean {
+        val message = generateSequence<Throwable>(ex) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
+
+        return message.contains("does not have access to model", ignoreCase = true) ||
+            message.contains("model_not_found", ignoreCase = true)
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ProResponsesApiIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ProResponsesApiIT.kt
@@ -53,7 +53,7 @@ class Gpt5ProTestConfig
  *
  * This is the test that was missing: the `*-pro` models were declared in the catalog and the build
  * stayed green, because nothing ever called them. Every real call returned HTTP 400 until
- * [com.embabel.agent.openai.OpenAiResponsesChatModel] was routed in.
+ * [OpenAiResponsesChatModel] was routed in.
  *
  * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
  */

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ProResponsesApiIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ProResponsesApiIT.kt
@@ -18,12 +18,12 @@ package com.embabel.agent.config.models.openai
 import com.embabel.agent.api.common.Ai
 import com.embabel.agent.api.models.OpenAiModels
 import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.sayReady
 import com.embabel.agent.spi.LlmService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
-import org.opentest4j.TestAbortedException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.test.context.SpringBootTest
@@ -81,18 +81,7 @@ class Gpt5ProResponsesApiIT(
 
     @Test
     fun `calls the real Responses API`() {
-        val response = try {
-            ai.withLlm(OpenAiModels.GPT_5_PRO).generateText("Reply with exactly the word READY.").trim()
-        } catch (ex: Exception) {
-            if (isModelAccessError(ex)) {
-                throw TestAbortedException(
-                    "OPENAI_API_KEY is set, but the configured OpenAI project does not have access to " +
-                        OpenAiModels.GPT_5_PRO,
-                    ex,
-                )
-            }
-            throw ex
-        }
+        val response = sayReady(ai, OpenAiModels.GPT_5_PRO)
 
         assertTrue(response.isNotBlank(), "Expected non-empty response from GPT-5 Pro")
         assertTrue(response.contains("READY", ignoreCase = true), "Expected GPT-5 Pro to reply with READY, got: $response")
@@ -100,11 +89,4 @@ class Gpt5ProResponsesApiIT(
     }
 
     private fun findLlm(): LlmService<*>? = llms.find { it.name == OpenAiModels.GPT_5_PRO }
-
-    private fun isModelAccessError(ex: Exception): Boolean {
-        val message = generateSequence<Throwable>(ex) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
-
-        return message.contains("does not have access to model", ignoreCase = true) ||
-            message.contains("model_not_found", ignoreCase = true)
-    }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5SamplingParamsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5SamplingParamsIT.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.sayReady
+import com.embabel.common.ai.model.LlmOptions
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.test.context.ActiveProfiles
+
+@Profile("gpt5-sampling-params-test")
+@ConfigurationPropertiesScan(basePackages = ["com.embabel.agent"])
+@ComponentScan(basePackages = ["com.embabel.agent"])
+class Gpt5SamplingParamsTestConfig
+
+/**
+ * Exercises GPT-5 models with sampling parameters set, against the real API.
+ *
+ * The token limit was not the only field the family refuses. Most GPT-5 models reject the sampling
+ * parameters too — as a block, each for its presence alone:
+ *
+ * `400 Unsupported parameter: 'top_p' is not supported with this model.`
+ *
+ * and the converter used to forward `top_p` and both penalties to every one of them. Nothing
+ * noticed, because nothing called a GPT-5 model *with* a sampling parameter set.
+ *
+ * The refusal is per model rather than per family — gpt-5.1, gpt-5.2 and the gpt-5.4 tiers do
+ * accept these parameters — so both sides are called here: the strict models must stop refusing,
+ * and the permissive ones must keep answering now that the parameters are dropped for the family as
+ * a whole. The cheapest model on each side is used: these tests assert that a request is accepted,
+ * and the answer's content is beside the point.
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=gpt-4o-mini",
+        "embabel.agent.platform.models.openai.max-attempts=1",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("gpt5-sampling-params-test")
+@Import(Gpt5SamplingParamsTestConfig::class, AgentOpenAiAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(
+    named = "OPENAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires OPENAI_API_KEY",
+)
+class Gpt5SamplingParamsIT(
+    @param:Autowired private val ai: Ai,
+) {
+
+    @Test
+    fun `a GPT-5 model that refuses sampling parameters answers once they are dropped`() {
+        val response = replyWithSamplingParameters(OpenAiModels.GPT_5_NANO)
+
+        assertTrue(response.contains("READY", ignoreCase = true), "Got: $response")
+    }
+
+    @Test
+    fun `a GPT-5 model that accepts them is unharmed by their absence`() {
+        val response = replyWithSamplingParameters(OpenAiModels.GPT_54_NANO)
+
+        assertTrue(response.contains("READY", ignoreCase = true), "Got: $response")
+    }
+
+    /**
+     * Every sampling parameter at once, each with a value the strict models refuse: a converter that
+     * lets a single one through fails here rather than in front of a user.
+     */
+    private fun replyWithSamplingParameters(model: String): String =
+        sayReady(
+            ai,
+            model,
+            LlmOptions.withModel(model)
+                .withTemperature(0.5)
+                .withTopP(0.2)
+                .withPresencePenalty(0.6)
+                .withFrequencyPenalty(0.4)
+                // Reasoning tokens are spent from this budget too, so a limit sized for the answer
+                // alone comes back empty — see Gpt5MaxTokensIT.
+                .withMaxTokens(8192),
+        )
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiCatalogIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiCatalogIT.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.sayReady
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.openai.client.okhttp.OpenAIOkHttpClient
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.test.context.ActiveProfiles
+
+@Profile("openai-catalog-test")
+@ConfigurationPropertiesScan(basePackages = ["com.embabel.agent"])
+@ComponentScan(basePackages = ["com.embabel.agent"])
+class OpenAiCatalogTestConfig
+
+/**
+ * Holds the shipped catalog against the real OpenAI API.
+ *
+ * The unit tests prove the catalog is *read* as written; nothing until here proves it describes
+ * models that exist. That gap is how `*-pro` shipped broken — declared, never called, build green.
+ * Every entry added since carries the same risk, so the two claims a catalog entry makes are
+ * checked against the provider: that the id resolves, and that the declared transport works.
+ *
+ * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=gpt-4o-mini",
+        "embabel.agent.platform.models.openai.max-attempts=1",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("openai-catalog-test")
+@Import(OpenAiCatalogTestConfig::class, AgentOpenAiAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(
+    named = "OPENAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires OPENAI_API_KEY",
+)
+class OpenAiCatalogIT(
+    @param:Autowired private val ai: Ai,
+    @param:Autowired private val llms: List<LlmService<*>>,
+    @param:Autowired private val applicationContext: ApplicationContext,
+) {
+
+    /**
+     * One `GET /v1/models` covers the whole catalog, so a typo in any entry is caught without
+     * calling that model — the cheapest coverage available for the thing most easily got wrong.
+     */
+    @Nested
+    inner class ModelIdsResolve {
+
+        @Test
+        fun `every catalog model id is one OpenAI serves`() {
+            val definitions = OpenAiModelLoader().loadAutoConfigMetadata()
+            val declared = definitions.effectiveModels().map { it.modelId } +
+                definitions.embeddingModels.map { it.modelId }
+
+            val client = OpenAIOkHttpClient.builder()
+                .apiKey(System.getenv("OPENAI_API_KEY"))
+                .build()
+            val served = client.models().list().autoPager().map { it.id() }.toSet()
+
+            val unknown = declared.filterNot { it in served }
+
+            assertTrue(
+                unknown.isEmpty(),
+                "Catalog ids OpenAI does not serve for this project — a typo, a retired model, " +
+                    "or one this project is not entitled to: $unknown",
+            )
+        }
+    }
+
+    /**
+     * The families added on 2026-08-04, none of which had ever been called. Parameterized rather
+     * than one class per model: they differ only by id, and the pro entry — the one whose
+     * transport is unusual — earns nothing from being spelled out separately.
+     */
+    @Nested
+    inner class NewFamiliesAnswer {
+
+        @ParameterizedTest(name = "{0} answers over its declared transport")
+        @ValueSource(
+            strings = [
+                "gpt-5.6-sol",
+                "gpt-5.6-terra",
+                "gpt-5.6-luna",
+                "gpt-5.5",
+                // Responses-only: Chat Completions is "Not supported" for this one.
+                "gpt-5.5-pro",
+            ]
+        )
+        fun `the model replies over the transport the catalog declares`(model: String) {
+            val response = sayReady(ai, model)
+
+            assertTrue(
+                response.contains("READY", ignoreCase = true),
+                "Expected $model to reply READY, got: $response",
+            )
+        }
+
+        @ParameterizedTest(name = "{0} is registered")
+        @ValueSource(strings = ["gpt56sol", "gpt56terra", "gpt56luna", "gpt55", "gpt55pro"])
+        fun `the catalog entry becomes a bean`(beanName: String) {
+            assertTrue(
+                applicationContext.containsBean(beanName),
+                "Expected $beanName to be registered from the catalog",
+            )
+        }
+
+        /** The pro tier is the only new model whose transport differs; pin what it was wired onto. */
+        @Test
+        fun `the pro tier is wired onto the Responses adapter`() {
+            val llm = llms.find { it.name == "gpt-5.5-pro" } as? SpringAiLlmService
+
+            assertInstanceOf(
+                OpenAiResponsesChatModel::class.java,
+                llm?.chatModel,
+                "gpt-5.5-pro on the Chat Completions client fails on every call",
+            )
+        }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiCatalogIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiCatalogIT.kt
@@ -18,12 +18,8 @@ package com.embabel.agent.config.models.openai
 import com.embabel.agent.api.common.Ai
 import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
 import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.sayReady
-import com.embabel.agent.spi.LlmService
-import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.openai.client.okhttp.OpenAIOkHttpClient
-import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.junit.jupiter.params.ParameterizedTest
@@ -31,7 +27,6 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Profile
@@ -68,85 +63,60 @@ class OpenAiCatalogTestConfig
 )
 class OpenAiCatalogIT(
     @param:Autowired private val ai: Ai,
-    @param:Autowired private val llms: List<LlmService<*>>,
-    @param:Autowired private val applicationContext: ApplicationContext,
 ) {
 
     /**
      * One `GET /v1/models` covers the whole catalog, so a typo in any entry is caught without
-     * calling that model — the cheapest coverage available for the thing most easily got wrong.
+     * calling that model: the cheapest coverage available for the thing most easily got wrong.
+     *
+     * Deliberately built on a bare client rather than the configured one. The question here is what
+     * OpenAI serves, not what a custom base URL would answer.
      */
-    @Nested
-    inner class ModelIdsResolve {
+    @Test
+    fun `every catalog model id is one OpenAI serves`() {
+        val definitions = OpenAiModelLoader().loadAutoConfigMetadata()
+        val declared = definitions.effectiveModels().map { it.modelId } +
+            definitions.embeddingModels.map { it.modelId }
 
-        @Test
-        fun `every catalog model id is one OpenAI serves`() {
-            val definitions = OpenAiModelLoader().loadAutoConfigMetadata()
-            val declared = definitions.effectiveModels().map { it.modelId } +
-                definitions.embeddingModels.map { it.modelId }
+        val client = OpenAIOkHttpClient.builder()
+            .apiKey(System.getenv("OPENAI_API_KEY"))
+            .build()
+        val served = client.models().list().autoPager().map { it.id() }.toSet()
 
-            val client = OpenAIOkHttpClient.builder()
-                .apiKey(System.getenv("OPENAI_API_KEY"))
-                .build()
-            val served = client.models().list().autoPager().map { it.id() }.toSet()
+        val unknown = declared.filterNot { it in served }
 
-            val unknown = declared.filterNot { it in served }
-
-            assertTrue(
-                unknown.isEmpty(),
-                "Catalog ids OpenAI does not serve for this project — a typo, a retired model, " +
-                    "or one this project is not entitled to: $unknown",
-            )
-        }
+        assertTrue(
+            unknown.isEmpty(),
+            "Catalog ids OpenAI does not serve for this project. Either a typo, a retired model, " +
+                "or one this project is not entitled to: $unknown",
+        )
     }
 
     /**
-     * The families added on 2026-08-04, none of which had ever been called. Parameterized rather
-     * than one class per model: they differ only by id, and the pro entry — the one whose
-     * transport is unusual — earns nothing from being spelled out separately.
+     * The GPT-5.5 and GPT-5.6 entries, none of which had ever been called. A wrong transport is a
+     * hard failure rather than a wrong answer, so a reply at all is the assertion that matters:
+     * `gpt-5.5-pro` on Chat Completions never returns one.
+     *
+     * That the entries register and route correctly is unit-tested in `OpenAiModelsConfigRoutingTest`,
+     * which needs neither a key nor a network and therefore runs on every build.
      */
-    @Nested
-    inner class NewFamiliesAnswer {
+    @ParameterizedTest(name = "{0} answers over its declared transport")
+    @ValueSource(
+        strings = [
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+            "gpt-5.5",
+            // Responses-only: Chat Completions is "Not supported" for this one.
+            "gpt-5.5-pro",
+        ]
+    )
+    fun `each new model replies over the transport the catalog declares`(model: String) {
+        val response = sayReady(ai, model)
 
-        @ParameterizedTest(name = "{0} answers over its declared transport")
-        @ValueSource(
-            strings = [
-                "gpt-5.6-sol",
-                "gpt-5.6-terra",
-                "gpt-5.6-luna",
-                "gpt-5.5",
-                // Responses-only: Chat Completions is "Not supported" for this one.
-                "gpt-5.5-pro",
-            ]
+        assertTrue(
+            response.contains("READY", ignoreCase = true),
+            "Expected $model to reply READY, got: $response",
         )
-        fun `the model replies over the transport the catalog declares`(model: String) {
-            val response = sayReady(ai, model)
-
-            assertTrue(
-                response.contains("READY", ignoreCase = true),
-                "Expected $model to reply READY, got: $response",
-            )
-        }
-
-        @ParameterizedTest(name = "{0} is registered")
-        @ValueSource(strings = ["gpt56sol", "gpt56terra", "gpt56luna", "gpt55", "gpt55pro"])
-        fun `the catalog entry becomes a bean`(beanName: String) {
-            assertTrue(
-                applicationContext.containsBean(beanName),
-                "Expected $beanName to be registered from the catalog",
-            )
-        }
-
-        /** The pro tier is the only new model whose transport differs; pin what it was wired onto. */
-        @Test
-        fun `the pro tier is wired onto the Responses adapter`() {
-            val llm = llms.find { it.name == "gpt-5.5-pro" } as? SpringAiLlmService
-
-            assertInstanceOf(
-                OpenAiResponsesChatModel::class.java,
-                llm?.chatModel,
-                "gpt-5.5-pro on the Chat Completions client fails on every call",
-            )
-        }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiIntegrationSupport.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiIntegrationSupport.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.common.ai.model.LlmOptions
+import org.opentest4j.TestAbortedException
+
+/**
+ * Shared plumbing for the integration tests that call the real OpenAI API.
+ *
+ * A key that works is not a key entitled to every model: access is granted per project, and the
+ * pro tiers routinely are not. Left unhandled that reads as a broken build rather than an
+ * unentitled project, so it is skipped rather than failed — and only for that one reason, so a
+ * genuine breakage still fails.
+ */
+object OpenAiIntegrationSupport {
+
+    /** Short and unambiguous: any drift in the answer is the model's, not the prompt's. */
+    const val READY_PROMPT = "Reply with exactly the word READY."
+
+    /**
+     * Calls [model] with [READY_PROMPT], skipping the test if the project cannot reach it.
+     *
+     * @param options extra request options, e.g. a token limit
+     */
+    fun sayReady(ai: Ai, model: String, options: LlmOptions = LlmOptions.withModel(model)): String =
+        try {
+            ai.withLlm(options).generateText(READY_PROMPT).trim()
+        } catch (ex: Exception) {
+            if (isModelAccessError(ex)) {
+                throw TestAbortedException(
+                    "OPENAI_API_KEY is set, but the configured OpenAI project has no access to $model",
+                    ex,
+                )
+            }
+            throw ex
+        }
+
+    /** The whole cause chain is searched: the provider error arrives wrapped by the retry layer. */
+    fun isModelAccessError(ex: Exception): Boolean {
+        val message = generateSequence<Throwable>(ex) { it.cause }
+            .mapNotNull { it.message }
+            .joinToString(" | ")
+
+        return message.contains("does not have access to model", ignoreCase = true) ||
+            message.contains("model_not_found", ignoreCase = true)
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
@@ -651,7 +651,7 @@ class OpenAiModelLoaderTest {
             val byFormat = models.groupBy({ it.apiFormat }, { it.modelId })
 
             assertEquals(
-                setOf("gpt-5-pro", "gpt-5.2-pro", "gpt-5.4-pro"),
+                setOf("gpt-5-pro", "gpt-5.2-pro", "gpt-5.4-pro", "gpt-5.5-pro"),
                 byFormat[OpenAiApiFormat.RESPONSES].orEmpty().toSet(),
                 "Only the *-pro models are served over /v1/responses",
             )
@@ -663,6 +663,27 @@ class OpenAiModelLoaderTest {
                 models.size,
                 byFormat.values.sumOf { it.size },
                 "Every catalog model resolves to a transport",
+            )
+        }
+
+        /**
+         * GPT-5.6 dropped the `-pro` suffix — its tiers are Luna/Terra/Sol and "pro" became a
+         * Responses-only *reasoning mode*, not a model. The suffix guard above therefore says
+         * nothing about them, so their transport is pinned by name.
+         */
+        @Test
+        fun `the GPT-5_6 tiers stay on Chat Completions, which they all support`() {
+            val models = OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels()
+                .filter { it.modelId.startsWith("gpt-5.6") }
+                .associate { it.modelId to it.apiFormat }
+
+            assertEquals(
+                mapOf(
+                    "gpt-5.6-sol" to OpenAiApiFormat.CHAT_COMPLETIONS,
+                    "gpt-5.6-terra" to OpenAiApiFormat.CHAT_COMPLETIONS,
+                    "gpt-5.6-luna" to OpenAiApiFormat.CHAT_COMPLETIONS,
+                ),
+                models,
             )
         }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
@@ -630,6 +630,105 @@ class OpenAiModelLoaderTest {
         assertTrue(result.embeddingModels.isEmpty(), "Should fail validation for negative pricing")
     }
 
+    /**
+     * The transport a model is served over, declared per model rather than inferred from its id.
+     *
+     * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
+     */
+    @Nested
+    inner class ApiFormatTests {
+
+        /**
+         * Pins the catalog contract the routing depends on: exactly the `*-pro` models ask for the
+         * Responses API, and every other model keeps the Chat Completions path it has today. A model
+         * added to the wrong bucket is a production outage — either a 404 on every call, or a working
+         * model silently rerouted onto an adapter it was never exercised against.
+         */
+        @Test
+        fun `shipped catalog routes the pro models to Responses and everything else to Chat Completions`() {
+            val models = OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels()
+
+            val byFormat = models.groupBy({ it.apiFormat }, { it.modelId })
+
+            assertEquals(
+                setOf("gpt-5-pro", "gpt-5.2-pro", "gpt-5.4-pro"),
+                byFormat[OpenAiApiFormat.RESPONSES].orEmpty().toSet(),
+                "Only the *-pro models are served over /v1/responses",
+            )
+            assertTrue(
+                byFormat[OpenAiApiFormat.CHAT_COMPLETIONS].orEmpty().none { it.endsWith("-pro") },
+                "No *-pro model may keep the Chat Completions path: every call 404s",
+            )
+            assertEquals(
+                models.size,
+                byFormat.values.sumOf { it.size },
+                "Every catalog model resolves to a transport",
+            )
+        }
+
+        /**
+         * The field is additive. Catalogs written before it existed — including the ones users
+         * override `embabel.agent.platform.models.openai` with — must keep working unchanged.
+         */
+        @Test
+        fun `model without api_format falls back to Chat Completions`() {
+            val tempYaml = createTempYamlFile(
+                """
+                models:
+                  - name: legacy-model
+                    model_id: gpt-legacy
+                """.trimIndent()
+            )
+
+            val loader = OpenAiModelLoader(tempYaml.resourceLoader, tempYaml.configPath)
+
+            assertEquals(
+                OpenAiApiFormat.CHAT_COMPLETIONS,
+                loader.loadAutoConfigMetadata().effectiveModels().single().apiFormat,
+            )
+        }
+
+        @Test
+        fun `api_format is read from YAML`() {
+            val tempYaml = createTempYamlFile(
+                """
+                models:
+                  - name: responses-model
+                    model_id: gpt-responses
+                    api_format: RESPONSES
+                  - name: chat-model
+                    model_id: gpt-chat
+                    api_format: CHAT_COMPLETIONS
+                """.trimIndent()
+            )
+
+            val loader = OpenAiModelLoader(tempYaml.resourceLoader, tempYaml.configPath)
+            val models = loader.loadAutoConfigMetadata().effectiveModels().associateBy { it.modelId }
+
+            assertEquals(OpenAiApiFormat.RESPONSES, models["gpt-responses"]?.apiFormat)
+            assertEquals(OpenAiApiFormat.CHAT_COMPLETIONS, models["gpt-chat"]?.apiFormat)
+        }
+
+        /**
+         * The pro models reject any temperature but the default, so the transport switch must not
+         * cost them the [Gpt5ChatOptionsConverter] selection that `createOpenAiLlm` keys off.
+         */
+        @Test
+        fun `pro models keep their existing special handling`() {
+            val models = OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels()
+                .filter { it.apiFormat == OpenAiApiFormat.RESPONSES }
+
+            assertTrue(models.isNotEmpty(), "Guard against the filter silently matching nothing")
+            models.forEach {
+                assertEquals(
+                    false,
+                    it.specialHandling?.supportsTemperature,
+                    "${it.modelId} must stay on the no-temperature converter",
+                )
+            }
+        }
+    }
+
     private data class TempYamlResource(
         val resourceLoader: ResourceLoader,
         val configPath: String,

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
@@ -16,40 +16,509 @@
 package com.embabel.agent.config.models.openai
 
 import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
 import org.springframework.core.io.ByteArrayResource
+import org.springframework.core.io.DefaultResourceLoader
 import org.springframework.core.io.ResourceLoader
+import java.time.LocalDate
 
 class OpenAiModelLoaderTest {
+
+    /**
+     * The catalogue we actually ship, in `src/main/resources/models/openai-models.yml`.
+     *
+     * Every assertion here starts by proving the catalogue is non-empty. The loader answers a
+     * missing or unparseable file with an *empty* provider rather than an exception, so a test
+     * that iterates the catalogue without that guard stays green after the file is deleted,
+     * renamed, or broken — it asserts nothing at all.
+     */
+    @Nested
+    inner class ShippedCatalogue {
+
+        @Test
+        fun `loads model definitions with non-blank names and ids`() {
+            assertTrue(shippedCatalogue.models.isNotEmpty(), "Should load at least one model")
+
+            shippedCatalogue.models.forEach { model ->
+                assertTrue(model.name.isNotBlank(), "Model name should not be blank")
+                assertTrue(model.modelId.isNotBlank(), "Model ID should not be blank for ${model.name}")
+            }
+        }
+
+        @Test
+        fun `every model carries values inside the ranges the loader validates`() {
+            assertTrue(shippedCatalogue.models.isNotEmpty(), "Guard against asserting over an empty catalogue")
+
+            shippedCatalogue.models.forEach { model ->
+                assertTrue(model.maxTokens > 0, "Max tokens should be positive for ${model.name}")
+                assertTrue(model.temperature in 0.0..2.0, "Temperature should be in valid range for ${model.name}")
+                model.topP?.let {
+                    assertTrue(it in 0.0..1.0, "Top P should be between 0 and 1 for ${model.name}")
+                }
+            }
+        }
+
+        @Test
+        fun `known models are present and priced`() {
+            val modelNames = shippedCatalogue.models.map { it.name }
+            assertTrue(modelNames.contains("gpt53chat"), "Should include GPT-5.3 Chat")
+
+            assertTrue(
+                shippedCatalogue.models.any { it.pricingModel != null },
+                "At least one model should have pricing information",
+            )
+        }
+
+        /**
+         * The whole GPT-5 line rejects any temperature but the default, and `createOpenAiLlm` keys
+         * the [Gpt5ChatOptionsConverter] selection off this flag. A model shipped without it sends
+         * a temperature OpenAI will reject.
+         */
+        @Test
+        fun `every GPT-5 model declares that it does not support temperature`() {
+            val gpt5Models = shippedCatalogue.models.filter { it.name.startsWith("gpt5") }
+            assertTrue(gpt5Models.isNotEmpty(), "Should have GPT-5 models")
+
+            gpt5Models.forEach { model ->
+                assertNotNull(model.specialHandling, "GPT-5 models should have special handling")
+                assertEquals(
+                    false,
+                    model.specialHandling?.supportsTemperature,
+                    "GPT-5 models should not support temperature adjustment",
+                )
+            }
+        }
+
+        @Test
+        fun `embedding models are loaded with positive dimensions`() {
+            assertTrue(shippedCatalogue.embeddingModels.isNotEmpty(), "Should load at least one embedding model")
+
+            shippedCatalogue.embeddingModels.forEach { embedding ->
+                assertTrue(embedding.name.isNotBlank(), "Embedding name should not be blank")
+                assertTrue(embedding.modelId.isNotBlank(), "Embedding model ID should not be blank")
+                val dimensions = assertPresent(
+                    embedding.dimensions,
+                    "Dimensions should not be null for ${embedding.name}",
+                )
+                assertTrue(dimensions > 0, "Dimensions should be positive for ${embedding.name}")
+            }
+        }
+
+        @Test
+        fun `embedding pricing is non-negative`() {
+            assertTrue(shippedCatalogue.embeddingModels.isNotEmpty(), "Guard against asserting over an empty list")
+
+            shippedCatalogue.embeddingModels.forEach { embedding ->
+                embedding.pricingModel?.let { pricing ->
+                    assertTrue(
+                        pricing.usdPer1mTokens >= 0.0,
+                        "Pricing should be non-negative for ${embedding.name}",
+                    )
+                }
+            }
+        }
+    }
+
+    @Nested
+    inner class ModelParsing {
+
+        @Test
+        fun `loads a model with all optional fields`() {
+            val result = loaderFor(
+                """
+                models:
+                  - name: test-model
+                    model_id: gpt-test
+                    display_name: Test Model
+                    knowledge_cutoff_date: 2026-01-31
+                    max_tokens: 4096
+                    temperature: 0.7
+                    top_p: 0.9
+                    special_handling:
+                      supports_temperature: false
+                    pricing_model:
+                      usd_per1m_input_tokens: 10.0
+                      usd_per1m_output_tokens: 20.0
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            val model = assertSingleModel(result)
+            assertEquals("test-model", model.name)
+            assertEquals("gpt-test", model.modelId)
+            assertEquals("Test Model", model.displayName)
+            assertEquals(LocalDate.of(2026, 1, 31), model.knowledgeCutoffDate)
+            assertEquals(4096, model.maxTokens)
+            assertEquals(0.7, model.temperature)
+            assertEquals(0.9, model.topP)
+            assertEquals(false, model.specialHandling?.supportsTemperature)
+            assertEquals(10.0, model.pricingModel?.usdPer1mInputTokens)
+            assertEquals(20.0, model.pricingModel?.usdPer1mOutputTokens)
+        }
+
+        @Test
+        fun `applies documented defaults to a model with minimal fields`() {
+            val result = loaderFor(
+                """
+                models:
+                  - name: minimal-model
+                    model_id: gpt-minimal
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            val model = assertSingleModel(result)
+            assertEquals("minimal-model", model.name)
+            assertEquals("gpt-minimal", model.modelId)
+            assertNull(model.displayName)
+            assertNull(model.knowledgeCutoffDate)
+            assertEquals(16384, model.maxTokens) // Default value
+            assertEquals(1.0, model.temperature) // Default value
+            assertNull(model.topP)
+            assertNull(model.specialHandling)
+            assertNull(model.pricingModel)
+        }
+
+        @Test
+        fun `loads multiple models in declaration order`() {
+            val result = loaderFor(
+                """
+                models:
+                  - name: model-1
+                    model_id: gpt-1
+                    max_tokens: 2000
+                  - name: model-2
+                    model_id: gpt-2
+                    max_tokens: 4000
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            assertEquals(listOf("model-1", "model-2"), result.models.map { it.name })
+            assertEquals(listOf(2000, 4000), result.models.map { it.maxTokens })
+        }
+
+        @Test
+        fun `loads both LLM and embedding models from the same file`() {
+            val result = loaderFor(
+                """
+                models:
+                  - name: llm-1
+                    model_id: gpt-test-1
+                    max_tokens: 4096
+                  - name: llm-2
+                    model_id: gpt-test-2
+                    max_tokens: 8192
+                embedding_models:
+                  - name: embedding-1
+                    model_id: text-embedding-1
+                    dimensions: 1536
+                  - name: embedding-2
+                    model_id: text-embedding-2
+                    dimensions: 3072
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            assertEquals(2, result.models.size, "Should load 2 LLM models")
+            assertEquals(2, result.embeddingModels.size, "Should load 2 embedding models")
+        }
+
+        @Test
+        fun `an empty model list is not an error`() {
+            val result = loaderFor("models: []").loadAutoConfigMetadata()
+
+            assertTrue(result.models.isEmpty())
+            assertTrue(result.embeddingModels.isEmpty())
+        }
+    }
+
+    @Nested
+    inner class EmbeddingModelParsing {
+
+        @Test
+        fun `loads an embedding model with all fields`() {
+            val result = loaderFor(
+                """
+                embedding_models:
+                  - name: test-embedding
+                    model_id: text-embedding-test
+                    display_name: Test Embedding
+                    dimensions: 1536
+                    pricing_model:
+                      usd_per1m_tokens: 0.02
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            assertEquals(1, result.embeddingModels.size)
+            val embedding = result.embeddingModels.first()
+            assertEquals("test-embedding", embedding.name)
+            assertEquals("text-embedding-test", embedding.modelId)
+            assertEquals("Test Embedding", embedding.displayName)
+            assertEquals(1536, embedding.dimensions)
+            assertEquals(0.02, embedding.pricingModel?.usdPer1mTokens)
+        }
+
+        @Test
+        fun `loads multiple embedding models in declaration order`() {
+            val result = loaderFor(
+                """
+                embedding_models:
+                  - name: embedding-1
+                    model_id: text-embedding-1
+                    dimensions: 1536
+                  - name: embedding-2
+                    model_id: text-embedding-2
+                    dimensions: 3072
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            assertEquals(listOf("embedding-1", "embedding-2"), result.embeddingModels.map { it.name })
+            assertEquals(listOf(1536, 3072), result.embeddingModels.map { it.dimensions })
+        }
+    }
+
+    /**
+     * Validation is all-or-nothing and *silent*: [OpenAiModelLoader.validateModels] throws on the
+     * first offending entry, and the loader answers by logging and returning an empty provider.
+     * One bad line in a user override therefore costs every model in the file, not just its own —
+     * so each case below is asserted against a file that also contains a valid model, otherwise
+     * `models.isEmpty()` would prove nothing about the blast radius.
+     */
+    @Nested
+    inner class Validation {
+
+        @Test
+        fun `one invalid model discards every model in the file`() {
+            val result = loaderFor(
+                """
+                models:
+                  - name: perfectly-good-model
+                    model_id: gpt-good
+                  - name: bad-model
+                    model_id: gpt-bad
+                    max_tokens: -100
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            assertTrue(
+                result.models.isEmpty(),
+                "A single invalid model must not leave a partially loaded catalogue behind",
+            )
+        }
+
+        @Test
+        fun `one invalid embedding model also discards the LLM models`() {
+            val result = loaderFor(
+                """
+                models:
+                  - name: perfectly-good-model
+                    model_id: gpt-good
+                embedding_models:
+                  - name: bad-embedding
+                    model_id: text-embedding-bad
+                    dimensions: -100
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            assertTrue(result.models.isEmpty(), "Validation failure is file-wide, not per-section")
+            assertTrue(result.embeddingModels.isEmpty())
+        }
+
+        @Test
+        fun `rejects negative maxTokens`() {
+            assertModelRejected(
+                """
+                - name: test-model
+                  model_id: gpt-test
+                  max_tokens: -100
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        fun `rejects temperature above the supported range`() {
+            assertModelRejected(
+                """
+                - name: test-model
+                  model_id: gpt-test
+                  temperature: 3.0
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        fun `rejects topP above the supported range`() {
+            assertModelRejected(
+                """
+                - name: test-model
+                  model_id: gpt-test
+                  top_p: 1.5
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        fun `rejects a blank model name`() {
+            assertModelRejected(
+                """
+                - name: ""
+                  model_id: gpt-test
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        fun `rejects a blank model id`() {
+            assertModelRejected(
+                """
+                - name: test-model
+                  model_id: ""
+                """.trimIndent()
+            )
+        }
+
+        /**
+         * Negative pricing is caught for embedding models, so it must be caught here too:
+         * a negative rate silently turns cost accounting into a credit.
+         */
+        @Test
+        fun `rejects negative LLM input pricing`() {
+            assertModelRejected(
+                """
+                - name: test-model
+                  model_id: gpt-test
+                  pricing_model:
+                    usd_per1m_input_tokens: -5.0
+                    usd_per1m_output_tokens: 20.0
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        fun `rejects negative LLM output pricing`() {
+            assertModelRejected(
+                """
+                - name: test-model
+                  model_id: gpt-test
+                  pricing_model:
+                    usd_per1m_input_tokens: 5.0
+                    usd_per1m_output_tokens: -20.0
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        fun `rejects negative embedding dimensions`() {
+            assertEmbeddingRejected(
+                """
+                - name: test-embedding
+                  model_id: text-embedding-test
+                  dimensions: -100
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        fun `rejects a blank embedding name`() {
+            assertEmbeddingRejected(
+                """
+                - name: ""
+                  model_id: text-embedding-test
+                  dimensions: 1536
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        fun `rejects negative embedding pricing`() {
+            assertEmbeddingRejected(
+                """
+                - name: test-embedding
+                  model_id: text-embedding-test
+                  dimensions: 1536
+                  pricing_model:
+                    usd_per1m_tokens: -0.5
+                """.trimIndent()
+            )
+        }
+
+        private fun assertModelRejected(invalidEntry: String) {
+            assertRejected(CANARY_MODEL + "\n" + invalidEntry.prependIndent("  "))
+        }
+
+        private fun assertEmbeddingRejected(invalidEntry: String) {
+            assertRejected(CANARY_MODEL + "\nembedding_models:\n" + invalidEntry.prependIndent("  "))
+        }
+
+        /**
+         * The offending file always also declares a valid model, so an empty result proves the
+         * loader rejected the file rather than merely failing to see the invalid entry.
+         */
+        private fun assertRejected(yaml: String) {
+            val result = loaderFor(yaml).loadAutoConfigMetadata()
+
+            assertTrue(
+                result.models.isEmpty() && result.embeddingModels.isEmpty(),
+                "Invalid definition should be rejected, dropping the canary model with it:\n$yaml",
+            )
+        }
+    }
+
+    @Nested
+    inner class LoadFailures {
+
+        @Test
+        fun `returns empty definitions when the file does not exist`() {
+            val result = OpenAiModelLoader(
+                resourceLoader = DefaultResourceLoader(),
+                configPath = "classpath:nonexistent-file.yml",
+            ).loadAutoConfigMetadata()
+
+            assertTrue(result.models.isEmpty(), "Should return empty list when file not found")
+            assertTrue(result.embeddingModels.isEmpty(), "Should return empty embedding list when file not found")
+        }
+
+        @Test
+        fun `returns empty definitions on a YAML parse error`() {
+            val result = loaderFor("invalid: yaml: content: ][").loadAutoConfigMetadata()
+
+            assertTrue(result.models.isEmpty(), "Should return empty list on parse error")
+            assertTrue(result.embeddingModels.isEmpty(), "Should return empty embedding list on parse error")
+        }
+    }
 
     @Nested
     inner class NativeSupportTests {
 
         @Test
         fun `default YAML loads native structured-output metadata for chat models`() {
-            val loader = OpenAiModelLoader()
+            val structuredOutput = assertPresent(
+                shippedCatalogue.nativeSupportDefaults?.structuredOutput,
+                "The shipped catalogue declares native_support_defaults",
+            )
+            assertEquals("response_format", structuredOutput.strategy)
+            assertEquals(false, structuredOutput.strict)
+            assertEquals("include", structuredOutput.promptInstructions)
+            assertEquals("response_format", structuredOutput.options["response_format_field"])
+            assertEquals("json_schema", structuredOutput.options["type_value"])
+            assertEquals("json_schema", structuredOutput.options["json_schema_field"])
 
-            val result = loader.loadAutoConfigMetadata()
-            val defaults = result.nativeSupportDefaults
-            assertNotNull(defaults)
-            val structuredOutput = defaults?.structuredOutput
-            assertNotNull(structuredOutput)
-            assertEquals("response_format", structuredOutput?.strategy)
-            assertEquals(false, structuredOutput?.strict)
-            assertEquals("include", structuredOutput?.promptInstructions)
-            assertEquals("response_format", structuredOutput?.options?.get("response_format_field"))
-            assertEquals("json_schema", structuredOutput?.options?.get("type_value"))
-            assertEquals("json_schema", structuredOutput?.options?.get("json_schema_field"))
-
-            val effectiveModel = result.effectiveModels().first { it.name == "gpt54" }
-            assertNotNull(effectiveModel.nativeSupport)
-            assertEquals("response_format", effectiveModel.nativeSupport?.structuredOutput?.strategy)
+            val effectiveModel = shippedCatalogue.effectiveModels().first { it.name == "gpt54" }
+            assertEquals(
+                "response_format",
+                effectiveModel.nativeSupport?.structuredOutput?.strategy,
+                "A model declaring no native_support of its own inherits the defaults",
+            )
         }
 
+        /**
+         * The interesting half of [NativeStructuredOutputCapability.merge] is the *partial*
+         * override: unset fields fall back to the defaults and `options` is a union, not a
+         * replacement. A model that restates every default proves none of that, so this fixture
+         * deliberately sets only `strict` and a single option key.
+         */
         @Test
-        fun `model native support overrides defaults in YAML`() {
-            val tempYaml = createTempYamlFile("""
+        fun `a partial model override inherits unset fields and unions the options`() {
+            val model = loaderFor(
+                """
                 native_support_defaults:
                   structured_output:
                     supported: true
@@ -64,570 +533,108 @@ class OpenAiModelLoaderTest {
                     model_id: gpt-alias
                     native_support:
                       structured_output:
-                        supported: true
-                        strategy: response_format
+                        strict: false
+                        options:
+                          json_schema_field: custom_json_schema
+                """.trimIndent()
+            ).loadAutoConfigMetadata().effectiveModels().single()
+
+            val structuredOutput = assertPresent(
+                model.nativeSupport?.structuredOutput,
+                "Native structured-output metadata should be present",
+            )
+            assertEquals(false, structuredOutput.strict, "The model's own value wins")
+            assertEquals(true, structuredOutput.supported, "Unset fields fall back to the defaults")
+            assertEquals("response_format", structuredOutput.strategy)
+            assertEquals("include", structuredOutput.promptInstructions)
+            assertEquals(
+                mapOf(
+                    "response_format_field" to "response_format",
+                    "json_schema_field" to "custom_json_schema",
+                ),
+                structuredOutput.options,
+                "Options merge key by key: the default key survives, the overridden key changes",
+            )
+        }
+
+        @Test
+        fun `a fully specified model override replaces every default`() {
+            val model = loaderFor(
+                """
+                native_support_defaults:
+                  structured_output:
+                    supported: true
+                    strategy: response_format
+                    strict: true
+                    prompt_instructions: include
+                    options:
+                      response_format_field: response_format
+                      json_schema_field: json_schema
+                models:
+                  - name: alias-model
+                    model_id: gpt-alias
+                    native_support:
+                      structured_output:
+                        supported: false
+                        strategy: tool
                         strict: false
                         prompt_instructions: suppress
                         options:
-                          response_format_field: response_format
+                          response_format_field: custom_response_format
                           json_schema_field: custom_json_schema
-            """.trimIndent())
+                """.trimIndent()
+            ).loadAutoConfigMetadata().effectiveModels().single()
 
-            val loader = OpenAiModelLoader(
-                resourceLoader = tempYaml.resourceLoader,
-                configPath = tempYaml.configPath
+            val structuredOutput = assertPresent(
+                model.nativeSupport?.structuredOutput,
+                "Native structured-output metadata should be present",
             )
-
-            val result = loader.loadAutoConfigMetadata()
-            val model = result.effectiveModels().single()
-            val structuredOutput = model.nativeSupport?.structuredOutput
-
-            assertNotNull(structuredOutput)
-            assertEquals(true, structuredOutput?.supported)
-            assertEquals("response_format", structuredOutput?.strategy)
-            assertEquals(false, structuredOutput?.strict)
-            assertEquals("suppress", structuredOutput?.promptInstructions)
-            assertEquals("response_format", structuredOutput?.options?.get("response_format_field"))
-            assertEquals("custom_json_schema", structuredOutput?.options?.get("json_schema_field"))
+            assertEquals(false, structuredOutput.supported)
+            assertEquals("tool", structuredOutput.strategy)
+            assertEquals(false, structuredOutput.strict)
+            assertEquals("suppress", structuredOutput.promptInstructions)
+            assertEquals("custom_response_format", structuredOutput.options["response_format_field"])
+            assertEquals("custom_json_schema", structuredOutput.options["json_schema_field"])
         }
 
         @Test
-        fun `native support defaults and overrides merge in YAML`() {
-            val tempYaml = createTempYamlFile("""
-                native_support_defaults:
-                  structured_output:
-                    supported: true
-                    strategy: response_format
-                    strict: true
-                    prompt_instructions: include
-                    options:
-                      response_format_field: response_format
-                      json_schema_field: json_schema
+        fun `effectiveModels leaves native support null when the file declares no defaults`() {
+            val model = loaderFor(
+                """
+                models:
+                  - name: plain-model
+                    model_id: gpt-plain
+                """.trimIndent()
+            ).loadAutoConfigMetadata().effectiveModels().single()
+
+            assertNull(model.nativeSupport)
+        }
+
+        /**
+         * The kebab-case spellings are wired through [com.fasterxml.jackson.annotation.JsonAlias]
+         * rather than the snake_case naming strategy, so they need their own coverage.
+         */
+        @Test
+        fun `kebab-case native-support aliases are accepted`() {
+            val model = loaderFor(
+                """
                 models:
                   - name: alias-model
                     model_id: gpt-alias
-                    native_support:
-                      structured_output:
-                        supported: true
+                    native-support:
+                      structured-output:
                         strategy: response_format
-                        strict: true
-                        prompt_instructions: include
-                        options:
-                          response_format_field: response_format
-                          json_schema_field: json_schema
-            """.trimIndent())
+                        prompt-instructions: suppress
+                """.trimIndent()
+            ).loadAutoConfigMetadata().models.single()
 
-            val loader = OpenAiModelLoader(
-                resourceLoader = tempYaml.resourceLoader,
-                configPath = tempYaml.configPath
+            val structuredOutput = assertPresent(
+                model.nativeSupport?.structuredOutput,
+                "Native structured-output metadata should be present",
             )
-
-            val result = loader.loadAutoConfigMetadata()
-            val model = result.effectiveModels().single()
-            val structuredOutput = model.nativeSupport?.structuredOutput
-
-            assertNotNull(structuredOutput)
-            assertEquals("response_format", structuredOutput?.strategy)
-            assertEquals("include", structuredOutput?.promptInstructions)
-            assertEquals("response_format", structuredOutput?.options?.get("response_format_field"))
-            assertEquals("json_schema", structuredOutput?.options?.get("json_schema_field"))
+            assertEquals("response_format", structuredOutput.strategy)
+            assertEquals("suppress", structuredOutput.promptInstructions)
         }
-
-    }
-
-    @Test
-    fun `should load valid model definitions from default YAML file`() {
-        // Arrange
-        val loader = OpenAiModelLoader()
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertNotNull(result)
-        assertTrue(result.models.isNotEmpty(), "Should load at least one model")
-
-        // Verify first model has required fields
-        val firstModel = result.models.first()
-        assertNotNull(firstModel.name)
-        assertNotNull(firstModel.modelId)
-        assertTrue(firstModel.name.isNotBlank(), "Model name should not be blank")
-        assertTrue(firstModel.modelId.isNotBlank(), "Model ID should not be blank")
-    }
-
-    @Test
-    fun `should validate all loaded models have correct default values`() {
-        // Arrange
-        val loader = OpenAiModelLoader()
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        result.models.forEach { model ->
-            // Verify defaults
-            assertTrue(model.maxTokens > 0, "Max tokens should be positive for ${model.name}")
-            assertTrue(model.temperature in 0.0..2.0, "Temperature should be in valid range for ${model.name}")
-
-            // Verify optional fields when present
-            model.topP?.let {
-                assertTrue(it in 0.0..1.0, "Top P should be between 0 and 1 for ${model.name}")
-            }
-        }
-    }
-
-    @Test
-    fun `should verify specific known models are loaded`() {
-        // Arrange
-        val loader = OpenAiModelLoader()
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert - verify some known OpenAI models are present
-        val modelNames = result.models.map { it.name }
-        assertTrue(modelNames.isNotEmpty(), "Should have loaded model names")
-        assertTrue(modelNames.contains("gpt53chat"), "Should include GPT-5.3 Chat")
-
-        // Verify at least one model has pricing info
-        assertTrue(result.models.any { it.pricingModel != null },
-            "At least one model should have pricing information")
-    }
-
-    @Test
-    fun `should verify GPT-5 models have temperature handling configuration`() {
-        // Arrange
-        val loader = OpenAiModelLoader()
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert - verify GPT-5 models have special handling configured
-        val gpt5Models = result.models.filter { it.name.startsWith("gpt5") }
-        assertTrue(gpt5Models.isNotEmpty(), "Should have GPT-5 models")
-
-        gpt5Models.forEach { model ->
-            assertNotNull(model.specialHandling, "GPT-5 models should have special handling")
-            assertEquals(false, model.specialHandling?.supportsTemperature,
-                "GPT-5 models should not support temperature adjustment")
-        }
-    }
-
-    @Test
-    fun `should verify embedding models are loaded`() {
-        // Arrange
-        val loader = OpenAiModelLoader()
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertTrue(result.embeddingModels.isNotEmpty(), "Should load at least one embedding model")
-
-        result.embeddingModels.forEach { embedding ->
-            assertNotNull(embedding.name)
-            assertNotNull(embedding.modelId)
-            assertNotNull(embedding.dimensions, "Dimensions should not be null for ${embedding.name}")
-            embedding.dimensions?.let { dims ->
-                assertTrue(dims > 0, "Dimensions should be positive for ${embedding.name}")
-            }
-            assertTrue(embedding.name.isNotBlank(), "Embedding name should not be blank")
-            assertTrue(embedding.modelId.isNotBlank(), "Embedding model ID should not be blank")
-        }
-    }
-
-    @Test
-    fun `should validate embedding model dimensions and pricing`() {
-        // Arrange
-        val loader = OpenAiModelLoader()
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        result.embeddingModels.forEach { embedding ->
-            assertNotNull(embedding.dimensions, "Dimensions should not be null for ${embedding.name}")
-            embedding.dimensions?.let { dims ->
-                assertTrue(dims > 0, "Dimensions should be positive for ${embedding.name}")
-            }
-
-            embedding.pricingModel?.let { pricing ->
-                assertTrue(pricing.usdPer1mTokens >= 0.0,
-                    "Pricing should be non-negative for ${embedding.name}")
-            }
-        }
-    }
-
-    @Test
-    fun `should return empty definitions when file does not exist`() {
-        // Arrange
-        val loader = OpenAiModelLoader(
-            resourceLoader = org.springframework.core.io.DefaultResourceLoader(),
-            configPath = "classpath:nonexistent-file.yml"
-        )
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertNotNull(result)
-        assertTrue(result.models.isEmpty(), "Should return empty list when file not found")
-        assertTrue(result.embeddingModels.isEmpty(), "Should return empty embedding list when file not found")
-    }
-
-    @Test
-    fun `should handle invalid YAML gracefully`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("invalid: yaml: content: ][")
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertNotNull(result)
-        assertTrue(result.models.isEmpty(), "Should return empty list on parse error")
-        assertTrue(result.embeddingModels.isEmpty(), "Should return empty embedding list on parse error")
-    }
-
-    @Test
-    fun `should validate model with invalid maxTokens`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            models:
-              - name: test-model
-                model_id: gpt-test
-                max_tokens: -100
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act & Assert
-        val result = loader.loadAutoConfigMetadata()
-        assertTrue(result.models.isEmpty(), "Should fail validation for negative maxTokens")
-    }
-
-    @Test
-    fun `should validate model with invalid temperature`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            models:
-              - name: test-model
-                model_id: gpt-test
-                temperature: 3.0
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act & Assert
-        val result = loader.loadAutoConfigMetadata()
-        assertTrue(result.models.isEmpty(), "Should fail validation for temperature out of range")
-    }
-
-    @Test
-    fun `should validate model with invalid topP`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            models:
-              - name: test-model
-                model_id: gpt-test
-                top_p: 1.5
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act & Assert
-        val result = loader.loadAutoConfigMetadata()
-        assertTrue(result.models.isEmpty(), "Should fail validation for topP out of range")
-    }
-
-    @Test
-    fun `should validate model with blank name`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            models:
-              - name: ""
-                model_id: gpt-test
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act & Assert
-        val result = loader.loadAutoConfigMetadata()
-        assertTrue(result.models.isEmpty(), "Should fail validation for blank name")
-    }
-
-    @Test
-    fun `should load valid model with all optional fields`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            models:
-              - name: test-model
-                model_id: gpt-test
-                display_name: Test Model
-                max_tokens: 4096
-                temperature: 0.7
-                top_p: 0.9
-                special_handling:
-                  supports_temperature: false
-                pricing_model:
-                  usd_per1m_input_tokens: 10.0
-                  usd_per1m_output_tokens: 20.0
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertEquals(1, result.models.size)
-        val model = result.models.first()
-        assertEquals("test-model", model.name)
-        assertEquals("gpt-test", model.modelId)
-        assertEquals("Test Model", model.displayName)
-        assertEquals(4096, model.maxTokens)
-        assertEquals(0.7, model.temperature)
-        assertEquals(0.9, model.topP)
-        assertNotNull(model.specialHandling)
-        assertEquals(false, model.specialHandling?.supportsTemperature)
-        assertNotNull(model.pricingModel)
-        assertEquals(10.0, model.pricingModel?.usdPer1mInputTokens)
-        assertEquals(20.0, model.pricingModel?.usdPer1mOutputTokens)
-    }
-
-    @Test
-    fun `should load multiple models correctly`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            models:
-              - name: model-1
-                model_id: gpt-1
-                max_tokens: 2000
-              - name: model-2
-                model_id: gpt-2
-                max_tokens: 4000
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertEquals(2, result.models.size)
-        assertEquals("model-1", result.models[0].name)
-        assertEquals("model-2", result.models[1].name)
-        assertEquals(2000, result.models[0].maxTokens)
-        assertEquals(4000, result.models[1].maxTokens)
-    }
-
-    @Test
-    fun `should load model with minimal fields`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            models:
-              - name: minimal-model
-                model_id: gpt-minimal
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertEquals(1, result.models.size)
-        val model = result.models.first()
-        assertEquals("minimal-model", model.name)
-        assertEquals("gpt-minimal", model.modelId)
-        assertNull(model.displayName)
-        assertEquals(16384, model.maxTokens) // Default value
-        assertEquals(1.0, model.temperature) // Default value
-        assertNull(model.topP)
-        assertNull(model.specialHandling)
-        assertNull(model.pricingModel)
-    }
-
-    @Test
-    fun `should validate embedding model with invalid dimensions`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            embedding_models:
-              - name: test-embedding
-                model_id: text-embedding-test
-                dimensions: -100
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act & Assert
-        val result = loader.loadAutoConfigMetadata()
-        assertTrue(result.embeddingModels.isEmpty(), "Should fail validation for negative dimensions")
-    }
-
-    @Test
-    fun `should validate embedding model with blank name`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            embedding_models:
-              - name: ""
-                model_id: text-embedding-test
-                dimensions: 1536
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act & Assert
-        val result = loader.loadAutoConfigMetadata()
-        assertTrue(result.embeddingModels.isEmpty(), "Should fail validation for blank name")
-    }
-
-    @Test
-    fun `should load valid embedding model with all fields`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            embedding_models:
-              - name: test-embedding
-                model_id: text-embedding-test
-                display_name: Test Embedding
-                dimensions: 1536
-                pricing_model:
-                  usd_per1m_tokens: 0.02
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertEquals(1, result.embeddingModels.size)
-        val embedding = result.embeddingModels.first()
-        assertEquals("test-embedding", embedding.name)
-        assertEquals("text-embedding-test", embedding.modelId)
-        assertEquals("Test Embedding", embedding.displayName)
-        assertEquals(1536, embedding.dimensions)
-        assertNotNull(embedding.pricingModel)
-        assertEquals(0.02, embedding.pricingModel?.usdPer1mTokens)
-    }
-
-    @Test
-    fun `should load multiple embedding models correctly`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            embedding_models:
-              - name: embedding-1
-                model_id: text-embedding-1
-                dimensions: 1536
-              - name: embedding-2
-                model_id: text-embedding-2
-                dimensions: 3072
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertEquals(2, result.embeddingModels.size)
-        assertEquals("embedding-1", result.embeddingModels[0].name)
-        assertEquals("embedding-2", result.embeddingModels[1].name)
-        assertEquals(1536, result.embeddingModels[0].dimensions)
-        assertEquals(3072, result.embeddingModels[1].dimensions)
-    }
-
-    @Test
-    fun `should load both LLM and embedding models from same file`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            models:
-              - name: llm-1
-                model_id: gpt-test-1
-                max_tokens: 4096
-              - name: llm-2
-                model_id: gpt-test-2
-                max_tokens: 8192
-            embedding_models:
-              - name: embedding-1
-                model_id: text-embedding-1
-                dimensions: 1536
-              - name: embedding-2
-                model_id: text-embedding-2
-                dimensions: 3072
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act
-        val result = loader.loadAutoConfigMetadata()
-
-        // Assert
-        assertEquals(2, result.models.size, "Should load 2 LLM models")
-        assertEquals(2, result.embeddingModels.size, "Should load 2 embedding models")
-    }
-
-    @Test
-    fun `should validate embedding model with invalid pricing`() {
-        // Arrange
-        val tempYaml = createTempYamlFile("""
-            embedding_models:
-              - name: test-embedding
-                model_id: text-embedding-test
-                dimensions: 1536
-                pricing_model:
-                  usd_per1m_tokens: -0.5
-        """.trimIndent())
-
-        val loader = OpenAiModelLoader(
-            resourceLoader = tempYaml.resourceLoader,
-            configPath = tempYaml.configPath
-        )
-
-        // Act & Assert
-        val result = loader.loadAutoConfigMetadata()
-        assertTrue(result.embeddingModels.isEmpty(), "Should fail validation for negative pricing")
     }
 
     /**
@@ -646,7 +653,7 @@ class OpenAiModelLoaderTest {
          */
         @Test
         fun `shipped catalog routes the pro models to Responses and everything else to Chat Completions`() {
-            val models = OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels()
+            val models = shippedCatalogue.effectiveModels()
 
             val byFormat = models.groupBy({ it.apiFormat }, { it.modelId })
 
@@ -673,7 +680,7 @@ class OpenAiModelLoaderTest {
          */
         @Test
         fun `the GPT-5_6 tiers stay on Chat Completions, which they all support`() {
-            val models = OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels()
+            val models = shippedCatalogue.effectiveModels()
                 .filter { it.modelId.startsWith("gpt-5.6") }
                 .associate { it.modelId to it.apiFormat }
 
@@ -693,15 +700,13 @@ class OpenAiModelLoaderTest {
          */
         @Test
         fun `model without api_format falls back to Chat Completions`() {
-            val tempYaml = createTempYamlFile(
+            val loader = loaderFor(
                 """
                 models:
                   - name: legacy-model
                     model_id: gpt-legacy
                 """.trimIndent()
             )
-
-            val loader = OpenAiModelLoader(tempYaml.resourceLoader, tempYaml.configPath)
 
             assertEquals(
                 OpenAiApiFormat.CHAT_COMPLETIONS,
@@ -711,7 +716,7 @@ class OpenAiModelLoaderTest {
 
         @Test
         fun `api_format is read from YAML`() {
-            val tempYaml = createTempYamlFile(
+            val models = loaderFor(
                 """
                 models:
                   - name: responses-model
@@ -721,13 +726,48 @@ class OpenAiModelLoaderTest {
                     model_id: gpt-chat
                     api_format: CHAT_COMPLETIONS
                 """.trimIndent()
-            )
-
-            val loader = OpenAiModelLoader(tempYaml.resourceLoader, tempYaml.configPath)
-            val models = loader.loadAutoConfigMetadata().effectiveModels().associateBy { it.modelId }
+            ).loadAutoConfigMetadata().effectiveModels().associateBy { it.modelId }
 
             assertEquals(OpenAiApiFormat.RESPONSES, models["gpt-responses"]?.apiFormat)
             assertEquals(OpenAiApiFormat.CHAT_COMPLETIONS, models["gpt-chat"]?.apiFormat)
+        }
+
+        /**
+         * Characterises a sharp edge rather than endorsing it: the enum is matched case-sensitively,
+         * so the lowercase spelling every other key in the file uses does not merely default the
+         * field — it fails the whole document and the user loses every model, with only a logged
+         * error to explain it. Change this test the day the mapper is taught to accept `responses`.
+         */
+        @Test
+        fun `lowercase api_format is not recognised and discards the whole file`() {
+            val result = loaderFor(
+                """
+                models:
+                  - name: canary-model
+                    model_id: gpt-canary
+                  - name: responses-model
+                    model_id: gpt-responses
+                    api_format: responses
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            assertTrue(result.models.isEmpty(), "Enum matching is case-sensitive; the canary dies with it")
+        }
+
+        @Test
+        fun `an unknown api_format discards the whole file`() {
+            val result = loaderFor(
+                """
+                models:
+                  - name: canary-model
+                    model_id: gpt-canary
+                  - name: typo-model
+                    model_id: gpt-typo
+                    api_format: RESPONSE
+                """.trimIndent()
+            ).loadAutoConfigMetadata()
+
+            assertTrue(result.models.isEmpty())
         }
 
         /**
@@ -736,7 +776,7 @@ class OpenAiModelLoaderTest {
          */
         @Test
         fun `pro models keep their existing special handling`() {
-            val models = OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels()
+            val models = shippedCatalogue.effectiveModels()
                 .filter { it.apiFormat == OpenAiApiFormat.RESPONSES }
 
             assertTrue(models.isNotEmpty(), "Guard against the filter silently matching nothing")
@@ -750,20 +790,56 @@ class OpenAiModelLoaderTest {
         }
     }
 
-    private data class TempYamlResource(
-        val resourceLoader: ResourceLoader,
-        val configPath: String,
-    )
+    private fun assertSingleModel(result: OpenAiModelDefinitions): OpenAiModelDefinition {
+        assertEquals(1, result.models.size)
+        return result.models.first()
+    }
 
-    private fun createTempYamlFile(content: String): TempYamlResource {
+    /**
+     * JUnit's own `assertNotNull` returns `Unit`, which leaves the caller re-asserting nullability
+     * on every subsequent access. This one hands the value back.
+     */
+    private fun <T : Any> assertPresent(value: T?, message: String): T {
+        assertNotNull(value, message)
+        return value!!
+    }
+
+    /**
+     * A loader over an in-memory YAML document. The backing [ResourceLoader] answers the configured
+     * path and nothing else, so a test that asks for the wrong location fails instead of silently
+     * receiving the fixture anyway.
+     */
+    private fun loaderFor(content: String): OpenAiModelLoader {
         val resource = ByteArrayResource(content.toByteArray())
         val resourceLoader = object : ResourceLoader {
-            override fun getResource(location: String) = resource
+            override fun getResource(location: String) = when (location) {
+                IN_MEMORY_CONFIG_PATH -> resource
+                else -> error("Unexpected resource location: $location")
+            }
+
             override fun getClassLoader() = javaClass.classLoader
         }
-        return TempYamlResource(
-            resourceLoader = resourceLoader,
-            configPath = "memory:test-openai.yml"
-        )
+        return OpenAiModelLoader(resourceLoader, IN_MEMORY_CONFIG_PATH)
+    }
+
+    companion object {
+        private const val IN_MEMORY_CONFIG_PATH = "memory:test-openai.yml"
+
+        /**
+         * A valid model prepended to every rejection fixture, so an empty result distinguishes
+         * "the loader threw the file away" from "the invalid entry was never parsed at all".
+         */
+        private val CANARY_MODEL = """
+            models:
+              - name: canary-model
+                model_id: gpt-canary
+        """.trimIndent()
+
+        /**
+         * Loading is pure and the file is immutable, so the shipped catalogue is read once.
+         */
+        private val shippedCatalogue: OpenAiModelDefinitions by lazy {
+            OpenAiModelLoader().loadAutoConfigMetadata()
+        }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfigRoutingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfigRoutingTest.kt
@@ -22,9 +22,9 @@ import com.embabel.common.ai.model.LlmOptionsProperties
 import com.embabel.common.util.ObjectProviders
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.ai.openai.OpenAiChatModel
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
@@ -87,22 +87,45 @@ class OpenAiModelsConfigRoutingTest {
         assertEquals(setOf("proModel", "chatModel"), registeredLlms().keys)
     }
 
-    /** Runs the real bean-registration path and returns what it registered. */
-    private fun registeredLlms(): Map<String, SpringAiLlmService> {
-        val names = mutableListOf<String>()
-        val beans = mutableListOf<Any>()
-        val beanFactory = mockk<ConfigurableBeanFactory>()
-        val name = slot<String>()
-        val bean = slot<Any>()
-        every { beanFactory.registerSingleton(capture(name), capture(bean)) } answers {
-            names += name.captured
-            beans += bean.captured
+    /**
+     * The same registration path, driven by the catalog that actually ships rather than the
+     * synthetic one above. That one proves the switch works; this proves the shipped entries reach
+     * it. Neither needs a Spring context or the network, so both run on every build.
+     */
+    @Nested
+    inner class ShippedCatalog {
+
+        private val shipped = registeredLlms(OpenAiModelLoader())
+
+        /**
+         * Every entry, rather than a list of the names that happened to be new: the invariant is
+         * that the catalog and the registry cannot drift, and it holds for models not yet written.
+         */
+        @Test
+        fun `every catalog entry becomes a bean`() {
+            val declared = OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels().map { it.name }
+
+            assertEquals(declared.toSet(), shipped.keys)
         }
 
-        val resource = ByteArrayResource(catalog.toByteArray())
-        val resourceLoader = object : ResourceLoader {
-            override fun getResource(location: String) = resource
-            override fun getClassLoader(): ClassLoader = javaClass.classLoader
+        @Test
+        fun `the pro tier is wired onto the Responses adapter`() {
+            assertInstanceOf(
+                OpenAiResponsesChatModel::class.java,
+                shipped.values.single { it.name == "gpt-5.5-pro" }.chatModel,
+                "gpt-5.5-pro left on the Chat Completions client fails on every call",
+            )
+        }
+    }
+
+    /** Runs the real bean-registration path and returns the LLM services it registered. */
+    private fun registeredLlms(
+        modelLoader: OpenAiModelLoader = inMemoryLoader(catalog),
+    ): Map<String, SpringAiLlmService> {
+        val registered = mutableMapOf<String, Any>()
+        val beanFactory = mockk<ConfigurableBeanFactory>()
+        every { beanFactory.registerSingleton(any(), any()) } answers {
+            registered[firstArg()] = secondArg()
         }
 
         OpenAiModelsConfig(
@@ -115,11 +138,22 @@ class OpenAiModelsConfigRoutingTest {
             properties = OpenAiProperties(),
             llmOptionsProperties = LlmOptionsProperties(),
             configurableBeanFactory = beanFactory,
-            modelLoader = OpenAiModelLoader(resourceLoader, "memory:routing-test.yml"),
+            modelLoader = modelLoader,
             webClientBuilder = ObjectProviders.empty(),
         ).openAiModelsInitializer()
 
-        return names.zip(beans).toMap()
-            .mapValues { (_, service) -> service as SpringAiLlmService }
+        // The shipped catalog also registers embedding services, which are not LLMs.
+        return registered
+            .mapNotNull { (name, bean) -> (bean as? SpringAiLlmService)?.let { name to it } }
+            .toMap()
+    }
+
+    private fun inMemoryLoader(yaml: String): OpenAiModelLoader {
+        val resource = ByteArrayResource(yaml.toByteArray())
+        val resourceLoader = object : ResourceLoader {
+            override fun getResource(location: String) = resource
+            override fun getClassLoader(): ClassLoader = javaClass.classLoader
+        }
+        return OpenAiModelLoader(resourceLoader, "memory:routing-test.yml")
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfigRoutingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfigRoutingTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.openai.Gpt5ChatOptionsConverter
+import com.embabel.agent.openai.StandardOpenAiOptionsConverter
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.model.LlmOptionsProperties
+import com.embabel.common.util.ObjectProviders
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.ai.openai.OpenAiChatModel
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.core.io.ResourceLoader
+
+/**
+ * The catalog decides the transport; this is where that decision reaches production wiring.
+ * The tests below drive the real registration path — no Spring context, no network — so a
+ * regression in either direction shows up here rather than as a 404 in front of a user.
+ *
+ * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
+ */
+class OpenAiModelsConfigRoutingTest {
+
+    private val catalog = """
+        models:
+          - name: proModel
+            model_id: gpt-5-pro
+            api_format: RESPONSES
+            special_handling:
+              supports_temperature: false
+          - name: chatModel
+            model_id: gpt-4o-mini
+    """.trimIndent()
+
+    @Test
+    fun `a RESPONSES model is wired onto the Responses adapter`() {
+        assertInstanceOf(
+            OpenAiResponsesChatModel::class.java,
+            registeredLlms()["proModel"]?.chatModel,
+            "A pro model left on the Chat Completions client 404s on every call",
+        )
+    }
+
+    @Test
+    fun `every other model keeps the Spring AI chat client`() {
+        assertInstanceOf(
+            OpenAiChatModel::class.java,
+            registeredLlms()["chatModel"]?.chatModel,
+            "Rerouting a working model onto the adapter changes its behaviour for no reason",
+        )
+    }
+
+    /**
+     * The transport switch sits next to the converter switch in `createOpenAiLlm`, and both read
+     * the same model definition. Keeping this assertion alongside the transport one pins that
+     * adding the first did not disturb the second.
+     */
+    @Test
+    fun `special handling still selects the options converter independently of transport`() {
+        val llms = registeredLlms()
+
+        assertEquals(Gpt5ChatOptionsConverter, llms["proModel"]?.optionsConverter)
+        assertEquals(StandardOpenAiOptionsConverter, llms["chatModel"]?.optionsConverter)
+    }
+
+    @Test
+    fun `both models are registered under their catalog names`() {
+        assertEquals(setOf("proModel", "chatModel"), registeredLlms().keys)
+    }
+
+    /** Runs the real bean-registration path and returns what it registered. */
+    private fun registeredLlms(): Map<String, SpringAiLlmService> {
+        val names = mutableListOf<String>()
+        val beans = mutableListOf<Any>()
+        val beanFactory = mockk<ConfigurableBeanFactory>()
+        val name = slot<String>()
+        val bean = slot<Any>()
+        every { beanFactory.registerSingleton(capture(name), capture(bean)) } answers {
+            names += name.captured
+            beans += bean.captured
+        }
+
+        val resource = ByteArrayResource(catalog.toByteArray())
+        val resourceLoader = object : ResourceLoader {
+            override fun getResource(location: String) = resource
+            override fun getClassLoader(): ClassLoader = javaClass.classLoader
+        }
+
+        OpenAiModelsConfig(
+            envBaseUrl = null,
+            envApiKey = "test-key",
+            envCompletionsPath = null,
+            envEmbeddingsPath = null,
+            observationRegistry = ObjectProviders.empty(),
+            restClientBuilder = ObjectProviders.empty(),
+            properties = OpenAiProperties(),
+            llmOptionsProperties = LlmOptionsProperties(),
+            configurableBeanFactory = beanFactory,
+            modelLoader = OpenAiModelLoader(resourceLoader, "memory:routing-test.yml"),
+            webClientBuilder = ObjectProviders.empty(),
+        ).openAiModelsInitializer()
+
+        return names.zip(beans).toMap()
+            .mapValues { (_, service) -> service as SpringAiLlmService }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesAdapterIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesAdapterIT.kt
@@ -128,6 +128,12 @@ class OpenAiResponsesAdapterIT(
      * function call, Embabel runs it and replays call and result on the next turn. The Responses
      * API pairs those by `call_id`, so a lost id leaves the model reissuing the same call until the
      * loop gives up.
+     *
+     * The prompt names the tool and orders the call rather than asking a question it happens to
+     * answer. Merely asking left the model free to decline, which it did on one run in six: a
+     * single iteration, no tool call, and a failure that looked like the transport rather than the
+     * model exercising its judgement. Whether a model volunteers a tool is not what this test is
+     * for.
      */
     @Test
     fun `a tool is called and its result reaches the answer`() {
@@ -136,7 +142,10 @@ class OpenAiResponsesAdapterIT(
         val answer = call {
             ai.withLlm(proModel)
                 .withToolObject(tool)
-                .generateText("What is the access code for the vault named 'north'? Answer with the code alone.")
+                .generateText(
+                    "Call the accessCode tool for the vault named 'north', " +
+                        "then reply with the code it returned and nothing else."
+                )
         }
 
         assertTrue(tool.invoked, "The model never called the tool, so the answer cannot be grounded")

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesAdapterIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesAdapterIT.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.common.Ai
+import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.isModelAccessError
+import com.embabel.common.ai.model.LlmOptions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.opentest4j.TestAbortedException
+import org.springframework.ai.tool.annotation.Tool
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Profile
+import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
+
+@Profile("openai-responses-adapter-test")
+@ConfigurationPropertiesScan(basePackages = ["com.embabel.agent"])
+@ComponentScan(basePackages = ["com.embabel.agent"])
+class OpenAiResponsesAdapterTestConfig
+
+/** Facts the model cannot know, so a right answer proves the extraction rather than a guess. */
+data class Shipment(
+    val trackingId: String,
+    val city: String,
+    val delayDays: Int,
+)
+
+/** Returns a code nothing else could supply: the answer carries it only if the tool really ran. */
+class VaultCodeTool {
+
+    var invoked: Boolean = false
+        private set
+
+    @Tool(description = "Returns the current access code for a named vault")
+    fun accessCode(vaultName: String): String {
+        invoked = true
+        return "ZX-9917"
+    }
+}
+
+/**
+ * Exercises [OpenAiResponsesChatModel]'s request mapping against the live endpoint.
+ *
+ * The unit tests assert what the adapter *builds*; the SDK is mocked, so a schema OpenAI would
+ * reject or a `call_id` it would not pair still passes them. These two paths are where a Chat
+ * Completions payload and a Responses one differ most — structured output moves from
+ * `response_format` to `text.format` and gains a mandatory name, tools move from `tools[].function`
+ * to a flat `FunctionTool` — so they are the two worth the price of a real call.
+ *
+ * Runs against [OpenAiModels.GPT_5_PRO]: one model is enough, the transport code is shared, and
+ * this is the model the adapter was written for.
+ *
+ * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
+ */
+@SpringBootTest(
+    properties = [
+        "embabel.models.default-llm=gpt-4o-mini",
+        "embabel.agent.platform.models.openai.max-attempts=1",
+        "spring.main.allow-bean-definition-overriding=true",
+    ]
+)
+@ActiveProfiles("openai-responses-adapter-test")
+@Import(OpenAiResponsesAdapterTestConfig::class, AgentOpenAiAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(
+    named = "OPENAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires OPENAI_API_KEY",
+)
+class OpenAiResponsesAdapterIT(
+    @param:Autowired private val ai: Ai,
+) {
+
+    /**
+     * The platform default is 60s, which a pro model exceeds on a two-turn tool loop: observed at
+     * 108s. Left at the default the call times out and succeeds only on retry, running the loop —
+     * and billing the reasoning — twice over.
+     */
+    private val proModel = LlmOptions.withModel(OpenAiModels.GPT_5_PRO)
+        .withTimeout(Duration.ofMinutes(5))
+
+    /**
+     * Native structured output reaches the adapter as a Chat Completions `response_format` and is
+     * rewritten under `text.format`, with a name derived on the way. A schema OpenAI refuses fails
+     * the whole call; one it accepts but the adapter mangled comes back unbindable.
+     */
+    @Test
+    fun `structured output binds over the Responses transport`() {
+        val shipment = call {
+            ai.withLlm(proModel).createObject(
+                "Extract the shipment. Tracking XY-4423 is held in Lyon and is 3 days late.",
+                Shipment::class.java,
+            )
+        }
+
+        assertEquals("XY-4423", shipment.trackingId)
+        assertEquals(3, shipment.delayDays)
+        assertTrue(shipment.city.contains("Lyon", ignoreCase = true), "Got city: ${shipment.city}")
+    }
+
+    /**
+     * The full loop, which no mock reaches: the adapter sends the tool, OpenAI answers with a
+     * function call, Embabel runs it and replays call and result on the next turn. The Responses
+     * API pairs those by `call_id`, so a lost id leaves the model reissuing the same call until the
+     * loop gives up.
+     */
+    @Test
+    fun `a tool is called and its result reaches the answer`() {
+        val tool = VaultCodeTool()
+
+        val answer = call {
+            ai.withLlm(proModel)
+                .withToolObject(tool)
+                .generateText("What is the access code for the vault named 'north'? Answer with the code alone.")
+        }
+
+        assertTrue(tool.invoked, "The model never called the tool, so the answer cannot be grounded")
+        assertTrue(
+            answer.contains("ZX-9917"),
+            "The tool result never made it back into the answer, got: $answer",
+        )
+    }
+
+    /** Same skip-on-no-entitlement contract as the other integration tests, for a non-text return. */
+    private fun <T> call(block: () -> T): T =
+        try {
+            block()
+        } catch (ex: Exception) {
+            if (isModelAccessError(ex)) {
+                throw TestAbortedException(
+                    "OPENAI_API_KEY is set, but the configured OpenAI project has no access to " +
+                        OpenAiModels.GPT_5_PRO,
+                    ex,
+                )
+            }
+            throw ex
+        }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesAdapterIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesAdapterIT.kt
@@ -103,7 +103,11 @@ class OpenAiResponsesAdapterIT(
     /**
      * Native structured output reaches the adapter as a Chat Completions `response_format` and is
      * rewritten under `text.format`, with a name derived on the way. A schema OpenAI refuses fails
-     * the whole call; one it accepts but the adapter mangled comes back unbindable.
+     * the whole call, so this proves the endpoint accepts what the adapter builds.
+     *
+     * It cannot prove *which* path produced the object. Embabel also injects the schema into the
+     * prompt, so a broken native path would still bind here. The rewrite itself is pinned in
+     * `OpenAiResponsesChatModelTest`, and the catalog's declaration of it in `OpenAiModelLoaderTest`.
      */
     @Test
     fun `structured output binds over the Responses transport`() {

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.config.models.openai
 
+import com.embabel.agent.spi.loop.StructuredOutputRequest
 import com.openai.client.OpenAIClient
 import com.openai.models.responses.Response
 import com.openai.models.responses.ResponseCreateParams
@@ -193,6 +194,71 @@ class OpenAiResponsesChatModelTest {
                 properties["properties"].toString().contains("answer"),
                 "The schema must survive the format change intact, got: $properties",
             )
+        }
+
+        /**
+         * The test above builds the options the way the configurer does. This one runs the real
+         * chain — shipped catalogue, real configurer, real adapter — so the three stay in step:
+         * a `strategy` renamed in the YAML, or a configurer that stopped writing `responseFormat`,
+         * would leave a `*-pro` model answering in free text with every unit test still green.
+         */
+        @Test
+        fun `a schema the native support configures reaches the Responses API`() {
+            val proModel = OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels()
+                .first { it.apiFormat == OpenAiApiFormat.RESPONSES }
+
+            val configured = OpenAiNativeStructuredOutputConfigurer.configure(
+                options = OpenAiChatOptions.builder().model(proModel.modelId).build(),
+                structuredOutput = StructuredOutputRequest(
+                    name = "Answer",
+                    schema = """{"title":"Answer","type":"object","properties":{"answer":{"type":"string"}}}""",
+                ),
+                nativeSupport = proModel.nativeSupport,
+                llm = null,
+            )
+
+            val params = capture(Prompt(listOf(UserMessage("Hi")), configured))
+
+            val format = params.text().orElseThrow().format().orElseThrow().jsonSchema().orElseThrow()
+            assertEquals("Answer", format.name(), "The schema title should name the format")
+            assertEquals(
+                "object",
+                format.schema()._additionalProperties()["type"]?.asString()?.orElse(null),
+            )
+        }
+
+        /** The name OpenAI accepts, for a schema titled [title], or none when it is null. */
+        private fun schemaNameFor(title: String?): String {
+            val titleField = title?.let { """"title":"$it",""" } ?: ""
+            val params = capture(
+                Prompt(
+                    listOf(UserMessage("Hi")),
+                    OpenAiChatOptions.builder()
+                        .model("gpt-5-pro")
+                        .responseFormat(
+                            OpenAiChatModel.ResponseFormat.builder()
+                                .type(OpenAiChatModel.ResponseFormat.Type.JSON_SCHEMA)
+                                .jsonSchema("""{$titleField"type":"object"}""")
+                                .build()
+                        )
+                        .build(),
+                )
+            )
+            return params.text().orElseThrow().format().orElseThrow().jsonSchema().orElseThrow().name()
+        }
+
+        /**
+         * A title OpenAI would reject costs the whole call, and it is never worth an answer: the
+         * name is a label echoed back, not something the model reasons over. So it is folded, and
+         * a schema with no title still gets one, since the API refuses an unnamed schema either way.
+         */
+        @Test
+        fun `schema names are folded to what the api accepts`() {
+            assertEquals("Answer", schemaNameFor("Answer"))
+            assertEquals("com_example_Answer", schemaNameFor("com.example.Answer"))
+            assertEquals("List_Answer_", schemaNameFor("List<Answer>"))
+            assertEquals("response", schemaNameFor(null), "The API refuses an unnamed schema")
+            assertEquals("response", schemaNameFor(""), "An empty title names nothing")
         }
 
         /** A response_format that is not a JSON schema has no Responses equivalent to carry. */

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
@@ -18,12 +18,14 @@ package com.embabel.agent.config.models.openai
 import com.openai.client.OpenAIClient
 import com.openai.models.responses.Response
 import com.openai.models.responses.ResponseCreateParams
+import com.openai.models.responses.ResponseError
 import com.openai.models.responses.ResponseFunctionToolCall
 import com.openai.models.responses.ResponseInputItem
 import com.openai.models.responses.ResponseOutputItem
 import com.openai.models.responses.ResponseOutputMessage
 import com.openai.models.responses.ResponseOutputText
 import com.openai.models.responses.ResponseReasoningItem
+import com.openai.models.responses.ResponseStatus
 import com.openai.models.responses.ResponseUsage
 import com.openai.services.blocking.ResponseService
 import io.micrometer.observation.Observation
@@ -44,9 +46,13 @@ import org.springframework.ai.chat.messages.SystemMessage
 import org.springframework.ai.chat.messages.ToolResponseMessage
 import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.content.Media
 import org.springframework.ai.openai.OpenAiChatModel
 import org.springframework.ai.openai.OpenAiChatOptions
+import org.springframework.ai.retry.NonTransientAiException
 import org.springframework.ai.tool.definition.ToolDefinition
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.util.MimeTypeUtils
 import java.util.Optional
 
 /**
@@ -238,6 +244,87 @@ class OpenAiResponsesChatModelTest {
         }
 
         /**
+         * Dropped quietly, the model answers in free text and the failure surfaces later as a
+         * binding error naming the wrong culprit.
+         */
+        @Test
+        fun `an unparseable structured output schema is refused, not silently downgraded`() {
+            respondWith(textResponse("ok"))
+
+            val failure = assertThrows(IllegalArgumentException::class.java) {
+                model.call(
+                    Prompt(
+                        listOf(UserMessage("Hi")),
+                        OpenAiChatOptions.builder()
+                            .model("gpt-5-pro")
+                            .responseFormat(
+                                OpenAiChatModel.ResponseFormat.builder()
+                                    .type(OpenAiChatModel.ResponseFormat.Type.JSON_SCHEMA)
+                                    .jsonSchema("{ not json")
+                                    .build()
+                            )
+                            .build(),
+                    )
+                )
+            }
+
+            assertTrue(
+                failure.message.orEmpty().contains("schema", ignoreCase = true),
+                "The failure must name what could not be read, got: ${failure.message}",
+            )
+        }
+
+        /** An empty parameter schema tells the model the tool takes no arguments — it never does. */
+        @Test
+        fun `an unparseable tool schema is refused rather than sent as a parameterless tool`() {
+            respondWith(textResponse("ok"))
+
+            val failure = assertThrows(IllegalArgumentException::class.java) {
+                model.call(
+                    Prompt(
+                        listOf(UserMessage("Hi")),
+                        OpenAiChatOptions.builder()
+                            .model("gpt-5-pro")
+                            .toolCallbacks(listOf(toolCallback("lookup", "Looks things up", "{ not json")))
+                            .build(),
+                    )
+                )
+            }
+
+            assertTrue(
+                failure.message.orEmpty().contains("lookup"),
+                "The failure must name the offending tool, got: ${failure.message}",
+            )
+        }
+
+        /** An image-bearing prompt sent as text alone yields a confident answer about nothing. */
+        @Test
+        fun `media is refused rather than silently dropped`() {
+            respondWith(textResponse("ok"))
+
+            assertThrows(UnsupportedOperationException::class.java) {
+                model.call(
+                    Prompt(
+                        listOf(
+                            UserMessage.builder()
+                                .text("What is in this image?")
+                                .media(
+                                    listOf(
+                                        Media.builder()
+                                            .mimeType(MimeTypeUtils.IMAGE_PNG)
+                                            .data(ByteArrayResource(byteArrayOf(1, 2, 3)))
+                                            .build()
+                                    )
+                                )
+                                .build()
+                        ),
+                        OpenAiChatOptions.builder().model("gpt-5-pro").build(),
+                    )
+                )
+            }
+        }
+
+        /**
          * `SpringAiLlmService.convertOptions` stamps the configured model onto every request, but
          * the converters it delegates to do not set one, so the default has to hold the floor.
          */
@@ -339,6 +426,104 @@ class OpenAiResponsesChatModelTest {
         }
     }
 
+    /**
+     * The Responses API reports a refusal or a truncation *inside a 200*, so nothing throws on its
+     * own. Read only `output`, and a failed call is indistinguishable from a model that had nothing
+     * to say.
+     */
+    @Nested
+    inner class FailureAndTruncation {
+
+        @Test
+        fun `a failed response is raised, not passed off as an empty answer`() {
+            respondWith(
+                response(
+                    status = ResponseStatus.FAILED,
+                    error = ResponseError.builder()
+                        .code(ResponseError.Code.SERVER_ERROR)
+                        .message("The model failed to generate a response.")
+                        .build(),
+                )
+            )
+
+            val failure = assertThrows(NonTransientAiException::class.java) {
+                model.call(Prompt("Hi"))
+            }
+
+            assertTrue(
+                failure.message.orEmpty().contains("The model failed to generate a response."),
+                "OpenAI's own explanation is the only useful part, got: ${failure.message}",
+            )
+        }
+
+        /**
+         * `max_output_tokens` is spent on reasoning too, so a pro model runs out mid-thought
+         * routinely. The partial answer is worth keeping — but silently, it reads as a complete one.
+         */
+        @Test
+        fun `a truncated response keeps its text and reports why it stopped`() {
+            respondWith(
+                textResponse("As far as I got").toBuilder()
+                    .status(ResponseStatus.INCOMPLETE)
+                    .incompleteDetails(
+                        Response.IncompleteDetails.builder()
+                            .reason(Response.IncompleteDetails.Reason.MAX_OUTPUT_TOKENS)
+                            .build()
+                    )
+                    .build()
+            )
+
+            val generation = model.call(Prompt("Hi")).result
+
+            assertEquals("As far as I got", generation.output.text, "Partial output is still useful")
+            assertEquals(
+                "length",
+                generation.metadata.finishReason,
+                "Truncation is reported in the vocabulary the rest of Spring AI uses",
+            )
+        }
+
+        @Test
+        fun `a content filtered response is reported as such rather than as an empty answer`() {
+            respondWith(
+                response(
+                    status = ResponseStatus.INCOMPLETE,
+                    incompleteDetails = Response.IncompleteDetails.builder()
+                        .reason(Response.IncompleteDetails.Reason.CONTENT_FILTER)
+                        .build(),
+                )
+            )
+
+            assertEquals("content_filter", model.call(Prompt("Hi")).result.metadata.finishReason)
+        }
+
+        @Test
+        fun `a completed response reports its finish reason too`() {
+            respondWith(textResponse("ok").toBuilder().status(ResponseStatus.COMPLETED).build())
+
+            assertEquals("stop", model.call(Prompt("Hi")).result.metadata.finishReason)
+        }
+
+        /** Spring AI's convention: a turn that ends in tool calls did not stop, it yielded. */
+        @Test
+        fun `a response ending in tool calls is reported as such`() {
+            respondWith(
+                response(
+                    ResponseOutputItem.ofFunctionCall(
+                        ResponseFunctionToolCall.builder()
+                            .callId("call_7")
+                            .name("lookup")
+                            .arguments("{}")
+                            .build()
+                    ),
+                    status = ResponseStatus.COMPLETED,
+                )
+            )
+
+            assertEquals("tool_calls", model.call(Prompt("Hi")).result.metadata.finishReason)
+        }
+    }
+
     @Nested
     inner class ContractWithSurroundingCode {
 
@@ -421,13 +606,17 @@ class OpenAiResponsesChatModelTest {
 
     // --- fixtures -------------------------------------------------------------------------
 
-    private fun toolCallback(name: String, description: String) =
+    private fun toolCallback(
+        name: String,
+        description: String,
+        inputSchema: String = """{"type":"object","properties":{"q":{"type":"string"}}}""",
+    ) =
         object : org.springframework.ai.tool.ToolCallback {
             override fun getToolDefinition(): ToolDefinition =
                 ToolDefinition.builder()
                     .name(name)
                     .description(description)
-                    .inputSchema("""{"type":"object","properties":{"q":{"type":"string"}}}""")
+                    .inputSchema(inputSchema)
                     .build()
 
             override fun call(toolInput: String): String = "unused"
@@ -454,7 +643,13 @@ class OpenAiResponsesChatModelTest {
             usage = usage,
         )
 
-    private fun response(vararg output: ResponseOutputItem, usage: ResponseUsage? = null): Response =
+    private fun response(
+        vararg output: ResponseOutputItem,
+        usage: ResponseUsage? = null,
+        status: ResponseStatus? = null,
+        error: ResponseError? = null,
+        incompleteDetails: Response.IncompleteDetails? = null,
+    ): Response =
         Response.builder()
             .id("resp_1")
             .createdAt(0.0)
@@ -464,12 +659,13 @@ class OpenAiResponsesChatModelTest {
             .toolChoice(com.openai.models.responses.ToolChoiceOptions.AUTO)
             .tools(emptyList())
             // The SDK treats these as required even when absent on the wire.
-            .error(Optional.empty())
-            .incompleteDetails(Optional.empty())
+            .error(Optional.ofNullable(error))
+            .incompleteDetails(Optional.ofNullable(incompleteDetails))
             .instructions(Optional.empty())
             .metadata(Optional.empty())
             .temperature(Optional.empty())
             .topP(Optional.empty())
             .apply { usage?.let { usage(it) } }
+            .apply { status?.let { status(it) } }
             .build()
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
@@ -1,0 +1,475 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.openai.client.OpenAIClient
+import com.openai.models.responses.Response
+import com.openai.models.responses.ResponseCreateParams
+import com.openai.models.responses.ResponseFunctionToolCall
+import com.openai.models.responses.ResponseInputItem
+import com.openai.models.responses.ResponseOutputItem
+import com.openai.models.responses.ResponseOutputMessage
+import com.openai.models.responses.ResponseOutputText
+import com.openai.models.responses.ResponseReasoningItem
+import com.openai.models.responses.ResponseUsage
+import com.openai.services.blocking.ResponseService
+import io.micrometer.observation.Observation
+import io.micrometer.observation.ObservationHandler
+import io.micrometer.observation.ObservationRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.SystemMessage
+import org.springframework.ai.chat.messages.ToolResponseMessage
+import org.springframework.ai.chat.messages.UserMessage
+import org.springframework.ai.chat.prompt.Prompt
+import org.springframework.ai.openai.OpenAiChatModel
+import org.springframework.ai.openai.OpenAiChatOptions
+import org.springframework.ai.tool.definition.ToolDefinition
+import java.util.Optional
+
+/**
+ * The adapter is the only thing standing between Embabel and a wire format Spring AI cannot
+ * speak, so these tests pin the contract in both directions: what Embabel guarantees to the
+ * adapter, and what the surrounding code assumes of what comes back.
+ *
+ * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
+ */
+class OpenAiResponsesChatModelTest {
+
+    private val client = mockk<OpenAIClient>()
+    private val responseService = mockk<ResponseService>()
+
+    private val model = OpenAiResponsesChatModel(
+        client = client,
+        defaultOptions = OpenAiChatOptions.builder().model("gpt-5-pro").build(),
+    )
+
+    /** Stubs the SDK call and returns the params the adapter built. */
+    private fun capture(prompt: Prompt, response: Response = textResponse("ok")): ResponseCreateParams {
+        val params = slot<ResponseCreateParams>()
+        every { client.responses() } returns responseService
+        every { responseService.create(capture(params)) } returns response
+        model.call(prompt)
+        return params.captured
+    }
+
+    private fun respondWith(response: Response) {
+        every { client.responses() } returns responseService
+        every { responseService.create(any<ResponseCreateParams>()) } returns response
+    }
+
+    @Nested
+    inner class RequestMapping {
+
+        /**
+         * The Responses API has no system role: a system message carried as an input item is
+         * treated as ordinary user text, quietly losing its authority over the model.
+         */
+        @Test
+        fun `system messages become instructions, everything else becomes input`() {
+            val params = capture(
+                Prompt(
+                    listOf(SystemMessage("You are terse."), UserMessage("Hello")),
+                    OpenAiChatOptions.builder().model("gpt-5-pro").build(),
+                )
+            )
+
+            assertEquals("You are terse.", params.instructions().orElse(null))
+
+            val input = params.input().orElseThrow().asResponse()
+            assertEquals(1, input.size, "The system message must not also appear as input")
+            assertEquals("Hello", input.single().easyInputMessage().orElseThrow().content().asTextInput())
+        }
+
+        /**
+         * Embabel drives its own tool loop: it replays the assistant's tool calls and their results
+         * on the next turn. The Responses API pairs the two by `call_id`, so a lost or renamed id
+         * strands the loop — the model reissues the same call forever.
+         */
+        @Test
+        fun `tool calls and their results are paired by call id`() {
+            val toolCall = AssistantMessage.ToolCall("call_42", "function", "lookup", """{"q":"x"}""")
+            val params = capture(
+                Prompt(
+                    listOf(
+                        UserMessage("Find x"),
+                        AssistantMessage.builder().content("").toolCalls(listOf(toolCall)).build(),
+                        ToolResponseMessage.builder()
+                            .responses(listOf(ToolResponseMessage.ToolResponse("call_42", "lookup", "found")))
+                            .build(),
+                    ),
+                    OpenAiChatOptions.builder().model("gpt-5-pro").build(),
+                )
+            )
+
+            val input = params.input().orElseThrow().asResponse()
+
+            val call = input.mapNotNull { it.functionCall().orElse(null) }.single()
+            assertEquals("call_42", call.callId())
+            assertEquals("lookup", call.name())
+            assertEquals("""{"q":"x"}""", call.arguments())
+
+            val output = input.mapNotNull { it.functionCallOutput().orElse(null) }.single()
+            assertEquals("call_42", output.callId(), "call_id must survive the round trip")
+            assertTrue(output.output().toString().contains("found"), "Tool result reaches the model")
+        }
+
+        @Test
+        fun `tool definitions are forwarded as function tools`() {
+            val params = capture(
+                Prompt(
+                    listOf(UserMessage("Hi")),
+                    OpenAiChatOptions.builder()
+                        .model("gpt-5-pro")
+                        .toolCallbacks(listOf(toolCallback("lookup", "Looks things up")))
+                        .build(),
+                )
+            )
+
+            val tool = params.tools().orElseThrow().single().function().orElseThrow()
+            assertEquals("lookup", tool.name())
+            assertEquals("Looks things up", tool.description().orElse(null))
+            assertNotNull(tool.parameters(), "A tool without parameters cannot be called")
+        }
+
+        /**
+         * `OpenAiNativeStructuredOutputConfigurer` writes the schema as a Chat Completions
+         * `response_format`. The Responses API carries it under `text.format` instead, and unlike
+         * Chat Completions it requires a name — so the adapter has to supply one.
+         */
+        @Test
+        fun `native structured output is rewritten as a text format`() {
+            val schema = """{"type":"object","properties":{"answer":{"type":"string"}}}"""
+            val params = capture(
+                Prompt(
+                    listOf(UserMessage("Hi")),
+                    OpenAiChatOptions.builder()
+                        .model("gpt-5-pro")
+                        .responseFormat(
+                            OpenAiChatModel.ResponseFormat.builder()
+                                .type(OpenAiChatModel.ResponseFormat.Type.JSON_SCHEMA)
+                                .jsonSchema(schema)
+                                .build()
+                        )
+                        .build(),
+                )
+            )
+
+            val format = params.text().orElseThrow().format().orElseThrow().jsonSchema().orElseThrow()
+            assertTrue(format.name().isNotBlank(), "The Responses API rejects an unnamed json_schema")
+
+            val properties = format.schema()._additionalProperties()
+            assertEquals("object", properties["type"]?.asString()?.orElse(null))
+            assertTrue(
+                properties["properties"].toString().contains("answer"),
+                "The schema must survive the format change intact, got: $properties",
+            )
+        }
+
+        /** A response_format that is not a JSON schema has no Responses equivalent to carry. */
+        @Test
+        fun `non schema response formats are dropped rather than mistranslated`() {
+            val params = capture(
+                Prompt(
+                    listOf(UserMessage("Hi")),
+                    OpenAiChatOptions.builder()
+                        .model("gpt-5-pro")
+                        .responseFormat(
+                            OpenAiChatModel.ResponseFormat.builder()
+                                .type(OpenAiChatModel.ResponseFormat.Type.TEXT)
+                                .build()
+                        )
+                        .build(),
+                )
+            )
+
+            assertTrue(params.text().isEmpty)
+        }
+
+        /**
+         * The pro models are served by [Gpt5ChatOptionsConverter], which carries the caller's token
+         * limit on `maxCompletionTokens` because the GPT-5 family rejects `max_tokens`. Reading only
+         * the latter here would silently drop every limit the caller set.
+         */
+        @Test
+        fun `token limit is read from either options field`() {
+            assertEquals(
+                256L,
+                capture(
+                    Prompt(
+                        listOf(UserMessage("Hi")),
+                        OpenAiChatOptions.builder().model("gpt-5-pro").maxCompletionTokens(256).build(),
+                    )
+                ).maxOutputTokens().orElse(null),
+            )
+
+            assertEquals(
+                128L,
+                capture(
+                    Prompt(
+                        listOf(UserMessage("Hi")),
+                        OpenAiChatOptions.builder().model("gpt-5-pro").maxTokens(128).build(),
+                    )
+                ).maxOutputTokens().orElse(null),
+                "Options built elsewhere still use maxTokens",
+            )
+        }
+
+        /**
+         * `SpringAiLlmService.convertOptions` stamps the configured model onto every request, but
+         * the converters it delegates to do not set one, so the default has to hold the floor.
+         */
+        @Test
+        fun `request model comes from the prompt, falling back to the configured default`() {
+            assertEquals(
+                "gpt-5.4-pro",
+                capture(
+                    Prompt(
+                        listOf(UserMessage("Hi")),
+                        OpenAiChatOptions.builder().model("gpt-5.4-pro").build(),
+                    )
+                ).model().orElseThrow().asString(),
+            )
+
+            assertEquals(
+                "gpt-5-pro",
+                capture(Prompt(listOf(UserMessage("Hi")))).model().orElseThrow().asString(),
+            )
+        }
+    }
+
+    @Nested
+    inner class ResponseMapping {
+
+        @Test
+        fun `text output becomes the assistant message`() {
+            respondWith(textResponse("READY"))
+
+            assertEquals("READY", model.call(Prompt("Hi")).result.output.text)
+        }
+
+        /**
+         * `SpringAiLlmMessageSender.findGenerationWithToolCalls` looks for tool calls on the
+         * generations to decide whether the loop continues.
+         */
+        @Test
+        fun `function call output becomes a tool call embabel can dispatch`() {
+            respondWith(
+                response(
+                    ResponseOutputItem.ofFunctionCall(
+                        ResponseFunctionToolCall.builder()
+                            .callId("call_7")
+                            .name("lookup")
+                            .arguments("""{"q":"x"}""")
+                            .build()
+                    )
+                )
+            )
+
+            val toolCall = model.call(Prompt("Hi")).result.output.toolCalls.single()
+            assertEquals("call_7", toolCall.id)
+            assertEquals("function", toolCall.type, "Spring AI dispatches on this discriminator")
+            assertEquals("lookup", toolCall.name)
+            assertEquals("""{"q":"x"}""", toolCall.arguments)
+        }
+
+        /**
+         * `SpringAiLlmMessageSender` dereferences `response.result` without a null check. A
+         * reasoning model can return output holding nothing but reasoning items — no message, no
+         * tool call — for instance when it exhausts its output budget while thinking. Returning an
+         * empty generation list there turns a recoverable empty answer into an NPE inside Embabel.
+         */
+        @Test
+        fun `reasoning-only output still yields one generation`() {
+            respondWith(
+                response(
+                    ResponseOutputItem.ofReasoning(
+                        ResponseReasoningItem.builder().id("rs_1").summary(emptyList()).build()
+                    )
+                )
+            )
+
+            val response = model.call(Prompt("Hi"))
+
+            assertEquals(1, response.results.size)
+            assertNotNull(response.result.output, "Embabel dereferences this without a null check")
+            assertEquals("", response.result.output.text)
+            assertTrue(response.result.output.toolCalls.isEmpty())
+        }
+
+        /** Without usage, every pro-model call is priced at zero. */
+        @Test
+        fun `token usage is carried through for cost tracking`() {
+            respondWith(textResponse("ok", usage(inputTokens = 120, outputTokens = 34)))
+
+            val usage = model.call(Prompt("Hi")).metadata.usage
+            assertEquals(120, usage.promptTokens)
+            assertEquals(34, usage.completionTokens)
+            assertEquals(154, usage.totalTokens)
+        }
+
+        /** OpenAI's own ids deserialize to a union variant, not to a plain string. */
+        @Test
+        fun `model name is reported in the response metadata`() {
+            respondWith(textResponse("ok"))
+
+            assertEquals("gpt-5-pro", model.call(Prompt("Hi")).metadata.model)
+        }
+    }
+
+    @Nested
+    inner class ContractWithSurroundingCode {
+
+        /**
+         * `StreamingCapabilityVerifier` probes streaming support by calling [stream] and catching
+         * exactly [UnsupportedOperationException]; any other type propagates and takes down the
+         * caller instead of reporting "no streaming here".
+         */
+        @Test
+        fun `stream signals unsupported in the one way the verifier understands`() {
+            assertThrows(UnsupportedOperationException::class.java) {
+                model.stream(Prompt("Hi"))
+            }
+        }
+
+        @Test
+        fun `default options expose the configured model`() {
+            assertEquals("gpt-5-pro", model.defaultOptions.model)
+        }
+
+        /**
+         * Embabel's `embabel.llm` and `embabel.tool_loop` spans are deliberately thin, because the
+         * generation content is expected on the nested Spring AI ChatModel observation. Without one,
+         * pro-model calls lose their prompt, completion and token counts from every trace.
+         */
+        @Test
+        fun `the call is observed so traces keep their generation content`() {
+            val observed = mutableListOf<String>()
+            val registry = ObservationRegistry.create().apply {
+                observationConfig().observationHandler(
+                    object : ObservationHandler<Observation.Context> {
+                        override fun supportsContext(context: Observation.Context) = true
+                        override fun onStop(context: Observation.Context) {
+                            observed += context.name
+                        }
+                    }
+                )
+            }
+            val observedModel = OpenAiResponsesChatModel(
+                client = client,
+                defaultOptions = OpenAiChatOptions.builder().model("gpt-5-pro").build(),
+                observationRegistry = registry,
+            )
+            respondWith(textResponse("ok"))
+
+            observedModel.call(Prompt("Hi"))
+
+            assertEquals(1, observed.size, "Exactly one chat model observation per call")
+            assertTrue(observed.single().startsWith("gen_ai"), "Observed as: ${observed.single()}")
+        }
+
+        /** A failed call must not leave the observation open, or the trace never closes. */
+        @Test
+        fun `a failing call still closes its observation`() {
+            val errors = mutableListOf<Throwable?>()
+            val registry = ObservationRegistry.create().apply {
+                observationConfig().observationHandler(
+                    object : ObservationHandler<Observation.Context> {
+                        override fun supportsContext(context: Observation.Context) = true
+                        override fun onStop(context: Observation.Context) {
+                            errors += context.error
+                        }
+                    }
+                )
+            }
+            val observedModel = OpenAiResponsesChatModel(
+                client = client,
+                defaultOptions = OpenAiChatOptions.builder().model("gpt-5-pro").build(),
+                observationRegistry = registry,
+            )
+            every { client.responses() } returns responseService
+            every { responseService.create(any<ResponseCreateParams>()) } throws IllegalStateException("boom")
+
+            assertThrows(IllegalStateException::class.java) { observedModel.call(Prompt("Hi")) }
+
+            assertEquals(1, errors.size, "The observation must be stopped even on failure")
+            assertNotNull(errors.single(), "The failure must be recorded on the observation")
+        }
+    }
+
+    // --- fixtures -------------------------------------------------------------------------
+
+    private fun toolCallback(name: String, description: String) =
+        object : org.springframework.ai.tool.ToolCallback {
+            override fun getToolDefinition(): ToolDefinition =
+                ToolDefinition.builder()
+                    .name(name)
+                    .description(description)
+                    .inputSchema("""{"type":"object","properties":{"q":{"type":"string"}}}""")
+                    .build()
+
+            override fun call(toolInput: String): String = "unused"
+        }
+
+    private fun usage(inputTokens: Long, outputTokens: Long): ResponseUsage =
+        ResponseUsage.builder()
+            .inputTokens(inputTokens)
+            .inputTokensDetails(ResponseUsage.InputTokensDetails.builder().cachedTokens(0).build())
+            .outputTokens(outputTokens)
+            .outputTokensDetails(ResponseUsage.OutputTokensDetails.builder().reasoningTokens(0).build())
+            .totalTokens(inputTokens + outputTokens)
+            .build()
+
+    private fun textResponse(text: String, usage: ResponseUsage? = null): Response =
+        response(
+            ResponseOutputItem.ofMessage(
+                ResponseOutputMessage.builder()
+                    .id("msg_1")
+                    .addContent(ResponseOutputText.builder().text(text).annotations(emptyList()).build())
+                    .status(ResponseOutputMessage.Status.COMPLETED)
+                    .build()
+            ),
+            usage = usage,
+        )
+
+    private fun response(vararg output: ResponseOutputItem, usage: ResponseUsage? = null): Response =
+        Response.builder()
+            .id("resp_1")
+            .createdAt(0.0)
+            .model("gpt-5-pro")
+            .output(output.toList())
+            .parallelToolCalls(false)
+            .toolChoice(com.openai.models.responses.ToolChoiceOptions.AUTO)
+            .tools(emptyList())
+            // The SDK treats these as required even when absent on the wire.
+            .error(Optional.empty())
+            .incompleteDetails(Optional.empty())
+            .instructions(Optional.empty())
+            .metadata(Optional.empty())
+            .temperature(Optional.empty())
+            .topP(Optional.empty())
+            .apply { usage?.let { usage(it) } }
+            .build()
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
@@ -23,6 +23,7 @@ import com.openai.models.responses.ResponseFunctionToolCall
 import com.openai.models.responses.ResponseInputItem
 import com.openai.models.responses.ResponseOutputItem
 import com.openai.models.responses.ResponseOutputMessage
+import com.openai.models.responses.ResponseOutputRefusal
 import com.openai.models.responses.ResponseOutputText
 import com.openai.models.responses.ResponseReasoningItem
 import com.openai.models.responses.ResponseStatus
@@ -456,6 +457,38 @@ class OpenAiResponsesChatModelTest {
             )
         }
 
+        /** A refusal comes back `completed` with no output text — indistinguishable from silence. */
+        @Test
+        fun `a refusal is raised, not passed off as an empty answer`() {
+            respondWith(
+                response(
+                    ResponseOutputItem.ofMessage(
+                        ResponseOutputMessage.builder()
+                            .id("msg_1")
+                            .addContent(ResponseOutputRefusal.builder().refusal("I cannot help with that.").build())
+                            .status(ResponseOutputMessage.Status.COMPLETED)
+                            .build()
+                    ),
+                    status = ResponseStatus.COMPLETED,
+                )
+            )
+
+            val failure = assertThrows(NonTransientAiException::class.java) { model.call(Prompt("Hi")) }
+
+            assertTrue(
+                failure.message.orEmpty().contains("I cannot help with that."),
+                "The model's own wording is the only useful part, got: ${failure.message}",
+            )
+        }
+
+        /** Cancellation is another 200 carrying no answer. */
+        @Test
+        fun `a cancelled response is raised rather than returned empty`() {
+            respondWith(response(status = ResponseStatus.CANCELLED))
+
+            assertThrows(NonTransientAiException::class.java) { model.call(Prompt("Hi")) }
+        }
+
         /**
          * `max_output_tokens` is spent on reasoning too, so a pro model runs out mid-thought
          * routinely. The partial answer is worth keeping — but silently, it reads as a complete one.
@@ -527,11 +560,7 @@ class OpenAiResponsesChatModelTest {
     @Nested
     inner class ContractWithSurroundingCode {
 
-        /**
-         * `StreamingCapabilityVerifier` probes streaming support by calling [stream] and catching
-         * exactly [UnsupportedOperationException]; any other type propagates and takes down the
-         * caller instead of reporting "no streaming here".
-         */
+        /** `StreamingCapabilityVerifier` probes streaming support by calling [stream] and catching this. */
         @Test
         fun `stream signals unsupported in the one way the verifier understands`() {
             assertThrows(UnsupportedOperationException::class.java) {

--- a/embabel-agent-observability/src/main/java/com/embabel/agent/observability/tracing/ChatModelObservationFilter.java
+++ b/embabel-agent-observability/src/main/java/com/embabel/agent/observability/tracing/ChatModelObservationFilter.java
@@ -24,7 +24,10 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.util.ReflectionUtils;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -135,9 +138,10 @@ public class ChatModelObservationFilter implements ObservationFilter {
                     context.addHighCardinalityKeyValue(KeyValue.of(SpanAttributes.GEN_AI_REQUEST_TEMPERATURE,
                             String.valueOf(request.getOptions().getTemperature())));
                 }
-                if (request.getOptions().getMaxTokens() != null) {
+                Integer maxTokens = maxTokensOf(request.getOptions());
+                if (maxTokens != null) {
                     context.addHighCardinalityKeyValue(KeyValue.of(SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS,
-                            String.valueOf(request.getOptions().getMaxTokens())));
+                            String.valueOf(maxTokens)));
                 }
                 if (request.getOptions().getTopP() != null) {
                     context.addHighCardinalityKeyValue(KeyValue.of(SpanAttributes.GEN_AI_REQUEST_TOP_P,
@@ -175,6 +179,22 @@ public class ChatModelObservationFilter implements ObservationFilter {
         }
 
         return context;
+    }
+
+    /**
+     * The GPT-5 family rejects {@code max_tokens} and carries the limit on {@code maxCompletionTokens},
+     * a field only provider-specific options declare — hence the reflective read rather than a cast.
+     */
+    private static Integer maxTokensOf(ChatOptions options) {
+        if (options.getMaxTokens() != null) {
+            return options.getMaxTokens();
+        }
+        Method getter = ReflectionUtils.findMethod(options.getClass(), "getMaxCompletionTokens");
+        if (getter == null) {
+            return null;
+        }
+        ReflectionUtils.makeAccessible(getter);
+        return (Integer) ReflectionUtils.invokeMethod(getter, options);
     }
 
     /**

--- a/embabel-agent-observability/src/test/java/com/embabel/agent/observability/tracing/ChatModelObservationFilterTest.java
+++ b/embabel-agent-observability/src/test/java/com/embabel/agent/observability/tracing/ChatModelObservationFilterTest.java
@@ -15,6 +15,8 @@
  */
 package com.embabel.agent.observability.tracing;
 
+import com.embabel.agent.observability.SpanAttributes;
+
 import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.observation.Observation;
@@ -27,6 +29,8 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.model.Generation;
 import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.DefaultChatOptions;
 import org.springframework.ai.chat.prompt.Prompt;
 
 import java.util.List;
@@ -210,6 +214,52 @@ class ChatModelObservationFilterTest {
             assertSame(plain, result);
             assertFalse(result.getHighCardinalityKeyValues().iterator().hasNext());
             assertFalse(result.getLowCardinalityKeyValues().iterator().hasNext());
+        }
+    }
+
+    @Nested
+    @DisplayName("request max tokens")
+    class RequestMaxTokens {
+
+        /** Providers that reject {@code max_tokens} — the GPT-5 family — carry the limit here instead. */
+        private static final class OptionsWithCompletionTokens extends DefaultChatOptions {
+            private OptionsWithCompletionTokens() {
+                super(null, null, null, null, null, null, null, null);
+            }
+
+            public Integer getMaxCompletionTokens() {
+                return 512;
+            }
+        }
+
+        private Map<String, String> mappedKeyValues(ChatOptions options) {
+            ChatModelObservationContext context = contextWith(new Prompt(List.of(new UserMessage("hi")), options));
+            return highCardinality(new ChatModelObservationFilter(4000).map(context));
+        }
+
+        @Test
+        @DisplayName("maxTokens is reported when the provider uses it")
+        void maxTokensReported() {
+            Map<String, String> kv = mappedKeyValues(ChatOptions.builder().maxTokens(256).build());
+
+            assertEquals("256", kv.get(SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS));
+        }
+
+        @Test
+        @DisplayName("maxCompletionTokens stands in when the provider rejects max_tokens")
+        void maxCompletionTokensReported() {
+            Map<String, String> kv = mappedKeyValues(new OptionsWithCompletionTokens());
+
+            assertEquals("512", kv.get(SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS),
+                    "Without this the whole GPT-5 family loses its token limit from every trace");
+        }
+
+        @Test
+        @DisplayName("no limit set means no attribute")
+        void noLimitNoAttribute() {
+            Map<String, String> kv = mappedKeyValues(ChatOptions.builder().build());
+
+            assertNull(kv.get(SpanAttributes.GEN_AI_REQUEST_MAX_TOKENS));
         }
     }
 }

--- a/embabel-agent-openai/pom.xml
+++ b/embabel-agent-openai/pom.xml
@@ -38,22 +38,16 @@
         <!--
           Spring AI 2.0 swapped its hand-rolled OpenAiApi for the openai-java SDK.
           The factory references OpenAIClient / OpenAIOkHttpClient directly, so we
-          need both on the compile classpath. Versions pinned inline (matching
-          spring-ai-openai 2.0.0-M8's compile-time expectation) to keep this module
-          self-contained — the parent BOM's `openai-java` entry is for older tests
-          and is scope=test by default, which would hide OpenAIClient from main.
+          need both on the compile classpath. Versions come from the root pom, which
+          aligns them with the openai-java-core that spring-ai-openai pulls in.
         -->
         <dependency>
             <groupId>com.openai</groupId>
             <artifactId>openai-java</artifactId>
-            <version>4.36.0</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.openai</groupId>
             <artifactId>openai-java-client-okhttp</artifactId>
-            <version>4.36.0</version>
-            <scope>compile</scope>
         </dependency>
 
         <!--

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/converters.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/converters.kt
@@ -21,26 +21,52 @@ import com.embabel.common.util.loggerFor
 import org.springframework.ai.openai.OpenAiChatOptions
 
 /**
- * Options converter for GPT-5 models that don't support temperature adjustment.
+ * Options converter for GPT-5 models, which take a token limit and no other hyperparameter.
+ *
+ * `temperature`, `top_p`, `presence_penalty` and `frequency_penalty` are refused as a block — each
+ * for its presence alone, exactly like `max_tokens`:
+ *
+ * `400 Unsupported parameter: 'top_p' is not supported with this model.`
+ *
+ * so none of them is sent, and the limit travels on `max_completion_tokens`.
+ *
+ * The refusal is per model rather than per family, verified against the live API on 2026-08-05:
+ * gpt-5, gpt-5-mini, gpt-5-nano, gpt-5.3-chat, gpt-5.5 and the gpt-5.6 tiers refuse all four, while
+ * gpt-5.1, gpt-5.2 and the gpt-5.4 tiers accept them. Sending none of them to any of them keeps one
+ * converter for the whole family: the models that would have honoured a `topP` lose it the way they
+ * already lost `temperature`, and no caller gets a 400 for a parameter that was never essential.
  */
 object Gpt5ChatOptionsConverter : OptionsConverter<OpenAiChatOptions> {
 
     override fun convertOptions(options: LlmOptions): OpenAiChatOptions {
-        if (options.temperature != null && options.temperature != 1.0) {
-            loggerFor<Gpt5ChatOptionsConverter>().warn(
-                "GPT-5 models do not support temperature settings other than default 1.0. You set {} but it will be ignored.",
-                options.temperature,
-            )
-        }
+        warnAboutIgnoredParameters(options)
         return OpenAiChatOptions.builder()
-            .topP(options.topP)
             // Not maxTokens: the GPT-5 family rejects `max_tokens` with
             // "Unsupported parameter ... use 'max_completion_tokens' instead", and refuses the
             // request for the field's presence alone.
             .maxCompletionTokens(options.maxTokens)
-            .presencePenalty(options.presencePenalty)
-            .frequencyPenalty(options.frequencyPenalty)
             .build()
+    }
+
+    /**
+     * Dropping these silently would read as the model ignoring them; refusing the call outright
+     * would cost the caller an answer over a parameter that was never essential.
+     */
+    private fun warnAboutIgnoredParameters(options: LlmOptions) {
+        val ignored = buildList {
+            // The default temperature is what the model uses anyway, so asking for it is not a
+            // request that went unanswered.
+            options.temperature?.takeIf { it != 1.0 }?.let { add("temperature=$it") }
+            options.topP?.let { add("topP=$it") }
+            options.presencePenalty?.let { add("presencePenalty=$it") }
+            options.frequencyPenalty?.let { add("frequencyPenalty=$it") }
+        }
+        if (ignored.isNotEmpty()) {
+            loggerFor<Gpt5ChatOptionsConverter>().warn(
+                "This model rejects sampling parameters outright, so the following are ignored rather than sent: {}",
+                ignored.joinToString(", "),
+            )
+        }
     }
 }
 

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/converters.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/converters.kt
@@ -34,7 +34,10 @@ object Gpt5ChatOptionsConverter : OptionsConverter<OpenAiChatOptions> {
         }
         return OpenAiChatOptions.builder()
             .topP(options.topP)
-            .maxTokens(options.maxTokens)
+            // Not maxTokens: the GPT-5 family rejects `max_tokens` with
+            // "Unsupported parameter ... use 'max_completion_tokens' instead", and refuses the
+            // request for the field's presence alone.
+            .maxCompletionTokens(options.maxTokens)
             .presencePenalty(options.presencePenalty)
             .frequencyPenalty(options.frequencyPenalty)
             .build()
@@ -43,6 +46,9 @@ object Gpt5ChatOptionsConverter : OptionsConverter<OpenAiChatOptions> {
 
 /**
  * Standard options converter for OpenAI models that support all parameters.
+ *
+ * Keeps `maxTokens`: the models routed here — the GPT-4 family and OpenAI-compatible providers —
+ * accept it, and several do not know `max_completion_tokens` at all.
  */
 object StandardOpenAiOptionsConverter : OptionsConverter<OpenAiChatOptions> {
 

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ChatOptionsConverterTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ChatOptionsConverterTest.kt
@@ -37,14 +37,34 @@ class Gpt5ChatOptionsConverterTest(
         assertNull(temperature, "Custom temperature should be ignored for GPT-5")
     }
 
+    /**
+     * Sampling parameters are refused as a block, not one by one, and each with the same 400 the
+     * token limit used to earn:
+     * `400 Unsupported parameter: 'top_p' is not supported with this model.`
+     *
+     * Verified against the live API on 2026-08-05 for gpt-5, gpt-5-mini, gpt-5-nano,
+     * gpt-5.3-chat-latest, gpt-5.5 and the three gpt-5.6 tiers: `temperature`, `top_p`,
+     * `presence_penalty` and `frequency_penalty` are each rejected for their presence alone. So none
+     * of them may be sent — dropping only `temperature` still 400s the moment a caller sets a
+     * `topP`.
+     */
     @Test
-    fun `respects non-temperature options`() {
-        val llmo = LlmOptions.withModel(OpenAiModels.GPT_5).withTopK(10).withTopP(.2)
+    fun `sends no sampling parameter at all, since the model refuses every one of them`() {
+        val llmo = LlmOptions.withModel(OpenAiModels.GPT_5)
+            .withTopP(.2)
+            .withPresencePenalty(0.6)
+            .withFrequencyPenalty(0.4)
+
         val options = Gpt5ChatOptionsConverter.convertOptions(llmo)
-        assertEquals(llmo.topP, options.topP, "Top P should be preserved for GPT-5")
-        // Same @NullMarked workaround as in `ignores temperature` above.
-        val temperature: Double? = options.temperature
-        assertNull(temperature, "Temperature should not be set for GPT-5")
+
+        // Spring AI 2.0's OpenAiChatOptions package is @NullMarked, so Kotlin treats these getters
+        // as returning non-null — read into nullable locals to bypass, as in `ignores temperature`.
+        val topP: Double? = options.topP
+        val presencePenalty: Double? = options.presencePenalty
+        val frequencyPenalty: Double? = options.frequencyPenalty
+        assertNull(topP, "top_p is a 400 for these models")
+        assertNull(presencePenalty, "presence_penalty is a 400 for these models")
+        assertNull(frequencyPenalty, "frequency_penalty is a 400 for these models")
     }
 
     @Disabled("We not support thinking effort yet")
@@ -97,22 +117,12 @@ class Gpt5ChatOptionsConverterTest(
         assertNull(maxTokens)
     }
 
+    /**
+     * The token limit is the one hyperparameter these models do take, so a request built from a
+     * fully populated [LlmOptions] carries it and nothing else.
+     */
     @Test
-    fun `preserves presencePenalty`() {
-        val llmo = LlmOptions().withPresencePenalty(0.6)
-        val options = Gpt5ChatOptionsConverter.convertOptions(llmo)
-        assertEquals(0.6, options.presencePenalty, "Presence penalty should be preserved")
-    }
-
-    @Test
-    fun `preserves frequencyPenalty`() {
-        val llmo = LlmOptions().withFrequencyPenalty(0.4)
-        val options = Gpt5ChatOptionsConverter.convertOptions(llmo)
-        assertEquals(0.4, options.frequencyPenalty, "Frequency penalty should be preserved")
-    }
-
-    @Test
-    fun `converts all options except temperature`() {
+    fun `keeps the token limit and drops everything else`() {
         val llmo = LlmOptions()
             .withTemperature(0.7)
             .withTopP(0.9)
@@ -122,11 +132,15 @@ class Gpt5ChatOptionsConverterTest(
 
         val options = Gpt5ChatOptionsConverter.convertOptions(llmo)
 
-        assertNull(options.temperature, "Temperature should be ignored")
-        assertEquals(0.9, options.topP, "Top P should be preserved")
         assertEquals(1000, options.maxCompletionTokens, "Max tokens should be preserved")
-        assertEquals(0.5, options.presencePenalty, "Presence penalty should be preserved")
-        assertEquals(0.3, options.frequencyPenalty, "Frequency penalty should be preserved")
+        val temperature: Double? = options.temperature
+        val topP: Double? = options.topP
+        val presencePenalty: Double? = options.presencePenalty
+        val frequencyPenalty: Double? = options.frequencyPenalty
+        assertNull(temperature, "Temperature should be ignored")
+        assertNull(topP, "Top P should be ignored")
+        assertNull(presencePenalty, "Presence penalty should be ignored")
+        assertNull(frequencyPenalty, "Frequency penalty should be ignored")
     }
 
 }

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ChatOptionsConverterTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt5ChatOptionsConverterTest.kt
@@ -67,11 +67,34 @@ class Gpt5ChatOptionsConverterTest(
         assertNull(options.temperature, "Null temperature should remain null")
     }
 
+    /**
+     * The GPT-5 family rejects `max_tokens` outright:
+     * `400 Unsupported parameter: 'max_tokens' is not supported with this model.
+     * Use 'max_completion_tokens' instead.`
+     *
+     * Spring AI serialises [org.springframework.ai.openai.OpenAiChatOptions.maxTokens] to the
+     * former and `maxCompletionTokens` to the latter, so the limit has to be carried on the
+     * second field — and the first must stay unset, or the request is refused for its presence
+     * alone.
+     */
     @Test
-    fun `preserves maxTokens`() {
-        val llmo = LlmOptions().withMaxTokens(500)
-        val options = Gpt5ChatOptionsConverter.convertOptions(llmo)
-        assertEquals(500, options.maxTokens, "Max tokens should be preserved")
+    fun `carries a token limit on maxCompletionTokens, which is the field GPT-5 accepts`() {
+        val options = Gpt5ChatOptionsConverter.convertOptions(LlmOptions().withMaxTokens(500))
+
+        assertEquals(500, options.maxCompletionTokens, "The limit must still reach the model")
+
+        val maxTokens: Int? = options.maxTokens
+        assertNull(maxTokens, "Sending max_tokens at all is a 400 for every GPT-5 model")
+    }
+
+    @Test
+    fun `sends neither token field when no limit was asked for`() {
+        val options = Gpt5ChatOptionsConverter.convertOptions(LlmOptions())
+
+        val maxCompletionTokens: Int? = options.maxCompletionTokens
+        val maxTokens: Int? = options.maxTokens
+        assertNull(maxCompletionTokens)
+        assertNull(maxTokens)
     }
 
     @Test
@@ -101,7 +124,7 @@ class Gpt5ChatOptionsConverterTest(
 
         assertNull(options.temperature, "Temperature should be ignored")
         assertEquals(0.9, options.topP, "Top P should be preserved")
-        assertEquals(1000, options.maxTokens, "Max tokens should be preserved")
+        assertEquals(1000, options.maxCompletionTokens, "Max tokens should be preserved")
         assertEquals(0.5, options.presencePenalty, "Presence penalty should be preserved")
         assertEquals(0.3, options.frequencyPenalty, "Frequency penalty should be preserved")
     }

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,9 @@
         <argLine />
         <embabel-common.version>2.0.0-SNAPSHOT</embabel-common.version>
         <netty.version>4.2.16.Final</netty.version>
+        <!-- Matches the openai-java-core that spring-ai-openai 2.0.0 depends on. Bump in
+             step with spring-ai-openai; drop once embabel-build-dependencies catches up. -->
+        <openai-java.version>4.39.1</openai-java.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>
     </properties>
@@ -52,6 +55,27 @@
     <!-- Embabel Common BOM -->
     <dependencyManagement>
         <dependencies>
+            <!--
+              OpenAI SDK, aligned repo-wide.
+
+              embabel-build-dependencies manages these at 4.36.0, the version
+              spring-ai-openai 2.0.0-M8 compiled against. The 2.0.0 GA release moved its
+              own openai-java-core to 4.39.1, so the managed version now puts two releases
+              of the same SDK on the classpath. Managing them here overrides the parent BOM
+              for direct and transitive uses alike — a version set in a module's
+              <dependencies> only governs that module, and reverts to the managed value
+              wherever it is inherited downstream.
+            -->
+            <dependency>
+                <groupId>com.openai</groupId>
+                <artifactId>openai-java</artifactId>
+                <version>${openai-java.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.openai</groupId>
+                <artifactId>openai-java-client-okhttp</artifactId>
+                <version>${openai-java.version}</version>
+            </dependency>
             <!-- Embabel Agent BOM -->
             <dependency>
                 <groupId>com.embabel.agent</groupId>


### PR DESCRIPTION
## Summary

OpenAI serves the `*-pro` models only over `/v1/responses`. Embabel routed them to `/v1/chat/completions`, so every call returned HTTP 400. No test ever called them, so the build stayed green.

Spring AI has no client for that endpoint (spring-projects/spring-ai#2962, milestone 2.1.x), so this adds an adapter. Fixing the transport surfaced three defects on the same path, all included here.

Fixes #1758

## 1. Responses API transport

`OpenAiResponsesChatModel` adapts the OpenAI SDK to Spring AI's `ChatModel`. Single request/response only: Embabel drives its own tool loop, so background mode, server-side conversation state and remote MCP stay unused. Non-streaming.

The two APIs differ on most of what matters:

| Chat Completions | Responses |
|---|---|
| `system` role message | `instructions` field |
| `response_format.json_schema` | `text.format`, schema **must** be named |
| `tools[].function` | flat `FunctionTool` |
| `max_tokens` | `max_output_tokens`, which reasoning tokens also consume |
| `finish_reason` | `status` + `incomplete_details.reason` |

Transport is declared per model, defaulting to `CHAT_COMPLETIONS` so existing catalogs keep working:

```yaml
- name: "gpt5pro"
  model_id: "gpt-5-pro"
  api_format: "RESPONSES"
```

Declared, not inferred from the id. GPT-5.6 dropped the `-pro` suffix one release later: its tiers are Luna/Terra/Sol, and "pro" became a reasoning mode.

## 2. GPT-5 takes a token limit and nothing else

`max_tokens` is rejected for its presence alone:

```
400 Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
```

Same for `top_p`, `presence_penalty` and `frequency_penalty`. The converter now sends `max_completion_tokens` and no sampling parameter at all, warning on whatever it drops.

The refusal is per model, verified live on 2026-08-05: `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5.3-chat`, `gpt-5.5` and the `gpt-5.6` tiers refuse all four; `gpt-5.1`, `gpt-5.2` and the `gpt-5.4` tiers accept them. Sending none to any keeps a single converter for the family.

`StandardOpenAiOptionsConverter` is untouched: GPT-4 and OpenAI-compatible providers still get everything, `max_tokens` included.

Side effect fixed: `gen_ai.request.max_tokens` had disappeared from traces for the whole GPT-5 family, since `ChatModelObservationFilter` reads `getMaxTokens()`. It now falls back to `maxCompletionTokens`.

## 3. Failures that looked like success

The Responses API reports refusals, failures and truncation inside a 200. Read only `output` and a refused call is indistinguishable from a model with nothing to say.

Now raised as `NonTransientAiException`, which `SpringAiRetryPolicy` reads to skip a pointless retry:

- `status: failed` and `status: cancelled`
- a `refusal` content part, which arrives as `completed` with no output text

Truncation is kept rather than raised: `status: incomplete` returns its partial text with `length` or `content_filter` as the finish reason.

## 4. Dependency alignment

`spring-ai-openai` 2.0.0 moved `openai-java-core` to 4.39.1 while the parent BOM still manages `openai-java` at 4.36.0, putting two releases of one SDK on the classpath. Managed at 4.39.1 in the root pom, to be dropped once the BOM catches up.

## 5. Catalog: GPT-5.5 and GPT-5.6

The catalog stopped at GPT-5.4. Verified against `developers.openai.com` on 2026-08-04:

| model | transport | input /1M | output /1M |
|---|---|---|---|
| `gpt-5.6-sol` | Chat Completions | $5.00 | $30.00 |
| `gpt-5.6-terra` | Chat Completions | $2.00 | $12.00 |
| `gpt-5.6-luna` | Chat Completions | $0.20 | $1.20 |
| `gpt-5.5` | Chat Completions | $5.00 | $30.00 |
| `gpt-5.5-pro` | **Responses** | $30.00 | $180.00 |

`gpt-5.5-pro` lists Chat Completions as "Not supported": a model released after the fix was written, landing in exactly the case it handles.

## Testing

Unit tests cover the adapter's mapping in both directions, catalog parsing, and transport routing through the real bean-registration path. No Spring context, no network.

Integration tests hit the live API, gated on `OPENAI_API_KEY` and skipped when the project is not entitled to a model:

- `OpenAiCatalogIT`: one `GET /v1/models` validates every catalog id; the five new models each answer over the transport they declare.
- `OpenAiResponsesAdapterIT`: structured output and tool calling, the two paths a mocked SDK cannot check.
- `Gpt5SamplingParamsIT` and `Gpt5MaxTokensIT`: which parameters each model accepts. This is how the per-model split above was established rather than assumed.

All green, including `gpt-5.5-pro` over Responses. These are excluded from `mvn test` by the parent POM's `**/*IT.java` rule and do not run in CI without a key.

## Known limitations

- **No streaming.** `stream()` throws `UnsupportedOperationException`, which is how the capability is reported absent.
- **No media.** An image-bearing prompt is refused rather than sent as text alone.
- **GPT-5.6 long-context pricing** is not represented. `PerTokenPricingModel` holds one price pair, so cost under-reports very large prompts.
- **`reasoning.mode: pro`** is not wired through. Different axis from `api_format`, out of scope here.

## Noted, not fixed

A pro model on a two-turn tool loop exceeds the 60s default LLM timeout (108s observed). It then succeeds only on retry, which replays the whole loop: tools called twice, reasoning billed twice. Worked around in the integration test; the default deserves its own issue.
