### PR TITLE
fix(openai): route GPT-5.6 models to the Responses API

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/resources/models/openai-models.yml
@@ -42,14 +42,25 @@ models:
   # GPT-5.6 FAMILY (Current Flagship - July 2026)
   # Model pages and pricing verified: developers.openai.com 2026-08-04
   # Tiers are Luna/Terra/Sol, not nano/mini/pro: "pro" became a Responses-only
-  # reasoning MODE (reasoning.mode) rather than a model. All three tiers are
-  # served over both Chat Completions and Responses.
+  # reasoning MODE (reasoning.mode) rather than a model.
   # The "gpt-5.6" alias routes to Sol; the tiers are registered by their own ids.
   # Prices are the short-context tier (<272K); long context is billed higher.
+  #
+  # All three answer a plain prompt over either endpoint, but Chat Completions
+  # refuses any request carrying function tools:
+  #   400: Function tools with reasoning_effort are not supported for
+  #        gpt-5.6-luna in /v1/chat/completions.
+  # These models default to `medium` reasoning effort server-side when the
+  # request omits it, which every Embabel request does, so the combination is
+  # unavoidable there. Chat Completions would take tools only at effort `none`
+  # — not something to impose on models bought for their reasoning. Responses
+  # accepts every effort level alongside tools, and is the endpoint OpenAI
+  # documents for tool-calling workflows, so all three are pinned to it.
   # ========================================
 
   - name: "gpt56sol"
     model_id: "gpt-5.6-sol"
+    api_format: "RESPONSES"
     display_name: "GPT-5.6 Sol"
     max_tokens: 16384
     temperature: 1.0
@@ -61,6 +72,7 @@ models:
 
   - name: "gpt56terra"
     model_id: "gpt-5.6-terra"
+    api_format: "RESPONSES"
     display_name: "GPT-5.6 Terra"
     max_tokens: 16384
     temperature: 1.0
@@ -72,6 +84,7 @@ models:
 
   - name: "gpt56luna"
     model_id: "gpt-5.6-luna"
+    api_format: "RESPONSES"
     display_name: "GPT-5.6 Luna"
     max_tokens: 16384
     temperature: 1.0

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiCatalogIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiCatalogIT.kt
@@ -17,13 +17,17 @@ package com.embabel.agent.config.models.openai
 
 import com.embabel.agent.api.common.Ai
 import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.isModelAccessError
 import com.embabel.agent.config.models.openai.OpenAiIntegrationSupport.sayReady
+import com.embabel.common.ai.model.LlmOptions
 import com.openai.client.okhttp.OpenAIOkHttpClient
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.opentest4j.TestAbortedException
+import org.springframework.ai.tool.annotation.Tool
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.test.context.SpringBootTest
@@ -31,25 +35,46 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Profile
 import org.springframework.test.context.ActiveProfiles
+import java.time.Duration
 
 @Profile("openai-catalog-test")
 @ConfigurationPropertiesScan(basePackages = ["com.embabel.agent"])
 @ComponentScan(basePackages = ["com.embabel.agent"])
 class OpenAiCatalogTestConfig
 
+/** Returns a code nothing else could supply: the answer carries it only if the tool really ran. */
+class BadgeCodeTool {
+
+    var invoked: Boolean = false
+        private set
+
+    @Tool(description = "Returns the current badge code for a named door")
+    fun badgeCode(doorName: String): String {
+        invoked = true
+        return "QP-4471"
+    }
+}
+
 /**
  * Holds the shipped catalog against the real OpenAI API.
  *
  * The unit tests prove the catalog is *read* as written; nothing until here proves it describes
  * models that exist. That gap is how `*-pro` shipped broken — declared, never called, build green.
- * Every entry added since carries the same risk, so the two claims a catalog entry makes are
- * checked against the provider: that the id resolves, and that the declared transport works.
+ * Every entry added since carries the same risk, so the claims a catalog entry makes are checked
+ * against the provider: that the id resolves, that the declared transport works, and that the
+ * transport still works once the request carries tools.
+ *
+ * The parameter lists are derived from the catalog rather than written out, so a model added to
+ * the YAML is covered without anyone remembering to add it here. A hand-written list is the same
+ * mechanism as no list at all: `gpt-5.6-luna` was in one, and its tool calling was still broken.
  *
  * @see <a href="https://github.com/embabel/embabel-agent/issues/1758">Issue 1758</a>
  */
 @SpringBootTest(
     properties = [
         "embabel.models.default-llm=gpt-4o-mini",
+        // One attempt: a rejected payload is not a transient failure, and retrying it only buries
+        // the provider's message under a "Failed after 3 attempt(s)".
         "embabel.agent.platform.models.openai.max-attempts=1",
         "spring.main.allow-bean-definition-overriding=true",
     ]
@@ -64,6 +89,24 @@ class OpenAiCatalogTestConfig
 class OpenAiCatalogIT(
     @param:Autowired private val ai: Ai,
 ) {
+
+    companion object {
+
+        /**
+         * Every chat model the catalog ships, so coverage tracks the YAML instead of a copy of it.
+         */
+        @JvmStatic
+        fun catalogModels(): List<String> =
+            OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels().map { it.modelId }
+    }
+
+    /**
+     * The platform default of 60s is exceeded by the pro tiers on a two-turn tool loop — observed
+     * at 108s in `OpenAiResponsesAdapterIT`. Left at the default those calls time out and succeed
+     * only on retry, running the loop, and billing the reasoning, twice over.
+     */
+    private fun optionsFor(model: String) =
+        LlmOptions.withModel(model).withTimeout(Duration.ofMinutes(5))
 
     /**
      * One `GET /v1/models` covers the whole catalog, so a typo in any entry is caught without
@@ -93,30 +136,72 @@ class OpenAiCatalogIT(
     }
 
     /**
-     * The GPT-5.5 and GPT-5.6 entries, none of which had ever been called. A wrong transport is a
-     * hard failure rather than a wrong answer, so a reply at all is the assertion that matters:
-     * `gpt-5.5-pro` on Chat Completions never returns one.
+     * A wrong transport is a hard failure rather than a wrong answer, so a reply at all is the
+     * assertion that matters: `gpt-5.5-pro` on Chat Completions never returns one.
      *
      * That the entries register and route correctly is unit-tested in `OpenAiModelsConfigRoutingTest`,
      * which needs neither a key nor a network and therefore runs on every build.
      */
     @ParameterizedTest(name = "{0} answers over its declared transport")
-    @ValueSource(
-        strings = [
-            "gpt-5.6-sol",
-            "gpt-5.6-terra",
-            "gpt-5.6-luna",
-            "gpt-5.5",
-            // Responses-only: Chat Completions is "Not supported" for this one.
-            "gpt-5.5-pro",
-        ]
-    )
-    fun `each new model replies over the transport the catalog declares`(model: String) {
-        val response = sayReady(ai, model)
+    @MethodSource("catalogModels")
+    fun `each catalog model replies over the transport the catalog declares`(model: String) {
+        val response = sayReady(ai, model, optionsFor(model))
 
         assertTrue(
             response.contains("READY", ignoreCase = true),
             "Expected $model to reply READY, got: $response",
         )
     }
+
+    /**
+     * The same models again, with a tool bound. This is a separate claim from the one above, and
+     * the reason this test exists: a payload carrying `tools` can be refused by a model that
+     * answers a plain prompt perfectly well over the same endpoint. Reported against the GPT-5.6
+     * tiers as
+     *
+     *     400: Function tools with reasoning_effort are not supported for gpt-5.6-luna in
+     *     /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort
+     *     to 'none'.
+     *
+     * Tool calling is what every agent run does, so a model that fails here is unusable for the
+     * thing this project is for, however well it answers a bare prompt.
+     *
+     * The prompt names the tool and orders the call rather than asking a question the model happens
+     * to answer with it. Whether a model volunteers a tool is its own judgement and not what this
+     * test is for; what is under test is whether the request is accepted and the result returned.
+     */
+    @ParameterizedTest(name = "{0} answers a request carrying function tools")
+    @MethodSource("catalogModels")
+    fun `each catalog model answers a tool-carrying request over its declared transport`(model: String) {
+        val tool = BadgeCodeTool()
+
+        val answer = call(model) {
+            ai.withLlm(optionsFor(model))
+                .withToolObject(tool)
+                .generateText(
+                    "Call the badgeCode tool for the door named 'north', " +
+                        "then reply with the code it returned and nothing else."
+                )
+        }
+
+        assertTrue(tool.invoked, "$model never called the tool, so the answer cannot be grounded")
+        assertTrue(
+            answer.contains("QP-4471"),
+            "The tool result never made it back into the answer from $model, got: $answer",
+        )
+    }
+
+    /** Same skip-on-no-entitlement contract as [sayReady], for a call that is not a bare prompt. */
+    private fun <T> call(model: String, block: () -> T): T =
+        try {
+            block()
+        } catch (ex: Exception) {
+            if (isModelAccessError(ex)) {
+                throw TestAbortedException(
+                    "OPENAI_API_KEY is set, but the configured OpenAI project has no access to $model",
+                    ex,
+                )
+            }
+            throw ex
+        }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiModelLoaderTest.kt
@@ -646,21 +646,25 @@ class OpenAiModelLoaderTest {
     inner class ApiFormatTests {
 
         /**
-         * Pins the catalog contract the routing depends on: exactly the `*-pro` models ask for the
-         * Responses API, and every other model keeps the Chat Completions path it has today. A model
-         * added to the wrong bucket is a production outage — either a 404 on every call, or a working
-         * model silently rerouted onto an adapter it was never exercised against.
+         * Pins the catalog contract the routing depends on: the `*-pro` models and the GPT-5.6
+         * tiers ask for the Responses API, and every other model keeps the Chat Completions path it
+         * has today. A model added to the wrong bucket is a production outage — either a 404 on
+         * every call, or a working model silently rerouted onto an adapter it was never exercised
+         * against.
          */
         @Test
-        fun `shipped catalog routes the pro models to Responses and everything else to Chat Completions`() {
+        fun `shipped catalog routes the pro models and the GPT-5_6 tiers to Responses`() {
             val models = shippedCatalogue.effectiveModels()
 
             val byFormat = models.groupBy({ it.apiFormat }, { it.modelId })
 
             assertEquals(
-                setOf("gpt-5-pro", "gpt-5.2-pro", "gpt-5.4-pro", "gpt-5.5-pro"),
+                setOf(
+                    "gpt-5-pro", "gpt-5.2-pro", "gpt-5.4-pro", "gpt-5.5-pro",
+                    "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+                ),
                 byFormat[OpenAiApiFormat.RESPONSES].orEmpty().toSet(),
-                "Only the *-pro models are served over /v1/responses",
+                "Only the *-pro models and the GPT-5.6 tiers are served over /v1/responses",
             )
             assertTrue(
                 byFormat[OpenAiApiFormat.CHAT_COMPLETIONS].orEmpty().none { it.endsWith("-pro") },
@@ -674,21 +678,32 @@ class OpenAiModelLoaderTest {
         }
 
         /**
-         * GPT-5.6 dropped the `-pro` suffix — its tiers are Luna/Terra/Sol and "pro" became a
-         * Responses-only *reasoning mode*, not a model. The suffix guard above therefore says
-         * nothing about them, so their transport is pinned by name.
+         * GPT-5.6 dropped the `-pro` suffix — its tiers are Luna/Terra/Sol — so the suffix guard
+         * above says nothing about them and their transport is pinned by name.
+         *
+         * They are served over both endpoints for a plain prompt, but Chat Completions refuses any
+         * request that carries function tools:
+         *
+         *     400: Function tools with reasoning_effort are not supported for gpt-5.6-luna in
+         *     /v1/chat/completions.
+         *
+         * These models default to `medium` reasoning effort server-side when the request omits it,
+         * which every Embabel request does, so the combination is unavoidable on that endpoint.
+         * Chat Completions would only accept tools at effort `none`, which is not something to
+         * impose on models bought for their reasoning. Responses accepts the full range of efforts
+         * alongside tools, and is what OpenAI documents for tool-calling workflows.
          */
         @Test
-        fun `the GPT-5_6 tiers stay on Chat Completions, which they all support`() {
+        fun `the GPT-5_6 tiers use Responses, the only transport that accepts their tool calls`() {
             val models = shippedCatalogue.effectiveModels()
                 .filter { it.modelId.startsWith("gpt-5.6") }
                 .associate { it.modelId to it.apiFormat }
 
             assertEquals(
                 mapOf(
-                    "gpt-5.6-sol" to OpenAiApiFormat.CHAT_COMPLETIONS,
-                    "gpt-5.6-terra" to OpenAiApiFormat.CHAT_COMPLETIONS,
-                    "gpt-5.6-luna" to OpenAiApiFormat.CHAT_COMPLETIONS,
+                    "gpt-5.6-sol" to OpenAiApiFormat.RESPONSES,
+                    "gpt-5.6-terra" to OpenAiApiFormat.RESPONSES,
+                    "gpt-5.6-luna" to OpenAiApiFormat.RESPONSES,
                 ),
                 models,
             )


### PR DESCRIPTION
Closes #1895 

The three GPT-5.6 models reject every request carrying tools:

```
400: Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions.
```

Requests without tools are unaffected, which is why a plain-prompt check showed nothing.

This is not the same as #1758  There, the *-pro models were rejected outright, for any request. Here the GPT-5.6 tiers answer a plain prompt fine over Chat Completions - what fails is any request carrying function tools, which is what every agent run does. The fix pins them to the Responses API, so they work both plain and with tools.

## Cause

These models were routed to Chat Completions, which refuses to combine function tools with reasoning for this family. We send no `reasoning_effort` at all - OpenAI defaults it to `medium` server-side when omitted, so the rejected combination comes from their default and cannot be avoided on that endpoint.

## Fix

`api_format: "RESPONSES"` on the three entries in `openai-models.yml`.


## Tests

`OpenAiCatalogIT` now derives its model list from the catalog instead of a hand-written one, and calls every model twice - plain prompt, then with a tool bound. The previous hand-written list contained `gpt-5.6-luna` and still missed this.

```
Tests run: 45, Failures: 0, Errors: 0, Skipped: 0
```

All 22 models pass both calls, with no regression on the 19 that already worked. The endpoint pins in  OpenAiModelLoaderTest` were updated first, seen failing, then made to pass.
