### PR TITLE
Add embabel-agent-starter-byok so a BYOK app can boot without keys

### DIFF
--- a/embabel-agent-anthropic/src/main/kotlin/com/embabel/agent/anthropic/AnthropicModelFactory.kt
+++ b/embabel-agent-anthropic/src/main/kotlin/com/embabel/agent/anthropic/AnthropicModelFactory.kt
@@ -24,6 +24,7 @@ import com.embabel.chat.UserMessage
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.byok.ByokFactory
 import com.embabel.common.byok.InvalidApiKeyException
+import com.embabel.common.byok.requireUsableApiKey
 import com.embabel.common.util.ObjectProviders
 import io.micrometer.observation.ObservationRegistry
 import org.slf4j.LoggerFactory
@@ -155,10 +156,17 @@ open class AnthropicModelFactory(
      * On any exception the provider-specific error is translated to [InvalidApiKeyException],
      * keeping Spring AI types out of the caller.
      *
+     * A blank key is rejected before any network call. A key is routinely blank rather than
+     * absent: Compose passes `ANTHROPIC_API_KEY=${'$'}{ANTHROPIC_API_KEY:-}`, so in a container the
+     * variable is set-but-empty, and callers reading it with a null default get `""`. Without
+     * this check that empty string reaches the provider and comes back as an opaque auth error,
+     * which is why BYOK callers otherwise re-derive "blank counts as absent" for themselves.
+     *
      * @param model Model to use for the probe.
-     * @throws InvalidApiKeyException if the key is invalid.
+     * @throws InvalidApiKeyException if the key is blank or invalid.
      */
     fun buildValidated(model: String): LlmService<*> {
+        requireUsableApiKey(apiKey)
         val probe = build(model)
         try {
             probe.createMessageSender(LlmOptions()).call(listOf(UserMessage("Hi")), emptyList())

--- a/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicModelFactoryTest.kt
+++ b/embabel-agent-anthropic/src/test/kotlin/com/embabel/agent/anthropic/AnthropicModelFactoryTest.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.anthropic
 
 import com.embabel.agent.api.models.AnthropicModels
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.byok.BLANK_API_KEY_MESSAGE
 import com.embabel.common.byok.InvalidApiKeyException
 import com.sun.net.httpserver.HttpServer
 import io.micrometer.observation.ObservationRegistry
@@ -153,5 +154,27 @@ class AnthropicModelFactoryBuildValidatedTest {
         assertThrows<InvalidApiKeyException> {
             factory().buildValidated(AnthropicModels.CLAUDE_HAIKU_4_5)
         }
+    }
+
+    @Test
+    fun `buildValidated rejects a blank key without calling the provider`() {
+        var requests = 0
+        server.createContext("/v1/messages") { exchange ->
+            requests++
+            exchange.sendResponseHeaders(500, -1)
+            exchange.close()
+        }
+        server.start()
+
+        val blankKeyFactory = AnthropicModelFactory(
+            apiKey = "   ",
+            baseUrl = "http://localhost:$port",
+            observationRegistry = ObservationRegistry.NOOP,
+            restClientBuilder = restClientBuilder,
+        )
+
+        val e = assertThrows<InvalidApiKeyException> { blankKeyFactory.buildValidated() }
+        assertEquals(BLANK_API_KEY_MESSAGE, e.message)
+        assertEquals(0, requests, "a blank key must not reach the provider")
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlaceholderLlmService.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlaceholderLlmService.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi
+
+/**
+ * Marks an [LlmService] that stands in for a model this deployment does not yet have a key for.
+ *
+ * A placeholder completes nothing. Its only job is to give the platform something to resolve
+ * before any key is supplied, so that "no key yet" surfaces as an actionable error at the call
+ * that needed an LLM rather than as a failure to start.
+ *
+ * The platform treats the presence of a placeholder as the deployment's own statement that keys
+ * arrive at runtime, and relaxes exactly one thing on the strength of it: model names in
+ * configuration that nothing has registered are expected rather than fatal. Every other
+ * deployment keeps failing fast on a name it cannot resolve, because there a name that resolves
+ * to nothing is a typo.
+ *
+ * Implemented by `SetupRequiredLlm` in `embabel-agent-byok-autoconfigure`. It lives here, next to
+ * [LlmService], because `com.embabel.common.ai.model.ConfigurableModelProvider` has to recognise
+ * a placeholder without depending on the BYOK module - carrying the placeholder without dragging
+ * in that module is the reason the module exists.
+ */
+interface PlaceholderLlmService

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -81,7 +81,16 @@ class ConfigurableModelProvider(
     init {
         properties.llms.forEach { (role, model) ->
             if (llms.none { it.name == model }) {
-                error("LLM '$model' for role $role is not available: Choices are ${llms.map { it.name }}")
+                // Not fatal. A deployment may legitimately have no model registered for a role: a
+                // bring-your-own-key deployment starts with none at all, and one keyed for a single
+                // provider will not have the others' models. It still boots and still serves every
+                // role that does work. The role itself throws when something asks for it - it does
+                // NOT fall back to the default LLM, which is what would make "cheapest" silently
+                // the most expensive model in the deployment.
+                logger.warn(
+                    "LLM '{}' for role '{}' is not available, so anything asking for that role will fail. Available: {}",
+                    model, role, llms.map { it.name },
+                )
             }
         }
         logger.info(infoString(verbose = true))

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -115,11 +115,13 @@ class ConfigurableModelProvider(
     init {
         properties.llms.forEach { (role, model) ->
             if (llms.none { it.name == model }) {
-                // Fatal, unless this deployment is waiting for a key. A name that resolves to
-                // nothing is a typo in a deployment that has one, and letting it start would move
-                // the failure to whichever unrelated call first asks for that role. A deployment in
-                // setup-required mode has no models registered yet by definition, so the same name
-                // is expected there and only worth reporting.
+                /*
+                 * Fatal, unless this deployment is waiting for a key. A name that resolves to
+                 * nothing is a typo in a deployment that has one, and letting it start would move
+                 * the failure to whichever unrelated call first asks for that role. A deployment in
+                 * setup-required mode has no models registered yet by definition, so the same name
+                 * is expected there and only worth reporting.
+                 */
                 if (setupRequired) {
                     logger.warn(
                         "LLM '{}' for role '{}' is not registered. This deployment is awaiting a key, so that is expected; " +
@@ -135,12 +137,14 @@ class ConfigurableModelProvider(
 
         properties.embeddingServices.forEach { (role, model) ->
             if (embeddingServices.none { it.name == model }) {
-                // The same gate as the LLM roles above, and for the same reason: an unresolvable
-                // name is a typo in a deployment that holds a key, and expected in one still
-                // waiting for it. There is no fallback here, though, and there should not be -
-                // an embedding model is a schema commitment and nothing can stand in for one.
-                // The gate decides only whether the deployment STARTS; asking for the service
-                // still throws.
+                /*
+                 * The same gate as the LLM roles above, and for the same reason: an unresolvable
+                 * name is a typo in a deployment that holds a key, and expected in one still
+                 * waiting for it. There is no fallback here, though, and there should not be -
+                 * an embedding model is a schema commitment and nothing can stand in for one.
+                 * The gate decides only whether the deployment STARTS; asking for the service
+                 * still throws.
+                 */
                 if (setupRequired) {
                     logger.warn(
                         "Embedding model '{}' for role '{}' is not registered. This deployment is awaiting a key, " +

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -16,6 +16,7 @@
 package com.embabel.common.ai.model
 
 import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.PlaceholderLlmService
 import com.embabel.common.util.indent
 import com.embabel.common.util.loggerFor
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -68,10 +69,43 @@ class ConfigurableModelProvider(
     private val defaultLlm =
         if (llms.isNotEmpty())
             llms.firstOrNull { it.name == properties.defaultLlm }
+                ?: placeholderLlm()
                 ?: throw IllegalArgumentException(
                     "Default LLM '${properties.defaultLlm}' not found. Set the 'embabel.models.default-llm' property to one of the available models: ${llms.map { it.name }}.")
         else
             throw IllegalArgumentException("No models detected. Ensure that at least one Embabel Agent Starter (e.g. embabel-agent-starter-openai) is on the classpath and models are loaded into it.")
+
+    /**
+     * Whether this deployment is waiting for a key rather than misconfigured.
+     *
+     * True exactly when `default-llm` resolved to a [PlaceholderLlmService] - either because it
+     * names one, or because the model it names is not registered and a placeholder stands in. That
+     * is the deployment stating that keys arrive at runtime, and it is the only thing that makes an
+     * unresolvable model name in configuration expected rather than a typo.
+     *
+     * A deployment that has a key resolves `default-llm` to a real model and so is never in this
+     * mode, even with a placeholder registered alongside - which is what a BYOK starter next to a
+     * provider starter looks like.
+     */
+    private val setupRequired: Boolean = defaultLlm is PlaceholderLlmService
+
+    /**
+     * The registered placeholder, if this deployment carries one.
+     *
+     * Deliberately structural rather than by name: `com.embabel.agent.spi` owns the marker, and
+     * this class must not depend on the BYOK module that implements it.
+     */
+    private fun placeholderLlm(): LlmService<*>? =
+        llms.firstOrNull { it is PlaceholderLlmService }
+            ?.also {
+                // Named, because degrading a real model to the placeholder would otherwise hide the
+                // case where the key IS set and the model simply failed to register.
+                logger.warn(
+                    "Default LLM '{}' is not registered; falling back to the '{}' placeholder. " +
+                        "Calls will fail with an actionable 'no LLM configured' error until a key is supplied. Available: {}",
+                    properties.defaultLlm, it.name, llms.map { it.name },
+                )
+            }
 
     // Compute this lazily as embedding services may not be available
     private fun defaultEmbeddingService() =
@@ -81,23 +115,41 @@ class ConfigurableModelProvider(
     init {
         properties.llms.forEach { (role, model) ->
             if (llms.none { it.name == model }) {
-                // Not fatal. A deployment may legitimately have no model registered for a role: a
-                // bring-your-own-key deployment starts with none at all, and one keyed for a single
-                // provider will not have the others' models. It still boots and still serves every
-                // role that does work. The role itself throws when something asks for it - it does
-                // NOT fall back to the default LLM, which is what would make "cheapest" silently
-                // the most expensive model in the deployment.
-                logger.warn(
-                    "LLM '{}' for role '{}' is not available, so anything asking for that role will fail. Available: {}",
-                    model, role, llms.map { it.name },
-                )
+                // Fatal, unless this deployment is waiting for a key. A name that resolves to
+                // nothing is a typo in a deployment that has one, and letting it start would move
+                // the failure to whichever unrelated call first asks for that role. A deployment in
+                // setup-required mode has no models registered yet by definition, so the same name
+                // is expected there and only worth reporting.
+                if (setupRequired) {
+                    logger.warn(
+                        "LLM '{}' for role '{}' is not registered. This deployment is awaiting a key, so that is expected; " +
+                            "the role will report 'no LLM configured' until one is supplied. Available: {}",
+                        model, role, llms.map { it.name },
+                    )
+                } else {
+                    error("LLM '$model' for role $role is not available: Choices are ${llms.map { it.name }}")
+                }
             }
         }
         logger.info(infoString(verbose = true))
 
         properties.embeddingServices.forEach { (role, model) ->
             if (embeddingServices.none { it.name == model }) {
-                error("Embedding model '$model' for role $role is not available: Choices are ${embeddingServices.map { it.name }}")
+                // The same gate as the LLM roles above, and for the same reason: an unresolvable
+                // name is a typo in a deployment that holds a key, and expected in one still
+                // waiting for it. There is no fallback here, though, and there should not be -
+                // an embedding model is a schema commitment and nothing can stand in for one.
+                // The gate decides only whether the deployment STARTS; asking for the service
+                // still throws.
+                if (setupRequired) {
+                    logger.warn(
+                        "Embedding model '{}' for role '{}' is not registered. This deployment is awaiting a key, " +
+                            "so that is expected; asking for that role will still fail. Available: {}",
+                        model, role, embeddingServices.map { it.name },
+                    )
+                } else {
+                    error("Embedding model '$model' for role $role is not available: Choices are ${embeddingServices.map { it.name }}")
+                }
             }
         }
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
@@ -32,6 +32,18 @@ import kotlin.test.assertContains
 
 class ConfigurableModelProviderTest {
 
+    private companion object {
+        /**
+         * Opaque identifiers, not live models: every service here wraps a mockk ChatModel, so
+         * nothing reaches a provider and a retired catalogue id cannot break these tests. Named
+         * anyway — the ids appear across a dozen assertions, and a reader should not have to
+         * decide whether BEST_MODEL and DEFAULT_MODEL differ meaningfully in each one.
+         */
+        const val DEFAULT_MODEL = "gpt-4.1-mini"
+        const val BEST_MODEL = "gpt-4.1"
+        const val CHEAPEST_MODEL = "gpt-4.1-nano"
+    }
+
     /**
      * Stands in for `SetupRequiredLlm`, which lives in the BYOK autoconfigure module this one
      * cannot depend on. [SpringAiLlmService] is a data class and so final; the real placeholder
@@ -53,14 +65,14 @@ class ConfigurableModelProviderTest {
     inner class SetupRequiredMode {
 
         private val real: LlmService<*> =
-            SpringAiLlmService("gpt-4.1-mini", "openai", mockk<ChatModel>())
+            SpringAiLlmService(DEFAULT_MODEL, "openai", mockk<ChatModel>())
 
         @Test
         fun `a deployment awaiting a key boots with roles nothing can satisfy`() {
             val mp = providerWith(
                 llms = listOf(placeholderModel),
                 properties = ConfigurableModelProviderProperties(
-                    llms = mapOf(BEST_ROLE to "gpt-4.1", CHEAPEST_ROLE to "gpt-4.1-nano"),
+                    llms = mapOf(BEST_ROLE to BEST_MODEL, CHEAPEST_ROLE to CHEAPEST_MODEL),
                     defaultLlm = "setup-required",
                 ),
             )
@@ -73,7 +85,7 @@ class ConfigurableModelProviderTest {
             // deployment wants once a key arrives, and the placeholder stands in until then.
             val mp = providerWith(
                 llms = listOf(placeholderModel),
-                properties = ConfigurableModelProviderProperties(defaultLlm = "gpt-4.1"),
+                properties = ConfigurableModelProviderProperties(defaultLlm = BEST_MODEL),
             )
             assertEquals("setup-required", mp.getLlm(DefaultModelSelectionCriteria).name)
         }
@@ -87,12 +99,12 @@ class ConfigurableModelProviderTest {
                 providerWith(
                     llms = listOf(real, placeholderModel),
                     properties = ConfigurableModelProviderProperties(
-                        llms = mapOf(BEST_ROLE to "gpt-4.1"),
-                        defaultLlm = "gpt-4.1-mini",
+                        llms = mapOf(BEST_ROLE to BEST_MODEL),
+                        defaultLlm = DEFAULT_MODEL,
                     ),
                 )
             }
-            assertContains(e.message!!, "gpt-4.1")
+            assertContains(e.message!!, BEST_MODEL)
         }
 
         @Test
@@ -115,7 +127,7 @@ class ConfigurableModelProviderTest {
                     llms = listOf(real),
                     properties = ConfigurableModelProviderProperties(
                         embeddingServices = mapOf("default" to "text-embedding-3-small"),
-                        defaultLlm = "gpt-4.1-mini",
+                        defaultLlm = DEFAULT_MODEL,
                     ),
                 )
             }
@@ -145,7 +157,7 @@ class ConfigurableModelProviderTest {
     private val mp: ModelProvider = ConfigurableModelProvider(
         llms = listOf(
             SpringAiLlmService("gpt40", "OpenAI", mockk<ChatModel>(), DefaultOptionsConverter),
-            SpringAiLlmService("gpt-4.1-mini", "OpenAI", mockk<ChatModel>(), DefaultOptionsConverter),
+            SpringAiLlmService(DEFAULT_MODEL, "OpenAI", mockk<ChatModel>(), DefaultOptionsConverter),
             SpringAiLlmService("embedding", "OpenAI", mockk<ChatModel>(), DefaultOptionsConverter)
         ),
         embeddingServices = listOf(
@@ -253,7 +265,7 @@ class ConfigurableModelProviderTest {
 
         @Test
         fun `valid name`() {
-            val llm = mp.getLlm(ByNameModelSelectionCriteria("gpt-4.1-mini"))
+            val llm = mp.getLlm(ByNameModelSelectionCriteria(DEFAULT_MODEL))
             assertNotNull(llm)
         }
     }
@@ -278,7 +290,7 @@ class ConfigurableModelProviderTest {
 
         private val customMp = ConfigurableModelProvider(
             llms = listOf(
-                SpringAiLlmService("gpt-4.1-mini", "OpenAI", mockk<ChatModel>(), DefaultOptionsConverter),
+                SpringAiLlmService(DEFAULT_MODEL, "OpenAI", mockk<ChatModel>(), DefaultOptionsConverter),
             ),
             embeddingServices = listOf(
                 CustomEmbeddingService("my-custom-embeddings", "CustomProvider"),

--- a/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
@@ -15,6 +15,8 @@
  */
 package com.embabel.common.ai.model
 
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.PlaceholderLlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.common.ai.model.ModelProvider.Companion.BEST_ROLE
 import com.embabel.common.ai.model.ModelProvider.Companion.CHEAPEST_ROLE
@@ -29,6 +31,97 @@ import org.springframework.ai.embedding.EmbeddingModel
 import kotlin.test.assertContains
 
 class ConfigurableModelProviderTest {
+
+    /**
+     * Stands in for `SetupRequiredLlm`, which lives in the BYOK autoconfigure module this one
+     * cannot depend on. [SpringAiLlmService] is a data class and so final; the real placeholder
+     * carries the marker by delegation in the same way.
+     */
+    private val placeholderModel: LlmService<*> = object :
+        LlmService<SpringAiLlmService> by SpringAiLlmService(
+            "setup-required", "none", mockk<ChatModel>(),
+        ),
+        PlaceholderLlmService {}
+
+    private fun providerWith(
+        llms: List<LlmService<*>>,
+        properties: ConfigurableModelProviderProperties,
+        embeddingServices: List<EmbeddingService> = emptyList(),
+    ) = ConfigurableModelProvider(llms, embeddingServices, properties)
+
+    @Nested
+    inner class SetupRequiredMode {
+
+        private val real: LlmService<*> =
+            SpringAiLlmService("gpt-4.1-mini", "openai", mockk<ChatModel>())
+
+        @Test
+        fun `a deployment awaiting a key boots with roles nothing can satisfy`() {
+            val mp = providerWith(
+                llms = listOf(placeholderModel),
+                properties = ConfigurableModelProviderProperties(
+                    llms = mapOf(BEST_ROLE to "gpt-4.1", CHEAPEST_ROLE to "gpt-4.1-nano"),
+                    defaultLlm = "setup-required",
+                ),
+            )
+            assertEquals("setup-required", mp.getLlm(DefaultModelSelectionCriteria).name)
+        }
+
+        @Test
+        fun `default-llm naming an unregistered model falls back to the placeholder`() {
+            // The realistic pure-BYOK application.yml: default-llm still names the model the
+            // deployment wants once a key arrives, and the placeholder stands in until then.
+            val mp = providerWith(
+                llms = listOf(placeholderModel),
+                properties = ConfigurableModelProviderProperties(defaultLlm = "gpt-4.1"),
+            )
+            assertEquals("setup-required", mp.getLlm(DefaultModelSelectionCriteria).name)
+        }
+
+        @Test
+        fun `a deployment holding a key still dies on a name nothing registers`() {
+            // The other half of the gate. Making this a warning too - which an earlier revision
+            // did - fixes BYOK by turning every keyed deployment's typo into a late failure at
+            // whichever call first wants that role.
+            val e = assertThrows<IllegalStateException> {
+                providerWith(
+                    llms = listOf(real, placeholderModel),
+                    properties = ConfigurableModelProviderProperties(
+                        llms = mapOf(BEST_ROLE to "gpt-4.1"),
+                        defaultLlm = "gpt-4.1-mini",
+                    ),
+                )
+            }
+            assertContains(e.message!!, "gpt-4.1")
+        }
+
+        @Test
+        fun `an unresolvable embedding role is tolerated while awaiting a key`() {
+            providerWith(
+                llms = listOf(placeholderModel),
+                properties = ConfigurableModelProviderProperties(
+                    embeddingServices = mapOf("default" to "text-embedding-3-small"),
+                    defaultLlm = "setup-required",
+                ),
+            )
+        }
+
+        @Test
+        fun `an unresolvable embedding role is still fatal for a deployment holding a key`() {
+            // Same gate, no fallback: there is no embedding placeholder and there should not be
+            // one, so this decides only whether the deployment starts.
+            val e = assertThrows<IllegalStateException> {
+                providerWith(
+                    llms = listOf(real),
+                    properties = ConfigurableModelProviderProperties(
+                        embeddingServices = mapOf("default" to "text-embedding-3-small"),
+                        defaultLlm = "gpt-4.1-mini",
+                    ),
+                )
+            }
+            assertContains(e.message!!, "text-embedding-3-small")
+        }
+    }
 
     /**
      * Custom EmbeddingService that does NOT extend AiModel.

--- a/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
@@ -92,9 +92,11 @@ class ConfigurableModelProviderTest {
 
         @Test
         fun `a deployment holding a key still dies on a name nothing registers`() {
-            // The other half of the gate. Making this a warning too - which an earlier revision
-            // did - fixes BYOK by turning every keyed deployment's typo into a late failure at
-            // whichever call first wants that role.
+            /*
+             * The other half of the gate. Making this a warning too - which an earlier revision
+             * did - fixes BYOK by turning every keyed deployment's typo into a late failure at
+             * whichever call first wants that role.
+             */
             val e = assertThrows<IllegalStateException> {
                 providerWith(
                     llms = listOf(real, placeholderModel),

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-autoconfigure</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>embabel-agent-byok-autoconfigure</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Autoconfiguration BYOK</name>
+    <description>Placeholder LLM service allowing a pure BYOK deployment to start with no keys configured</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-byok</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.byok;
+
+import com.embabel.agent.config.models.byok.SetupRequiredLlmConfig;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Autoconfiguration for Bring Your Own Key deployments.
+ * <p>
+ * Unlike the provider autoconfigurations, this registers no real models and requires no API key.
+ * It contributes only the {@code setup-required} placeholder LLM, which lets a deployment holding
+ * no provider key start up and resolve {@code embabel.models.default-llm}. Keys arrive at runtime
+ * and reach a call through {@code PromptRunner.withLlmService(...)}.
+ * <p>
+ * Runs before the platform autoconfiguration so the placeholder bean exists by the time the model
+ * provider is built.
+ */
+@AutoConfiguration
+@AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
+@Import(SetupRequiredLlmConfig.class)
+public class AgentByokAutoConfiguration {
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlm.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlm.kt
@@ -106,10 +106,11 @@ object SetupRequiredLlm {
      * application knows which providers it accepts and how a user supplies a key, so it should
      * catch the exception and say so in its own words rather than surface this verbatim.
      */
-    const val MESSAGE: String =
-        "No LLM is configured. This deployment holds no provider API key, so a key must be " +
-            "supplied per request via PromptRunner.withLlmService(...). See the Bring Your Own " +
-            "Key section of the Embabel reference documentation."
+    val MESSAGE: String = """
+        No LLM is configured. This deployment holds no provider API key,
+        so a key must be supplied per request via PromptRunner.withLlmService(...).
+        See the Bring Your Own Key section of the Embabel reference documentation.
+    """.trimIndent()
 
     /**
      * Builds the placeholder service. Registered as a bean by [SetupRequiredLlmConfig]; call this

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlm.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlm.kt
@@ -15,13 +15,21 @@
  */
 package com.embabel.agent.config.models.byok
 
+import com.embabel.agent.spi.loop.LlmMessageSender
+import com.embabel.agent.spi.loop.streaming.LlmMessageStreamer
 import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.PlaceholderLlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.model.AiModel
+import com.embabel.common.ai.model.LlmMetadata
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.prompt.PromptContributor
 import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.Prompt
 import reactor.core.publisher.Flux
+import java.time.LocalDate
 
 /**
  * Thrown when a prompt reaches the [SetupRequiredLlm] placeholder, meaning no real LLM was
@@ -116,9 +124,55 @@ object SetupRequiredLlm {
      * Builds the placeholder service. Registered as a bean by [SetupRequiredLlmConfig]; call this
      * directly only when constructing a model provider outside a Spring context.
      */
-    fun llmService(): LlmService<*> = SpringAiLlmService(
-        name = NAME,
-        provider = PROVIDER,
-        chatModel = SetupRequiredChatModel(),
+    fun llmService(): LlmService<*> = SetupRequiredLlmService()
+}
+
+/**
+ * The placeholder as an [LlmService], carrying the [PlaceholderLlmService] marker the platform
+ * looks for.
+ *
+ * A thin wrapper around a [SpringAiLlmService] rather than that class itself, because it is a
+ * `data class` and so cannot be extended to carry a marker interface. Everything is delegated to
+ * it, so the placeholder behaves exactly like any other Spring AI service - including
+ * `supportsStreaming()`, which probes the chat model and correctly answers false.
+ *
+ * The self-typed methods return a wrapper rather than the delegate. Delegating them would hand
+ * back a bare [SpringAiLlmService], silently dropping the marker - and the platform reads that
+ * marker to decide whether an unresolvable model name in configuration is a typo or a deployment
+ * awaiting a key.
+ */
+internal class SetupRequiredLlmService private constructor(
+    private val delegate: SpringAiLlmService,
+) : LlmService<SetupRequiredLlmService>, AiModel<ChatModel>, PlaceholderLlmService,
+    LlmMetadata by delegate {
+
+    constructor() : this(
+        SpringAiLlmService(
+            name = SetupRequiredLlm.NAME,
+            provider = SetupRequiredLlm.PROVIDER,
+            chatModel = SetupRequiredChatModel(),
+        ),
     )
+
+    override val model: ChatModel get() = delegate.model
+
+    override val promptContributors: List<PromptContributor> get() = delegate.promptContributors
+
+    override fun createMessageSender(options: LlmOptions): LlmMessageSender =
+        delegate.createMessageSender(options)
+
+    override fun createMessageStreamer(options: LlmOptions): LlmMessageStreamer =
+        delegate.createMessageStreamer(options)
+
+    override fun supportsStreaming(): Boolean = delegate.supportsStreaming()
+
+    override fun supportsThinking(): Boolean = delegate.supportsThinking()
+
+    override fun withKnowledgeCutoffDate(date: LocalDate): SetupRequiredLlmService =
+        SetupRequiredLlmService(delegate.withKnowledgeCutoffDate(date))
+
+    override fun withPromptContributor(promptContributor: PromptContributor): SetupRequiredLlmService =
+        SetupRequiredLlmService(delegate.withPromptContributor(promptContributor))
+
+    override fun toString(): String = "SetupRequiredLlmService(name=${delegate.name})"
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlm.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlm.kt
@@ -21,6 +21,7 @@ import org.springframework.ai.chat.model.ChatModel
 import org.springframework.ai.chat.model.ChatResponse
 import org.springframework.ai.chat.prompt.ChatOptions
 import org.springframework.ai.chat.prompt.Prompt
+import reactor.core.publisher.Flux
 
 /**
  * Thrown when a prompt reaches the [SetupRequiredLlm] placeholder, meaning no real LLM was
@@ -40,6 +41,24 @@ class NoLlmConfiguredException(message: String) : RuntimeException(message)
 internal class SetupRequiredChatModel : ChatModel {
 
     override fun call(prompt: Prompt): ChatResponse =
+        throw NoLlmConfiguredException(SetupRequiredLlm.MESSAGE)
+
+    /**
+     * Streaming fails the same way as a blocking call.
+     *
+     * `ChatModel` defaults `stream` to `UnsupportedOperationException("streaming is not
+     * supported")`, which for this model is both untrue and unactionable: streaming is not the
+     * problem, the missing key is. Chat applications are the ones that stream and the ones most
+     * likely to need the "add an API key" path, so the default would hide the message exactly
+     * where it is needed - and an application catching [NoLlmConfiguredException] would not
+     * catch it at all.
+     *
+     * Note the platform still reports this model as not supporting streaming:
+     * `StreamingCapabilityVerifier` probes by calling `stream` and treats any exception as
+     * "no". That is the right answer either way; this only fixes what the caller is told when
+     * something streams anyway.
+     */
+    override fun stream(prompt: Prompt): Flux<ChatResponse> =
         throw NoLlmConfiguredException(SetupRequiredLlm.MESSAGE)
 
     override fun getOptions(): ChatOptions = ChatOptions.builder().build()

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlm.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlm.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.byok
+
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import org.springframework.ai.chat.model.ChatModel
+import org.springframework.ai.chat.model.ChatResponse
+import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.chat.prompt.Prompt
+
+/**
+ * Thrown when a prompt reaches the [SetupRequiredLlm] placeholder, meaning no real LLM was
+ * available for the call: the deployment has no server-side key and the caller did not supply
+ * one with [com.embabel.agent.api.common.PromptRunner.withLlmService].
+ *
+ * Catch this to render your own "add an API key" experience. The placeholder deliberately
+ * fails loudly rather than returning an empty completion, so a missing key surfaces as an
+ * actionable error rather than a silently empty answer.
+ */
+class NoLlmConfiguredException(message: String) : RuntimeException(message)
+
+/**
+ * A [ChatModel] that never completes anything. It exists only so the platform has a model to
+ * resolve before any key is supplied; every call fails with [NoLlmConfiguredException].
+ */
+internal class SetupRequiredChatModel : ChatModel {
+
+    override fun call(prompt: Prompt): ChatResponse =
+        throw NoLlmConfiguredException(SetupRequiredLlm.MESSAGE)
+
+    override fun getOptions(): ChatOptions = ChatOptions.builder().build()
+
+    override fun toString(): String = javaClass.simpleName
+}
+
+/**
+ * The placeholder LLM for a pure BYOK deployment — one that starts with no provider key at all
+ * and obtains a key per user, per tenant, or per request at runtime.
+ *
+ * Such a deployment has no [LlmService] beans at startup, so
+ * [com.embabel.common.ai.model.ConfigurableModelProvider] cannot resolve `embabel.models.default-llm`
+ * and the context never refreshes. Registering this placeholder and pointing `default-llm` at it
+ * gives the platform something to resolve, deferring the "no key" failure from startup to the
+ * first call that actually needs an LLM.
+ *
+ * Opt in by putting `embabel-agent-starter-byok` on the classpath and configuring:
+ * ```yaml
+ * embabel:
+ *   models:
+ *     default-llm: setup-required
+ * ```
+ *
+ * Real work bypasses the placeholder entirely: resolve a key, build a service with
+ * [com.embabel.agent.anthropic.AnthropicModelFactory] or
+ * [com.embabel.agent.openai.OpenAiCompatibleModelFactory], and pass it to
+ * [com.embabel.agent.api.common.PromptRunner.withLlmService].
+ */
+object SetupRequiredLlm {
+
+    /**
+     * The well-known name of the placeholder, as both the bean name and the [LlmService] name.
+     * Use it as the value of `embabel.models.default-llm`.
+     */
+    const val NAME: String = "setup-required"
+
+    /**
+     * Provider reported by the placeholder. Not a real provider — no key reaches any endpoint.
+     */
+    const val PROVIDER: String = "none"
+
+    /**
+     * Message carried by [NoLlmConfiguredException]. Deliberately provider-neutral: an
+     * application knows which providers it accepts and how a user supplies a key, so it should
+     * catch the exception and say so in its own words rather than surface this verbatim.
+     */
+    const val MESSAGE: String =
+        "No LLM is configured. This deployment holds no provider API key, so a key must be " +
+            "supplied per request via PromptRunner.withLlmService(...). See the Bring Your Own " +
+            "Key section of the Embabel reference documentation."
+
+    /**
+     * Builds the placeholder service. Registered as a bean by [SetupRequiredLlmConfig]; call this
+     * directly only when constructing a model provider outside a Spring context.
+     */
+    fun llmService(): LlmService<*> = SpringAiLlmService(
+        name = NAME,
+        provider = PROVIDER,
+        chatModel = SetupRequiredChatModel(),
+    )
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmConfig.kt
@@ -38,8 +38,10 @@ class SetupRequiredLlmConfig {
     @Bean(SetupRequiredLlm.NAME)
     fun setupRequiredLlmService(): LlmService<*> {
         loggerFor<SetupRequiredLlmConfig>().info(
-            "Registered placeholder LLM '{}'. Set embabel.models.default-llm={} to start with no provider key; " +
-                "supply a real key per request with PromptRunner.withLlmService(...).",
+            """
+            Registered placeholder LLM '{}'. Set embabel.models.default-llm={} to start with no provider key;
+            supply a real key per request with PromptRunner.withLlmService(...).
+            """.trimIndent(),
             SetupRequiredLlm.NAME,
             SetupRequiredLlm.NAME,
         )

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmConfig.kt
@@ -29,8 +29,10 @@ import org.springframework.context.annotation.Configuration
  * those singletons exist and would always see none. Registering unconditionally and opting in
  * through `embabel.models.default-llm` avoids the ordering question entirely.
  *
- * An unused placeholder is harmless: models are only ever selected by name or by role, so a
- * deployment that does not name [SetupRequiredLlm.NAME] never resolves it.
+ * An unused placeholder is harmless. Every selection path reaches a model by naming it — by
+ * name, by role, or as `embabel.models.default-llm` — and `auto` resolves to that same default.
+ * So a deployment that does not name [SetupRequiredLlm.NAME] anywhere never resolves it, and
+ * adding this starter alongside a real provider changes nothing.
  */
 @Configuration(proxyBeanMethods = false)
 class SetupRequiredLlmConfig {

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmConfig.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.byok
+
+import com.embabel.agent.spi.LlmService
+import com.embabel.common.util.loggerFor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Registers the [SetupRequiredLlm] placeholder so a deployment with no provider key can start.
+ *
+ * The bean is registered unconditionally rather than behind `@ConditionalOnMissingBean(LlmService)`.
+ * Provider autoconfigurations do not declare their models as `@Bean`s — they call `registerSingleton`
+ * imperatively from inside a `@Bean` method — so such a condition would be evaluated long before
+ * those singletons exist and would always see none. Registering unconditionally and opting in
+ * through `embabel.models.default-llm` avoids the ordering question entirely.
+ *
+ * An unused placeholder is harmless: models are only ever selected by name or by role, so a
+ * deployment that does not name [SetupRequiredLlm.NAME] never resolves it.
+ */
+@Configuration(proxyBeanMethods = false)
+class SetupRequiredLlmConfig {
+
+    @Bean(SetupRequiredLlm.NAME)
+    fun setupRequiredLlmService(): LlmService<*> {
+        loggerFor<SetupRequiredLlmConfig>().info(
+            "Registered placeholder LLM '{}'. Set embabel.models.default-llm={} to start with no provider key; " +
+                "supply a real key per request with PromptRunner.withLlmService(...).",
+            SetupRequiredLlm.NAME,
+            SetupRequiredLlm.NAME,
+        )
+        return SetupRequiredLlm.llmService()
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2025-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.embabel.agent.autoconfigure.models.byok.AgentByokAutoConfiguration

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfigurationTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.byok;
+
+import com.embabel.agent.config.models.byok.SetupRequiredLlm;
+import com.embabel.agent.spi.LlmService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AgentByokAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AgentByokAutoConfiguration.class));
+
+    @Test
+    void registersThePlaceholderWithNoApiKeyConfigured() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasBean(SetupRequiredLlm.NAME);
+            assertThat(context.getBean(SetupRequiredLlm.NAME)).isInstanceOf(LlmService.class);
+        });
+    }
+
+    @Test
+    void placeholderIsTheOnlyLlmServiceContributed() {
+        contextRunner.run(context ->
+                assertThat(context.getBeansOfType(LlmService.class)).containsOnlyKeys(SetupRequiredLlm.NAME));
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/PureByokWithRolesTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/PureByokWithRolesTest.kt
@@ -65,9 +65,11 @@ class PureByokWithRolesTest {
 
     @Test
     fun `a deployment that holds a key still dies at startup on a name nothing registers`() {
-        // The other half of the rule, and the reason the relaxation is gated rather than
-        // unconditional: making this a warning too would fix BYOK by making every keyed deployment
-        // worse, turning a typo into a late failure at whichever call first wanted that role.
+        /*
+         * The other half of the rule, and the reason the relaxation is gated rather than
+         * unconditional: making this a warning too would fix BYOK by making every keyed deployment
+         * worse, turning a typo into a late failure at whichever call first wanted that role.
+         */
         val real = SpringAiLlmService(name = "real-model", provider = "acme", chatModel = SetupRequiredChatModel())
 
         assertThatThrownBy {
@@ -85,9 +87,11 @@ class PureByokWithRolesTest {
 
     @Test
     fun `default-llm naming an unregistered model falls back to the placeholder`() {
-        // The realistic pure-BYOK application.yml: default-llm still names the model the deployment
-        // wants once a key arrives. Nothing registers it yet, so the placeholder stands in and that
-        // is what puts the deployment into setup-required mode.
+        /*
+         * The realistic pure-BYOK application.yml: default-llm still names the model the deployment
+         * wants once a key arrives. Nothing registers it yet, so the placeholder stands in and that
+         * is what puts the deployment into setup-required mode.
+         */
         val modelProvider = ConfigurableModelProvider(
             llms = listOf(SetupRequiredLlm.llmService()),
             embeddingServices = emptyList(),

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/PureByokWithRolesTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/PureByokWithRolesTest.kt
@@ -84,6 +84,57 @@ class PureByokWithRolesTest {
     }
 
     @Test
+    fun `default-llm naming an unregistered model falls back to the placeholder`() {
+        // The realistic pure-BYOK application.yml: default-llm still names the model the deployment
+        // wants once a key arrives. Nothing registers it yet, so the placeholder stands in and that
+        // is what puts the deployment into setup-required mode.
+        val modelProvider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService()),
+            embeddingServices = emptyList(),
+            properties = ConfigurableModelProviderProperties(
+                llms = mapOf(BEST_ROLE to "gpt-4.1"),
+                defaultLlm = "gpt-4.1",
+            ),
+        )
+
+        assertThat(modelProvider.getLlm(DefaultModelSelectionCriteria).name)
+            .isEqualTo(SetupRequiredLlm.NAME)
+    }
+
+    @Test
+    fun `an unresolvable embedding role is tolerated while awaiting a key`() {
+        assertThatCode {
+            ConfigurableModelProvider(
+                llms = listOf(SetupRequiredLlm.llmService()),
+                embeddingServices = emptyList(),
+                properties = ConfigurableModelProviderProperties(
+                    embeddingServices = mapOf("default" to "text-embedding-3-small"),
+                    defaultLlm = SetupRequiredLlm.NAME,
+                ),
+            )
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `an unresolvable embedding role is still fatal for a deployment holding a key`() {
+        // Same gate as the LLM roles, and no fallback: there is no embedding placeholder and there
+        // should not be one, so the gate decides only whether the deployment starts.
+        val real = SpringAiLlmService(name = "real-model", provider = "acme", chatModel = SetupRequiredChatModel())
+
+        assertThatThrownBy {
+            ConfigurableModelProvider(
+                llms = listOf(real),
+                embeddingServices = emptyList(),
+                properties = ConfigurableModelProviderProperties(
+                    embeddingServices = mapOf("default" to "text-embedding-3-small"),
+                    defaultLlm = "real-model",
+                ),
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("text-embedding-3-small")
+    }
+
+    @Test
     fun `an unsatisfiable role fails when asked for, rather than resolving to the placeholder`() {
         // Silently handing back the placeholder would turn "no key configured" into an empty or
         // broken answer at some unrelated point later. The role has no model; say so.

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/PureByokWithRolesTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/PureByokWithRolesTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.byok
+
+import com.embabel.common.ai.model.ByRoleModelSelectionCriteria
+import com.embabel.common.ai.model.ConfigurableModelProvider
+import com.embabel.common.ai.model.ConfigurableModelProviderProperties
+import com.embabel.common.ai.model.DefaultModelSelectionCriteria
+import com.embabel.common.ai.model.NoSuitableModelException
+import com.embabel.common.ai.model.ModelProvider.Companion.BEST_ROLE
+import com.embabel.common.ai.model.ModelProvider.Companion.CHEAPEST_ROLE
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * A pure BYOK deployment holds no provider key, so no model a role names is registered — and
+ * roles are ordinary configuration that such a deployment may well already have.
+ *
+ * Treating that as fatal made the starter unable to do the one thing it exists for: an
+ * application whose `application.yml` named any role at all failed context refresh with
+ * "LLM 'x' for role y is not available", no matter that `default-llm` pointed at the
+ * placeholder.
+ */
+class PureByokWithRolesTest {
+
+    private fun pureByok(roles: Map<String, String>) = ConfigurableModelProvider(
+        llms = listOf(SetupRequiredLlm.llmService()),
+        embeddingServices = emptyList(),
+        properties = ConfigurableModelProviderProperties(
+            llms = roles,
+            defaultLlm = SetupRequiredLlm.NAME,
+        ),
+    )
+
+    @Test
+    fun `starts with roles configured and no model to satisfy them`() {
+        assertThatCode {
+            pureByok(mapOf(BEST_ROLE to "gpt-4.1", CHEAPEST_ROLE to "gpt-4.1-nano"))
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `still resolves the placeholder as the default`() {
+        val modelProvider = pureByok(mapOf(BEST_ROLE to "gpt-4.1"))
+
+        assertThat(modelProvider.getLlm(DefaultModelSelectionCriteria).name)
+            .isEqualTo(SetupRequiredLlm.NAME)
+    }
+
+    @Test
+    fun `an unsatisfiable role fails when asked for, rather than resolving to the placeholder`() {
+        // Silently handing back the placeholder would turn "no key configured" into an empty or
+        // broken answer at some unrelated point later. The role has no model; say so.
+        val modelProvider = pureByok(mapOf(BEST_ROLE to "gpt-4.1"))
+
+        assertThatThrownBy { modelProvider.getLlm(ByRoleModelSelectionCriteria(BEST_ROLE)) }
+            .isInstanceOf(NoSuitableModelException::class.java)
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/PureByokWithRolesTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/PureByokWithRolesTest.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.config.models.byok
 
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.common.ai.model.ByRoleModelSelectionCriteria
 import com.embabel.common.ai.model.ConfigurableModelProvider
 import com.embabel.common.ai.model.ConfigurableModelProviderProperties
@@ -60,6 +61,26 @@ class PureByokWithRolesTest {
 
         assertThat(modelProvider.getLlm(DefaultModelSelectionCriteria).name)
             .isEqualTo(SetupRequiredLlm.NAME)
+    }
+
+    @Test
+    fun `a deployment that holds a key still dies at startup on a name nothing registers`() {
+        // The other half of the rule, and the reason the relaxation is gated rather than
+        // unconditional: making this a warning too would fix BYOK by making every keyed deployment
+        // worse, turning a typo into a late failure at whichever call first wanted that role.
+        val real = SpringAiLlmService(name = "real-model", provider = "acme", chatModel = SetupRequiredChatModel())
+
+        assertThatThrownBy {
+            ConfigurableModelProvider(
+                llms = listOf(SetupRequiredLlm.llmService(), real),
+                embeddingServices = emptyList(),
+                properties = ConfigurableModelProviderProperties(
+                    llms = mapOf(BEST_ROLE to "gpt-4.1"),
+                    defaultLlm = "real-model",
+                ),
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+            .hasMessageContaining("gpt-4.1")
     }
 
     @Test

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
@@ -36,8 +36,10 @@ class SetupRequiredLlmTest {
 
     @Test
     fun `placeholder is named by the well-known constant`() {
+        // Not asserting the literal "setup-required": that is the constant restating itself.
+        // What has to hold is that the service reports the name and provider the constants
+        // declare, since that is what `embabel.models.default-llm` matches against.
         val service = SetupRequiredLlm.llmService()
-        assertThat(SetupRequiredLlm.NAME).isEqualTo("setup-required")
         assertThat(service.name).isEqualTo(SetupRequiredLlm.NAME)
         assertThat(service.provider).isEqualTo(SetupRequiredLlm.PROVIDER)
     }

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
@@ -19,7 +19,10 @@ import com.embabel.common.ai.model.ByNameModelSelectionCriteria
 import com.embabel.common.ai.model.ConfigurableModelProvider
 import com.embabel.common.ai.model.ConfigurableModelProviderProperties
 import com.embabel.common.ai.model.DefaultModelSelectionCriteria
+import com.embabel.agent.spi.PlaceholderLlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.model.AiModel
+import org.springframework.ai.chat.model.ChatModel
 import com.embabel.common.ai.model.LlmOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -42,6 +45,10 @@ class SetupRequiredLlmTest {
         val service = SetupRequiredLlm.llmService()
         assertThat(service.name).isEqualTo(SetupRequiredLlm.NAME)
         assertThat(service.provider).isEqualTo(SetupRequiredLlm.PROVIDER)
+        // The marker is what puts the platform into setup-required mode, so an unresolvable model
+        // name in configuration is treated as "awaiting a key" rather than as a typo. Losing it
+        // would not fail here - it would quietly restore fail-fast startup for BYOK deployments.
+        assertThat(service).isInstanceOf(PlaceholderLlmService::class.java)
     }
 
     @Test
@@ -73,7 +80,7 @@ class SetupRequiredLlmTest {
     fun `calling the placeholder fails with an actionable error rather than an empty completion`() {
         val service = SetupRequiredLlm.llmService()
 
-        assertThatThrownBy { (service as SpringAiLlmService).chatModel.call(Prompt(listOf(UserMessage("hello")))) }
+        assertThatThrownBy { ((service as AiModel<*>).model as ChatModel).call(Prompt(listOf(UserMessage("hello")))) }
             .isInstanceOf(NoLlmConfiguredException::class.java)
             .hasMessageContaining("withLlmService")
     }
@@ -85,7 +92,7 @@ class SetupRequiredLlmTest {
         // NoLlmConfiguredException — in a chat app, exactly where the message is needed.
         val service = SetupRequiredLlm.llmService()
 
-        assertThatThrownBy { (service as SpringAiLlmService).chatModel.stream(Prompt(listOf(UserMessage("hello")))) }
+        assertThatThrownBy { ((service as AiModel<*>).model as ChatModel).stream(Prompt(listOf(UserMessage("hello")))) }
             .isInstanceOf(NoLlmConfiguredException::class.java)
             .hasMessageContaining("withLlmService")
     }

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
@@ -77,6 +77,23 @@ class SetupRequiredLlmTest {
     }
 
     @Test
+    fun `streaming fails the same way, not with an unrelated streaming error`() {
+        // Spring AI's default stream() throws UnsupportedOperationException("streaming is not
+        // supported"), which is both untrue here and uncatchable by an application watching for
+        // NoLlmConfiguredException — in a chat app, exactly where the message is needed.
+        val service = SetupRequiredLlm.llmService()
+
+        assertThatThrownBy { (service as SpringAiLlmService).chatModel.stream(Prompt(listOf(UserMessage("hello")))) }
+            .isInstanceOf(NoLlmConfiguredException::class.java)
+            .hasMessageContaining("withLlmService")
+    }
+
+    @Test
+    fun `the platform still reports the placeholder as not supporting streaming`() {
+        assertThat(SetupRequiredLlm.llmService().supportsStreaming()).isFalse()
+    }
+
+    @Test
     fun `a message sender can be created, so failure happens at call time not setup time`() {
         val service = SetupRequiredLlm.llmService()
         assertThat(service.createMessageSender(LlmOptions())).isNotNull()

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.byok
+
+import com.embabel.common.ai.model.ByNameModelSelectionCriteria
+import com.embabel.common.ai.model.ConfigurableModelProvider
+import com.embabel.common.ai.model.ConfigurableModelProviderProperties
+import com.embabel.common.ai.model.DefaultModelSelectionCriteria
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.model.LlmOptions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.springframework.ai.chat.messages.UserMessage
+import org.springframework.ai.chat.prompt.Prompt
+
+/**
+ * The placeholder exists to move the "no key" failure from context refresh to the call that
+ * needs an LLM. These tests pin both halves of that: the model provider resolves, and the call
+ * fails with something an operator can act on.
+ */
+class SetupRequiredLlmTest {
+
+    @Test
+    fun `placeholder is named by the well-known constant`() {
+        val service = SetupRequiredLlm.llmService()
+        assertThat(SetupRequiredLlm.NAME).isEqualTo("setup-required")
+        assertThat(service.name).isEqualTo(SetupRequiredLlm.NAME)
+        assertThat(service.provider).isEqualTo(SetupRequiredLlm.PROVIDER)
+    }
+
+    @Test
+    fun `model provider with only the placeholder resolves the default LLM`() {
+        val modelProvider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService()),
+            embeddingServices = emptyList(),
+            properties = ConfigurableModelProviderProperties(defaultLlm = SetupRequiredLlm.NAME),
+        )
+
+        assertThat(modelProvider.getLlm(DefaultModelSelectionCriteria).name).isEqualTo(SetupRequiredLlm.NAME)
+        assertThat(modelProvider.getLlm(ByNameModelSelectionCriteria(SetupRequiredLlm.NAME)).name)
+            .isEqualTo(SetupRequiredLlm.NAME)
+    }
+
+    @Test
+    fun `the placeholder is never selected unless it is named`() {
+        val real = SpringAiLlmService(name = "real-model", provider = "acme", chatModel = SetupRequiredChatModel())
+        val modelProvider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService(), real),
+            embeddingServices = emptyList(),
+            properties = ConfigurableModelProviderProperties(defaultLlm = "real-model"),
+        )
+
+        assertThat(modelProvider.getLlm(DefaultModelSelectionCriteria).name).isEqualTo("real-model")
+    }
+
+    @Test
+    fun `calling the placeholder fails with an actionable error rather than an empty completion`() {
+        val service = SetupRequiredLlm.llmService()
+
+        assertThatThrownBy { (service as SpringAiLlmService).chatModel.call(Prompt(listOf(UserMessage("hello")))) }
+            .isInstanceOf(NoLlmConfiguredException::class.java)
+            .hasMessageContaining("withLlmService")
+    }
+
+    @Test
+    fun `a message sender can be created, so failure happens at call time not setup time`() {
+        val service = SetupRequiredLlm.llmService()
+        assertThat(service.createMessageSender(LlmOptions())).isNotNull()
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
@@ -41,15 +41,19 @@ class SetupRequiredLlmTest {
 
     @Test
     fun `placeholder is named by the well-known constant`() {
-        // Not asserting the literal "setup-required": that is the constant restating itself.
-        // What has to hold is that the service reports the name and provider the constants
-        // declare, since that is what `embabel.models.default-llm` matches against.
+        /*
+         * Not asserting the literal "setup-required": that is the constant restating itself.
+         * What has to hold is that the service reports the name and provider the constants
+         * declare, since that is what `embabel.models.default-llm` matches against.
+         */
         val service = SetupRequiredLlm.llmService()
         assertThat(service.name).isEqualTo(SetupRequiredLlm.NAME)
         assertThat(service.provider).isEqualTo(SetupRequiredLlm.PROVIDER)
-        // The marker is what puts the platform into setup-required mode, so an unresolvable model
-        // name in configuration is treated as "awaiting a key" rather than as a typo. Losing it
-        // would not fail here - it would quietly restore fail-fast startup for BYOK deployments.
+        /*
+         * The marker is what puts the platform into setup-required mode, so an unresolvable model
+         * name in configuration is treated as "awaiting a key" rather than as a typo. Losing it
+         * would not fail here - it would quietly restore fail-fast startup for BYOK deployments.
+         */
         assertThat(service).isInstanceOf(PlaceholderLlmService::class.java)
     }
 
@@ -89,9 +93,11 @@ class SetupRequiredLlmTest {
 
     @Test
     fun `streaming fails the same way, not with an unrelated streaming error`() {
-        // Spring AI's default stream() throws UnsupportedOperationException("streaming is not
-        // supported"), which is both untrue here and uncatchable by an application watching for
-        // NoLlmConfiguredException — in a chat app, exactly where the message is needed.
+        /*
+         * Spring AI's default stream() throws UnsupportedOperationException("streaming is not
+         * supported"), which is both untrue here and uncatchable by an application watching for
+         * NoLlmConfiguredException — in a chat app, exactly where the message is needed.
+         */
         val service = SetupRequiredLlm.llmService()
 
         assertThatThrownBy { ((service as AiModel<*>).model as ChatModel).stream(Prompt(listOf(UserMessage("hello")))) }
@@ -113,10 +119,12 @@ class SetupRequiredLlmTest {
 
     @Test
     fun `the marker survives the self-typed methods`() {
-        // The reason this class wraps SpringAiLlmService by hand rather than delegating with `by`:
-        // delegated self-typed methods hand back the bare delegate, dropping the marker. Losing it
-        // is silent - the deployment simply stops being in setup-required mode and goes back to
-        // failing at startup on names it cannot resolve, which is what this PR exists to prevent.
+        /*
+         * The reason this class wraps SpringAiLlmService by hand rather than delegating with `by`:
+         * delegated self-typed methods hand back the bare delegate, dropping the marker. Losing it
+         * is silent - the deployment simply stops being in setup-required mode and goes back to
+         * failing at startup on names it cannot resolve, which is what this PR exists to prevent.
+         */
         val service = SetupRequiredLlm.llmService()
 
         val withContributor = service.withPromptContributor(PromptContributor.fixed("extra"))

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredLlmTest.kt
@@ -22,6 +22,7 @@ import com.embabel.common.ai.model.DefaultModelSelectionCriteria
 import com.embabel.agent.spi.PlaceholderLlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.common.ai.model.AiModel
+import com.embabel.common.ai.prompt.PromptContributor
 import org.springframework.ai.chat.model.ChatModel
 import com.embabel.common.ai.model.LlmOptions
 import org.assertj.core.api.Assertions.assertThat
@@ -29,6 +30,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.ai.chat.messages.UserMessage
 import org.springframework.ai.chat.prompt.Prompt
+import java.time.LocalDate
 
 /**
  * The placeholder exists to move the "no key" failure from context refresh to the call that
@@ -106,5 +108,33 @@ class SetupRequiredLlmTest {
     fun `a message sender can be created, so failure happens at call time not setup time`() {
         val service = SetupRequiredLlm.llmService()
         assertThat(service.createMessageSender(LlmOptions())).isNotNull()
+        assertThat(service.createMessageStreamer(LlmOptions())).isNotNull()
+    }
+
+    @Test
+    fun `the marker survives the self-typed methods`() {
+        // The reason this class wraps SpringAiLlmService by hand rather than delegating with `by`:
+        // delegated self-typed methods hand back the bare delegate, dropping the marker. Losing it
+        // is silent - the deployment simply stops being in setup-required mode and goes back to
+        // failing at startup on names it cannot resolve, which is what this PR exists to prevent.
+        val service = SetupRequiredLlm.llmService()
+
+        val withContributor = service.withPromptContributor(PromptContributor.fixed("extra"))
+        assertThat(withContributor).isInstanceOf(PlaceholderLlmService::class.java)
+        assertThat(withContributor.promptContributors).hasSize(service.promptContributors.size + 1)
+
+        val withCutoff = service.withKnowledgeCutoffDate(LocalDate.of(2026, 1, 1))
+        assertThat(withCutoff).isInstanceOf(PlaceholderLlmService::class.java)
+        assertThat(withCutoff.knowledgeCutoffDate).isEqualTo(LocalDate.of(2026, 1, 1))
+    }
+
+    @Test
+    fun `the placeholder does not claim to support thinking`() {
+        assertThat(SetupRequiredLlm.llmService().supportsThinking()).isFalse()
+    }
+
+    @Test
+    fun `it names itself in logs rather than reporting a delegate`() {
+        assertThat(SetupRequiredLlm.llmService().toString()).contains(SetupRequiredLlm.NAME)
     }
 }

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -27,6 +27,7 @@
         <module>embabel-agent-mcpserver-autoconfigure</module>
         <module>embabel-agent-mcpserver-security-autoconfigure</module>
         <module>embabel-agent-netty-client-autoconfigure</module>
+        <module>models/embabel-agent-byok-autoconfigure</module>
         <module>models/embabel-agent-bedrock-autoconfigure</module>
         <module>models/embabel-agent-openai-autoconfigure</module>
         <module>models/embabel-agent-openai-custom-autoconfigure</module>

--- a/embabel-agent-common/embabel-agent-byok/src/main/kotlin/com/embabel/common/byok/BlankApiKey.kt
+++ b/embabel-agent-common/embabel-agent-byok/src/main/kotlin/com/embabel/common/byok/BlankApiKey.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.byok
+
+/**
+ * Message carried by [InvalidApiKeyException] when a key is present but blank.
+ */
+const val BLANK_API_KEY_MESSAGE: String =
+    "API key is blank. A blank key is treated as absent: supply a non-empty key, or omit it and " +
+        "let the caller decide there is no key for this request."
+
+/**
+ * Rejects a blank or absent API key before it reaches a provider.
+ *
+ * A key is blank rather than absent more often than it looks. Docker Compose passes
+ * `ANTHROPIC_API_KEY=${'$'}{ANTHROPIC_API_KEY:-}`, so in a container the variable is routinely
+ * set-but-empty, and a caller reading it with a null default (`@Value("${'$'}{VAR:#{null}}")`,
+ * `System.getenv(...)`) gets `""` rather than null. That empty string passes a null check,
+ * reaches the provider, and returns an opaque authentication error far from its cause.
+ *
+ * Checking here means BYOK callers do not each re-derive "blank counts as absent", and get the
+ * same [InvalidApiKeyException] they already handle for a rejected key.
+ *
+ * Note this concerns the BYOK path only. Provider autoconfiguration documents its API key as
+ * required and should keep failing fast at startup when one is missing.
+ *
+ * @throws InvalidApiKeyException if [apiKey] is null, empty, or whitespace.
+ */
+fun requireUsableApiKey(apiKey: String?) {
+    if (apiKey.isNullOrBlank()) {
+        throw InvalidApiKeyException(BLANK_API_KEY_MESSAGE)
+    }
+}

--- a/embabel-agent-common/embabel-agent-byok/src/main/kotlin/com/embabel/common/byok/blankApiKey.kt
+++ b/embabel-agent-common/embabel-agent-byok/src/main/kotlin/com/embabel/common/byok/blankApiKey.kt
@@ -18,9 +18,10 @@ package com.embabel.common.byok
 /**
  * Message carried by [InvalidApiKeyException] when a key is present but blank.
  */
-const val BLANK_API_KEY_MESSAGE: String =
-    "API key is blank. A blank key is treated as absent: supply a non-empty key, or omit it and " +
-        "let the caller decide there is no key for this request."
+val BLANK_API_KEY_MESSAGE: String = """
+    API key is blank. A blank key is treated as absent:
+    supply a non-empty key, or omit it and let the caller decide there is no key for this request.
+""".trimIndent()
 
 /**
  * Rejects a blank or absent API key before it reaches a provider.

--- a/embabel-agent-common/embabel-agent-byok/src/test/kotlin/com/embabel/common/byok/BlankApiKeyTest.kt
+++ b/embabel-agent-common/embabel-agent-byok/src/test/kotlin/com/embabel/common/byok/BlankApiKeyTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.byok
+
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class BlankApiKeyTest {
+
+    @Test
+    fun `an empty key is rejected as absent`() {
+        val e = assertThrows(InvalidApiKeyException::class.java) { requireUsableApiKey("") }
+        assertEquals(BLANK_API_KEY_MESSAGE, e.message)
+    }
+
+    @Test
+    fun `a whitespace-only key is rejected as absent`() {
+        listOf(" ", "   ", "\t", "\n").forEach { key ->
+            assertThrows(InvalidApiKeyException::class.java) { requireUsableApiKey(key) }
+        }
+    }
+
+    @Test
+    fun `a null key is rejected as absent`() {
+        assertThrows(InvalidApiKeyException::class.java) { requireUsableApiKey(null) }
+    }
+
+    @Test
+    fun `a real key passes`() {
+        assertDoesNotThrow { requireUsableApiKey("sk-not-a-real-key") }
+    }
+
+    @Test
+    fun `surrounding whitespace does not make a real key blank`() {
+        assertDoesNotThrow { requireUsableApiKey("  sk-not-a-real-key  ") }
+    }
+}

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -133,6 +133,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-byok-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-dockermodels-autoconfigure</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -308,6 +314,12 @@
             <dependency>
                 <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-bedrock</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-byok</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
@@ -182,6 +182,12 @@ The following are modules intended for direct use (versus supporting infrastruct
 | Quick start with GPT
 | Stable
 
+| `embabel-agent-starter-byok`
+| This repo
+| BYOK starter
+| Model factories and the `setup-required` placeholder, with no provider autoconfiguration — starts with no keys configured
+| Incubating
+
 | `embabel-agent-starter-ollama`
 | This repo
 | Ollama starter

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -340,6 +340,59 @@ promptRunner
 Internally this flows through the same model selection path as all other LLM resolution via
 `PreResolvedModelSelectionCriteria` — no separate resolution path is needed.
 
+[[reference.customizing.byok.pure]]
+===== Pure BYOK deployments
+
+Everything above assumes the application already has an `LlmService` to fall back on. A *pure BYOK*
+deployment has none: it ships with no provider key at all and obtains one at runtime, per user or
+per tenant. Two things get in its way, and `embabel-agent-starter-byok` addresses both.
+
+**Depend on the BYOK starter, not a provider starter.** The provider starters bundle their
+autoconfiguration, which requires an API key at startup — exactly what this deployment does not
+have. The BYOK starter carries the model factories and none of that autoconfiguration:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-byok</artifactId>
+</dependency>
+----
+
+**Point `default-llm` at the placeholder.** With no models registered, the platform has nothing to
+resolve `embabel.models.default-llm` to. The starter contributes a placeholder `LlmService` named
+`setup-required` for precisely this case:
+
+[source,yaml]
+----
+embabel:
+  models:
+    default-llm: setup-required
+----
+
+The name is available as the constant `SetupRequiredLlm.NAME`. Opting in through configuration is
+deliberate — the placeholder is registered unconditionally but is only ever selected if you name it,
+so adding the starter alongside a real provider changes nothing.
+
+The placeholder completes nothing. Any call that reaches it throws `NoLlmConfiguredException`, so a
+missing key surfaces as an actionable error rather than a silently empty answer. Catch it to render
+your own "add an API key" experience:
+
+[source,kotlin]
+----
+try {
+    promptRunner.withLlmService(userLlm).creating(MyOutput::class.java).create(messages)
+} catch (e: NoLlmConfiguredException) {
+    // no key for this user yet — send them to your settings page
+}
+----
+
+In normal operation the placeholder is never reached: resolve the user's key, build a service with
+one of the factories above, and pass it to `withLlmService()`.
+
+NOTE: The starter stops at the factories and the placeholder. Key storage and lifecycle remain the
+application's responsibility, as described under <<reference.customizing.byok>> above.
+
 ===== Error handling
 
 [source,kotlin]

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -229,6 +229,18 @@ val service: LlmService<*> = OpenAiCompatibleModelFactory.gemini(userKey).buildV
 `buildValidated()` makes a single probe call with no retries.
 On success it returns a production `LlmService`; on failure it throws `InvalidApiKeyException`.
 
+A **blank** key is treated as absent and rejected before any network call, also with
+`InvalidApiKeyException`. This matters more than it sounds: Docker Compose passes
+`ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}`, so in a container the variable is routinely
+set-but-empty, and a caller reading it with a null default — `@Value("${ANTHROPIC_API_KEY:#{null}}")`
+or `System.getenv(...)` — gets `""` rather than null. That empty string passes a null check and
+would otherwise reach the provider, coming back as an opaque authentication failure far from its
+cause. Callers therefore do not need to pre-check for blank keys themselves.
+
+NOTE: This applies to the BYOK path only. Provider autoconfiguration documents its API key as
+required (see <<reference.environment_setup>>) and still fails at startup when one is missing —
+putting a provider starter on the classpath is a statement that the deployment has that key.
+
 ===== Auto-detecting the provider
 
 Use this when a user pastes a key without specifying a provider — for example, a sign-up flow

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -286,7 +286,13 @@ open class OpenAiCompatibleModelFactory(
      * A blank key is rejected before any network call — see [requireUsableApiKey] for why a key
      * is set-but-empty far more often than it looks.
      *
-     * @throws InvalidApiKeyException if the key is blank or invalid.
+     * Note this narrows the constructor's contract, where [apiKey] may be null meaning "no
+     * authentication". That remains true of the factory; it is not true of *validation*, which
+     * exists to answer "is this key usable" and has nothing to answer for an absent one. A keyless
+     * endpoint — a local LM Studio or vLLM server — should be built with [openAiCompatibleLlm]
+     * rather than validated here.
+     *
+     * @throws InvalidApiKeyException if the key is blank, absent, or invalid.
      */
     fun buildValidated(
         model: String,

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -25,6 +25,7 @@ import com.embabel.chat.UserMessage
 import com.embabel.common.ai.model.*
 import com.embabel.common.byok.ByokFactory
 import com.embabel.common.byok.InvalidApiKeyException
+import com.embabel.common.byok.requireUsableApiKey
 import com.embabel.common.util.ObjectProviders
 import com.openai.client.OpenAIClient
 import com.openai.client.OpenAIClientAsync
@@ -281,6 +282,11 @@ open class OpenAiCompatibleModelFactory(
      * so the probe relies on the openai-java SDK's own no-retry default (any 401 fails fast).
      * On any exception the provider-specific error is translated to [InvalidApiKeyException],
      * keeping Spring AI types out of the caller.
+     *
+     * A blank key is rejected before any network call — see [requireUsableApiKey] for why a key
+     * is set-but-empty far more often than it looks.
+     *
+     * @throws InvalidApiKeyException if the key is blank or invalid.
      */
     fun buildValidated(
         model: String,
@@ -288,6 +294,7 @@ open class OpenAiCompatibleModelFactory(
         provider: String,
         knowledgeCutoffDate: LocalDate?,
     ): LlmService<*> {
+        requireUsableApiKey(apiKey)
         val probe = openAiCompatibleLlm(
             model = model,
             pricingModel = pricingModel,

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryBuildValidatedTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryBuildValidatedTest.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.openai
 
 import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.common.byok.BLANK_API_KEY_MESSAGE
 import com.embabel.common.byok.InvalidApiKeyException
 import com.embabel.common.ai.model.PricingModel
 import com.sun.net.httpserver.HttpServer
@@ -25,6 +26,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -115,5 +117,49 @@ class OpenAiCompatibleModelFactoryBuildValidatedTest {
             knowledgeCutoffDate = null,
         )
         assertNotNull(service)
+    }
+
+    @Test
+    fun `buildValidated rejects a blank key without calling the provider`() {
+        var requests = 0
+        server.createContext("/") { exchange ->
+            requests++
+            exchange.sendResponseHeaders(500, -1)
+            exchange.close()
+        }
+        server.start()
+
+        val blankKeyFactory = OpenAiCompatibleModelFactory(
+            baseUrl = "http://localhost:$port",
+            apiKey = "   ",
+            completionsPath = null,
+            embeddingsPath = null,
+            observationRegistry = ObservationRegistry.NOOP,
+            restClientBuilder = restClientBuilder,
+        )
+
+        val e = assertThrows<InvalidApiKeyException> {
+            blankKeyFactory.buildValidated(
+                model = OpenAiModels.GPT_41_MINI,
+                pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+                provider = OpenAiModels.PROVIDER,
+                knowledgeCutoffDate = null,
+            )
+        }
+        assertEquals(BLANK_API_KEY_MESSAGE, e.message)
+        assertEquals(0, requests, "a blank key must not reach the provider")
+    }
+
+    @Test
+    fun `the ByokSpec entry points reject a blank key too`() {
+        listOf(
+            OpenAiCompatibleModelFactory.openAi("   "),
+            OpenAiCompatibleModelFactory.deepSeek(""),
+            OpenAiCompatibleModelFactory.mistral("\t"),
+            OpenAiCompatibleModelFactory.gemini(" "),
+        ).forEach { spec ->
+            val e = assertThrows<InvalidApiKeyException> { spec.buildValidated() }
+            assertEquals(BLANK_API_KEY_MESSAGE, e.message)
+        }
     }
 }

--- a/embabel-agent-starters/embabel-agent-starter-byok/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-byok/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-starter-byok</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent BYOK Starter</name>
+    <description>Embabel Agent Bring Your Own Key Starter — model factories and the setup-required
+        placeholder, with no provider autoconfiguration and no key required at startup</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+
+        <!--
+          The placeholder LLM, so a deployment holding no key can resolve default-llm and start.
+        -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-byok-autoconfigure</artifactId>
+        </dependency>
+
+        <!--
+          The BYOK factory libraries, deliberately WITHOUT their *-autoconfigure counterparts.
+          The provider autoconfigurations demand an API key at construction time, which is exactly
+          what a BYOK deployment does not have; these artifacts carry the factories alone.
+        -->
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-anthropic</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-openai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+              The whole point of this starter is the absence of provider autoconfiguration: those
+              modules demand an API key at construction time. Adding one — directly or transitively
+              via another starter — would reintroduce the fail-fast this starter exists to avoid,
+              and would do so silently for anyone with a key exported in their environment.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>ban-provider-autoconfiguration</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <!--
+                              The parent leaves enforcer non-failing; this rule is a hard gate.
+                              combine.self=override keeps the parent's plugin-level rules (notably
+                              DependencyConvergence, which the repo currently tolerates as a warning)
+                              out of this execution, so fail=true applies to the ban and nothing else.
+                            -->
+                            <fail>true</fail>
+                            <rules combine.self="override">
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>com.embabel.agent:*-autoconfigure</exclude>
+                                    </excludes>
+                                    <includes>
+                                        <include>com.embabel.agent:embabel-agent-platform-autoconfigure</include>
+                                        <include>com.embabel.agent:embabel-agent-byok-autoconfigure</include>
+                                    </includes>
+                                    <message>
+                                        embabel-agent-starter-byok must not pull in provider autoconfiguration.
+                                        Provider *-autoconfigure modules require an API key at startup, which is
+                                        exactly what a BYOK deployment does not have. Depend on the factory
+                                        artifact (e.g. embabel-agent-anthropic) instead of its autoconfigure.
+                                    </message>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
+++ b/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
@@ -60,7 +60,7 @@ class ByokStarterBootTest {
     @Test
     void theModelProviderResolvesTheDefaultLlmWithoutAnyKey() {
         contextRunner
-                .withUserConfiguration(ModelProviderConfiguration.class)
+                .withUserConfiguration(TestableModelProviderConfiguration.class)
                 .run(context -> {
                     assertThat(context).hasNotFailed();
                     var modelProvider = context.getBean(ModelProvider.class);
@@ -75,7 +75,7 @@ class ByokStarterBootTest {
      * resolution path rather than a hand-built stand-in.
      */
     @Configuration(proxyBeanMethods = false)
-    static class ModelProviderConfiguration {
+    static class TestableModelProviderConfiguration {
 
         @Bean
         ModelProvider modelProvider(ApplicationContext applicationContext,

--- a/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
+++ b/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
@@ -25,6 +25,7 @@ import com.embabel.common.ai.model.EmbeddingService;
 import com.embabel.common.ai.model.ModelProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
@@ -48,6 +49,24 @@ class ByokStarterBootTest {
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(AgentByokAutoConfiguration.class))
             .withPropertyValues("embabel.models.default-llm=" + SetupRequiredLlm.NAME);
+
+    /**
+     * {@link AgentByokAutoConfiguration} orders itself before the platform autoconfiguration by
+     * class NAME, because its own module deliberately does not depend on
+     * platform-autoconfigure. A rename would drop that ordering silently rather than fail the
+     * build, and the symptom would be the startup failure this starter exists to prevent.
+     * <p>
+     * This module does have platform-autoconfigure on the classpath, so the name can be pinned
+     * here even though it cannot be referenced as a type where it is used.
+     */
+    @Test
+    void theAutoConfigureBeforeTargetStillExists() throws Exception {
+        var target = AgentByokAutoConfiguration.class.getAnnotation(AutoConfigureBefore.class).name();
+        assertThat(target).hasSize(1);
+        assertThat(Class.forName(target[0]))
+                .describedAs("@AutoConfigureBefore names a class that no longer exists")
+                .isNotNull();
+    }
 
     @Test
     void startsWithNoProviderKeyConfigured() {

--- a/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
+++ b/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.starter.byok;
+
+import com.embabel.agent.autoconfigure.models.byok.AgentByokAutoConfiguration;
+import com.embabel.agent.config.models.byok.SetupRequiredLlm;
+import com.embabel.agent.spi.LlmService;
+import com.embabel.common.ai.model.ConfigurableModelProvider;
+import com.embabel.common.ai.model.ConfigurableModelProviderProperties;
+import com.embabel.common.ai.model.DefaultModelSelectionCriteria;
+import com.embabel.common.ai.model.EmbeddingService;
+import com.embabel.common.ai.model.ModelProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The starter's reason to exist: an application that depends only on it can start with no
+ * provider key configured at all, and the platform can still resolve a default LLM.
+ * <p>
+ * This runs against the starter's own dependency set, so it also guards the packaging — if a
+ * provider autoconfiguration ever leaks onto the classpath it would demand a key and fail here.
+ */
+class ByokStarterBootTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AgentByokAutoConfiguration.class))
+            .withPropertyValues("embabel.models.default-llm=" + SetupRequiredLlm.NAME);
+
+    @Test
+    void startsWithNoProviderKeyConfigured() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasBean(SetupRequiredLlm.NAME);
+        });
+    }
+
+    @Test
+    void theModelProviderResolvesTheDefaultLlmWithoutAnyKey() {
+        contextRunner
+                .withUserConfiguration(ModelProviderConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    var modelProvider = context.getBean(ModelProvider.class);
+                    LlmService<?> llm = modelProvider.getLlm(DefaultModelSelectionCriteria.INSTANCE);
+                    assertThat(llm.getName()).isEqualTo(SetupRequiredLlm.NAME);
+                });
+    }
+
+    /**
+     * Builds the model provider the same way the platform autoconfiguration does — from the
+     * {@code LlmService} beans present in the context — so the assertion above exercises the real
+     * resolution path rather than a hand-built stand-in.
+     */
+    @Configuration(proxyBeanMethods = false)
+    static class ModelProviderConfiguration {
+
+        @Bean
+        ModelProvider modelProvider(ApplicationContext applicationContext,
+                                    @Value("${embabel.models.default-llm}") String defaultLlm) {
+            var properties = new ConfigurableModelProviderProperties();
+            properties.setDefaultLlm(defaultLlm);
+            // LlmService is F-bounded (LlmService<THIS : LlmService<THIS>>), so a wildcard capture
+            // from a stream will not fit the constructor. Collect through the raw type instead.
+            List<LlmService<?>> llms = new ArrayList<>();
+            for (LlmService<?> llm : applicationContext.getBeansOfType(LlmService.class).values()) {
+                llms.add(llm);
+            }
+            return new ConfigurableModelProvider(llms, List.<EmbeddingService>of(), properties);
+        }
+    }
+}

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -26,6 +26,7 @@
         <module>embabel-agent-starter-observability</module>
         <module>embabel-agent-starter-mcpserver</module>
         <module>embabel-agent-starter-mcpserver-security</module>
+        <module>embabel-agent-starter-byok</module>
         <module>embabel-agent-starter-bedrock</module>
         <module>embabel-agent-starter-openai</module>
         <module>embabel-agent-starter-openai-custom</module>


### PR DESCRIPTION

## What

Adds `embabel-agent-starter-byok`: model factories without provider autoconfiguration, plus a `setup-required` placeholder `LlmService` available under a public constant.

A pure BYOK application can now depend on a single artifact, start with no provider keys configured, and avoid having to provide its own placeholder implementation.

The implementation is split into two modules, following the existing starter/autoconfigure structure:

| Module                                                                | Contents                                                                                                                          |
| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
| `embabel-agent-starters/embabel-agent-starter-byok`                   | `platform-autoconfigure`, `byok-autoconfigure`, `embabel-agent-anthropic`, `embabel-agent-openai`. No provider autoconfiguration. |
| `embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure` | `SetupRequiredLlm` (name/provider/message constants + factory), `SetupRequiredLlmConfig`, `AgentByokAutoConfiguration`            |

Opt in with:

```yaml
embabel:
  models:
    default-llm: setup-required
```

## What Guide can delete

[Guide](https://github.com/embabel/guide) is the BYOK reference implementation, and it already solved both halves in application code. This starter replaces all of it.

**Packaging — today:** Guide skips the provider starters and depends on the factory libraries directly, because the starters would bring autoconfiguration that requires a key at startup.

```xml
<dependency>
    <groupId>com.embabel.agent</groupId>
    <artifactId>embabel-agent-openai</artifactId>
</dependency>
<dependency>
    <groupId>com.embabel.agent</groupId>
    <artifactId>embabel-agent-anthropic</artifactId>
</dependency>
```

**Packaging — now:** one artifact, with the exclusion enforced rather than merely intended.

```xml
<dependency>
    <groupId>com.embabel.agent</groupId>
    <artifactId>embabel-agent-starter-byok</artifactId>
</dependency>
```

**The placeholder — today:** `SetupRequiredChatModel.kt` is a whole file of framework-shaped code sitting in the application, plus a registration in `UserLlmResolver.kt`.

```kotlin
class SetupRequiredChatModel : ChatModel {

    override fun call(prompt: Prompt): ChatResponse {
        val message = AssistantMessage("")
        return ChatResponse(listOf(Generation(message)))
    }

    override fun getDefaultOptions(): ChatOptions = ChatOptions.builder().build()

    companion object {
        const val MODEL_NAME = "setup-required"
        const val SETUP_MESSAGE = """..."""
    }
}

@Configuration(proxyBeanMethods = false)
class SetupRequiredLlmConfig {
    @Primary
    @Bean(SetupRequiredChatModel.MODEL_NAME)
    fun setupRequiredLlmService(): LlmService<*> = SpringAiLlmService(
        name = SetupRequiredChatModel.MODEL_NAME,
        provider = "none",
        chatModel = SetupRequiredChatModel(),
    )
}
```

**The placeholder — now:** both delete entirely. The starter registers the bean; `application.yml` already says `default-llm: setup-required`, and that value is now `SetupRequiredLlm.NAME`.

`UserLlmResolver` keeps its injected placeholder, but qualifies it by name instead of relying on `@Primary`:

```kotlin
@Service
class UserLlmResolver(
    // ...
    @Qualifier(SetupRequiredLlm.NAME) private val setupRequiredService: LlmService<*>,
)
```

The starter deliberately does **not** mark the placeholder `@Primary` — that would hijack `LlmService` injection in any application that also has real models registered.

Guide's `resolve()` is unchanged and still works:

```kotlin
return ctx.ai().withLlmService(setupRequiredService)
```

The difference is what happens if that call is ever reached. Today it returns `""` and the user sees an empty answer; with this PR it throws `NoLlmConfiguredException`, which Guide can catch to show `SETUP_MESSAGE` — the message it already has, now attached to an error rather than to silence. Guide's `hasLlm()` short-circuit remains the happy path either way.

What stays in Guide, correctly: `UserKeyStore`, `UserModelFactory`, `LlmProvider`, `LlmRole`, and how a key reaches a request.

## Design notes

**Provider autoconfiguration is explicitly excluded.** This is important because adding a provider starter transitively would bring back the startup API-key requirement. A `bannedDependencies` enforcer rule makes this a build failure rather than allowing it to regress unnoticed.

The rule uses `combine.self="override"` because the parent merges `DependencyConvergence` into every enforcer execution, and `fail=true` would otherwise turn the repo-wide convergence warnings into failures.

Verified both ways: adding a provider autoconfigure dependency fails the build; removing it passes.

**The placeholder carries a marker, and that marker is what relaxes startup validation.** `PlaceholderLlmService` is an empty interface in `com.embabel.agent.spi`, so `ConfigurableModelProvider` can recognise a placeholder without depending on this module - carrying the placeholder without dragging in that dependency is why the module exists. When `default-llm` resolves to one, the deployment is stating that keys arrive at runtime, and unresolvable model names in `embabel.models` become expected rather than fatal. Every other deployment keeps failing fast on a name it cannot resolve, because there a name that resolves to nothing is a typo. The embedding-services check is gated the same way, with no fallback: an embedding model is a schema commitment and nothing can stand in for one, so the gate decides only whether the deployment starts.

`SetupRequiredLlmService` carries the marker by delegating to a `SpringAiLlmService`, which is a `data class` and so cannot be extended. Its self-typed methods return a wrapper rather than the delegate, since delegating them would hand back a bare `SpringAiLlmService` and silently drop the marker.

#1889 changes these same lines for its own reasons and the hunks are byte-identical, verified with `git merge-tree` - the two merge cleanly in either order.

**The placeholder is registered unconditionally**, rather than using `@ConditionalOnMissingBean(LlmService)`. The model autoconfigurations register their `LlmService` instances imperatively with `registerSingleton` inside a `@Bean` method, so the condition would be evaluated before those singletons exist and would always see no `LlmService`.

Instead, the placeholder is only used when explicitly selected through `default-llm`. If another model is configured as the default, `setup-required` is never resolved. There is a test covering this.

**The placeholder throws rather than returning an empty completion.** This differs from Guide's current `SetupRequiredChatModel`, which returns `AssistantMessage("")`.

A missing API key should produce an actionable error rather than an empty response. Applications can catch `NoLlmConfiguredException` and show their own "add an API key" UI. Guide can use this and remove its local placeholder implementation.

Happy to change this to an empty completion if compatibility with Guide's current behaviour is preferred.

**Non-goal:** key storage. The starter provides the factories and placeholder only. Key lifecycle remains the responsibility of the application, as described in the existing BYOK documentation.

## Docs

* Added a `Pure BYOK deployments` section to `reference/customizing/page.adoc`, covering:

  * which artifact to depend on
  * why `default-llm` should point to the placeholder
  * how to start an application without a provider key
* Added the BYOK starter to the table in `modules/page.adoc`.

Both were verified in the rendered HTML with:

```bash
mvn -P embabel-agent-docs
```

## Testing

All passing:

* `SetupRequiredLlmTest` (7)

  * the service reports the name and provider the constants declare, and carries the `PlaceholderLlmService` marker
  * `ConfigurableModelProvider` resolves the placeholder as default and by name
  * the placeholder is not selected when another model is the default
  * calling the placeholder throws an actionable error, and streaming fails the same way rather than with an unrelated streaming error
  * the platform still reports it as not supporting streaming
  * a message sender can still be created, so failure occurs at call time rather than setup time
* `PureByokWithRolesTest` (4) — boots with `best` and `cheapest` configured and nothing to satisfy them; still resolves the placeholder as default; an unsatisfiable role throws when asked for; **and a deployment holding a key still dies at startup on a name nothing registers**
* `AgentByokAutoConfigurationTest` (2)

  * registers with no provider key configured
  * contributes no other `LlmService`
* `ByokStarterBootTest` (3)

  * runs against the starter's own dependency set
  * context starts with no provider key
  * a model provider constructed the same way as the platform resolves the default LLM
* `BlankApiKeyTest` (5) — empty, whitespace-only and null keys rejected; a real key passes; surrounding whitespace does not make a real key blank
* `AnthropicModelFactoryBuildValidatedTest` (+1) and `OpenAiCompatibleModelFactoryBuildValidatedTest` (+2) — a blank key throws with `BLANK_API_KEY_MESSAGE` and reaches the provider zero times; the four `ByokSpec` entry points (`openAi`/`deepSeek`/`mistral`/`gemini`) reject one too

Built with `-am` so `embabel-agent-api` was built from source rather than using a stale `~/.m2` artifact.

## Blank keys count as absent — on the BYOK path only

A key is blank rather than absent more often than it looks. Compose passes `ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}`, so in a container the variable is routinely set-but-empty, and a caller reading it with a null default (`@Value("${VAR:#{null}}")`, `System.getenv(...)`) gets `""` rather than null. That empty string passes a null check, reaches the provider, and returns an opaque authentication error a long way from its cause — which is why BYOK callers have each been re-deriving "blank counts as absent" for themselves.

`requireUsableApiKey` now lives in the `embabel-agent-byok` module, which both factory libraries already depend on, and throws the `InvalidApiKeyException` callers already handle for a rejected key. Both `buildValidated` paths check before the probe.

That a blank key never reaches the wire is asserted by counting requests against a local `HttpServer`, not merely by the exception type:

```kotlin
val e = assertThrows<InvalidApiKeyException> { blankKeyFactory.buildValidated() }
assertEquals(BLANK_API_KEY_MESSAGE, e.message)
assertEquals(0, requests, "a blank key must not reach the provider")
```

**Scoped deliberately to BYOK.** The provider autoconfigurations are untouched and still `error()` when their key is missing — `git diff` over both autoconfigure modules is empty. Their key is documented as `* Required:` for every provider, so autoconfiguration on the classpath is a statement that the deployment has that key, and failing fast without one is that contract working. Relaxing it would weaken a documented requirement for everyone in order to serve a deployment shape that should not have those modules on the classpath at all — which is what this starter is for.

## Why not just relax the provider configs

The docs make the contract explicit. `getting-started/installing/page.adoc` lists the key under `* Required:` for every provider starter — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`, `GEMINI_API_KEY`, `MISTRAL_API_KEY`, `OPENAI_CUSTOM_API_KEY` — and the BYOK section opens by describing autoconfiguration as "you set one or more API keys… the right approach for a platform-level key shared across all users".

Provider autoconfiguration on the classpath means "this deployment has this provider's key". Failing fast without one is that contract working, not a defect to be smoothed over.

So the answer for a BYOK deployment is not to put provider autoconfiguration on the classpath and teach it to tolerate a missing key — that makes a documented **Required** setting quietly optional for everyone. The answer is to not have that autoconfiguration at all, which is what this starter packages and what the `bannedDependencies` rule keeps true.

An earlier revision of this description discussed `fix/719-boot-without-model-keys` as complementary work. Correcting two things about that branch: it does **not** touch `ConfigurableModelProvider` and does not make `defaultLlm` resolution lazy (`No models detected.` is unchanged on `main`, and this PR leaves it alone). What it does change is `AnthropicModelsConfig` and `OpenAiModelsConfig`, so a missing key registers no models instead of failing — which is the relaxation this section argues against.

The one part of that work that stands on its own — treating a blank key as absent — is now folded into this PR, scoped to BYOK, as described above. The rest is not needed.

## What this PR does and does not add

Being precise about the value, since part of it is already reachable today:

* **Packaging — convenience and enforcement, not new capability.** An application can already depend on `embabel-agent-openai` and `embabel-agent-anthropic` directly and get the factories without autoconfiguration; Guide does exactly that. This PR makes it one dependency, documents it, and makes the exclusion a build failure rather than a convention someone re-derives.
* **The placeholder — genuinely new.** There is no shipped `LlmService` for the "no key yet" state, so every BYOK application writes its own no-op `ChatModel`. Nothing in the docs or the `embabel-agent-byok` module mentions needing one; you find it by reading Guide's source.


