### PR TITLE
Fix/1871 observability boot4 regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1306,7 +1306,8 @@ embabel:
 # Enable Spring Boot tracing
 management:
   tracing:
-    enabled: true
+    export:
+      enabled: true
     sampling:
       probability: 1.0
 

--- a/embabel-agent-api/src/main/resources/agent-application.properties
+++ b/embabel-agent-api/src/main/resources/agent-application.properties
@@ -18,7 +18,14 @@ spring.ai.ollama.base-url=http://localhost:11434
 spring.ai.openai.api-key=${OPENAI_API_KEY}
 
 # Management
-management.tracing.enabled=false
+# management.tracing.enabled used to live here; Spring Boot 4 no longer binds it. Whether tracing
+# runs at all is governed by embabel.agent.platform.observability.* instead.
+#
+# The sampler IS honoured now, and Spring Boot defaults it to 10% of traces. Agent traces are
+# low-volume and individually valuable, so the platform default is full sampling. This file is a
+# @PropertySource, which ranks below an application's own application.properties/yml, so a
+# consumer wanting to sample down simply sets its own value.
+management.tracing.sampling.probability=1.0
 
 # MIGRATED TO agent-platform.properties with unified embabel.agent.platform.* prefix
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/ShippedApplicationPropertiesTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/ShippedApplicationPropertiesTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.config.spring
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.Properties
+
+/**
+ * Guards the property files that [AgentPlatformPropertiesLoader] contributes through
+ * `@PropertySource`. They are main resources, so every key declared there is imposed on every
+ * consuming application. A key that Spring Boot has removed or deprecated at error level is
+ * therefore not merely dead here — it silently stops doing whatever consumers relied on it for.
+ */
+internal class ShippedApplicationPropertiesTest {
+
+    /**
+     * Keys Spring Boot 4 no longer binds, mapped to their replacement.
+     */
+    private val unsupportedKeys = mapOf(
+        "management.tracing.enabled" to "management.tracing.export.enabled",
+    )
+
+    @Test
+    fun `shipped properties declare no key that Spring Boot 4 no longer binds`() {
+        for (resource in listOf("agent-application.properties", "agent-platform.properties")) {
+            val properties = load(resource)
+            for ((unsupported, replacement) in unsupportedKeys) {
+                assertTrue(
+                    !properties.containsKey(unsupported),
+                    "$resource declares '$unsupported', which Spring Boot 4 no longer binds. Use '$replacement'.",
+                )
+            }
+        }
+    }
+
+    /**
+     * Spring Boot samples 10% of traces by default. Now that the sampler is actually applied to the
+     * tracer provider, leaving that default in place would silently discard nine agent traces out
+     * of ten.
+     */
+    @Test
+    fun `shipped properties keep full trace sampling`() {
+        assertEquals(
+            "1.0",
+            load("agent-application.properties")["management.tracing.sampling.probability"],
+        )
+    }
+
+    private fun load(resource: String): Properties {
+        val properties = Properties()
+        javaClass.classLoader.getResourceAsStream(resource).use {
+            checkNotNull(it) { "$resource not found on the classpath" }.let(properties::load)
+        }
+        return properties
+    }
+}

--- a/embabel-agent-api/src/test/resources/application.properties
+++ b/embabel-agent-api/src/test/resources/application.properties
@@ -9,7 +9,7 @@ spring.ai.ollama.base-url=http://localhost:11434
 spring.ai.openai.api-key=${OPENAI_API_KEY}
 
 # Management
-management.tracing.enabled=false
+management.tracing.export.enabled=false
 
 # Embabel Agent Platform
 embabel.agent-platform.name=embabel-default

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/pom.xml
@@ -119,6 +119,27 @@
             <scope>test</scope>
         </dependency>
 
+        <!--
+            Boot's OpenTelemetryTracingAutoConfiguration lives here. The observability starter
+            ships it, so consumers always have it on the classpath; test scope lets this module
+            verify how Embabel's auto-configuration composes with Boot's (#1871).
+        -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-tracing-opentelemetry</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
+            Boot's CompositeMeterRegistryAutoConfiguration lives here; test scope so this module
+            can verify MeterRegistry-dependent wiring across auto-configuration boundaries (#1871).
+        -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-metrics</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test-internal</artifactId>

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/pom.xml
@@ -51,6 +51,19 @@
             <optional>true</optional>
         </dependency>
 
+        <!--
+            Spring Boot 4 moved MicrometerTracingAutoConfiguration out of
+            spring-boot-actuator-autoconfigure into spring-boot-micrometer-tracing
+            (org.springframework.boot.micrometer.tracing.autoconfigure).
+            Optional here so afterName FQCN can resolve when present; the
+            observability starter brings spring-boot-micrometer-tracing-opentelemetry.
+        -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-tracing</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- AspectJ weaver for @Tracked aspect support (direct dep, not spring-boot-starter-aspectj); provides org.aspectj.lang.* -->
         <dependency>
             <groupId>org.aspectj</groupId>

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfiguration.java
@@ -31,9 +31,11 @@ import com.embabel.agent.api.event.observation.AgentInstrumentation;
 import com.embabel.agent.observability.metrics.EmbabelMetricsEventListener;
 import com.embabel.agent.observability.tracing.MicrometerAgentInstrumentation;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.micrometer.observation.autoconfigure.ObservationRegistryCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -301,17 +303,30 @@ public class ObservabilityAutoConfiguration {
     /**
      * Creates the Micrometer business metrics listener.
      *
-     * @param meterRegistry the meter registry
+     * <p>The {@link MeterRegistry} is resolved lazily through an {@link ObjectProvider} rather than
+     * required as a bean condition: {@code @ConditionalOnBean} is evaluated while bean definitions
+     * are still being registered, so across auto-configuration boundaries it only sees registries
+     * declared by an auto-configuration that happened to run earlier. Spring Boot 4 split metrics
+     * and observation into separate modules and dropped the ordering edge that used to make that
+     * true, which silently suppressed this listener and with it every business metric. The provider
+     * defers resolution to instantiation time, when every definition is known.
+     *
+     * <p>Falls back to an empty {@code CompositeMeterRegistry}, which discards every measurement, so
+     * the listener stays wired without a registry rather than disappearing.
+     *
+     * @param meterRegistryProvider lazy provider for the meter registry
      * @param properties the observability properties
      * @return the metrics event listener
      */
     @Bean
-    @ConditionalOnBean(MeterRegistry.class)
+    @ConditionalOnClass(MeterRegistry.class)
     @ConditionalOnProperty(prefix = "embabel.agent.platform.observability", name = "metrics-enabled",
             havingValue = "true", matchIfMissing = true)
     public EmbabelMetricsEventListener embabelMetricsEventListener(
-            MeterRegistry meterRegistry, ObservabilityProperties properties) {
-        log.info("Configuring Embabel Agent Micrometer metrics listener");
+            ObjectProvider<MeterRegistry> meterRegistryProvider, ObservabilityProperties properties) {
+        MeterRegistry meterRegistry = meterRegistryProvider.getIfUnique(CompositeMeterRegistry::new);
+        log.info("Configuring Embabel Agent Micrometer metrics listener on {}",
+                meterRegistry.getClass().getSimpleName());
         return new EmbabelMetricsEventListener(meterRegistry, properties);
     }
 

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfiguration.java
@@ -56,8 +56,9 @@ import org.springframework.context.annotation.Primary;
 @AutoConfiguration(
         after = MicrometerTracingAutoConfiguration.class,
         afterName = {
-                "org.springframework.boot.actuate.autoconfigure.tracing.MicrometerTracingAutoConfiguration",
-                "org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration"
+                // Spring Boot 4 moved these out of spring-boot-actuator-autoconfigure
+                "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration",
+                "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration"
         }
 )
 @EnableConfigurationProperties(ObservabilityProperties.class)

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/OpenTelemetrySdkAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/OpenTelemetrySdkAutoConfiguration.java
@@ -25,6 +25,7 @@ import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
 import io.opentelemetry.semconv.ServiceAttributes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 
 import java.util.List;
 import java.util.Objects;
@@ -61,6 +63,18 @@ public class OpenTelemetrySdkAutoConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(OpenTelemetrySdkAutoConfiguration.class);
 
+    /** Order of the built-in customizer attaching the {@link Resource}. */
+    public static final int RESOURCE_CUSTOMIZER_ORDER = 0;
+
+    /** Order of the built-in customizer applying the {@code Sampler}. */
+    public static final int SAMPLER_CUSTOMIZER_ORDER = 100;
+
+    /** Order of the built-in customizer attaching the {@code SpanProcessor} beans. */
+    public static final int PROCESSOR_CUSTOMIZER_ORDER = 200;
+
+    /** Order of the built-in customizer attaching the {@code SpanExporter} beans. */
+    public static final int EXPORTER_CUSTOMIZER_ORDER = 300;
+
     /**
      * Creates the OpenTelemetry Resource with service name.
      *
@@ -77,63 +91,120 @@ public class OpenTelemetrySdkAutoConfiguration {
     }
 
     /**
-     * Creates the SdkTracerProvider with all configured SpanExporters and SpanProcessors.
+     * Attaches the OpenTelemetry {@link Resource} carrying the service identity.
      *
-     * @param exportersProvider provider for the list of SpanExporter beans
-     * @param processorsProvider provider for the list of SpanProcessor beans
-     * @param resource the OpenTelemetry Resource to associate with traces
+     * @param resource the resource to associate with every span
+     * @return the resource customizer
+     */
+    @Bean
+    @Order(RESOURCE_CUSTOMIZER_ORDER)
+    public SdkTracerProviderCustomizer embabelResourceCustomizer(Resource resource) {
+        return builder -> builder.setResource(resource);
+    }
+
+    /**
+     * Applies the {@link Sampler} bean, which is what makes {@code management.tracing.sampling.*}
+     * effective. Without it the provider keeps its {@code AlwaysOn} default and the configured
+     * sampling probability is silently ignored.
+     *
+     * <p>The sampler is resolved through an {@link ObjectProvider} rather than required as a bean
+     * condition: {@code @ConditionalOnBean} across auto-configuration boundaries is order-sensitive,
+     * and the sampler is contributed by a different auto-configuration.
+     *
+     * @param samplerProvider lazy provider for the sampler, absent when no tracing bridge is present
+     * @return the sampler customizer
+     */
+    @Bean
+    @Order(SAMPLER_CUSTOMIZER_ORDER)
+    public SdkTracerProviderCustomizer embabelSamplerCustomizer(ObjectProvider<Sampler> samplerProvider) {
+        return builder -> {
+            Sampler sampler = samplerProvider.getIfUnique();
+            if (sampler != null) {
+                log.debug("Applying Sampler: {}", sampler.getDescription());
+                builder.setSampler(sampler);
+            }
+        };
+    }
+
+    /**
+     * Attaches every {@code SpanProcessor} bean, whoever contributed it.
+     *
+     * @param processorsProvider provider for the SpanProcessor beans
+     * @return the span processor customizer
+     */
+    @Bean
+    @Order(PROCESSOR_CUSTOMIZER_ORDER)
+    public SdkTracerProviderCustomizer embabelSpanProcessorCustomizer(
+            ObjectProvider<List<SpanProcessor>> processorsProvider) {
+        return builder -> {
+            for (SpanProcessor processor : nonNullElements(processorsProvider)) {
+                log.debug("Added SpanProcessor: {}", processor.getClass().getSimpleName());
+                builder.addSpanProcessor(processor);
+            }
+        };
+    }
+
+    /**
+     * Wraps each {@code SpanExporter} bean in its own batch processor, but only when no span
+     * processor is present at all. An exporter reaches a backend only through a processor, and
+     * Spring Boot's tracing auto-configuration contributes one that wraps <em>every</em> exporter
+     * bean; wrapping them again attaches each exporter twice and exports every span twice.
+     *
+     * <p>Whether a given processor exports a given exporter cannot be determined generically, so
+     * this assumes it does. An application whose processor does <em>not</em> export them can attach
+     * them itself by contributing a {@link SdkTracerProviderCustomizer} of its own.
+     *
+     * @param exportersProvider provider for the SpanExporter beans
+     * @param processorsProvider provider for the SpanProcessor beans
+     * @return the span exporter customizer
+     */
+    @Bean
+    @Order(EXPORTER_CUSTOMIZER_ORDER)
+    public SdkTracerProviderCustomizer embabelSpanExporterCustomizer(
+            ObjectProvider<List<SpanExporter>> exportersProvider,
+            ObjectProvider<List<SpanProcessor>> processorsProvider) {
+        return builder -> {
+            List<SpanExporter> exporters = nonNullElements(exportersProvider);
+            if (!nonNullElements(processorsProvider).isEmpty()) {
+                log.info("Delegating export of {} SpanExporter bean(s) to the span processors already present. " +
+                        "Contribute an SdkTracerProviderCustomizer if those processors do not export them.",
+                        exporters.size());
+                return;
+            }
+            for (SpanExporter exporter : exporters) {
+                log.debug("Added SpanExporter: {}", exporter.getClass().getSimpleName());
+                builder.addSpanProcessor(BatchSpanProcessor.builder(exporter).build());
+            }
+        };
+    }
+
+    private static <T> List<T> nonNullElements(ObjectProvider<List<T>> provider) {
+        List<T> elements = provider.getIfAvailable();
+        return elements == null ? List.of() : elements.stream().filter(Objects::nonNull).toList();
+    }
+
+    /**
+     * Assembles the SdkTracerProvider by applying every {@link SdkTracerProviderCustomizer} in order.
+     *
+     * @param customizers the ordered customizers contributing each aspect of the provider
+     * @param exportersProvider provider for the SpanExporter beans, used only to detect that there
+     *                          is nothing to export to
      * @return the configured SdkTracerProvider, or null if no exporters are available
      */
     @Bean
     @ConditionalOnMissingBean(SdkTracerProvider.class)
     public SdkTracerProvider sdkTracerProvider(
-            ObjectProvider<List<SpanExporter>> exportersProvider,
-            ObjectProvider<List<SpanProcessor>> processorsProvider,
-            Resource resource) {
-
-        List<SpanExporter> exporters = exportersProvider.getIfAvailable();
-        List<SpanProcessor> processors = processorsProvider.getIfAvailable();
-
-        List<SpanExporter> validExporters = exporters == null
-                ? List.of()
-                : exporters.stream()
-                    .filter(Objects::nonNull)
-                    .toList();
-
-        List<SpanProcessor> validProcessors = processors == null
-                ? List.of()
-                : processors.stream()
-                    .filter(Objects::nonNull)
-                    .toList();
-
-        if (validExporters.isEmpty()) {
+            ObjectProvider<SdkTracerProviderCustomizer> customizers,
+            ObjectProvider<List<SpanExporter>> exportersProvider) {
+        if (nonNullElements(exportersProvider).isEmpty()) {
             log.warn("No SpanExporter beans found. OpenTelemetry tracing will be disabled. " +
                     "To enable tracing, add an exporter dependency (e.g., opentelemetry-exporter-langfuse, " +
                     "opentelemetry-exporter-zipkin) and configure it properly.");
             return null;
         }
-
-        SdkTracerProviderBuilder tracerProviderBuilder = SdkTracerProvider.builder()
-                .setResource(resource);
-
-        for (SpanProcessor processor : validProcessors) {
-            tracerProviderBuilder.addSpanProcessor(processor);
-            log.debug("Added SpanProcessor: {}", processor.getClass().getSimpleName());
-        }
-
-        for (SpanExporter exporter : validExporters) {
-            tracerProviderBuilder.addSpanProcessor(
-                    BatchSpanProcessor.builder(exporter).build()
-            );
-            log.debug("Added SpanExporter: {}", exporter.getClass().getSimpleName());
-        }
-
-        SdkTracerProvider tracerProvider = tracerProviderBuilder.build();
-
-        log.info("SdkTracerProvider configured with {} processor(s) and {} exporter(s)",
-                validProcessors.size(), validExporters.size());
-
-        return tracerProvider;
+        SdkTracerProviderBuilder builder = SdkTracerProvider.builder();
+        customizers.orderedStream().forEach(customizer -> customizer.customize(builder));
+        return builder.build();
     }
 
     /**

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/SdkTracerProviderCustomizer.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/observability/SdkTracerProviderCustomizer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.observability;
+
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+
+/**
+ * Applies one aspect of the tracer provider configuration.
+ *
+ * <p>Each concern — resource, sampler, span processors, exporters — is a separate customizer bean
+ * rather than a branch inside the assembling method, so supporting a new aspect means contributing
+ * a bean instead of editing the assembly. Beans are applied in {@code @Order} order.
+ *
+ * <p>Applications may contribute their own; the built-in ones are ordered below
+ * {@link OpenTelemetrySdkAutoConfiguration#EXPORTER_CUSTOMIZER_ORDER} so a later customizer sees a
+ * fully populated builder.
+ */
+@FunctionalInterface
+public interface SdkTracerProviderCustomizer {
+
+    /**
+     * Applies this customizer's aspect to the builder.
+     *
+     * @param builder the tracer provider builder being assembled
+     */
+    void customize(SdkTracerProviderBuilder builder);
+}

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/BootObservabilityInteropTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/BootObservabilityInteropTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.observability;
+
+import com.embabel.agent.observability.metrics.EmbabelMetricsEventListener;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies how Embabel's observability auto-configuration composes with Spring Boot's own
+ * observability auto-configurations.
+ *
+ * <p>Unlike {@link ObservabilityAutoConfigurationTest}, which supplies collaborators such as the
+ * {@code MeterRegistry} through {@code withUserConfiguration}, these tests let Boot's real
+ * auto-configurations contribute them. That difference is the point: a user configuration is always
+ * registered before the auto-configurations under test, so it hides the ordering sensitivity that
+ * {@code @ConditionalOnBean} and {@code @ConditionalOnMissingBean} carry across auto-configuration
+ * boundaries.
+ */
+class BootObservabilityInteropTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(
+                    org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration.class,
+                    org.springframework.boot.micrometer.metrics.autoconfigure.export.simple.SimpleMetricsExportAutoConfiguration.class,
+                    org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration.class,
+                    org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration.class,
+                    org.springframework.boot.opentelemetry.autoconfigure.OpenTelemetrySdkAutoConfiguration.class,
+                    org.springframework.boot.micrometer.tracing.opentelemetry.autoconfigure.OpenTelemetryTracingAutoConfiguration.class,
+                    org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration.class,
+                    OpenTelemetrySdkAutoConfiguration.class,
+                    MicrometerTracingAutoConfiguration.class,
+                    ObservabilityAutoConfiguration.class));
+
+    @AfterEach
+    void tearDown() {
+        GlobalOpenTelemetry.resetForTest();
+    }
+
+    @Nested
+    class MetricsListenerWiring {
+
+        @Test
+        void metricsListener_shouldBeCreated_whenBootContributesTheMeterRegistry() {
+            contextRunner.run(context -> {
+                assertThat(context).hasSingleBean(MeterRegistry.class);
+                assertThat(context).hasSingleBean(EmbabelMetricsEventListener.class);
+            });
+        }
+    }
+
+    @Nested
+    class SpanExportFanOut {
+
+        @Test
+        void span_shouldReachEachExporterExactlyOnce() {
+            contextRunner
+                    .withUserConfiguration(RecordingExporterConfig.class)
+                    .withPropertyValues("management.tracing.sampling.probability=1.0")
+                    .run(context -> {
+                        var exporter = context.getBean(InMemorySpanExporter.class);
+                        emitSpan(context.getBean(SdkTracerProvider.class));
+                        assertThat(exporter.getFinishedSpanItems()).hasSize(1);
+                    });
+        }
+    }
+
+    @Nested
+    class SamplerWiring {
+
+        @Test
+        void span_shouldNotBeExported_whenSamplingProbabilityIsZero() {
+            contextRunner
+                    .withUserConfiguration(RecordingExporterConfig.class)
+                    .withPropertyValues("management.tracing.sampling.probability=0.0")
+                    .run(context -> {
+                        var exporter = context.getBean(InMemorySpanExporter.class);
+                        emitSpan(context.getBean(SdkTracerProvider.class));
+                        assertThat(exporter.getFinishedSpanItems()).isEmpty();
+                    });
+        }
+    }
+
+    /**
+     * Whether a given span processor exports a given exporter cannot be determined generically, so
+     * the exporter customizer assumes it does. These cover that assumption being wrong, and the
+     * customizer chain being the way out of it.
+     */
+    @Nested
+    class ExportDelegation {
+
+        private final ApplicationContextRunner embabelOnlyRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(OpenTelemetrySdkAutoConfiguration.class))
+                .withUserConfiguration(RecordingExporterConfig.class, NonExportingProcessorConfig.class);
+
+        @Test
+        void exporter_shouldBeSkipped_whenAnotherProcessorIsPresent() {
+            embabelOnlyRunner.run(context -> {
+                var exporter = context.getBean(InMemorySpanExporter.class);
+                emitSpan(context.getBean(SdkTracerProvider.class));
+                assertThat(exporter.getFinishedSpanItems()).isEmpty();
+            });
+        }
+
+        @Test
+        void exporter_shouldBeReached_whenApplicationContributesItsOwnCustomizer() {
+            embabelOnlyRunner
+                    .withUserConfiguration(ApplicationExporterCustomizerConfig.class)
+                    .run(context -> {
+                        var exporter = context.getBean(InMemorySpanExporter.class);
+                        emitSpan(context.getBean(SdkTracerProvider.class));
+                        assertThat(exporter.getFinishedSpanItems()).hasSize(1);
+                    });
+        }
+    }
+
+    private static void emitSpan(SdkTracerProvider tracerProvider) {
+        tracerProvider.get("interop-test").spanBuilder("unit").startSpan().end();
+        tracerProvider.forceFlush().join(10, TimeUnit.SECONDS);
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class RecordingExporterConfig {
+
+        @Bean
+        InMemorySpanExporter recordingExporter() {
+            return InMemorySpanExporter.create();
+        }
+    }
+
+    /**
+     * A processor that reaches no backend, so delegating the exporters to it loses them.
+     */
+    @Configuration(proxyBeanMethods = false)
+    static class NonExportingProcessorConfig {
+
+        @Bean
+        SpanProcessor nonExportingProcessor() {
+            return SpanProcessor.composite();
+        }
+    }
+
+    /**
+     * How an application attaches an exporter the built-in customizer has delegated away.
+     */
+    @Configuration(proxyBeanMethods = false)
+    static class ApplicationExporterCustomizerConfig {
+
+        @Bean
+        SdkTracerProviderCustomizer applicationExporterCustomizer(InMemorySpanExporter exporter) {
+            return builder -> builder.addSpanProcessor(SimpleSpanProcessor.create(exporter));
+        }
+    }
+}

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
@@ -339,12 +339,14 @@ class ObservabilityAutoConfigurationTest {
         assertThat(afterName).containsExactlyInAnyOrder(
                 "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration",
                 "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration");
-        // Boot 3 actuate paths are silently ignored under Boot 4 — must not remain
-        assertThat(afterName).noneMatch(name -> name.contains(".actuate.autoconfigure."));
 
-        // Observation auto-config is a direct optional dep; confirm the FQCN still resolves
+        // afterName FQCNs must resolve on the classpath; a wrong name is silently ignored by
+        // Spring and ordering never applies (#1808). Check both observation and tracing.
         assertThat(classExists(
                 "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration"))
+                .isTrue();
+        assertThat(classExists(
+                "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration"))
                 .isTrue();
     }
 

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
@@ -24,10 +24,14 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -321,6 +325,37 @@ class ObservabilityAutoConfigurationTest {
                 .run(context -> {
                     assertThat(context).hasSingleBean(HttpRequestObservationFilter.class);
                 });
+    }
+
+    // --- Boot 4 afterName ordering (#1808) ---
+
+    @Test
+    void autoConfiguration_afterName_shouldUseSpringBoot4MicrometerPackages() {
+        AutoConfiguration autoConfiguration =
+                ObservabilityAutoConfiguration.class.getAnnotation(AutoConfiguration.class);
+        assertThat(autoConfiguration).isNotNull();
+
+        List<String> afterName = Arrays.asList(autoConfiguration.afterName());
+        assertThat(afterName).containsExactlyInAnyOrder(
+                "org.springframework.boot.micrometer.tracing.autoconfigure.MicrometerTracingAutoConfiguration",
+                "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration");
+        // Boot 3 actuate paths are silently ignored under Boot 4 — must not remain
+        assertThat(afterName).noneMatch(name -> name.contains(".actuate.autoconfigure."));
+
+        // Observation auto-config is a direct optional dep; confirm the FQCN still resolves
+        assertThat(classExists(
+                "org.springframework.boot.micrometer.observation.autoconfigure.ObservationAutoConfiguration"))
+                .isTrue();
+    }
+
+    private static boolean classExists(String name) {
+        try {
+            Class.forName(name);
+            return true;
+        }
+        catch (ClassNotFoundException ex) {
+            return false;
+        }
     }
 
     // --- Metrics listener ---

--- a/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/embabel-agent-observability-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/observability/ObservabilityAutoConfigurationTest.java
@@ -381,12 +381,20 @@ class ObservabilityAutoConfigurationTest {
                 });
     }
 
+    /**
+     * The listener is no longer gated on a {@code MeterRegistry} bean being present: that condition
+     * had to be evaluated while definitions were still being registered, which made it depend on
+     * auto-configuration ordering and silently suppressed the listener under Spring Boot 4. It now
+     * falls back to a registry that discards every measurement, so the absence of a registry costs
+     * a listener that records nowhere rather than a platform with no metrics at all.
+     */
     @Test
-    void metricsListener_shouldNotBeCreated_whenNoMeterRegistry() {
+    void metricsListener_shouldRecordNowhere_whenNoMeterRegistry() {
         contextRunner
                 .withUserConfiguration(ObservationRegistryConfig.class)
                 .run(context -> {
-                    assertThat(context).doesNotHaveBean(EmbabelMetricsEventListener.class);
+                    assertThat(context).hasSingleBean(EmbabelMetricsEventListener.class);
+                    assertThat(context).doesNotHaveBean(MeterRegistry.class);
                 });
     }
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/integrations/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/integrations/page.adoc
@@ -888,7 +888,8 @@ embabel:
 
 management:
   tracing:
-    enabled: true
+    export:
+      enabled: true
     sampling:
       probability: 1.0
 

--- a/embabel-agent-observability/README.md
+++ b/embabel-agent-observability/README.md
@@ -65,10 +65,13 @@ embabel:
 # Spring Boot Tracing (required)
 management:
   tracing:
-    enabled: true
+    export:
+      enabled: true
     sampling:
-      probability: 1.0  # 1.0 = 100%, 0.5 = 50%, etc.
+      probability: 1.0  # 1.0 = 100%, 0.5 = 50%, etc. Platform default is 1.0
 ```
+
+> `management.tracing.enabled` was removed in Spring Boot 4; use `management.tracing.export.enabled`.
 
 ### 3. Choose your exporter
 

--- a/embabel-agent-starters/embabel-agent-starter-observability/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-observability/pom.xml
@@ -38,6 +38,18 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
 
+        <!--
+            Spring Boot 4 moved tracing auto-config out of spring-boot-actuator-autoconfigure.
+            Actuator alone no longer creates a Tracer / spans. This Boot module pulls
+            MicrometerTracingAutoConfiguration (and OTel bridge) so afterName ordering
+            and Embabel observations → spans work out of the box (#1808).
+            Version managed by spring-boot-dependencies BOM.
+        -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-micrometer-tracing-opentelemetry</artifactId>
+        </dependency>
+
         <!-- AspectJ weaver for @Tracked aspect support (direct dep, not spring-boot-starter-aspectj); provides org.aspectj.lang.* -->
         <dependency>
             <groupId>org.aspectj</groupId>


### PR DESCRIPTION
# fix(observability): restore metrics, single span export and sampling under Spring Boot 4

Fixes #1871

## Root cause

`@ConditionalOnBean` / `@ConditionalOnMissingBean` are evaluated while bean definitions are still being registered, so they depend on auto-configuration ordering. Boot 4 split observability into separate modules and dropped the ordering edges this module implicitly relied on.

## Defects fixed

| # | Symptom | Cause | Fix |
|---|---|---|---|
| 1 | No business metrics at all | `EmbabelMetricsEventListener` gated on `@ConditionalOnBean(MeterRegistry)`, evaluated before Boot's metrics auto-configurations | `@ConditionalOnClass` + lazy `ObjectProvider<MeterRegistry>`, falling back to an empty `CompositeMeterRegistry` |
| 2 | Every span exported twice | `sdkTracerProvider` attached Boot's `otelSpanProcessor` (which already wraps every `SpanExporter`) **and** wrapped each exporter again | Attach exporters only when no `SpanProcessor` is present |
| 3a | `management.tracing.sampling.*` ignored | Boot's `Sampler` bean was never applied; provider stayed on `AlwaysOn` | New `embabelSamplerCustomizer` applies it |
| 3b | `management.tracing.enabled` dead but shipped | Not bound by Boot 4, yet present in `agent-application.properties` (a main resource imposed on every consumer) | Removed; test resources and docs moved to `management.tracing.export.enabled` |


## Design change

`sdkTracerProvider` is now an ordered chain instead of a monolithic method:

```java
SdkTracerProviderBuilder builder = SdkTracerProvider.builder();
customizers.orderedStream().forEach(customizer -> customizer.customize(builder));
return builder.build();
```

| Bean | Order | Concern |
|---|---|---|
| `embabelResourceCustomizer` | 0 | service identity |
| `embabelSamplerCustomizer` | 100 | sampler |
| `embabelSpanProcessorCustomizer` | 200 | `SpanProcessor` beans |
| `embabelSpanExporterCustomizer` | 300 | `SpanExporter` beans |

`SdkTracerProviderCustomizer` is public - this is the idiom the module already uses for the `ObservationRegistry`, and it is how an application attaches an exporter that a foreign, non-exporting processor would otherwise swallow. No new configuration key is introduced.

## Needs a reviewer decision

- **Full sampling now ships as a platform default.** With the sampler honoured, Boot's 10% default   would silently discard nine agent traces out of ten, so `agent-application.properties` sets   `management.tracing.sampling.probability=1.0`. A consumer's own `application.properties` outranks   it.

- **One existing test changed meaning.** `metricsListener_shouldNotBeCreated_whenNoMeterRegistry` →
  `metricsListener_shouldRecordNowhere_whenNoMeterRegistry`. The "no registry, no listener"   behaviour is deliberately gone: that condition cannot be evaluated reliably.

## Testing

`BootObservabilityInteropTest` assembles Boot's *real* auto-configurations alongside Embabel's. The pre-existing metrics test passes today while the listener does not exist in production, because it supplies the `MeterRegistry` via `withUserConfiguration` — always registered first, hiding the ordering sensitivity.

Each new test failed before the fix:

| Test | Failure before |
|---|---|
| `metricsListener_shouldBeCreated_whenBootContributesTheMeterRegistry` | registry present, listener absent |
| `span_shouldReachEachExporterExactlyOnce` | `Expected size: 1 but was: 2` |
| `span_shouldNotBeExported_whenSamplingProbabilityIsZero` | 2 spans exported at `probability=0.0` |
| `shipped properties declare no key that Spring Boot 4 no longer binds` | dead key present |

Two more pin the delegation rule and its escape hatch:
`exporter_shouldBeSkipped_whenAnotherProcessorIsPresent` and
`exporter_shouldBeReached_whenApplicationContributesItsOwnCustomizer`.

`spring-boot-micrometer-tracing-opentelemetry` and `spring-boot-micrometer-metrics` are added at
test scope - only the starter carried them, so the composition with Boot was structurally
untestable, which is how these regressions shipped.

**Results:** observability + auto-configure 311 tests green · `embabel-agent-api` 3961 tests green ·
`embabel-agent-starter-observability` builds clean.

## Documentation

`README.md`, `embabel-agent-observability/README.md` and `reference/integrations/page.adoc` updated
for `management.tracing.export.enabled`.


