### PR TITLE
Prepare 1.5.0 release

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,7 +16,7 @@
 
     <properties>
         <argLine />
-        <embabel-common.version>2.0.0-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>2.0.1</embabel-common.version>
         <netty.version>4.2.16.Final</netty.version>
         <!-- Matches the openai-java-core that spring-ai-openai 2.0.0 depends on. Bump in
              step with spring-ai-openai; drop once embabel-build-dependencies catches up. -->


### PR DESCRIPTION
This pull request updates project dependencies from snapshot versions to stable releases and bumps the version of a common internal dependency. These changes help ensure the project is using finalized, stable versions of its parent and core libraries.

Dependency version updates:

* Updated the parent POM version from `2.0.0-SNAPSHOT` to the stable `2.0.0` in both `pom.xml` and `embabel-agent-dependencies/pom.xml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7) [[2]](diffhunk://#diff-afe07651950d7d2835eb6cc02163f9241976a101f42ab11fe2d932fc246750f9L7-R7)
* Updated the `embabel-common.version` property from `2.0.0-SNAPSHOT` to `2.0.1` in `pom.xml`.