### PR TITLE
Fix thinking mode parse error: Strip what a model writes after JSON block as well as before

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SuppressThinkingConverter.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/SuppressThinkingConverter.kt
@@ -56,7 +56,8 @@ class SuppressThinkingConverter<T : Any>(
      * This delegate handles the actual conversion from the cleaned string to the target type T.
      */
     private val delegate: StructuredOutputConverter<T>,
-    private val thinkBlockFinders: List<ThinkBlockFinder> = listOf(FindMarkupThinkBlock, FindPrefixThinkBlock),
+    private val thinkBlockFinders: List<ThinkBlockFinder> =
+        listOf(FindMarkupThinkBlock, FindPrefixThinkBlock, FindSuffixThinkBlock),
 ) : StructuredOutputConverter<T> {
     private val logger = LoggerFactory.getLogger(SuppressThinkingConverter::class.java)
 
@@ -128,6 +129,39 @@ val FindMarkupThinkBlock: ThinkBlockFinder = { input ->
 val FindPrefixThinkBlock: ThinkBlockFinder = { input ->
     val thinkBlockRegex = "[^{]*".toRegex(RegexOption.DOT_MATCHES_ALL)
     thinkBlockRegex.find(input)?.value
+}
+
+/**
+ * Everything AFTER the JSON object — the other half of [FindPrefixThinkBlock].
+ *
+ * A model that wraps its answer in a markdown fence produces text on BOTH sides of
+ * the object:
+ *
+ * ```
+ * Here is what I found:
+ * ```json
+ * {"name": "Rex"}
+ * ```
+ * ```
+ *
+ * The prefix finder removes the preamble and the opening fence, so the object now
+ * starts correctly — and parsing still fails, on the CLOSING fence, with
+ * `Unexpected character ('`' (code 96)): expected a valid value` as the parser
+ * looks for a second value where the input should have ended.
+ *
+ * Measured 2026-08-10 against a local model driving a retrieval loop: it selected
+ * the right document, scored it, and quoted a verbatim snippet — correct JSON,
+ * discarded over a trailing backtick, three retries deep, on every request. The
+ * failure looks exactly like an incapable model, which is why it survived so long.
+ *
+ * Anchored on the LAST `}` so an object spanning multiple lines is kept whole.
+ * Returns null when there is no `}` at all, rather than proposing to delete the
+ * entire input: with no object present there is nothing to salvage, and removing
+ * everything would turn a diagnosable parse error into an empty string.
+ */
+val FindSuffixThinkBlock: ThinkBlockFinder = { input ->
+    if (!input.contains('}')) null
+    else "[^}]*$".toRegex(RegexOption.DOT_MATCHES_ALL).find(input)?.value
 }
 
 fun stringWithoutThinkBlocks(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SuppressThinkingConverterTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/springai/SuppressThinkingConverterTest.kt
@@ -61,6 +61,82 @@ class SuppressThinkingConverterTest {
     }
 
     @Nested
+    inner class FencedJson {
+
+        /**
+         * The shape that motivated [FindSuffixThinkBlock]: a model that explains
+         * itself, then emits the object inside a markdown fence. The prefix finder
+         * already handled everything to the left of `{`; the closing fence was what
+         * killed it.
+         */
+        @Test
+        fun `object wrapped in a markdown fence, with a preamble`() {
+            val converter = SuppressThinkingConverter(BeanOutputConverter(Dog::class.java))
+            val input = """
+                Based on my research, I found one match.
+
+                ```json
+                {"name": "Rex"}
+                ```
+            """.trimIndent()
+            assertEquals("Rex", converter.convert(input)!!.name)
+        }
+
+        @Test
+        fun `fence with no language tag`() {
+            val converter = SuppressThinkingConverter(BeanOutputConverter(Dog::class.java))
+            val input = "```\n{\"name\": \"Rex\"}\n```"
+            assertEquals("Rex", converter.convert(input)!!.name)
+        }
+
+        @Test
+        fun `prose after the object, with no fence at all`() {
+            val converter = SuppressThinkingConverter(BeanOutputConverter(Dog::class.java))
+            val input = "{\"name\": \"Rex\"}\n\nLet me know if you need anything else."
+            assertEquals("Rex", converter.convert(input)!!.name)
+        }
+
+        @Test
+        fun `a multi-line object is kept whole - the anchor is the LAST brace`() {
+            val converter = SuppressThinkingConverter(BeanOutputConverter(Dog::class.java))
+            val input = """
+                ```json
+                {
+                  "name": "Rex"
+                }
+                ```
+            """.trimIndent()
+            assertEquals("Rex", converter.convert(input)!!.name)
+        }
+
+        @Test
+        fun `think tag, preamble, fence and trailing prose together`() {
+            val converter = SuppressThinkingConverter(BeanOutputConverter(Dog::class.java))
+            val input = """
+                <think>weighing the options</think>
+                Here is the answer.
+                ```json
+                {"name": "Rex"}
+                ```
+                Hope that helps.
+            """.trimIndent()
+            assertEquals("Rex", converter.convert(input)!!.name)
+        }
+
+        @Test
+        fun `input with no object at all is left alone for the parser to report`() {
+            // Deleting everything would replace a diagnosable parse error with an
+            // empty string, which is strictly harder to debug.
+            assertEquals(null, FindSuffixThinkBlock("I could not find anything relevant."))
+        }
+
+        @Test
+        fun `an already-clean object is untouched`() {
+            assertEquals("", FindSuffixThinkBlock("""{"name": "Rex"}"""))
+        }
+    }
+
+    @Nested
     inner class SequentialProcessing {
 
         @Test


### PR DESCRIPTION
`FindPrefixThinkBlock` removes everything up to the first `{`, so a prose preamble and an opening ```` ```json ```` fence are already handled. **Nothing removed the closing fence.** Jackson reports that as:

```
Unexpected character ('`' (code 96)): expected a valid value
```

— the parser reaching the end of a perfectly good object and finding a backtick where the input should have ended.

## Why this is worth fixing

The failure is indistinguishable from an incapable model, which is why it has survived so long.

Measured 2026-08-10 against a local model driving a document-retrieval loop over a 69-page statute. Its raw output:

> Based on my research, I found one document that directly addresses the brief…
> ```` ```json ````
> `{"documents":[{"documentId":"a926ef0f…","score":0.9,"snippet":"A general partner … must, within one month after the end of each quarter"}]}`
> ```` ``` ````

It searched, selected the right document, scored it, and quoted a **verbatim** snippet. Correct JSON — discarded over a trailing backtick, three retries deep, on request after request. It scored **2/12** on a benchmark that was, it turns out, measuring this rather than the model.

This also explains a note already in the codebase, that the same model *"scored 5/6 on the synthetic benchmark and then failed EVERY brief on the real corpus"*: the synthetic path returned bare JSON, the real one wrapped it.

## The change

`FindSuffixThinkBlock`, the mirror of the prefix finder: drop everything after the **last** `}`, so a multi-line object survives whole. It slots into the existing `ThinkBlockFinder` list, so the sanitizers still compose in order.

Returns `null` when the input contains no `}` at all, rather than proposing to delete everything — with no object present there is nothing to salvage, and blanking the input would turn a diagnosable parse error into an empty string.

## Tests

Seven new cases: fenced-with-preamble (the production payload), bare fence with no language tag, trailing prose with no fence at all, a multi-line object (pinning that the anchor is the last brace, not the first), all three sanitizers composed, and the two guards above. `SuppressThinkingConverterTest` is 14/14.

## Pre-existing failure, called out so it isn't attributed here

A module-wide `mvn test` fails 42 e2e context loads on this module. Unrelated to this change: a Kotlin backtick test name containing spaces and parentheses —

```
DefaultValidationPromptGeneratorTest$EdgeCases$should handle validation groups (basic test)$GroupedValidationClass
```

— emits a class file that Spring's component scanner rejects with `Bad method descriptor`, failing every `@SpringBootTest` at classpath scan. A string converter cannot cause a bean-scan failure. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FEKygjgq6wULpz53CYp8b