### PR TITLE
Do not kill the application context when a model provider key is absent

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfig.kt
@@ -89,15 +89,42 @@ class AnthropicProperties : RetryProperties {
 
 
 /**
+ * Placeholder handed to the superclass when no key is configured. It is never used to
+ * build a client: [AnthropicModelsConfig.anthropicModelsInitializer] registers nothing
+ * in that case. It exists only because [AnthropicModelFactory.apiKey] is non-nullable
+ * and a superclass constructor argument has to evaluate to something.
+ */
+private const val UNCONFIGURED_API_KEY = "anthropic-api-key-not-configured"
+
+/**
+ * The configured key, or `null` if there isn't one.
+ *
+ * A **blank** key counts as absent. That is not hypothetical tidiness: compose passes
+ * `ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}`, so inside a container the variable is
+ * routinely set-but-empty, and `@Value("\${ANTHROPIC_API_KEY:#{null}}")` resolves that
+ * to `""` rather than `null`. Treating blank as absent is what keeps the empty case on
+ * the same path as the missing one instead of handing a blank key to the client.
+ */
+private fun configuredAnthropicApiKey(envApiKey: String?, properties: AnthropicProperties): String? =
+    envApiKey?.takeIf(String::isNotBlank) ?: properties.apiKey?.takeIf(String::isNotBlank)
+
+/**
  * Configuration class for Anthropic models.
  * Extends [AnthropicModelFactory] so that the API client construction is shared
  * with the BYOK path. This class adds the Spring autoconfigure wiring on top:
  * loading model definitions from YAML, registering them as beans, and applying
  * the retry policy from [AnthropicProperties].
+ *
+ * With no API key this registers no models and lets the context start, the way the
+ * LM Studio config does when its server is unreachable. A missing key is a deployment
+ * that has not been given one yet — an appliance whose operator supplies keys through
+ * first-run setup — not a programming error, so it must not kill the context. Failing
+ * in the constructor took the whole application down, because a `@Configuration` whose
+ * superclass constructor throws cannot be conditioned away.
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(AnthropicProperties::class)
-@ExcludeFromJacocoGeneratedReport(reason = "Anthropic configuration can't be unit tested")
+@ExcludeFromJacocoGeneratedReport(reason = "Model registration needs a live Anthropic account; the no-key path is covered by AnthropicModelsConfigNoKeyTest")
 class AnthropicModelsConfig(
     @param:Value("\${ANTHROPIC_BASE_URL:#{null}}")
     private val envBaseUrl: String?,
@@ -112,19 +139,33 @@ class AnthropicModelsConfig(
     private val nativeStructuredOutputConfigurer: SpringAiNativeStructuredOutputConfigurer =
         SpringAiNativeStructuredOutputConfigurer.NOOP,
 ) : AnthropicModelFactory(
-    apiKey = envApiKey ?: properties.apiKey
-        ?: error("Anthropic API key required: set ANTHROPIC_API_KEY env var or embabel.agent.platform.models.anthropic.api-key"),
+    apiKey = configuredAnthropicApiKey(envApiKey, properties) ?: UNCONFIGURED_API_KEY,
     baseUrl = envBaseUrl ?: properties.baseUrl,
     observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
     restClientBuilder = restClientBuilder,
 ) {
 
+    private val apiKeyConfigured: Boolean = configuredAnthropicApiKey(envApiKey, properties) != null
+
     init {
-        logger.info("Anthropic models are available: {}", properties)
+        if (apiKeyConfigured) {
+            logger.info("Anthropic models are available: {}", properties)
+        } else {
+            logger.info(
+                "No Anthropic API key configured: set ANTHROPIC_API_KEY or {}.api-key to enable Anthropic models. Continuing without them.",
+                PREFIX,
+            )
+        }
     }
 
     @Bean
     fun anthropicModelsInitializer(): ProviderInitialization {
+        if (!apiKeyConfigured) {
+            return ProviderInitialization(
+                provider = AnthropicModels.PROVIDER,
+                registeredLlms = emptyList(),
+            )
+        }
         val definitions = modelLoader.loadAutoConfigMetadata()
         val effectiveModels = definitions.effectiveModels()
         val registeredLlms = buildList {

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfigNoKeyTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/AnthropicModelsConfigNoKeyTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.anthropic
+
+import com.embabel.agent.autoconfigure.models.anthropic.AgentAnthropicAutoConfiguration
+import com.embabel.common.ai.autoconfig.ProviderInitialization
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.core.env.StandardEnvironment
+
+/**
+ * The starter is on the classpath whether or not a key is present — the appliance bakes
+ * in both provider starters deliberately, so a runtime key works without a rebuild. An
+ * absent key must therefore degrade to "no models registered", the way the LM Studio
+ * config does when its server is unreachable, rather than kill the application context.
+ *
+ * Failing in the constructor was unconditional: a `@Configuration` whose superclass
+ * constructor throws cannot be conditioned away, so the whole context went down with it.
+ */
+class AnthropicModelsConfigNoKeyTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        // Drop the real environment. Without this the suite passes or fails according to
+        // whether the machine running it exports ANTHROPIC_API_KEY — and a developer
+        // machine always does, which is the exact reason this bug reached an appliance
+        // undetected. `withPropertyValues` sets system properties, which outrank the
+        // environment, so the keyed cases below still work with this removed.
+        .withInitializer { context ->
+            context.environment.propertySources.remove(
+                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+            )
+        }
+        .withConfiguration(AutoConfigurations.of(AgentAnthropicAutoConfiguration::class.java))
+
+    @Test
+    fun `starts and registers nothing when no api key is configured`() {
+        contextRunner.run { context ->
+            assertThat(context).hasNotFailed()
+            assertThat(context).hasSingleBean(ProviderInitialization::class.java)
+            assertThat(context.getBean(ProviderInitialization::class.java).registeredLlms).isEmpty()
+        }
+    }
+
+    @Test
+    fun `treats a blank api key as absent`() {
+        // Compose passes ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}, so in a container the
+        // variable is routinely set-but-empty. That resolves to "" rather than null, which
+        // used to slip past the null check and hand a blank key to the client.
+        contextRunner
+            .withPropertyValues("ANTHROPIC_API_KEY=")
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context.getBean(ProviderInitialization::class.java).registeredLlms).isEmpty()
+            }
+    }
+
+    @Test
+    fun `treats a whitespace-only api key as absent`() {
+        contextRunner
+            .withPropertyValues("ANTHROPIC_API_KEY=   ")
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context.getBean(ProviderInitialization::class.java).registeredLlms).isEmpty()
+            }
+    }
+
+    @Test
+    fun `registers models when an api key is configured`() {
+        // The other half of the gate: skipping registration when unkeyed must not stop
+        // registration when keyed. No network call is made to build the model beans.
+        contextRunner
+            .withPropertyValues("ANTHROPIC_API_KEY=sk-ant-test-key")
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context.getBean(ProviderInitialization::class.java).registeredLlms).isNotEmpty()
+            }
+    }
+
+    @Test
+    fun `property-configured key is honoured when the env var is absent`() {
+        contextRunner
+            .withPropertyValues("${AnthropicProperties.PREFIX}.api-key=sk-ant-test-key")
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context.getBean(ProviderInitialization::class.java).registeredLlms).isNotEmpty()
+            }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfig.kt
@@ -99,13 +99,32 @@ class OpenAiProperties : RetryProperties {
 }
 
 /**
+ * The configured key, or `null` if there isn't one.
+ *
+ * A **blank** key counts as absent. That is not hypothetical tidiness: compose passes
+ * `OPENAI_API_KEY=${OPENAI_API_KEY:-}`, so inside a container the variable is routinely
+ * set-but-empty, and `@Value("\${OPENAI_API_KEY:#{null}}")` resolves that to `""` rather
+ * than `null`. Treating blank as absent keeps the empty case on the same path as the
+ * missing one instead of handing a blank key to the client.
+ */
+private fun configuredOpenAiApiKey(envApiKey: String?, properties: OpenAiProperties): String? =
+    envApiKey?.takeIf(String::isNotBlank) ?: properties.apiKey?.takeIf(String::isNotBlank)
+
+/**
  * Configuration for OpenAI language and embedding models.
  * This class dynamically loads and registers OpenAI models from YAML configuration,
  * similar to the Anthropic and Bedrock configuration patterns.
+ *
+ * With no API key this registers no models and lets the context start, the way the
+ * LM Studio config does when its server is unreachable. A missing key is a deployment
+ * that has not been given one yet — an appliance whose operator supplies keys through
+ * first-run setup — not a programming error, so it must not kill the context. Failing
+ * in the constructor took the whole application down, because a `@Configuration` whose
+ * superclass constructor throws cannot be conditioned away.
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(OpenAiProperties::class, LlmOptionsProperties::class)
-@ExcludeFromJacocoGeneratedReport(reason = "OpenAi configuration can't be unit tested")
+@ExcludeFromJacocoGeneratedReport(reason = "Model registration needs a live OpenAI account; the no-key path is covered by OpenAiModelsConfigNoKeyTest")
 class OpenAiModelsConfig(
     @param:Value("\${OPENAI_BASE_URL:#{null}}")
     private val envBaseUrl: String?,
@@ -128,8 +147,9 @@ class OpenAiModelsConfig(
         OpenAiNativeStructuredOutputConfigurer,
 ) : OpenAiCompatibleModelFactory(
     baseUrl = envBaseUrl ?: properties.baseUrl,
-    apiKey = envApiKey ?: properties.apiKey
-    ?: error("OpenAI API key required: set OPENAI_API_KEY env var or embabel.agent.platform.models.openai.api-key"),
+    // The factory already models an absent key: resolvedApiKey() substitutes a
+    // placeholder, because the SDK rejects a null key even for no-auth servers.
+    apiKey = configuredOpenAiApiKey(envApiKey, properties),
     completionsPath = envCompletionsPath ?: properties.completions,
     embeddingsPath = envEmbeddingsPath ?: properties.embeddingsPath,
     httpHeaders = llmOptionsProperties.httpHeaders,
@@ -145,12 +165,28 @@ class OpenAiModelsConfig(
     private val resolvedObservationRegistry: ObservationRegistry =
         observationRegistry.getIfUnique { ObservationRegistry.NOOP }
 
+    private val apiKeyConfigured: Boolean = configuredOpenAiApiKey(envApiKey, properties) != null
+
     init {
-        logger.info("OpenAI models are available: {}", properties)
+        if (apiKeyConfigured) {
+            logger.info("OpenAI models are available: {}", properties)
+        } else {
+            logger.info(
+                "No OpenAI API key configured: set OPENAI_API_KEY or {}.api-key to enable OpenAI models. Continuing without them.",
+                PREFIX,
+            )
+        }
     }
 
     @Bean
     fun openAiModelsInitializer(): ProviderInitialization {
+        if (!apiKeyConfigured) {
+            return ProviderInitialization(
+                provider = OpenAiModels.PROVIDER,
+                registeredLlms = emptyList(),
+                registeredEmbeddings = emptyList(),
+            )
+        }
         val definitions = modelLoader.loadAutoConfigMetadata()
         val effectiveModels = definitions.effectiveModels()
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfigNoKeyTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelsConfigNoKeyTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.common.ai.autoconfig.ProviderInitialization
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.core.env.StandardEnvironment
+
+/**
+ * The starter is on the classpath whether or not a key is present — the appliance bakes
+ * in both provider starters deliberately, so a runtime key works without a rebuild. An
+ * absent key must therefore degrade to "no models registered", the way the LM Studio
+ * config does when its server is unreachable, rather than kill the application context.
+ *
+ * Failing in the constructor was unconditional: a `@Configuration` whose superclass
+ * constructor throws cannot be conditioned away, so the whole context went down with it.
+ */
+class OpenAiModelsConfigNoKeyTest {
+
+    private val contextRunner = ApplicationContextRunner()
+        // Drop the real environment. Without this the suite passes or fails according to
+        // whether the machine running it exports OPENAI_API_KEY — and a developer machine
+        // always does, which is the exact reason this bug reached an appliance undetected.
+        // `withPropertyValues` sets system properties, which outrank the environment, so
+        // the keyed cases below still work with this removed.
+        .withInitializer { context ->
+            context.environment.propertySources.remove(
+                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+            )
+        }
+        .withConfiguration(AutoConfigurations.of(AgentOpenAiAutoConfiguration::class.java))
+
+    @Test
+    fun `starts and registers nothing when no api key is configured`() {
+        contextRunner.run { context ->
+            assertThat(context).hasNotFailed()
+            assertThat(context).hasSingleBean(ProviderInitialization::class.java)
+            val initialization = context.getBean(ProviderInitialization::class.java)
+            assertThat(initialization.registeredLlms).isEmpty()
+            assertThat(initialization.registeredEmbeddings).isEmpty()
+        }
+    }
+
+    @Test
+    fun `treats a blank api key as absent`() {
+        // Compose passes OPENAI_API_KEY=${OPENAI_API_KEY:-}, so in a container the variable
+        // is routinely set-but-empty. That resolves to "" rather than null, which used to
+        // slip past the null check and hand a blank key to the client.
+        contextRunner
+            .withPropertyValues("OPENAI_API_KEY=")
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context.getBean(ProviderInitialization::class.java).registeredLlms).isEmpty()
+            }
+    }
+
+    @Test
+    fun `treats a whitespace-only api key as absent`() {
+        contextRunner
+            .withPropertyValues("OPENAI_API_KEY=   ")
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context.getBean(ProviderInitialization::class.java).registeredLlms).isEmpty()
+            }
+    }
+
+    @Test
+    fun `registers models when an api key is configured`() {
+        // The other half of the gate: skipping registration when unkeyed must not stop
+        // registration when keyed. No network call is made to build the model beans.
+        contextRunner
+            .withPropertyValues("OPENAI_API_KEY=sk-test-key")
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                val initialization = context.getBean(ProviderInitialization::class.java)
+                assertThat(initialization.registeredLlms).isNotEmpty()
+                assertThat(initialization.registeredEmbeddings).isNotEmpty()
+            }
+    }
+
+    @Test
+    fun `property-configured key is honoured when the env var is absent`() {
+        contextRunner
+            .withPropertyValues("${OpenAiProperties.PREFIX}.api-key=sk-test-key")
+            .run { context ->
+                assertThat(context).hasNotFailed()
+                assertThat(context.getBean(ProviderInitialization::class.java).registeredLlms).isNotEmpty()
+            }
+    }
+}


### PR DESCRIPTION
## Problem

`AnthropicModelsConfig` and `OpenAiModelsConfig` call `error()` in the argument to their superclass constructor:

```kotlin
) : AnthropicModelFactory(
    apiKey = envApiKey ?: properties.apiKey
        ?: error("Anthropic API key required: ..."),
```

A `@Configuration` whose superclass constructor throws **cannot be conditioned away** — no `@ConditionalOnProperty`, no `@ConditionalOnBean`, nothing downstream gets a say. The starter being on the classpath becomes an unconditional demand for a key, and the whole application context dies without one.

That is the only thing this PR changes.

## Change

Both configs now register no models when unkeyed, log one INFO line, and let the context start — the way the LM Studio config already degrades when its server is unreachable.

A **blank** key counts as absent. Compose passes `ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}`, so inside a container the variable is routinely set-but-empty, and `@Value("\${ANTHROPIC_API_KEY:#{null}}")` resolves that to `""` rather than `null` — slipping past the null check and handing a blank key to the client.

Note `OpenAiCompatibleModelFactory` already accepted a nullable key and substitutes a placeholder in `resolvedApiKey()`, so the `error()` there was a self-imposed constraint, not a factory requirement.

## Scope: deliberately not fixing "boot with no models at all"

An earlier version of this PR also made `ConfigurableModelProvider.defaultLlm` lazy and downgraded unsatisfiable role→model mappings from fatal to a warning, so that a deployment with no keys could boot.

**Both of those are intended behaviour, and relaxing them was the wrong fix.** They are fail-fast guarantees for every framework user: a developer who forgets a starter, or fat-fingers a model name in `embabel.models.llms`, should find out at boot with the valid choices listed — not at a call site in production.

The real gap is that BYOK builds a validated service but nothing can register one into a running platform, and `ConfigurableModelProvider` takes a snapshot of the model beans at construction (`AgentPlatformConfiguration:196`). Making the model set genuinely dynamic is the fix; once it is, "no models yet" becomes a valid state by design rather than a disabled guardrail, and role mappings can be re-validated as models arrive — stronger than today, not weaker.

That work is tracked separately. This PR stays at the one change that cannot be expressed any other way.

## Testing

- 10 new tests across the two autoconfigure modules: absent key, blank key, whitespace-only key, keyed, and property-configured — per provider
- Existing suites unaffected

The new tests remove the `systemEnvironment` property source. The first version of them **passed for the wrong reason and then failed**: the machine running them exports a real `ANTHROPIC_API_KEY`, which leaked into the context runner and registered nine Claude models. A test for the unkeyed path that depends on the developer's environment is worth nothing — and that is the same mechanism that let this reach a deployment undetected.

## Not included

Four sibling configs share the identical constructor `error()` — DeepSeek, Gemini, DashScope, MiniMax. Same defect, left out of scope here rather than widened unasked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
