### PR TITLE
Alert user by throwing exception on infra jackson deserialization errors

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -67,13 +67,7 @@ class LlmDataBindingProperties(
                     if (throwable is ToolControlFlowSignal) {
                         throw throwable
                     }
-                    // DatabindException in the cause chain = Jackson config/binding error — not transient.
-                    // MismatchedInputException (LLM omitted a required field) is excluded: it IS retryable.
-                    var cause: Throwable? = throwable
-                    while (cause != null) {
-                        if (cause is DatabindException && cause !is MismatchedInputException) throw throwable
-                        cause = cause.cause
-                    }
+                    if (hasNonRetryableDatabindException(throwable)) throw throwable
                     if (isRateLimitError(throwable)) {
                         logger.info(
                             "LLM invocation {} RATE LIMITED: Retry attempt {} of {}.{}",
@@ -126,6 +120,26 @@ class LlmDataBindingProperties(
             return RATE_LIMIT_PATTERNS.any { pattern ->
                 message.contains(pattern)
             }
+        }
+
+        /**
+         * Walks the full exception cause chain looking for a DatabindException that is NOT
+         * a MismatchedInputException. Such exceptions indicate Jackson config/annotation errors
+         * (e.g. wrong @JsonDeserialize target) — infrastructure bugs, not transient LLM output
+         * quality issues. MismatchedInputException (LLM omitted a required field) IS retryable
+         * and must be excluded.
+         *
+         * Note: DatabindException may be wrapped inside RuntimeException by JacksonOutputConverter
+         * before reaching the retry layer, so a full cause-chain walk is required rather than a
+         * simple instanceof check.
+         */
+        internal fun hasNonRetryableDatabindException(throwable: Throwable): Boolean {
+            var cause: Throwable? = throwable
+            while (cause != null) {
+                if (cause is DatabindException && cause !is MismatchedInputException) return true
+                cause = cause.cause
+            }
+            return false
         }
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmDataBindingProperties.kt
@@ -26,6 +26,8 @@ import org.springframework.retry.RetryCallback
 import org.springframework.retry.RetryContext
 import org.springframework.retry.RetryListener
 import org.springframework.retry.support.RetryTemplate
+import tools.jackson.databind.DatabindException
+import tools.jackson.databind.exc.MismatchedInputException
 import java.time.Duration
 
 /**
@@ -65,6 +67,13 @@ class LlmDataBindingProperties(
                     if (throwable is ToolControlFlowSignal) {
                         throw throwable
                     }
+                    // DatabindException in the cause chain = Jackson config/binding error — not transient.
+                    // MismatchedInputException (LLM omitted a required field) is excluded: it IS retryable.
+                    var cause: Throwable? = throwable
+                    while (cause != null) {
+                        if (cause is DatabindException && cause !is MismatchedInputException) throw throwable
+                        cause = cause.cause
+                    }
                     if (isRateLimitError(throwable)) {
                         logger.info(
                             "LLM invocation {} RATE LIMITED: Retry attempt {} of {}.{}",
@@ -88,11 +97,13 @@ class LlmDataBindingProperties(
                     throwable: Throwable?,
                 ) {
                     throwable?.let {
-                        logger.warn(
-                            "Maximum attempts of {} have reached. The maximum attempt can be configured using property {}.max-attempts",
-                            maxAttempts,
-                            propertyPrefix
-                        )
+                        if (context.retryCount >= maxAttempts) {
+                            logger.warn(
+                                "Maximum attempts of {} have reached. The maximum attempt can be configured using property {}.max-attempts",
+                                maxAttempts,
+                                propertyPrefix
+                            )
+                        }
                     }
                 }
             })

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmOperationsCommon.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/LlmOperationsCommon.kt
@@ -23,6 +23,7 @@ import tools.jackson.databind.DeserializationContext
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ValueDeserializer
 import tools.jackson.databind.annotation.JsonDeserialize
+import tools.jackson.databind.DatabindException
 import tools.jackson.databind.deser.std.StdDeserializer
 import tools.jackson.databind.exc.MismatchedInputException
 import tools.jackson.databind.node.NullNode
@@ -192,6 +193,7 @@ internal class MaybeReturnDeserializer<T> private constructor(
                         ERROR_INVALID_FORMAT
                     }
                 }
+                is DatabindException -> throw e  // Jackson config/binding error — not transient
                 else -> "$ERROR_INVALID_SUCCESS${e.message}"
             }
             MaybeReturn.failure(errorMessage)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
@@ -26,6 +26,8 @@ import org.springframework.ai.retry.TransientAiException
 import org.springframework.retry.RetryContext
 import org.springframework.retry.RetryPolicy
 import org.springframework.retry.context.RetryContextSupport
+import tools.jackson.databind.DatabindException
+import tools.jackson.databind.exc.MismatchedInputException
 
 /**
  * Retry policy for Spring AI operations.
@@ -67,6 +69,11 @@ internal class SpringAiRetryPolicy(
             }
             if (current is Retryable) {
                 return true
+            }
+            // DatabindException = Jackson config/binding error — not transient.
+            // MismatchedInputException (LLM omitted a required field) is excluded: it IS retryable.
+            if (current is DatabindException && current !is MismatchedInputException) {
+                return false
             }
             current = current.cause
         }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicy.kt
@@ -26,8 +26,7 @@ import org.springframework.ai.retry.TransientAiException
 import org.springframework.retry.RetryContext
 import org.springframework.retry.RetryPolicy
 import org.springframework.retry.context.RetryContextSupport
-import tools.jackson.databind.DatabindException
-import tools.jackson.databind.exc.MismatchedInputException
+import com.embabel.agent.spi.support.LlmDataBindingProperties
 
 /**
  * Retry policy for Spring AI operations.
@@ -70,12 +69,11 @@ internal class SpringAiRetryPolicy(
             if (current is Retryable) {
                 return true
             }
-            // DatabindException = Jackson config/binding error — not transient.
-            // MismatchedInputException (LLM omitted a required field) is excluded: it IS retryable.
-            if (current is DatabindException && current !is MismatchedInputException) {
-                return false
-            }
             current = current.cause
+        }
+
+        if (LlmDataBindingProperties.hasNonRetryableDatabindException(lastException)) {
+            return false
         }
 
         return when (lastException) {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/LlmDataBindingPropertiesTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/LlmDataBindingPropertiesTest.kt
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
+import tools.jackson.databind.DatabindException
+import tools.jackson.databind.exc.MismatchedInputException
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @ExtendWith(OutputCaptureExtension::class)
@@ -99,6 +102,54 @@ class LlmDataBindingPropertiesTest {
             verify { mockBlackboard["intent"] = "support" }
             verify { mockBlackboard["confidence"] = 0.95 }
             verify { mockBlackboard["target"] = "handleSupport" }
+        }
+
+        // DatabindException constructors are protected — subclass to instantiate in tests
+        private inner class TestDatabindException(msg: String) : DatabindException(msg)
+
+        @Test
+        fun `retryTemplate aborts immediately on DatabindException — not retried`() {
+            val properties = LlmDataBindingProperties(maxAttempts = 5)
+            val retryTemplate = properties.retryTemplate("test")
+            var attemptCount = 0
+            assertThrows<TestDatabindException> {
+                retryTemplate.execute<Unit, Exception> {
+                    attemptCount++
+                    throw TestDatabindException("wrong @JsonDeserialize annotation")
+                }
+            }
+            assertEquals(1, attemptCount, "DatabindException must not be retried")
+        }
+
+        @Test
+        fun `retryTemplate aborts immediately on DatabindException wrapped in RuntimeException`() {
+            // Mirrors real production chain: JacksonOutputConverter wraps DatabindException
+            // in RuntimeException before it reaches the retry layer
+            val properties = LlmDataBindingProperties(maxAttempts = 5)
+            val retryTemplate = properties.retryTemplate("test")
+            var attemptCount = 0
+            val root = TestDatabindException("annotation misconfiguration")
+            assertThrows<RuntimeException> {
+                retryTemplate.execute<Unit, Exception> {
+                    attemptCount++
+                    throw RuntimeException(root)
+                }
+            }
+            assertEquals(1, attemptCount, "Wrapped DatabindException must be detected via cause-chain walk and not retried")
+        }
+
+        @Test
+        fun `retryTemplate retries on MismatchedInputException (LLM omitted required field)`() {
+            val properties = LlmDataBindingProperties(maxAttempts = 3)
+            val retryTemplate = properties.retryTemplate("test")
+            var attemptCount = 0
+            assertThrows<MismatchedInputException> {
+                retryTemplate.execute<Unit, Exception> {
+                    attemptCount++
+                    throw MismatchedInputException.from(null, String::class.java, "missing field")
+                }
+            }
+            assertEquals(3, attemptCount, "MismatchedInputException is retryable — LLM may include field on next attempt")
         }
 
         @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SpringAiRetryPolicyTest.kt
@@ -29,6 +29,9 @@ import org.springframework.ai.retry.NonTransientAiException
 import org.springframework.ai.retry.TransientAiException
 import org.springframework.retry.RetryContext
 import org.springframework.retry.context.RetryContextSupport
+import com.embabel.agent.spi.support.LlmDataBindingProperties
+import tools.jackson.databind.DatabindException
+import tools.jackson.databind.exc.MismatchedInputException
 
 /**
  * Tests for SpringAiRetryPolicy retry decision logic.
@@ -236,6 +239,83 @@ class SpringAiRetryPolicyTest {
             val exception = RuntimeException("generic error")
             val context = createContext(1, exception)
             assertTrue(policy.canRetry(context))
+        }
+    }
+
+    @Nested
+    inner class JacksonDatabindExceptionTests {
+
+        // DatabindException constructors are protected — subclass to instantiate in tests
+        private inner class TestDatabindException(msg: String) : DatabindException(msg)
+
+        @Test
+        fun `direct DatabindException does not retry`() {
+            val context = createContext(1, TestDatabindException("Jackson config error"))
+            assertFalse(policy.canRetry(context))
+        }
+
+        @Test
+        fun `DatabindException wrapped in RuntimeException does not retry`() {
+            // Mirrors real production chain: JacksonOutputConverter wraps DatabindException
+            // in RuntimeException before it reaches the retry layer
+            val wrapped = RuntimeException(TestDatabindException("annotation misconfiguration"))
+            val context = createContext(1, wrapped)
+            assertFalse(policy.canRetry(context), "DatabindException must be detected even when wrapped in RuntimeException")
+        }
+
+        @Test
+        fun `MismatchedInputException retries (LLM omitted required field is transient)`() {
+            val mismatched = MismatchedInputException.from(null, String::class.java, "missing field")
+            val context = createContext(1, mismatched)
+            assertTrue(policy.canRetry(context), "MismatchedInputException is retryable — LLM may include field on next attempt")
+        }
+
+        @Test
+        fun `MismatchedInputException wrapped in RuntimeException retries`() {
+            val wrapped = RuntimeException(MismatchedInputException.from(null, String::class.java, "missing field"))
+            val context = createContext(1, wrapped)
+            assertTrue(policy.canRetry(context))
+        }
+    }
+
+    @Nested
+    inner class HasNonRetryableDatabindExceptionTests {
+
+        private inner class TestDatabindException(msg: String) : DatabindException(msg)
+
+        @Test
+        fun `returns true for direct DatabindException`() {
+            assert(LlmDataBindingProperties.hasNonRetryableDatabindException(TestDatabindException("config error")))
+        }
+
+        @Test
+        fun `returns true for DatabindException wrapped in RuntimeException`() {
+            val wrapped = RuntimeException(TestDatabindException("config error"))
+            assert(LlmDataBindingProperties.hasNonRetryableDatabindException(wrapped))
+        }
+
+        @Test
+        fun `returns true for deeply nested DatabindException`() {
+            val root = TestDatabindException("config error")
+            val wrapped = RuntimeException(RuntimeException(root))
+            assert(LlmDataBindingProperties.hasNonRetryableDatabindException(wrapped))
+        }
+
+        @Test
+        fun `returns false for MismatchedInputException`() {
+            val mismatched = MismatchedInputException.from(null, String::class.java, "missing field")
+            assert(!LlmDataBindingProperties.hasNonRetryableDatabindException(mismatched))
+        }
+
+        @Test
+        fun `returns false for MismatchedInputException wrapped in RuntimeException`() {
+            val wrapped = RuntimeException(MismatchedInputException.from(null, String::class.java, "missing field"))
+            assert(!LlmDataBindingProperties.hasNonRetryableDatabindException(wrapped))
+        }
+
+        @Test
+        fun `returns false for unrelated exception`() {
+            assert(!LlmDataBindingProperties.hasNonRetryableDatabindException(RuntimeException("transient")))
         }
     }
 


### PR DESCRIPTION
# Overview

Closes #1870 

  LlmOperationsCommon.kt 
  - _MismatchedInputException_ branch precedes is _DatabindException_ in the _when_ — Kotlin evaluates top-to-bottom, so retryable missing-field errors still return MaybeReturn.failure, never hit the rethrow.
  - is _DatabindException_ -> _throw_ propagates infra errors (**wrong annotation, type narrowing**) out of the deserializer.
  - Normal LLM decline path — unaffected.

  LlmDataBindingProperties.kt 
  - Cause-chain walk in onError: reaches DatabindException,  throws to abort after 1 attempt.
  - MismatchedInputException excluded — missing-field retries continue normally.
  - retryCount >= maxAttempts guard in close() — "Maximum attempts reached" log is now accurate.

  SpringAiRetryPolicy.kt 
  - Same cause-chain walk in canRetry() — returns false immediately when DatabindException is found, stopping the outer action-level retry after 1 attempt.
  - MismatchedInputException excluded consistently.