### PR TITLE
RAG improvements: Make full-text scores absolute, and stop asking the LLM for a similarity threshold

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
@@ -444,12 +444,86 @@ fun respond(conversation: Conversation, context: ActionContext) {
 
 Based on the capabilities of the underlying `SearchOperations`, `ToolishRag` exposes:
 
-- **VectorSearchTools**: `vectorSearch(query, topK, threshold)` - semantic similarity search
-- **TextSearchTools**: `textSearch(query, topK, threshold)` - BM25 full-text search with Lucene syntax
+- **VectorSearchTools**: `vectorSearch(query, topK, [threshold])` - semantic similarity search
+- **TextSearchTools**: `textSearch(query, topK, [threshold])` - BM25 full-text search with Lucene syntax
 - **RegexSearchTools**: `regexSearch(regex, topK)` - pattern-based search using regular expressions
 - **ResultExpanderTools**: `broadenChunk(chunkId, chunksToAdd)` - expand to adjacent chunks, `zoomOut(id)` - expand to parent section
 
 The LLM autonomously decides when to use these tools based on user queries.
+
+===== Similarity Thresholds
+
+`threshold` is **optional** on the search tools, and normally you should let the model omit it.
+
+An absolute similarity cutoff is a hyperparameter the model has no feedback signal for.
+Similarity scores are not calibrated across embedding models — 0.7 against one model does not
+mean what 0.7 means against another — and the right cutoff varies per query.
+Models asked to supply one tend to guess high, retrieve nothing, and conclude that the corpus
+does not cover the question when the answer was sitting in the index.
+
+`topK` is the real limiter. The threshold is a noise floor, and when the model omits it the
+floor comes from `SearchDefaults`:
+
+[source,kotlin]
+----
+val rag = ToolishRag(
+    name = "docs",
+    description = "Product documentation",
+    searchOperations = store,
+).withSearchDefaults(
+    SearchDefaults(
+        vectorSimilarityThreshold = 0.25,
+        // BM25 scores are corpus-relative, so rank — not an absolute floor — is
+        // what meaningfully selects results
+        textSimilarityThreshold = 0.0,
+    )
+)
+----
+
+Set these if you have calibrated a cutoff against your own evaluation set. Do not expect the
+LLM to pass one.
+
+[IMPORTANT]
+.Migrating: full-text scores changed scale
+====
+Full-text scoring is **not** backward compatible, deliberately. Ranking is unchanged, but
+absolute scores are:
+
+* Lucene previously returned **raw, unbounded** BM25 scores (routinely 2-15), so any `0..1`
+  threshold was inert and admitted everything.
+* Graph stores previously divided by the **maximum score in the same result set**, so the top
+  hit always scored exactly `1.0` regardless of quality.
+
+Both now return `score/(score + k)` in `[0, 1)`.
+
+What this breaks:
+
+* Code that filters full-text results by threshold. A filter that was silently doing nothing
+  now takes effect. In particular `RagRequest` defaults `similarityThreshold` to `0.8` — a
+  *cosine* value — which on a full-text path now demands a raw score of roughly 12 and so
+  returns nothing. Pass an explicit low threshold on full-text searches, or omit it.
+* Code asserting that the best match scores `1.0`.
+* Persisted scores compared across versions.
+
+When a full-text search returns no results with a threshold above `0.5`, the store logs a WARN
+naming this as the likely cause, so the failure is not silent.
+
+The API itself is source-compatible: `threshold` only moves from required to optional, and
+`ToolishRag` gained a trailing constructor parameter with a default (its `@JvmOverloads`
+constructors are unchanged for Java callers). Pre-compiled *Kotlin* code calling
+`ToolishRag.copy(...)` needs recompilation, as with any data-class parameter addition.
+====
+
+[NOTE]
+====
+Full-text scores are mapped onto `[0, 1)` by `Bm25Normalization` (`score / (score + k)`) before
+any threshold is applied. This is monotonic, so ranking is unchanged, and — unlike normalizing
+against the best score in the result set — a document's score does not depend on what else
+happened to match. Stores that previously divided by the maximum score always gave their top hit
+exactly 1.0, so a threshold could never exclude a poor best-match. If your corpus produces
+unusually large or small raw scores, tune `k` (`Bm25Normalization.DEFAULT_K`, and `RagDialect.bm25K`
+for graph stores).
+====
 
 ===== Eager Search
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/Bm25Normalization.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/Bm25Normalization.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.service.support
+
+import com.embabel.common.core.types.ZeroToOne
+import org.slf4j.Logger
+
+/**
+ * Maps an unbounded BM25 relevance score onto `[0, 1)` **without reference to the
+ * other results in the same response**.
+ *
+ * ## Why not divide by the best score in the result set
+ *
+ * The obvious normalization — `score / maxScore` — is broken in three ways, and all
+ * three bit us:
+ *
+ * 1. **The top hit always scores 1.0**, however bad it is. A similarity threshold can
+ *    therefore never exclude a garbage best-match, which is exactly when you want it to.
+ * 2. **The threshold changes meaning per query.** The same document scores differently
+ *    depending on what else happened to match, so `threshold = 0.5` is not a stable
+ *    contract — it means "half as good as today's best hit".
+ * 3. **Scores are not comparable across calls**, so results from two searches cannot be
+ *    merged, ranked together, or deduplicated by score in any meaningful way.
+ *
+ * ## What this does instead
+ *
+ * A saturating transform `score / (score + k)`. It is strictly monotonic (so ranking is
+ * preserved exactly), bounded in `[0, 1)` across any magnitude BM25 produces, and depends
+ * only on the document's own score. (Only past ~1e16, where `score + k == score` in double
+ * arithmetic, does the ratio round to 1.0 — far outside any real relevance score.)
+ * `k` is the score at which a document maps to 0.5 — a soft "this is a decent match"
+ * midpoint. Raise it if your corpus produces large raw scores and everything saturates
+ * near 1.0; lower it if scores cluster near 0.
+ *
+ * Absolute BM25 magnitudes still depend on corpus statistics, so the output is a
+ * *stable, comparable* score rather than a calibrated probability of relevance. Rank —
+ * and topK — remain the meaningful selector; see
+ * [com.embabel.agent.rag.tools.SearchDefaults].
+ */
+object Bm25Normalization {
+
+    /**
+     * Raw BM25 score that maps to 0.5. Chosen as a reasonable midpoint for typical
+     * Lucene/Neo4j full-text scores; tune per store if scores cluster or saturate.
+     */
+    const val DEFAULT_K: Double = 3.0
+
+    /**
+     * @param rawScore the unbounded BM25 score. Negative values are treated as 0.
+     * @param k the score that maps to 0.5. Must be positive.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun normalize(
+        rawScore: Double,
+        k: Double = DEFAULT_K,
+    ): ZeroToOne {
+        require(k > 0.0) { "k must be positive, was $k" }
+        val score = rawScore.coerceAtLeast(0.0)
+        return score / (score + k)
+    }
+
+    /**
+     * A threshold above this requires a raw score above [DEFAULT_K] — already a strong
+     * match. Empty results above it are far more likely a mis-set threshold than an
+     * empty corpus.
+     */
+    const val SUPPRESSION_WARNING_THRESHOLD: ZeroToOne = 0.5
+
+    /**
+     * Explain an empty full-text result set that the caller's threshold most likely caused.
+     *
+     * Before scores were bounded, an out-of-range threshold was silently inert: raw BM25
+     * scores are unbounded, so any `0..1` floor admitted everything. Callers carrying a
+     * cosine-calibrated threshold (notably [com.embabel.agent.rag.service.RagRequest]'s
+     * 0.8 default) now get zero rows instead, with nothing to indicate why. This says why.
+     */
+    @JvmStatic
+    fun warnIfThresholdSuppressedResults(
+        logger: Logger,
+        query: String,
+        threshold: ZeroToOne,
+        resultCount: Int,
+    ) {
+        if (resultCount == 0 && threshold > SUPPRESSION_WARNING_THRESHOLD) {
+            logger.warn(
+                """
+                Full-text search for '{}' returned no results with similarityThreshold={}.
+                Full-text scores are normalized to [0, 1) as score/(score+{}), so a threshold this high
+                demands a very strong raw match — thresholds calibrated for cosine similarity do not
+                transfer. Lower or omit the threshold and let topK rank; see SearchDefaults.
+                """.trimIndent(),
+                query, threshold, DEFAULT_K,
+            )
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -24,6 +24,7 @@ import com.embabel.agent.rag.model.Chunk
 import com.embabel.agent.rag.model.Embeddable
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.*
+import com.embabel.agent.rag.service.support.Bm25Normalization
 import com.embabel.common.core.types.SimilarityResult
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.common.core.types.ZeroToOne
@@ -43,15 +44,22 @@ internal class VectorSearchTools @JvmOverloads constructor(
     private val metadataFilter: PropertyFilter? = null,
     private val entityFilter: EntityFilter? = null,
     private val resultsListener: ResultsListener? = null,
+    private val searchDefaults: SearchDefaults = SearchDefaults.DEFAULT,
 ) : SearchTools {
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
 
-    @LlmTool(description = "Perform vector search. Specify topK and similarity threshold from 0-1")
+    // `threshold` is OPTIONAL on purpose — see [SearchDefaults]. Models routinely
+    // guessed a high cutoff (0.7-0.8), got nothing back, and concluded the corpus
+    // didn't cover the question. topK is the limiter; the threshold is a noise floor.
+    @LlmTool(description = "Perform vector search. Specify topK. Ranking handles relevance — omit threshold unless you have a specific reason to floor it.")
     fun vectorSearch(
         query: String,
         topK: Int,
-        @LlmTool.Param(description = "similarity threshold from 0-1") threshold: ZeroToOne,
+        @LlmTool.Param(
+            description = "Optional similarity floor from 0-1. Omit this unless you need to exclude weak matches: scores are not calibrated across embedding models, and setting it too high silently returns nothing.",
+            required = false,
+        ) threshold: ZeroToOne = searchDefaults.vectorSimilarityThreshold,
     ): String {
         logger.info(
             "Performing vector search with query='{}', topK={}, threshold={}, types={}, metadataFilter={}, entityFilter={}",
@@ -175,6 +183,7 @@ internal class TextSearchTools @JvmOverloads constructor(
     private val metadataFilter: PropertyFilter? = null,
     private val entityFilter: EntityFilter? = null,
     private val resultsListener: ResultsListener? = null,
+    private val searchDefaults: SearchDefaults = SearchDefaults.DEFAULT,
 ) : SearchTools, Tool {
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
@@ -197,9 +206,11 @@ internal class TextSearchTools @JvmOverloads constructor(
                     name = "topK",
                     description = "Maximum number of results to return.",
                 ),
+                // Optional — mirrors [VectorSearchTools.vectorSearch]. See [SearchDefaults].
                 Tool.Parameter.double(
                     name = "threshold",
-                    description = "Similarity threshold from 0 to 1.",
+                    description = "Optional similarity floor from 0 to 1. Omit this unless you need to exclude weak matches: BM25 scores are corpus-relative, so ranking is what selects results.",
+                    required = false,
                 ),
             ),
         )
@@ -212,8 +223,10 @@ internal class TextSearchTools @JvmOverloads constructor(
             ?: return Tool.Result.error("'query' parameter is required")
         val topK = (params["topK"] as? Number)?.toInt()
             ?: return Tool.Result.error("'topK' parameter is required")
+        // Absent (or non-numeric, e.g. a JSON null) threshold falls back to the
+        // configured floor rather than erroring — the parameter is optional.
         val threshold = (params["threshold"] as? Number)?.toDouble()
-            ?: return Tool.Result.error("'threshold' parameter is required")
+            ?: searchDefaults.textSimilarityThreshold
         Tool.Result.text(textSearch(query, topK, threshold))
     } catch (e: Exception) {
         Tool.Result.error("textSearch failed: ${e.message}")
@@ -227,7 +240,7 @@ internal class TextSearchTools @JvmOverloads constructor(
     fun textSearch(
         query: String,
         topK: Int,
-        threshold: ZeroToOne,
+        threshold: ZeroToOne = searchDefaults.textSimilarityThreshold,
     ): String {
         logger.info(
             "Performing text search with query='{}', topK={}, threshold={}, types={}, metadataFilter={}, entityFilter={}",
@@ -238,6 +251,7 @@ internal class TextSearchTools @JvmOverloads constructor(
         val (results, ms) = time {
             searchForAllTypes(request)
         }
+        Bm25Normalization.warnIfThresholdSuppressedResults(logger, query, threshold, results.size)
         resultsListener?.onResultsEvent(ResultsEvent(this, query, results, Duration.ofMillis(ms)))
         return SimpleRetrievableResultsFormatter.formatResults(SimilarityResults.fromList<Retrievable>(results))
     }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/SearchDefaults.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/SearchDefaults.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.tools
+
+import com.embabel.common.core.types.ZeroToOne
+
+/**
+ * Similarity thresholds applied when the LLM does not supply one.
+ *
+ * The `threshold` parameter on [VectorSearchTools] and [TextSearchTools] is optional:
+ * an absolute similarity cutoff is a hyperparameter the model has no feedback signal
+ * for, and cosine scores are not calibrated across embedding models — 0.7 against one
+ * model is not 0.7 against another. A model guessing high silently turns retrieval off
+ * and reports "the documents don't cover it".
+ *
+ * `topK` remains the real limiter. These thresholds are a noise floor, not a relevance
+ * judgement, and are deliberately low. Deployments that HAVE calibrated a cutoff against
+ * their own eval set should raise them here rather than relying on the LLM to pass one.
+ *
+ * @param vectorSimilarityThreshold floor for vector search when the LLM omits `threshold`
+ * @param textSimilarityThreshold floor for text search when the LLM omits `threshold`.
+ * Defaults to 0.0 — BM25 scores are corpus-relative, so rank (topK) is the meaningful
+ * cutoff and any absolute floor is arbitrary.
+ */
+data class SearchDefaults @JvmOverloads constructor(
+    val vectorSimilarityThreshold: ZeroToOne = DEFAULT_VECTOR_SIMILARITY_THRESHOLD,
+    val textSimilarityThreshold: ZeroToOne = DEFAULT_TEXT_SIMILARITY_THRESHOLD,
+) {
+
+    init {
+        require(vectorSimilarityThreshold in 0.0..1.0) {
+            "vectorSimilarityThreshold must be in 0.0..1.0, was $vectorSimilarityThreshold"
+        }
+        require(textSimilarityThreshold in 0.0..1.0) {
+            "textSimilarityThreshold must be in 0.0..1.0, was $textSimilarityThreshold"
+        }
+    }
+
+    companion object {
+
+        const val DEFAULT_VECTOR_SIMILARITY_THRESHOLD: ZeroToOne = 0.25
+
+        const val DEFAULT_TEXT_SIMILARITY_THRESHOLD: ZeroToOne = 0.0
+
+        @JvmField
+        val DEFAULT: SearchDefaults = SearchDefaults()
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -109,6 +109,11 @@ data class ToolishRag @JvmOverloads constructor(
      * See [com.embabel.agent.api.tool.progressive.UnfoldingTool.childToolUsageNotes].
      */
     val childToolUsageNotes: String? = null,
+    /**
+     * Similarity floors used when the LLM omits the optional `threshold` parameter
+     * on the vector/text search tools. See [SearchDefaults] for why it is optional.
+     */
+    val searchDefaults: SearchDefaults = SearchDefaults.DEFAULT,
 ) : LlmReference, DelegatingTool, EagerSearch<ToolishRag> {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -147,7 +152,11 @@ data class ToolishRag @JvmOverloads constructor(
             }
             if (searchOperations is VectorSearch) {
                 logger.debug("Adding VectorSearchTools to ToolishRag '{}'", name)
-                add(VectorSearchTools(searchOperations, vectorSearchFor, metadataFilter, entityFilter, listener))
+                add(
+                    VectorSearchTools(
+                        searchOperations, vectorSearchFor, metadataFilter, entityFilter, listener, searchDefaults,
+                    )
+                )
             } else {
                 if (hints.any { it is TryHyDE }) {
                     logger.warn(
@@ -159,7 +168,11 @@ data class ToolishRag @JvmOverloads constructor(
             }
             if (searchOperations is TextSearch) {
                 logger.debug("Adding TextSearchTools to ToolishRag '{}'", name)
-                add(TextSearchTools(searchOperations, textSearchFor, metadataFilter, entityFilter, listener))
+                add(
+                    TextSearchTools(
+                        searchOperations, textSearchFor, metadataFilter, entityFilter, listener, searchDefaults,
+                    )
+                )
             }
             if (searchOperations is ResultExpander) {
                 logger.debug("Adding ResultExpanderTools to ToolishRag '{}'", name)
@@ -234,6 +247,14 @@ data class ToolishRag @JvmOverloads constructor(
      */
     fun withMaxZoomOutChars(maxChars: Int): ToolishRag =
         copy(maxZoomOutChars = maxChars)
+
+    /**
+     * Set the similarity floors applied when the LLM omits the optional `threshold`
+     * search parameter. Deployments that have calibrated a cutoff against their own
+     * eval set should set it here rather than expecting the model to pass one.
+     */
+    fun withSearchDefaults(searchDefaults: SearchDefaults): ToolishRag =
+        copy(searchDefaults = searchDefaults)
 
     override fun withEagerSearchAbout(request: TextSimilaritySearchRequest): ToolishRag {
         val vs = searchOperations as? VectorSearch

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/service/support/Bm25NormalizationTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/service/support/Bm25NormalizationTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.service.support
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * The properties that the discarded `score / maxScore` normalization violated.
+ */
+class Bm25NormalizationTest {
+
+    @Nested
+    inner class Bounds {
+
+        @Test
+        fun `maps into 0 to 1 exclusive of 1`() {
+            listOf(0.0, 0.1, 1.0, 3.0, 25.0, 1_000.0, 1e9).forEach { raw ->
+                val score = Bm25Normalization.normalize(raw)
+                assertTrue(score >= 0.0 && score < 1.0, "normalize($raw) = $score outside [0, 1)")
+            }
+        }
+
+        @Test
+        fun `no score reaches 1 across the realistic range`() {
+            // The old normalization pinned the best hit to exactly 1.0, so a
+            // similarity floor could never exclude a weak best-match. (At absurd
+            // magnitudes — around 1e16 and up — `score + k == score` in double
+            // arithmetic and the ratio rounds to 1.0. BM25 does not go there.)
+            assertTrue(Bm25Normalization.normalize(1e12) < 1.0)
+        }
+
+        @Test
+        fun `negative scores floor at zero`() {
+            assertEquals(0.0, Bm25Normalization.normalize(-5.0))
+        }
+
+        @Test
+        fun `k is the score that maps to one half`() {
+            assertEquals(0.5, Bm25Normalization.normalize(Bm25Normalization.DEFAULT_K))
+            assertEquals(0.5, Bm25Normalization.normalize(10.0, k = 10.0))
+        }
+
+        @Test
+        fun `rejects a non-positive k`() {
+            assertThrows<IllegalArgumentException> { Bm25Normalization.normalize(1.0, k = 0.0) }
+            assertThrows<IllegalArgumentException> { Bm25Normalization.normalize(1.0, k = -1.0) }
+        }
+    }
+
+    @Nested
+    inner class RankingPreserved {
+
+        @Test
+        fun `is strictly monotonic in the raw score`() {
+            val raw = listOf(0.0, 0.5, 1.0, 2.0, 3.0, 8.0, 20.0, 100.0)
+            val normalized = raw.map { Bm25Normalization.normalize(it) }
+            normalized.zipWithNext { a, b ->
+                assertTrue(a < b, "expected strictly increasing, got $a then $b")
+            }
+        }
+
+        @Test
+        fun `preserves the original ordering`() {
+            val raw = listOf(4.0, 19.0, 0.25, 7.5, 2.0)
+            assertEquals(
+                raw.sortedDescending().map { Bm25Normalization.normalize(it) },
+                raw.map { Bm25Normalization.normalize(it) }.sortedDescending(),
+            )
+        }
+    }
+
+    @Nested
+    inner class ResultSetIndependence {
+
+        /**
+         * The core defect: under `score / maxScore` the same document scored
+         * differently depending on what else happened to match, so a threshold
+         * meant "half as good as today's best hit" rather than anything stable,
+         * and scores from two searches could not be compared or merged.
+         */
+        @Test
+        fun `a document scores the same regardless of what else matched`() {
+            val document = 4.0
+
+            val amongWeakCompetition = listOf(document, 1.0, 0.5)
+            val amongStrongCompetition = listOf(document, 40.0, 35.0)
+
+            val scoreWithWeak = amongWeakCompetition.map { Bm25Normalization.normalize(it) }.first()
+            val scoreWithStrong = amongStrongCompetition.map { Bm25Normalization.normalize(it) }.first()
+
+            assertEquals(scoreWithWeak, scoreWithStrong)
+        }
+
+        @Test
+        fun `a weak best match does not become a perfect match`() {
+            val onlyResultIsWeak = listOf(0.3)
+            val score = onlyResultIsWeak.map { Bm25Normalization.normalize(it) }.first()
+
+            assertTrue(score < 0.2, "a weak sole result scored $score; a floor must still exclude it")
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/OptionalSimilarityThresholdTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/OptionalSimilarityThresholdTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.tools
+
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.service.CoreSearchOperations
+import com.embabel.agent.rag.service.TextSearch
+import com.embabel.agent.rag.service.VectorSearch
+import com.embabel.common.core.types.SimpleSimilaritySearchResult
+import com.embabel.common.core.types.TextSimilaritySearchRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * `threshold` is optional on the search tools.
+ *
+ * A model asked to supply an absolute similarity cutoff has no feedback signal to
+ * choose one, and cosine scores are not calibrated across embedding models. Models
+ * guessed high (0.7-0.8), got nothing back, and told the user the corpus did not
+ * cover the question — with the answer sitting in the index.
+ */
+class OptionalSimilarityThresholdTest {
+
+    private fun chunk(id: String, text: String): Chunk =
+        Chunk.create(id = id, text = text, parentId = "parent")
+
+    @Nested
+    inner class VectorSearchThreshold {
+
+        @Test
+        fun `omitted threshold falls back to the configured floor`() {
+            val vectorSearch = mockk<VectorSearch>()
+            every {
+                vectorSearch.vectorSearch(any<TextSimilaritySearchRequest>(), Chunk::class.java)
+            } returns listOf(SimpleSimilaritySearchResult(match = chunk("c1", "content"), score = 0.4))
+
+            val tools = VectorSearchTools(
+                vectorSearch,
+                searchDefaults = SearchDefaults(vectorSimilarityThreshold = 0.15),
+            )
+            tools.vectorSearch("a query", 10)
+
+            verify {
+                vectorSearch.vectorSearch(
+                    match<TextSimilaritySearchRequest> { it.similarityThreshold == 0.15 },
+                    Chunk::class.java,
+                )
+            }
+        }
+
+        @Test
+        fun `an explicit threshold still wins`() {
+            val vectorSearch = mockk<VectorSearch>()
+            every {
+                vectorSearch.vectorSearch(any<TextSimilaritySearchRequest>(), Chunk::class.java)
+            } returns emptyList()
+
+            val tools = VectorSearchTools(
+                vectorSearch,
+                searchDefaults = SearchDefaults(vectorSimilarityThreshold = 0.15),
+            )
+            tools.vectorSearch("a query", 10, 0.6)
+
+            verify {
+                vectorSearch.vectorSearch(
+                    match<TextSimilaritySearchRequest> { it.similarityThreshold == 0.6 },
+                    Chunk::class.java,
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class TextSearchThreshold {
+
+        private fun toolsReturningOneChunk(defaults: SearchDefaults): TextSearchTools {
+            val textSearch = mockk<TextSearch>()
+            every { textSearch.luceneSyntaxNotes } returns "Full Lucene syntax supported"
+            every {
+                textSearch.textSearch(any<TextSimilaritySearchRequest>(), Chunk::class.java)
+            } returns listOf(SimpleSimilaritySearchResult(match = chunk("c1", "content"), score = 0.7))
+            return TextSearchTools(textSearch, searchDefaults = defaults)
+        }
+
+        @Test
+        fun `a call omitting threshold succeeds instead of erroring`() {
+            val tools = toolsReturningOneChunk(SearchDefaults(textSimilarityThreshold = 0.0))
+
+            val result = tools.call("""{"query": "kotlin", "topK": 5}""")
+
+            assertTrue(result is Tool.Result.Text, "omitting the optional threshold must not be an error, was $result")
+            assertTrue((result as Tool.Result.Text).content.contains("content"))
+        }
+
+        @Test
+        fun `a JSON null threshold falls back to the floor rather than erroring`() {
+            val tools = toolsReturningOneChunk(SearchDefaults(textSimilarityThreshold = 0.0))
+
+            val result = tools.call("""{"query": "kotlin", "topK": 5, "threshold": null}""")
+
+            assertTrue(result is Tool.Result.Text, "a null threshold must fall back to the floor, was $result")
+        }
+
+        @Test
+        fun `query and topK remain required`() {
+            val tools = toolsReturningOneChunk(SearchDefaults())
+
+            assertTrue(tools.call("""{"topK": 5}""") is Tool.Result.Error, "query must still be required")
+            assertTrue(tools.call("""{"query": "kotlin"}""") is Tool.Result.Error, "topK must still be required")
+        }
+
+        @Test
+        fun `the declared schema marks threshold optional and the others required`() {
+            val tools = toolsReturningOneChunk(SearchDefaults())
+            val parameters = tools.definition.inputSchema.parameters.associateBy { it.name }
+
+            assertEquals(false, parameters.getValue("threshold").required)
+            assertEquals(true, parameters.getValue("query").required)
+            assertEquals(true, parameters.getValue("topK").required)
+        }
+    }
+
+    @Nested
+    inner class Wiring {
+
+        @Test
+        fun `ToolishRag propagates its search defaults to the search tools`() {
+            val searchOperations = mockk<CoreSearchOperations>()
+            every { searchOperations.luceneSyntaxNotes } returns ""
+            every {
+                searchOperations.vectorSearch(any<TextSimilaritySearchRequest>(), Chunk::class.java)
+            } returns emptyList()
+
+            val toolishRag = ToolishRag(
+                name = "docs",
+                description = "docs",
+                searchOperations = searchOperations,
+            ).withSearchDefaults(SearchDefaults(vectorSimilarityThreshold = 0.42))
+
+            val vectorSearchTool = toolishRag.tools().single { it.definition.name.endsWith("vectorSearch") }
+            vectorSearchTool.call("""{"query": "a query", "topK": 3}""")
+
+            verify {
+                searchOperations.vectorSearch(
+                    match<TextSimilaritySearchRequest> { it.similarityThreshold == 0.42 },
+                    Chunk::class.java,
+                )
+            }
+        }
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-lucene/src/main/kotlin/com/embabel/agent/rag/lucene/LuceneSearchOperations.kt
+++ b/embabel-agent-rag/embabel-agent-rag-lucene/src/main/kotlin/com/embabel/agent/rag/lucene/LuceneSearchOperations.kt
@@ -35,6 +35,7 @@ import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.CoreSearchOperations
 import com.embabel.agent.rag.service.RagRequest
 import com.embabel.agent.rag.service.ResultExpander
+import com.embabel.agent.rag.service.support.Bm25Normalization
 import com.embabel.agent.rag.service.support.RagFacetResults
 import com.embabel.agent.rag.service.support.VectorMath
 import com.embabel.agent.rag.store.AbstractChunkingContentElementRepository
@@ -428,6 +429,12 @@ class LuceneSearchOperations @JvmOverloads constructor(
             similarityResults.size,
             similarityResults.map { "(${it.match.id}, score=${"%.2f".format(it.score)})" },
         )
+        // RagRequest defaults similarityThreshold to 0.8 — a COSINE number. It used to be
+        // inert here because raw BM25 scores are unbounded; now that they are bounded it
+        // rejects everything, so say so rather than returning a silent empty list.
+        Bm25Normalization.warnIfThresholdSuppressedResults(
+            logger, ragRequest.query, ragRequest.similarityThreshold, similarityResults.size,
+        )
         return RagFacetResults(
             facetName = name,
             results = similarityResults
@@ -629,6 +636,9 @@ class LuceneSearchOperations @JvmOverloads constructor(
             request.query,
             results.size,
         )
+        Bm25Normalization.warnIfThresholdSuppressedResults(
+            logger, request.query, request.similarityThreshold, results.size,
+        )
         return results
     }
 
@@ -644,7 +654,10 @@ class LuceneSearchOperations @JvmOverloads constructor(
             val retrievable = createChunkFromLuceneDocument(doc)
             SimpleSimilaritySearchResult(
                 match = retrievable,
-                score = scoreDoc.score.toDouble()
+                // Raw Lucene BM25 scores are unbounded — they routinely exceed 1.0, which
+                // made the caller's `score >= similarityThreshold` filter a no-op. Map onto
+                // [0, 1) monotonically so the threshold means something. See [Bm25Normalization].
+                score = Bm25Normalization.normalize(scoreDoc.score.toDouble())
             )
         }
     }
@@ -666,9 +679,11 @@ class LuceneSearchOperations @JvmOverloads constructor(
             val doc = searcher.doc(scoreDoc.doc)
             val retrievable = createChunkFromLuceneDocument(doc)
 
-            // Get text similarity (normalized)
-            val textScore = scoreDoc.score.toDouble()
-            val normalizedTextScore = minOf(1.0, textScore / 10.0) // Rough normalization
+            // Get text similarity, mapped onto [0, 1) so it is commensurable with the
+            // cosine score below. The previous `min(1.0, score / 10.0)` clipped every
+            // strong match to exactly 1.0, collapsing the ranking among the best hits —
+            // precisely the ones the weighting is meant to discriminate between.
+            val normalizedTextScore = Bm25Normalization.normalize(scoreDoc.score.toDouble())
 
             // Calculate vector similarity if embedding exists
             val vectorScore = doc.getBinaryValue(LuceneFields.EMBEDDING_FIELD)?.let { embeddingBytes ->

--- a/embabel-agent-rag/embabel-agent-rag-lucene/src/test/kotlin/com/embabel/agent/rag/lucene/LuceneSearchOperationsTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-lucene/src/test/kotlin/com/embabel/agent/rag/lucene/LuceneSearchOperationsTest.kt
@@ -59,8 +59,10 @@ class LuceneSearchOperationsTest : LuceneSearchOperationsTestBase() {
 
         ragService.acceptDocuments(documents)
 
-        // Search for documents
-        val request = RagRequest.query("machine learning")
+        // No threshold: BM25 scores are corpus-relative, so ranking selects results.
+        // RagRequest's 0.8 default is a COSINE number — applying it to a text score
+        // rejects everything now that those scores are correctly bounded in [0, 1).
+        val request = RagRequest.query("machine learning").withSimilarityThreshold(0.0)
         val response = ragService.hybridSearch(request)
 
         assertEquals("lucene-rag", response.facetName)
@@ -81,15 +83,54 @@ class LuceneSearchOperationsTest : LuceneSearchOperationsTestBase() {
 
         ragService.acceptDocuments(documents)
 
-        // High threshold should filter out low-relevance results
-        val request = RagRequest.query("machine learning")
-            .withSimilarityThreshold(0.9)
+        // Without a floor the matching document comes back...
+        val unfiltered = ragService.hybridSearch(
+            RagRequest.query("machine learning").withSimilarityThreshold(0.0)
+        )
+        assertTrue(unfiltered.results.isNotEmpty(), "expected a match with no similarity floor")
 
-        val response = ragService.hybridSearch(request)
+        // ...and a high floor excludes it. Before scores were bounded this assertion
+        // held vacuously: the filter never removed anything, because raw BM25 scores
+        // are unbounded and always cleared any 0-1 threshold.
+        val filtered = ragService.hybridSearch(
+            RagRequest.query("machine learning").withSimilarityThreshold(0.99)
+        )
+        assertTrue(
+            filtered.results.size < unfiltered.results.size,
+            "a 0.99 floor should exclude results that a 0.0 floor admits",
+        )
+        filtered.results.forEach { result ->
+            assertTrue(result.score >= 0.99)
+        }
+    }
 
-        // Should only return highly relevant documents
-        response.results.forEach { result ->
-            assertTrue(result.score >= 0.9)
+    /**
+     * Regression: scores were normalized by dividing by the MAXIMUM score in the same
+     * result set, so the best hit always scored exactly 1.0 — however weak it was.
+     * A similarity floor could therefore never exclude a poor best-match, which is
+     * precisely when you want it to.
+     */
+    @Test
+    fun `top hit is not pinned to a perfect score`() {
+        ragService.acceptDocuments(
+            listOf(
+                Document("doc1", "a passing mention of machine learning in a longer text", emptyMap<String, Any>()),
+                Document("doc2", "cooking recipes", emptyMap<String, Any>()),
+            )
+        )
+
+        val response = ragService.hybridSearch(
+            RagRequest.query("machine learning").withSimilarityThreshold(0.0)
+        )
+
+        assertTrue(response.results.isNotEmpty())
+        val top = response.results.first()
+        assertTrue(
+            top.score < 1.0,
+            "top hit scored ${top.score}: scores must not be normalized against the result set",
+        )
+        response.results.forEach {
+            assertTrue(it.score >= 0.0 && it.score < 1.0, "score ${it.score} outside [0, 1)")
         }
     }
 


### PR DESCRIPTION
Two defects in retrieval scoring that were masking each other: full-text relevance scores were normalized against the result set, and the search tools demanded that the LLM supply an absolute similarity cutoff. An inert threshold hid the broken scores; meaningful scores turn a guessed threshold into silent empty results. Fixing either alone makes retrieval worse, so both are here.

## Scoring

**Lucene** returned raw, unbounded BM25 (routinely 2-15). Any `0..1` threshold was a no-op that admitted everything.

**Graph stores** divided by the maximum score in the same result set. Three consequences, all bad:

1. The top hit always scored exactly `1.0`, however weak — so a floor could never exclude a poor best-match, which is exactly when you want it to.
2. The same document scored differently depending on what else happened to match, so a threshold meant "half as good as today's best hit" rather than anything stable.
3. Scores were not comparable across calls, so results from two searches could not be merged or ranked together.

Both now use `Bm25Normalization`: `score / (score + k)`. Strictly monotonic (ranking is untouched), bounded in `[0, 1)`, and dependent only on the document's own score. `k` is the raw score mapping to 0.5, tunable per store via `RagDialect.bm25K`.

The hybrid path's `min(1.0, score / 10.0)` "rough normalization" goes with it — it clipped every strong match to exactly 1.0, collapsing the ranking among the best hits, which is precisely what the vector/text weighting exists to discriminate between.

## Threshold

An absolute similarity cutoff is a hyperparameter the model has no feedback signal for, and cosine scores are not calibrated across embedding models — 0.7 against one model is not 0.7 against another. Models guessed high (0.7-0.8), retrieved nothing, and told the user the corpus did not cover the question with the answer sitting in the index.

`threshold` is now **optional** on `vectorSearch` and `textSearch`, with floors from a new `SearchDefaults` carried on `ToolishRag` (`withSearchDefaults(...)`). `topK` is the real limiter. Deployments that have calibrated a cutoff against their own eval set set it there rather than hoping the model passes one.

## Compatibility

**API — compatible.** All additive. `threshold` only widens from required to optional, so every previously-valid tool call still works, and a `textSearch` call omitting it now succeeds where it used to return `Tool.Result.Error`. `ToolishRag`'s new parameter is trailing-with-default and its `@JvmOverloads` constructors are unchanged, so Java source and binary are unaffected and `component1..13` are stable. Caveat: pre-compiled *Kotlin* calling `ToolishRag.copy(...)` needs a recompile, as with any data-class parameter addition.

**Behaviour — deliberately not compatible for full-text scoring.** Ranking is identical; absolute values are not. This breaks code that filters full-text results by threshold (a filter that was doing nothing now bites), asserts the best match scores `1.0`, or compares persisted scores across versions.

The sharp edge: `RagRequest` defaults `similarityThreshold` to `0.8` — a cosine value. On a full-text path that now demands a raw score of roughly 12, so the legacy pipeline returns nothing. Rather than change a global default that also affects vector search, **every full-text path logs a WARN naming the cause and the fix** when it returns zero results above a 0.5 threshold, so the failure is never silent. The reference docs carry a migration admonition.

Nothing outside the rag modules references these types.

## Tests

rag-core **674 passing**, Lucene **91 passing**.

New coverage asserts the actual defect rather than mechanism:

- `Bm25NormalizationTest` — bounds, strict monotonicity, and result-set independence (a document scores the same regardless of what else matched; a weak sole result does not become a perfect match)
- `OptionalSimilarityThresholdTest` — omitted and JSON-`null` thresholds fall back to the floor, `query`/`topK` stay required, the declared schema marks `threshold` optional, and `ToolishRag` propagates its defaults
- `LuceneSearchOperationsTest` — a regression test that the top hit is not pinned to `1.0`

One existing test broke and I fixed the test, not the code: `should index and search documents` was passing only because the threshold never filtered. Its neighbour, `should respect similarity threshold`, was asserting vacuously over an empty list and is now real.

The companion dialect changes are in `embabel-agent-rag-graph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FEKygjgq6wULpz53CYp8b