### PR TITLE
Let a BYOK app with RAG start, without letting it guess a dimension

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlaceholderEmbeddingService.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlaceholderEmbeddingService.kt
@@ -38,7 +38,7 @@ package com.embabel.agent.spi
  * the exception: catching means the decision is made from a failure, and a failure cannot be told
  * apart from a provider that is merely unreachable right now.
  *
- * Ask it through [com.embabel.common.ai.model.EmbeddingService.awaitingKey], NOT by testing for
+ * Ask it through [com.embabel.common.ai.model.EmbeddingService.awaitingProviderKey], NOT by testing for
  * this interface. Wrapping is common — event tracking decorates the configured service,
  * applications add layers to hot-swap the model or meter it — and a wrapper around a placeholder is
  * not itself a placeholder, so a type test answers about the outermost layer and reports "there is

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlaceholderEmbeddingService.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlaceholderEmbeddingService.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi
+
+/**
+ * Marks an [com.embabel.common.ai.model.EmbeddingService] that stands in for a model this
+ * deployment does not yet have a key for.
+ *
+ * A placeholder embeds nothing. Its only job is to give the platform something to resolve before
+ * any key is supplied, so that a BYOK application using RAG or memory starts with zero keys, the
+ * same as one that only chats — the counterpart of [PlaceholderLlmService].
+ *
+ * ## A placeholder must not report a dimension
+ *
+ * This is the difference between this marker and the LLM one, and the reason the marker has to be
+ * checked rather than merely caught.
+ *
+ * There is no defensible dimension for a placeholder to return. Any number would be used to create
+ * a vector index; writes to that index would succeed; and a real model configured later would
+ * silently disagree with everything already stored. The failure would surface as bad search results
+ * rather than as an error — the worst kind, because nothing points at the cause.
+ *
+ * So `dimensions` fails like every other call. A consumer that provisions a vector index must
+ * therefore ask **whether the service is a placeholder** and skip, rather than call `dimensions`
+ * and handle the exception: catching means the decision is made from a failure, and a failure
+ * cannot be told apart from a provider that is merely unreachable right now. Checking the marker
+ * makes "there is no model yet" a state the consumer can read directly.
+ *
+ * Skipping is recoverable. The index is created once a real model is registered — on the next
+ * boot, or sooner for a consumer that re-checks, since the check is a type test rather than a call
+ * and costs nothing to repeat.
+ *
+ * Implemented by `SetupRequiredEmbedding` in `embabel-agent-byok-autoconfigure`. It lives here,
+ * next to [PlaceholderLlmService], because `com.embabel.common.ai.model.ConfigurableModelProvider`
+ * has to recognise a placeholder without depending on the BYOK module.
+ */
+interface PlaceholderEmbeddingService

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlaceholderEmbeddingService.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/PlaceholderEmbeddingService.kt
@@ -34,14 +34,21 @@ package com.embabel.agent.spi
  * rather than as an error — the worst kind, because nothing points at the cause.
  *
  * So `dimensions` fails like every other call. A consumer that provisions a vector index must
- * therefore ask **whether the service is a placeholder** and skip, rather than call `dimensions`
- * and handle the exception: catching means the decision is made from a failure, and a failure
- * cannot be told apart from a provider that is merely unreachable right now. Checking the marker
- * makes "there is no model yet" a state the consumer can read directly.
+ * therefore ask **whether there is a model yet** and skip, rather than call `dimensions` and handle
+ * the exception: catching means the decision is made from a failure, and a failure cannot be told
+ * apart from a provider that is merely unreachable right now.
+ *
+ * Ask it through [com.embabel.common.ai.model.EmbeddingService.awaitingKey], NOT by testing for
+ * this interface. Wrapping is common — event tracking decorates the configured service,
+ * applications add layers to hot-swap the model or meter it — and a wrapper around a placeholder is
+ * not itself a placeholder, so a type test answers about the outermost layer and reports "there is
+ * a model". The property rides through Kotlin's `by` delegation to any depth. This interface marks
+ * the implementation; the property is the question.
  *
  * Skipping is recoverable. The index is created once a real model is registered — on the next
- * boot, or sooner for a consumer that re-checks, since the check is a type test rather than a call
- * and costs nothing to repeat.
+ * boot, or sooner for a consumer that re-checks, since reading the property costs nothing to
+ * repeat. A consumer that wants recovery without a restart must re-resolve the service rather than
+ * hold the reference it was given, since the one it holds is the placeholder and stays so.
  *
  * Implemented by `SetupRequiredEmbedding` in `embabel-agent-byok-autoconfigure`. It lives here,
  * next to [PlaceholderLlmService], because `com.embabel.common.ai.model.ConfigurableModelProvider`

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -110,9 +110,20 @@ class ConfigurableModelProvider(
 
     // Compute this lazily as embedding services may not be available
     private fun defaultEmbeddingService() =
-        embeddingServices.firstOrNull { it.name == properties.defaultEmbeddingModel }
-            ?: placeholderEmbeddingService()
+        resolveDefaultEmbeddingService(warnOnFallback = true)
             ?: throw IllegalArgumentException("Default embedding service '${properties.defaultEmbeddingModel}' not found in available models: ${embeddingServices.map { it.name }}")
+
+    /**
+     * What `default-embedding-model` resolves to, or null if it resolves to nothing.
+     *
+     * Separate from [defaultEmbeddingService] because [embeddingSetupRequired] has to ask the
+     * question during construction, where throwing would take down the deployments this whole
+     * mechanism exists to let start - one with no embedding configuration at all resolves to
+     * nothing here and must still boot, since nothing has asked for an embedding yet.
+     */
+    private fun resolveDefaultEmbeddingService(warnOnFallback: Boolean): EmbeddingService? =
+        embeddingServices.firstOrNull { it.name == properties.defaultEmbeddingModel }
+            ?: placeholderEmbeddingService(warn = warnOnFallback)
 
     /**
      * The registered embedding placeholder, if this deployment carries one.
@@ -128,15 +139,27 @@ class ConfigurableModelProvider(
      * Consumers that provision a vector index should test for [PlaceholderEmbeddingService] and
      * skip until a real model is registered.
      */
-    private fun placeholderEmbeddingService(): EmbeddingService? =
+    private fun placeholderEmbeddingService(warn: Boolean = true): EmbeddingService? =
         embeddingServices.firstOrNull { it is PlaceholderEmbeddingService }
             ?.also {
-                logger.warn(
+                if (warn) logger.warn(
                     "Default embedding service '{}' is not registered; falling back to the '{}' placeholder. " +
                         "Embedding will fail with an actionable 'no embedding service configured' error until a key is supplied. Available: {}",
                     properties.defaultEmbeddingModel, it.name, embeddingServices.map { it.name },
                 )
             }
+
+    /**
+     * Whether this deployment is waiting for an EMBEDDING key, the counterpart of [setupRequired].
+     *
+     * Separate, because the two halves are configured independently: an application can hold a
+     * server-side chat key while embedding keys arrive per user, or the reverse. Deriving the
+     * embedding gate from [setupRequired] made a deployment with a real LLM fail its context
+     * refresh on an embedding role it has no key for yet - exactly the startup failure the
+     * placeholder exists to remove, reappearing in the mixed configuration.
+     */
+    private val embeddingSetupRequired: Boolean =
+        resolveDefaultEmbeddingService(warnOnFallback = false) is PlaceholderEmbeddingService
 
     init {
         properties.llms.forEach { (role, model) ->
@@ -170,8 +193,14 @@ class ConfigurableModelProvider(
                  * an embedding model is a schema commitment and nothing can stand in for one.
                  * The gate decides only whether the deployment STARTS; asking for the service
                  * still throws.
+                 *
+                 * Either gate opens it. [setupRequired] alone was not enough: the two halves are
+                 * configured independently, so a deployment holding a chat key while embedding keys
+                 * arrive at runtime is awaiting one here and was failing to start. [setupRequired]
+                 * still counts on its own, because a deployment awaiting a chat key has registered
+                 * nothing at all yet, embedding services included.
                  */
-                if (setupRequired) {
+                if (setupRequired || embeddingSetupRequired) {
                     logger.warn(
                         "Embedding model '{}' for role '{}' is not registered. This deployment is awaiting a key, " +
                             "so that is expected; asking for that role will still fail. Available: {}",

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -16,6 +16,7 @@
 package com.embabel.common.ai.model
 
 import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.PlaceholderEmbeddingService
 import com.embabel.agent.spi.PlaceholderLlmService
 import com.embabel.common.util.indent
 import com.embabel.common.util.loggerFor
@@ -110,7 +111,32 @@ class ConfigurableModelProvider(
     // Compute this lazily as embedding services may not be available
     private fun defaultEmbeddingService() =
         embeddingServices.firstOrNull { it.name == properties.defaultEmbeddingModel }
+            ?: placeholderEmbeddingService()
             ?: throw IllegalArgumentException("Default embedding service '${properties.defaultEmbeddingModel}' not found in available models: ${embeddingServices.map { it.name }}")
+
+    /**
+     * The registered embedding placeholder, if this deployment carries one.
+     *
+     * Structural rather than by name, like [placeholderLlm]: `com.embabel.agent.spi` owns the
+     * marker and this class must not depend on the BYOK module that implements it.
+     *
+     * Note what falling back does NOT do. The placeholder cannot embed and will not report a
+     * dimension, so every consumer that reaches it still fails - deliberately, because an
+     * embedding model is a schema commitment and nothing can stand in for one. What the fallback
+     * buys is that the deployment STARTS: a consumer resolving the default embedding service while
+     * its beans are being created no longer takes down the context before any BYOK code can run.
+     * Consumers that provision a vector index should test for [PlaceholderEmbeddingService] and
+     * skip until a real model is registered.
+     */
+    private fun placeholderEmbeddingService(): EmbeddingService? =
+        embeddingServices.firstOrNull { it is PlaceholderEmbeddingService }
+            ?.also {
+                logger.warn(
+                    "Default embedding service '{}' is not registered; falling back to the '{}' placeholder. " +
+                        "Embedding will fail with an actionable 'no embedding service configured' error until a key is supplied. Available: {}",
+                    properties.defaultEmbeddingModel, it.name, embeddingServices.map { it.name },
+                )
+            }
 
     init {
         properties.llms.forEach { (role, model) ->

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -16,7 +16,6 @@
 package com.embabel.common.ai.model
 
 import com.embabel.agent.spi.LlmService
-import com.embabel.agent.spi.PlaceholderEmbeddingService
 import com.embabel.agent.spi.PlaceholderLlmService
 import com.embabel.common.util.indent
 import com.embabel.common.util.loggerFor

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -140,7 +140,7 @@ class ConfigurableModelProvider(
      * until a real model is registered - the property, not a type test, because it survives
      * wrapping.
      */
-    private fun placeholderEmbeddingService(warn: Boolean = true): EmbeddingService? =
+    private fun placeholderEmbeddingService(warn: Boolean): EmbeddingService? =
         embeddingServices.firstOrNull { it.awaitingKey }
             ?.also {
                 if (warn) logger.warn(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -136,11 +136,12 @@ class ConfigurableModelProvider(
      * embedding model is a schema commitment and nothing can stand in for one. What the fallback
      * buys is that the deployment STARTS: a consumer resolving the default embedding service while
      * its beans are being created no longer takes down the context before any BYOK code can run.
-     * Consumers that provision a vector index should test for [PlaceholderEmbeddingService] and
-     * skip until a real model is registered.
+     * Consumers that provision a vector index should ask [EmbeddingService.awaitingKey] and skip
+     * until a real model is registered - the property, not a type test, because it survives
+     * wrapping.
      */
     private fun placeholderEmbeddingService(warn: Boolean = true): EmbeddingService? =
-        embeddingServices.firstOrNull { it is PlaceholderEmbeddingService }
+        embeddingServices.firstOrNull { it.awaitingKey }
             ?.also {
                 if (warn) logger.warn(
                     "Default embedding service '{}' is not registered; falling back to the '{}' placeholder. " +
@@ -159,7 +160,7 @@ class ConfigurableModelProvider(
      * placeholder exists to remove, reappearing in the mixed configuration.
      */
     private val embeddingSetupRequired: Boolean =
-        resolveDefaultEmbeddingService(warnOnFallback = false) is PlaceholderEmbeddingService
+        resolveDefaultEmbeddingService(warnOnFallback = false)?.awaitingKey == true
 
     init {
         properties.llms.forEach { (role, model) ->

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/ConfigurableModelProvider.kt
@@ -135,16 +135,18 @@ class ConfigurableModelProvider(
      * embedding model is a schema commitment and nothing can stand in for one. What the fallback
      * buys is that the deployment STARTS: a consumer resolving the default embedding service while
      * its beans are being created no longer takes down the context before any BYOK code can run.
-     * Consumers that provision a vector index should ask [EmbeddingService.awaitingKey] and skip
+     * Consumers that provision a vector index should ask [EmbeddingService.awaitingProviderKey] and skip
      * until a real model is registered - the property, not a type test, because it survives
      * wrapping.
      */
     private fun placeholderEmbeddingService(warn: Boolean): EmbeddingService? =
-        embeddingServices.firstOrNull { it.awaitingKey }
+        embeddingServices.firstOrNull { it.awaitingProviderKey }
             ?.also {
                 if (warn) logger.warn(
-                    "Default embedding service '{}' is not registered; falling back to the '{}' placeholder. " +
-                        "Embedding will fail with an actionable 'no embedding service configured' error until a key is supplied. Available: {}",
+                    """
+                    Default embedding service '{}' is not registered; falling back to the '{}' placeholder.
+                    Embedding will fail with an actionable 'no embedding service configured' error until a key is supplied. Available: {}
+                    """.trimIndent(),
                     properties.defaultEmbeddingModel, it.name, embeddingServices.map { it.name },
                 )
             }
@@ -159,7 +161,7 @@ class ConfigurableModelProvider(
      * placeholder exists to remove, reappearing in the mixed configuration.
      */
     private val embeddingSetupRequired: Boolean =
-        resolveDefaultEmbeddingService(warnOnFallback = false)?.awaitingKey == true
+        resolveDefaultEmbeddingService(warnOnFallback = false)?.awaitingProviderKey == true
 
     init {
         properties.llms.forEach { (role, model) ->
@@ -202,8 +204,10 @@ class ConfigurableModelProvider(
                  */
                 if (setupRequired || embeddingSetupRequired) {
                     logger.warn(
-                        "Embedding model '{}' for role '{}' is not registered. This deployment is awaiting a key, " +
-                            "so that is expected; asking for that role will still fail. Available: {}",
+                        """
+                        Embedding model '{}' for role '{}' is not registered. This deployment is awaiting a key,
+                        so that is expected; asking for that role will still fail. Available: {}
+                        """.trimIndent(),
                         model, role, embeddingServices.map { it.name },
                     )
                 } else {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/EmbeddingOperationsNonRegressionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/EmbeddingOperationsNonRegressionTest.kt
@@ -419,6 +419,31 @@ class EmbeddingOperationsNonRegressionTest {
             assertTrue(wrappedSpringAi is EmbeddingService)
         }
 
+        /**
+         * The decorator must not hide "this deployment has no embedding model yet".
+         *
+         * This is the wrapper that actually stands between a consumer and the configured service in
+         * any deployment with embedding tracking on, so it is the one that decides whether
+         * `awaitingKey` reaches the caller. It answers correctly today only because the wrapper is
+         * declared `by delegate`; a hand-written override list would silently report false and let a
+         * consumer commit a vector index at a dimension read from a placeholder.
+         */
+        @Test
+        fun `wrapper reports the delegate's awaitingKey rather than the default`() {
+            val placeholder = object : EmbeddingService by rawSpringAi {
+                override val awaitingKey = true
+            }
+
+            assertTrue(
+                EmbeddingOperations(placeholder).awaitingKey,
+                "the decorator hid awaitingKey; a consumer would provision from a placeholder",
+            )
+            assertFalse(
+                EmbeddingOperations(rawSpringAi).awaitingKey,
+                "a real service must not be reported as awaiting a key",
+            )
+        }
+
         @Test
         fun `wrapper does not call the delegate twice for a single embed call`() {
             // Accidentally double-invoking the underlying provider would double-bill costs.

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/EmbeddingOperationsNonRegressionTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/EmbeddingOperationsNonRegressionTest.kt
@@ -424,22 +424,22 @@ class EmbeddingOperationsNonRegressionTest {
          *
          * This is the wrapper that actually stands between a consumer and the configured service in
          * any deployment with embedding tracking on, so it is the one that decides whether
-         * `awaitingKey` reaches the caller. It answers correctly today only because the wrapper is
+         * `awaitingProviderKey` reaches the caller. It answers correctly today only because the wrapper is
          * declared `by delegate`; a hand-written override list would silently report false and let a
          * consumer commit a vector index at a dimension read from a placeholder.
          */
         @Test
-        fun `wrapper reports the delegate's awaitingKey rather than the default`() {
+        fun `wrapper reports the delegate's awaitingProviderKey rather than the default`() {
             val placeholder = object : EmbeddingService by rawSpringAi {
-                override val awaitingKey = true
+                override val awaitingProviderKey = true
             }
 
             assertTrue(
-                EmbeddingOperations(placeholder).awaitingKey,
-                "the decorator hid awaitingKey; a consumer would provision from a placeholder",
+                EmbeddingOperations(placeholder).awaitingProviderKey,
+                "the decorator hid awaitingProviderKey; a consumer would provision from a placeholder",
             )
             assertFalse(
-                EmbeddingOperations(rawSpringAi).awaitingKey,
+                EmbeddingOperations(rawSpringAi).awaitingProviderKey,
                 "a real service must not be reported as awaiting a key",
             )
         }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
@@ -16,6 +16,7 @@
 package com.embabel.common.ai.model
 
 import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.PlaceholderEmbeddingService
 import com.embabel.agent.spi.PlaceholderLlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.common.ai.model.ModelProvider.Companion.BEST_ROLE
@@ -54,6 +55,32 @@ class ConfigurableModelProviderTest {
             "setup-required", "none", mockk<ChatModel>(),
         ),
         PlaceholderLlmService {}
+
+    /**
+     * Stands in for `SetupRequiredEmbedding`, for the same reason [placeholderModel] does: it lives
+     * in the BYOK module this one cannot depend on. Refuses a dimension exactly as the real one
+     * does, so a test that provisions from it fails here rather than in a deployment.
+     */
+    private fun placeholderEmbedding(): EmbeddingService = object : EmbeddingService,
+        PlaceholderEmbeddingService {
+        override val name = "setup-required-embedding"
+        override val provider = "none"
+        override val pricingModel: PricingModel? = null
+        override val awaitingKey = true
+        override fun embed(text: String): FloatArray = error("no embedding service configured")
+        override fun embed(texts: List<String>): List<FloatArray> = error("no embedding service configured")
+        override val dimensions: Int get() = error("no embedding service configured")
+    }
+
+    private fun realEmbedding(name: String, dimensions: Int = 1536): EmbeddingService =
+        object : EmbeddingService {
+            override val name = name
+            override val provider = "openai"
+            override val pricingModel: PricingModel? = null
+            override fun embed(text: String): FloatArray = FloatArray(dimensions)
+            override fun embed(texts: List<String>): List<FloatArray> = texts.map { embed(it) }
+            override val dimensions = dimensions
+        }
 
     private fun providerWith(
         llms: List<LlmService<*>>,
@@ -322,6 +349,105 @@ class ConfigurableModelProviderTest {
             assertEquals("my-custom-embeddings", service.name)
             assertEquals("CustomProvider", service.provider)
             assertEquals(384, service.dimensions)
+        }
+    }
+
+    /**
+     * The embedding half of setup-required mode. Its LLM counterpart lives in [SetupRequiredMode];
+     * these belong here rather than in the BYOK module because it is this class that decides what a
+     * deployment awaiting a key is allowed to do.
+     */
+    @Nested
+    inner class EmbeddingSetupRequiredMode {
+
+        @Test
+        fun `default-embedding-model naming an unregistered model falls back to the placeholder`() {
+            // The realistic pure-BYOK application.yml: it still names the model the deployment wants
+            // once a key arrives, and the placeholder stands in until then.
+            val mp = providerWith(
+                llms = listOf(placeholderModel),
+                embeddingServices = listOf(placeholderEmbedding()),
+                properties = ConfigurableModelProviderProperties(
+                    defaultLlm = "setup-required",
+                    defaultEmbeddingModel = "text-embedding-3-small",
+                ),
+            )
+
+            assertTrue(mp.getEmbeddingService(DefaultModelSelectionCriteria).awaitingKey)
+        }
+
+        @Test
+        fun `a registered embedding model is never degraded to the placeholder`() {
+            val mp = providerWith(
+                llms = listOf(placeholderModel),
+                embeddingServices = listOf(placeholderEmbedding(), realEmbedding("text-embedding-3-small")),
+                properties = ConfigurableModelProviderProperties(
+                    defaultLlm = "setup-required",
+                    defaultEmbeddingModel = "text-embedding-3-small",
+                ),
+            )
+
+            val resolved = mp.getEmbeddingService(DefaultModelSelectionCriteria)
+            assertFalse(resolved.awaitingKey)
+            assertEquals(1536, resolved.dimensions)
+        }
+
+        @Test
+        fun `with no placeholder an unresolvable default embedding model still fails`() {
+            // Opt-in: without a placeholder the deployment is misconfigured, not waiting.
+            val mp = providerWith(
+                llms = listOf(placeholderModel),
+                embeddingServices = listOf(realEmbedding("text-embedding-3-large", dimensions = 3072)),
+                properties = ConfigurableModelProviderProperties(
+                    defaultLlm = "setup-required",
+                    defaultEmbeddingModel = "text-embedding-3-small",
+                ),
+            )
+
+            val e = assertThrows<IllegalArgumentException> {
+                mp.getEmbeddingService(DefaultModelSelectionCriteria)
+            }
+            assertContains(e.message!!, "text-embedding-3-small")
+        }
+
+        /**
+         * The mixed deployment — a server-side chat key with embedding keys arriving at runtime —
+         * which the LLM-derived gate used to kill during context refresh.
+         */
+        @Test
+        fun `a real LLM with a placeholder embedding tolerates an unregistered embedding role`() {
+            val mp = providerWith(
+                llms = listOf(SpringAiLlmService(DEFAULT_MODEL, "openai", mockk<ChatModel>())),
+                embeddingServices = listOf(placeholderEmbedding()),
+                properties = ConfigurableModelProviderProperties(
+                    embeddingServices = mapOf(BEST_ROLE to "text-embedding-3-small"),
+                    defaultLlm = DEFAULT_MODEL,
+                    defaultEmbeddingModel = "setup-required-embedding",
+                ),
+            )
+
+            assertThrows<NoSuitableModelException> {
+                mp.getEmbeddingService(ByRoleModelSelectionCriteria(BEST_ROLE))
+            }
+        }
+
+        /**
+         * And the complement, which is what keeps the gate from becoming permissive: with a real
+         * embedding model registered, an unresolvable embedding role is a typo and still fatal.
+         */
+        @Test
+        fun `a keyed deployment still dies on an embedding role nothing registers`() {
+            assertThrows<IllegalStateException> {
+                providerWith(
+                    llms = listOf(SpringAiLlmService(DEFAULT_MODEL, "openai", mockk<ChatModel>())),
+                    embeddingServices = listOf(realEmbedding("text-embedding-3-small")),
+                    properties = ConfigurableModelProviderProperties(
+                        embeddingServices = mapOf(BEST_ROLE to "nonexistent-embedding"),
+                        defaultLlm = DEFAULT_MODEL,
+                        defaultEmbeddingModel = "text-embedding-3-small",
+                    ),
+                )
+            }
         }
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/common/ai/model/ConfigurableModelProviderTest.kt
@@ -66,7 +66,7 @@ class ConfigurableModelProviderTest {
         override val name = "setup-required-embedding"
         override val provider = "none"
         override val pricingModel: PricingModel? = null
-        override val awaitingKey = true
+        override val awaitingProviderKey = true
         override fun embed(text: String): FloatArray = error("no embedding service configured")
         override fun embed(texts: List<String>): List<FloatArray> = error("no embedding service configured")
         override val dimensions: Int get() = error("no embedding service configured")
@@ -373,7 +373,7 @@ class ConfigurableModelProviderTest {
                 ),
             )
 
-            assertTrue(mp.getEmbeddingService(DefaultModelSelectionCriteria).awaitingKey)
+            assertTrue(mp.getEmbeddingService(DefaultModelSelectionCriteria).awaitingProviderKey)
         }
 
         @Test
@@ -388,7 +388,7 @@ class ConfigurableModelProviderTest {
             )
 
             val resolved = mp.getEmbeddingService(DefaultModelSelectionCriteria)
-            assertFalse(resolved.awaitingKey)
+            assertFalse(resolved.awaitingProviderKey)
             assertEquals(1536, resolved.dimensions)
         }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfiguration.java
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.autoconfigure.models.byok;
 
+import com.embabel.agent.config.models.byok.SetupRequiredEmbeddingConfig;
 import com.embabel.agent.config.models.byok.SetupRequiredLlmConfig;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -24,15 +25,20 @@ import org.springframework.context.annotation.Import;
  * Autoconfiguration for Bring Your Own Key deployments.
  * <p>
  * Unlike the provider autoconfigurations, this registers no real models and requires no API key.
- * It contributes only the {@code setup-required} placeholder LLM, which lets a deployment holding
- * no provider key start up and resolve {@code embabel.models.default-llm}. Keys arrive at runtime
- * and reach a call through {@code PromptRunner.withLlmService(...)}.
+ * It contributes only the {@code setup-required} placeholder LLM and its embedding counterpart,
+ * which let a deployment holding no provider key start up and resolve
+ * {@code embabel.models.default-llm} and {@code embabel.models.default-embedding-model}. Keys arrive
+ * at runtime and reach a call through {@code PromptRunner.withLlmService(...)}.
+ * <p>
+ * The embedding placeholder never reports a dimension: a vector index built at a guessed dimension
+ * would accept writes and disagree with the real model later, so anything provisioning one must
+ * check for {@code PlaceholderEmbeddingService} and wait.
  * <p>
  * Runs before the platform autoconfiguration so the placeholder bean exists by the time the model
  * provider is built.
  */
 @AutoConfiguration
 @AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
-@Import(SetupRequiredLlmConfig.class)
+@Import({SetupRequiredLlmConfig.class, SetupRequiredEmbeddingConfig.class})
 public class AgentByokAutoConfiguration {
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbedding.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbedding.kt
@@ -115,7 +115,7 @@ internal class SetupRequiredEmbeddingService : EmbeddingService, PlaceholderEmbe
      * The question consumers actually ask. It rides through `by` delegation, so a wrapper around
      * this one still answers true — which a `is PlaceholderEmbeddingService` test would not.
      */
-    override val awaitingKey: Boolean = true
+    override val awaitingProviderKey: Boolean = true
 
     override fun toString(): String = "SetupRequiredEmbeddingService(name=$name)"
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbedding.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbedding.kt
@@ -111,5 +111,11 @@ internal class SetupRequiredEmbeddingService : EmbeddingService, PlaceholderEmbe
     override val dimensions: Int
         get() = throw NoEmbeddingServiceConfiguredException(SetupRequiredEmbedding.MESSAGE)
 
+    /**
+     * The question consumers actually ask. It rides through `by` delegation, so a wrapper around
+     * this one still answers true — which a `is PlaceholderEmbeddingService` test would not.
+     */
+    override val awaitingKey: Boolean = true
+
     override fun toString(): String = "SetupRequiredEmbeddingService(name=$name)"
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbedding.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbedding.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.byok
+
+import com.embabel.agent.spi.PlaceholderEmbeddingService
+import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.ai.model.PricingModel
+
+/**
+ * Thrown when work reaches the [SetupRequiredEmbedding] placeholder, meaning no real embedding
+ * service was available: the deployment has no server-side key and none was supplied at runtime.
+ *
+ * Catch this to render your own "add an API key" experience. The placeholder fails loudly rather
+ * than returning an empty vector or a plausible dimension, so a missing key surfaces as an
+ * actionable error rather than as search results that are quietly wrong.
+ */
+class NoEmbeddingServiceConfiguredException(message: String) : RuntimeException(message)
+
+/**
+ * The placeholder embedding service for a pure BYOK deployment — one that starts with no provider
+ * key at all and obtains a key per user, per tenant, or per request at runtime.
+ *
+ * Such a deployment has no [EmbeddingService] beans at startup, so anything that resolves the
+ * default embedding service while its own beans are being created fails the context refresh —
+ * exactly the problem [SetupRequiredLlm] solved for the chat side. Registering this placeholder and
+ * pointing `default-embedding-model` at it gives the platform something to resolve, deferring the
+ * "no key" failure from startup to the first call that actually needs an embedding.
+ *
+ * Opt in by putting `embabel-agent-starter-byok` on the classpath and configuring:
+ * ```yaml
+ * embabel:
+ *   models:
+ *     default-llm: setup-required
+ *     default-embedding-model: setup-required-embedding
+ * ```
+ */
+object SetupRequiredEmbedding {
+
+    /**
+     * The well-known name of the placeholder, as both the bean name and the [EmbeddingService]
+     * name. Use it as the value of `embabel.models.default-embedding-model`.
+     *
+     * Distinct from [SetupRequiredLlm.NAME] because the two are selected by separate properties
+     * and a shared name would make a mis-set property resolve to the wrong kind of model.
+     */
+    const val NAME: String = "setup-required-embedding"
+
+    /** Provider reported by the placeholder. Not a real provider — no key reaches any endpoint. */
+    const val PROVIDER: String = "none"
+
+    /**
+     * Message carried by [NoEmbeddingServiceConfiguredException]. Deliberately provider-neutral:
+     * an application knows which providers it accepts and how a user supplies a key, so it should
+     * catch the exception and say so in its own words rather than surface this verbatim.
+     */
+    val MESSAGE: String = """
+        No embedding service is configured. This deployment holds no provider API key,
+        so a key must be supplied at runtime before anything can be embedded or retrieved.
+        See the Bring Your Own Key section of the Embabel reference documentation.
+    """.trimIndent()
+
+    /**
+     * Builds the placeholder service. Registered as a bean by [SetupRequiredEmbeddingConfig]; call
+     * this directly only when constructing a model provider outside a Spring context.
+     */
+    fun embeddingService(): EmbeddingService = SetupRequiredEmbeddingService()
+}
+
+/**
+ * The placeholder as an [EmbeddingService], carrying the [PlaceholderEmbeddingService] marker the
+ * platform looks for.
+ *
+ * Every member fails, [dimensions] included — see [PlaceholderEmbeddingService] for why a
+ * placeholder that answered with a number would be worse than one that fails.
+ */
+internal class SetupRequiredEmbeddingService : EmbeddingService, PlaceholderEmbeddingService {
+
+    override val name: String = SetupRequiredEmbedding.NAME
+
+    override val provider: String = SetupRequiredEmbedding.PROVIDER
+
+    override val pricingModel: PricingModel? = null
+
+    override fun embed(text: String): FloatArray =
+        throw NoEmbeddingServiceConfiguredException(SetupRequiredEmbedding.MESSAGE)
+
+    override fun embed(texts: List<String>): List<FloatArray> =
+        throw NoEmbeddingServiceConfiguredException(SetupRequiredEmbedding.MESSAGE)
+
+    /**
+     * Fails rather than answering.
+     *
+     * A dimension is a schema commitment: whatever this returned would become the shape of a
+     * vector index, and a real model configured later would disagree with everything written into
+     * it. A consumer that provisions an index should test for [PlaceholderEmbeddingService] and
+     * skip; this exists so that one which forgets fails loudly instead of building the wrong index.
+     */
+    override val dimensions: Int
+        get() = throw NoEmbeddingServiceConfiguredException(SetupRequiredEmbedding.MESSAGE)
+
+    override fun toString(): String = "SetupRequiredEmbeddingService(name=$name)"
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingConfig.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.byok
+
+import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.util.loggerFor
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Registers the [SetupRequiredEmbedding] placeholder so a deployment with no provider key can start
+ * even when it uses RAG or memory.
+ *
+ * Registered unconditionally, for the same reason as [SetupRequiredLlmConfig]: provider
+ * autoconfigurations register their models imperatively with `registerSingleton` rather than as
+ * `@Bean`s, so `@ConditionalOnMissingBean` would be evaluated before those singletons exist and
+ * would always see none. Opting in through `embabel.models.default-embedding-model` avoids the
+ * ordering question entirely.
+ *
+ * An unused placeholder is harmless: it is only ever reached by a deployment that names it, or by
+ * one whose configured default embedding model is not registered — where the alternative is
+ * failing to start.
+ */
+@Configuration(proxyBeanMethods = false)
+class SetupRequiredEmbeddingConfig {
+
+    @Bean(SetupRequiredEmbedding.NAME)
+    fun setupRequiredEmbeddingService(): EmbeddingService {
+        loggerFor<SetupRequiredEmbeddingConfig>().info(
+            """
+            Registered placeholder embedding service '{}'. Set embabel.models.default-embedding-model={}
+            to start with no provider key; anything that embeds or provisions a vector index should check
+            for PlaceholderEmbeddingService and wait for a real model.
+            """.trimIndent(),
+            SetupRequiredEmbedding.NAME,
+            SetupRequiredEmbedding.NAME,
+        )
+        return SetupRequiredEmbedding.embeddingService()
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfigurationTest.java
@@ -15,8 +15,11 @@
  */
 package com.embabel.agent.autoconfigure.models.byok;
 
+import com.embabel.agent.config.models.byok.SetupRequiredEmbedding;
 import com.embabel.agent.config.models.byok.SetupRequiredLlm;
 import com.embabel.agent.spi.LlmService;
+import com.embabel.agent.spi.PlaceholderEmbeddingService;
+import com.embabel.common.ai.model.EmbeddingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -41,5 +44,33 @@ class AgentByokAutoConfigurationTest {
     void placeholderIsTheOnlyLlmServiceContributed() {
         contextRunner.run(context ->
                 assertThat(context.getBeansOfType(LlmService.class)).containsOnlyKeys(SetupRequiredLlm.NAME));
+    }
+
+    /**
+     * The embedding placeholder is a separate {@code @Import} on the autoconfiguration, and the
+     * assertions above pass with or without it: an {@link EmbeddingService} is not an
+     * {@link LlmService}, so dropping the import would leave every other test in this module green
+     * while a BYOK app using RAG went back to failing its context refresh.
+     */
+    @Test
+    void registersTheEmbeddingPlaceholderWithNoApiKeyConfigured() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).hasBean(SetupRequiredEmbedding.NAME);
+            assertThat(context.getBean(SetupRequiredEmbedding.NAME))
+                    .isInstanceOf(EmbeddingService.class)
+                    .isInstanceOf(PlaceholderEmbeddingService.class);
+        });
+    }
+
+    /**
+     * Registered under the well-known name, because that is the value an operator puts in
+     * {@code embabel.models.default-embedding-model} and what the model provider matches against.
+     */
+    @Test
+    void embeddingPlaceholderIsTheOnlyEmbeddingServiceContributed() {
+        contextRunner.run(context ->
+                assertThat(context.getBeansOfType(EmbeddingService.class))
+                        .containsOnlyKeys(SetupRequiredEmbedding.NAME));
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
@@ -250,13 +250,13 @@ class SetupRequiredEmbeddingTest {
      * already does. `by` delegation forwards the property to any depth for free.
      */
     @Test
-    fun `awaitingKey survives wrapping, where a type test does not`() {
+    fun `awaitingProviderKey survives wrapping, where a type test does not`() {
         val wrapped: EmbeddingService = Wrapper(Wrapper(SetupRequiredEmbedding.embeddingService()))
 
         assertThat(wrapped is PlaceholderEmbeddingService)
             .describedAs("a type test sees only the outermost layer")
             .isFalse()
-        assertThat(wrapped.awaitingKey)
+        assertThat(wrapped.awaitingProviderKey)
             .describedAs("the question consumers actually ask")
             .isTrue()
     }
@@ -265,7 +265,7 @@ class SetupRequiredEmbeddingTest {
     fun `a wrapped real service is not awaiting a key`() {
         val wrapped: EmbeddingService = Wrapper(FakeEmbeddingService("text-embedding-3-small", dimensions = 1536))
 
-        assertThat(wrapped.awaitingKey).isFalse()
+        assertThat(wrapped.awaitingProviderKey).isFalse()
         assertThat(wrapped.dimensions).isEqualTo(1536)
     }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
@@ -48,6 +48,9 @@ class SetupRequiredEmbeddingTest {
          * an index from a dimension nobody can vouch for.
          */
         assertThat(service).isInstanceOf(PlaceholderEmbeddingService::class.java)
+        // Identifies itself in logs and model listings — an operator reading "why is retrieval
+        // empty" should see which service answered, not a bare class@hashcode.
+        assertThat(service.toString()).contains(SetupRequiredEmbedding.NAME)
     }
 
     /**

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
@@ -197,6 +197,50 @@ class SetupRequiredEmbeddingTest {
             .hasMessageContaining("text-embedding-3-small")
     }
 
+    /**
+     * A role pointed straight at the placeholder. An application that wires roles (memory,
+     * retrieval) has to be able to say "not yet" for them too, not only for the default — and role
+     * resolution takes a different branch of `getEmbeddingService`, which nothing else here covers.
+     */
+    @Test
+    fun `a role naming the placeholder resolves to it`() {
+        val provider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService()),
+            embeddingServices = listOf(SetupRequiredEmbedding.embeddingService()),
+            properties = ConfigurableModelProviderProperties(
+                defaultLlm = SetupRequiredLlm.NAME,
+                defaultEmbeddingModel = SetupRequiredEmbedding.NAME,
+                embeddingServices = mapOf("memory" to SetupRequiredEmbedding.NAME),
+            ),
+        )
+
+        val resolved = provider.getEmbeddingService(ByRoleModelSelectionCriteria("memory"))
+
+        assertThat(resolved).isInstanceOf(PlaceholderEmbeddingService::class.java)
+        assertThatThrownBy { resolved.dimensions }
+            .isInstanceOf(NoEmbeddingServiceConfiguredException::class.java)
+    }
+
+    /**
+     * The placeholder is listed like any other registered model. Worth pinning either way, because
+     * `listModels` feeds operator-facing surfaces: whichever answer is right, it should be a
+     * decision rather than an accident, and a UI showing "setup-required-embedding" as an available
+     * model is the visible consequence.
+     */
+    @Test
+    fun `the placeholder appears in listModels`() {
+        val provider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService()),
+            embeddingServices = listOf(SetupRequiredEmbedding.embeddingService()),
+            properties = ConfigurableModelProviderProperties(
+                defaultLlm = SetupRequiredLlm.NAME,
+                defaultEmbeddingModel = SetupRequiredEmbedding.NAME,
+            ),
+        )
+
+        assertThat(provider.listModels().map { it.name }).contains(SetupRequiredEmbedding.NAME)
+    }
+
     private class FakeEmbeddingService(
         override val name: String,
         override val dimensions: Int,

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.byok
+
+import com.embabel.agent.spi.PlaceholderEmbeddingService
+import com.embabel.common.ai.model.ConfigurableModelProvider
+import com.embabel.common.ai.model.ConfigurableModelProviderProperties
+import com.embabel.common.ai.model.DefaultModelSelectionCriteria
+import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.ai.model.PricingModel
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * The embedding placeholder exists so a BYOK application that uses RAG or memory starts with no
+ * keys, the same as one that only chats. These tests pin the two halves of that: the model provider
+ * resolves, and everything that would need a real model fails with something an operator can act on
+ * — `dimensions` above all.
+ */
+class SetupRequiredEmbeddingTest {
+
+    @Test
+    fun `placeholder is named by the well-known constants and carries the marker`() {
+        val service = SetupRequiredEmbedding.embeddingService()
+
+        assertThat(service.name).isEqualTo(SetupRequiredEmbedding.NAME)
+        assertThat(service.provider).isEqualTo(SetupRequiredEmbedding.PROVIDER)
+        /*
+         * The marker is the whole point: a consumer that provisions a vector index reads it to
+         * decide whether to skip. Losing it would not fail here — it would let that consumer build
+         * an index from a dimension nobody can vouch for.
+         */
+        assertThat(service).isInstanceOf(PlaceholderEmbeddingService::class.java)
+    }
+
+    /**
+     * The rule this file exists to defend. There is no defensible dimension for a placeholder: any
+     * number would become the shape of a vector index, writes to it would succeed, and a real model
+     * configured later would silently disagree with everything already stored. Failing is the only
+     * answer that surfaces as an error rather than as bad results.
+     */
+    @Test
+    fun `dimensions fails rather than answering`() {
+        assertThatThrownBy { SetupRequiredEmbedding.embeddingService().dimensions }
+            .isInstanceOf(NoEmbeddingServiceConfiguredException::class.java)
+    }
+
+    @Test
+    fun `embedding fails with an actionable error`() {
+        val service = SetupRequiredEmbedding.embeddingService()
+
+        assertThatThrownBy { service.embed("anything") }
+            .isInstanceOf(NoEmbeddingServiceConfiguredException::class.java)
+            .hasMessageContaining("No embedding service is configured")
+        assertThatThrownBy { service.embed(listOf("anything")) }
+            .isInstanceOf(NoEmbeddingServiceConfiguredException::class.java)
+    }
+
+    @Test
+    fun `model provider with only the placeholder resolves the default embedding service`() {
+        val modelProvider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService()),
+            embeddingServices = listOf(SetupRequiredEmbedding.embeddingService()),
+            properties = ConfigurableModelProviderProperties(
+                defaultLlm = SetupRequiredLlm.NAME,
+                defaultEmbeddingModel = SetupRequiredEmbedding.NAME,
+            ),
+        )
+
+        assertThat(modelProvider.getEmbeddingService(DefaultModelSelectionCriteria).name)
+            .isEqualTo(SetupRequiredEmbedding.NAME)
+    }
+
+    /**
+     * The case that motivated the issue: a BYOK deployment names an embedding model it has no key
+     * for yet, so nothing registered it. Before the fallback that threw, and the throw happened
+     * while consumer beans were being created — taking the context down before any BYOK code could
+     * run. Now it starts, and fails at the point of use instead.
+     */
+    @Test
+    fun `an unregistered default embedding model falls back to the placeholder`() {
+        val modelProvider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService()),
+            embeddingServices = listOf(SetupRequiredEmbedding.embeddingService()),
+            properties = ConfigurableModelProviderProperties(
+                defaultLlm = SetupRequiredLlm.NAME,
+                defaultEmbeddingModel = "text-embedding-3-small",
+            ),
+        )
+
+        val resolved = modelProvider.getEmbeddingService(DefaultModelSelectionCriteria)
+
+        assertThat(resolved).isInstanceOf(PlaceholderEmbeddingService::class.java)
+        assertThatThrownBy { resolved.dimensions }
+            .isInstanceOf(NoEmbeddingServiceConfiguredException::class.java)
+    }
+
+    /**
+     * A deployment that HAS a key must never be degraded to the placeholder — the fallback is for
+     * the deployment awaiting one, not a way to paper over a model that failed to register.
+     */
+    @Test
+    fun `a registered embedding model is preferred over the placeholder`() {
+        val real = FakeEmbeddingService("text-embedding-3-small", dimensions = 1536)
+        val modelProvider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService()),
+            embeddingServices = listOf(SetupRequiredEmbedding.embeddingService(), real),
+            properties = ConfigurableModelProviderProperties(
+                defaultLlm = SetupRequiredLlm.NAME,
+                defaultEmbeddingModel = "text-embedding-3-small",
+            ),
+        )
+
+        val resolved = modelProvider.getEmbeddingService(DefaultModelSelectionCriteria)
+
+        assertThat(resolved).isNotInstanceOf(PlaceholderEmbeddingService::class.java)
+        assertThat(resolved.dimensions).isEqualTo(1536)
+    }
+
+    /**
+     * With no placeholder registered, an unresolvable name is still a typo and still fatal. The
+     * fallback is opt-in by carrying the placeholder, exactly as on the LLM side.
+     */
+    @Test
+    fun `without a placeholder an unresolvable embedding model still fails`() {
+        val modelProvider = ConfigurableModelProvider(
+            llms = listOf(SetupRequiredLlm.llmService()),
+            embeddingServices = listOf(FakeEmbeddingService("some-other-model", dimensions = 768)),
+            properties = ConfigurableModelProviderProperties(
+                defaultLlm = SetupRequiredLlm.NAME,
+                defaultEmbeddingModel = "text-embedding-3-small",
+            ),
+        )
+
+        assertThatThrownBy { modelProvider.getEmbeddingService(DefaultModelSelectionCriteria) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("text-embedding-3-small")
+    }
+
+    private class FakeEmbeddingService(
+        override val name: String,
+        override val dimensions: Int,
+    ) : EmbeddingService {
+        override val provider: String = "acme"
+        override val pricingModel: PricingModel? = null
+        override fun embed(text: String): FloatArray = FloatArray(dimensions)
+        override fun embed(texts: List<String>): List<FloatArray> = texts.map { embed(it) }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
@@ -16,10 +16,13 @@
 package com.embabel.agent.config.models.byok
 
 import com.embabel.agent.spi.PlaceholderEmbeddingService
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.common.ai.model.ByRoleModelSelectionCriteria
 import com.embabel.common.ai.model.ConfigurableModelProvider
 import com.embabel.common.ai.model.ConfigurableModelProviderProperties
 import com.embabel.common.ai.model.DefaultModelSelectionCriteria
 import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.ai.model.NoSuitableModelException
 import com.embabel.common.ai.model.PricingModel
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -148,6 +151,49 @@ class SetupRequiredEmbeddingTest {
 
         assertThatThrownBy { modelProvider.getEmbeddingService(DefaultModelSelectionCriteria) }
             .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("text-embedding-3-small")
+    }
+
+    /**
+     * The mixed deployment: a server-side chat key, embedding keys arriving at runtime. Before the
+     * embedding gate was split from the LLM one this failed its context refresh on the embedding
+     * ROLE — the placeholder rescued `default-embedding-model` while the role check still treated
+     * the unregistered name as a typo, which is the startup failure #1909 exists to remove.
+     */
+    @Test
+    fun `a real LLM with byok embeddings still starts with an unregistered embedding role`() {
+        val provider = ConfigurableModelProvider(
+            llms = listOf(SpringAiLlmService("real-llm", "acme", SetupRequiredChatModel())),
+            embeddingServices = listOf(SetupRequiredEmbedding.embeddingService()),
+            properties = ConfigurableModelProviderProperties(
+                defaultLlm = "real-llm",
+                defaultEmbeddingModel = SetupRequiredEmbedding.NAME,
+                embeddingServices = mapOf("memory" to "text-embedding-3-small"),
+            ),
+        )
+
+        // Started. Asking for that role still fails, which is the point — deferred, not softened.
+        assertThatThrownBy { provider.getEmbeddingService(ByRoleModelSelectionCriteria("memory")) }
+            .isInstanceOf(NoSuitableModelException::class.java)
+    }
+
+    /**
+     * The complement, so the split gate cannot quietly become permissive: with no embedding
+     * placeholder anywhere, an unresolvable embedding role is still a typo and still fatal.
+     */
+    @Test
+    fun `without an embedding placeholder an unregistered embedding role is still fatal`() {
+        assertThatThrownBy {
+            ConfigurableModelProvider(
+                llms = listOf(SpringAiLlmService("real-llm", "acme", SetupRequiredChatModel())),
+                embeddingServices = listOf(FakeEmbeddingService("text-embedding-3-large", dimensions = 3072)),
+                properties = ConfigurableModelProviderProperties(
+                    defaultLlm = "real-llm",
+                    defaultEmbeddingModel = "text-embedding-3-large",
+                    embeddingServices = mapOf("memory" to "text-embedding-3-small"),
+                ),
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
             .hasMessageContaining("text-embedding-3-small")
     }
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/SetupRequiredEmbeddingTest.kt
@@ -241,6 +241,34 @@ class SetupRequiredEmbeddingTest {
         assertThat(provider.listModels().map { it.name }).contains(SetupRequiredEmbedding.NAME)
     }
 
+    /**
+     * The property, not the marker, is what consumers ask — because this is what happens to a type
+     * test the moment anything decorates the service, which the framework's own event tracking
+     * already does. `by` delegation forwards the property to any depth for free.
+     */
+    @Test
+    fun `awaitingKey survives wrapping, where a type test does not`() {
+        val wrapped: EmbeddingService = Wrapper(Wrapper(SetupRequiredEmbedding.embeddingService()))
+
+        assertThat(wrapped is PlaceholderEmbeddingService)
+            .describedAs("a type test sees only the outermost layer")
+            .isFalse()
+        assertThat(wrapped.awaitingKey)
+            .describedAs("the question consumers actually ask")
+            .isTrue()
+    }
+
+    @Test
+    fun `a wrapped real service is not awaiting a key`() {
+        val wrapped: EmbeddingService = Wrapper(FakeEmbeddingService("text-embedding-3-small", dimensions = 1536))
+
+        assertThat(wrapped.awaitingKey).isFalse()
+        assertThat(wrapped.dimensions).isEqualTo(1536)
+    }
+
+    /** Stands in for any decorator — event tracking, metering, a hot-swappable model holder. */
+    private class Wrapper(delegate: EmbeddingService) : EmbeddingService by delegate
+
     private class FakeEmbeddingService(
         override val name: String,
         override val dimensions: Int,

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/EmbeddingService.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/EmbeddingService.kt
@@ -93,7 +93,7 @@ interface EmbeddingService : EmbeddingServiceMetadata, HasInfoString {
      * A wrapper that implements [EmbeddingService] member by member rather than by delegation must
      * forward this too, or it will report "there is a model" on behalf of one that cannot embed.
      */
-    val awaitingKey: Boolean get() = false
+    val awaitingProviderKey: Boolean get() = false
 
     override fun infoString(verbose: Boolean?, indent: Int): String =
         "name: $name, provider: $provider".indent(indent)

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/EmbeddingService.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/EmbeddingService.kt
@@ -79,6 +79,22 @@ interface EmbeddingService : EmbeddingServiceMetadata, HasInfoString {
      */
     val dimensions: Int
 
+    /**
+     * Whether this service is standing in for a model the deployment does not have a key for yet,
+     * so nothing may be embedded and — above all — no dimension may be read from it.
+     *
+     * False for every real service, which is why it defaults. A placeholder overrides it, and
+     * anything that would commit a vector index asks THIS rather than testing the service's type:
+     * wrapping is common (event tracking decorates the configured service; applications add layers
+     * to hot-swap the model or meter it), a wrapper around a placeholder is not itself a
+     * placeholder, and Kotlin's `by` delegation forwards this property through any depth of
+     * wrapping for free. A type test answers about the outermost layer only.
+     *
+     * A wrapper that implements [EmbeddingService] member by member rather than by delegation must
+     * forward this too, or it will report "there is a model" on behalf of one that cannot embed.
+     */
+    val awaitingKey: Boolean get() = false
+
     override fun infoString(verbose: Boolean?, indent: Int): String =
         "name: $name, provider: $provider".indent(indent)
 }

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/util/EmbabelObjectMapperHolder.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/util/EmbabelObjectMapperHolder.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.embabel.common.util
 
 import tools.jackson.databind.ObjectMapper

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -488,7 +488,7 @@ is merely unreachable right now. Test for the marker and skip:
 
 [source,kotlin]
 ----
-if (embeddingService is PlaceholderEmbeddingService) {
+if (embeddingService.awaitingKey) {
     // No model yet. Skip provisioning — do NOT invent a dimension.
     logger.info("Awaiting an embedding key; vector index not provisioned yet")
 } else {
@@ -496,9 +496,40 @@ if (embeddingService is PlaceholderEmbeddingService) {
 }
 ----
 
-Skipping is recoverable. The check is a type test rather than a call, so it costs nothing to repeat
-— provision on the next boot, or re-check at the point of use if the deployment takes its key from a
-settings screen and never restarts.
+Three things about that check are easy to get wrong, and each costs an afternoon.
+
+**Ask `awaitingKey`, never `is PlaceholderEmbeddingService`.** Wrapping is common — event tracking
+decorates the configured service, and applications add layers for hot-swapping the model, metering,
+or per-tenant routing. A wrapper around a placeholder is not itself a placeholder, so a type test
+answers "there is a model" and the caller commits an index at a dimension it obtained by catching an
+exception. `awaitingKey` is a property of the interface, so Kotlin's `by` delegation forwards it
+through any depth of wrapping at no cost.
+
+CAUTION: A wrapper that implements `EmbeddingService` member by member rather than `by delegate`
+must forward `awaitingKey` explicitly. It defaults to false, so a wrapper that forgets reports
+"there is a model" on behalf of one that cannot embed.
+
+**Re-resolve the reference; do not hold it.** The marker lives on the object, so a held reference
+that *is* the placeholder stays the placeholder for the life of the process — re-checking it can
+never notice the key arriving, and recovery needs a restart. A component that wants to start working
+without one should take a supplier and ask the platform each time:
+
+[source,kotlin]
+----
+class MyProvisioner(private val embeddingService: () -> EmbeddingService) {
+    fun ensure() {
+        val embeddings = embeddingService()          // asks again; the answer changes
+        if (embeddings.isAwaitingKey()) return
+        // ... provision at embeddings.dimensions
+    }
+}
+----
+
+**The marker answers "is there a model yet", not "is it still the same one".** Once a real model is
+registered the placeholder is out of the picture, and a later change to a model of a different width
+is a different problem: the existing index keeps its original dimension, and vectors written under
+the new model disagree with everything already stored. That is drift, and it needs the corpus
+re-embedded — see the note under <<Embedding services>> above.
 
 NOTE: The starter stops at the factories and the placeholder. Key storage and lifecycle remain the
 application's responsibility, as described under <<reference.customizing.byok>> above.

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -460,6 +460,46 @@ try {
 In normal operation the placeholder is never reached: resolve the user's key, build a service with
 one of the factories above, and pass it to `withLlmService()`.
 
+**Point `default-embedding-model` at the embedding placeholder, if the application uses RAG or
+memory.** Anything that resolves the default embedding service while its own beans are being
+created — which is what RAG and memory components do — would otherwise fail the context refresh,
+for the same reason the LLM side did before its placeholder existed:
+
+[source,yaml]
+----
+embabel:
+  models:
+    default-llm: setup-required
+    default-embedding-model: setup-required-embedding
+----
+
+The name is available as `SetupRequiredEmbedding.NAME`. Calls that reach it throw
+`NoEmbeddingServiceConfiguredException`, the embedding counterpart of `NoLlmConfiguredException`.
+
+CAUTION: The embedding placeholder *refuses to report a dimension*. `dimensions` throws like every
+other call rather than returning a number, and this is deliberate. Any value it returned would be
+used to create a vector index; writes to that index would succeed; and a real model configured
+later would silently disagree with everything already stored. That failure surfaces as bad search
+results rather than as an error, which is far worse than not starting.
+
+So code that provisions a vector index must ask *whether there is a model yet* rather than call
+`dimensions` and handle the failure — a thrown exception cannot be told apart from a provider that
+is merely unreachable right now. Test for the marker and skip:
+
+[source,kotlin]
+----
+if (embeddingService is PlaceholderEmbeddingService) {
+    // No model yet. Skip provisioning — do NOT invent a dimension.
+    logger.info("Awaiting an embedding key; vector index not provisioned yet")
+} else {
+    provisioner.ensure(VectorIndexSpec(label, "embedding", embeddingService.dimensions))
+}
+----
+
+Skipping is recoverable. The check is a type test rather than a call, so it costs nothing to repeat
+— provision on the next boot, or re-check at the point of use if the deployment takes its key from a
+settings screen and never restarts.
+
 NOTE: The starter stops at the factories and the placeholder. Key storage and lifecycle remain the
 application's responsibility, as described under <<reference.customizing.byok>> above.
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -488,7 +488,7 @@ is merely unreachable right now. Test for the marker and skip:
 
 [source,kotlin]
 ----
-if (embeddingService.awaitingKey) {
+if (embeddingService.awaitingProviderKey) {
     // No model yet. Skip provisioning — do NOT invent a dimension.
     logger.info("Awaiting an embedding key; vector index not provisioned yet")
 } else {
@@ -498,15 +498,15 @@ if (embeddingService.awaitingKey) {
 
 Three things about that check are easy to get wrong, and each costs an afternoon.
 
-**Ask `awaitingKey`, never `is PlaceholderEmbeddingService`.** Wrapping is common — event tracking
+**Ask `awaitingProviderKey`, never `is PlaceholderEmbeddingService`.** Wrapping is common — event tracking
 decorates the configured service, and applications add layers for hot-swapping the model, metering,
 or per-tenant routing. A wrapper around a placeholder is not itself a placeholder, so a type test
 answers "there is a model" and the caller commits an index at a dimension it obtained by catching an
-exception. `awaitingKey` is a property of the interface, so Kotlin's `by` delegation forwards it
+exception. `awaitingProviderKey` is a property of the interface, so Kotlin's `by` delegation forwards it
 through any depth of wrapping at no cost.
 
 CAUTION: A wrapper that implements `EmbeddingService` member by member rather than `by delegate`
-must forward `awaitingKey` explicitly. It defaults to false, so a wrapper that forgets reports
+must forward `awaitingProviderKey` explicitly. It defaults to false, so a wrapper that forgets reports
 "there is a model" on behalf of one that cannot embed.
 
 **Re-resolve the reference; do not hold it.** The marker lives on the object, so a held reference

--- a/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
+++ b/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
@@ -212,7 +212,9 @@ class ByokStarterBootTest {
                 if (embeddingService instanceof PlaceholderEmbeddingService) {
                     skippedBecausePlaceholder = true;
                 } else {
-                    var ignored = embeddingService.getDimensions();
+                    // Reading the dimension is the point: it is what a provisioner would do, and
+                    // what must never happen while the service is a placeholder.
+                    embeddingService.getDimensions();
                     provisioned = true;
                 }
             }

--- a/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
+++ b/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
@@ -16,8 +16,11 @@
 package com.embabel.agent.starter.byok;
 
 import com.embabel.agent.autoconfigure.models.byok.AgentByokAutoConfiguration;
+import com.embabel.agent.config.models.byok.NoEmbeddingServiceConfiguredException;
+import com.embabel.agent.config.models.byok.SetupRequiredEmbedding;
 import com.embabel.agent.config.models.byok.SetupRequiredLlm;
 import com.embabel.agent.spi.LlmService;
+import com.embabel.agent.spi.PlaceholderEmbeddingService;
 import com.embabel.common.ai.model.ConfigurableModelProvider;
 import com.embabel.common.ai.model.ConfigurableModelProviderProperties;
 import com.embabel.common.ai.model.DefaultModelSelectionCriteria;
@@ -36,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * The starter's reason to exist: an application that depends only on it can start with no
@@ -48,7 +52,9 @@ class ByokStarterBootTest {
 
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(AgentByokAutoConfiguration.class))
-            .withPropertyValues("embabel.models.default-llm=" + SetupRequiredLlm.NAME);
+            .withPropertyValues(
+                    "embabel.models.default-llm=" + SetupRequiredLlm.NAME,
+                    "embabel.models.default-embedding-model=" + SetupRequiredEmbedding.NAME);
 
     /**
      * {@link AgentByokAutoConfiguration} orders itself before the platform autoconfiguration by
@@ -88,6 +94,136 @@ class ByokStarterBootTest {
                 });
     }
 
+
+    @Test
+    void theModelProviderResolvesTheDefaultEmbeddingServiceWithoutAnyKey() {
+        contextRunner
+                .withUserConfiguration(TestableModelProviderConfiguration.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    var embeddingService = context.getBean(ModelProvider.class)
+                            .getEmbeddingService(DefaultModelSelectionCriteria.INSTANCE);
+                    assertThat(embeddingService.getName()).isEqualTo(SetupRequiredEmbedding.NAME);
+                    assertThat(embeddingService).isInstanceOf(PlaceholderEmbeddingService.class);
+                });
+    }
+
+    /**
+     * The failure this whole mechanism exists to remove, reproduced through the starter's own
+     * dependency set: a consumer that resolves the default embedding service while ITS OWN bean is
+     * being created. That is what RAG and memory components do, and before the placeholder the
+     * resolution threw during context refresh — killing the application before any BYOK code could
+     * run and before a user could type a key anywhere.
+     */
+    @Test
+    void aConsumerResolvingEmbeddingsDuringBeanCreationNoLongerKillsTheContext() {
+        contextRunner
+                .withUserConfiguration(TestableModelProviderConfiguration.class, EagerEmbeddingConsumer.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBean(EagerEmbeddingConsumer.Consumer.class).resolved)
+                            .isInstanceOf(PlaceholderEmbeddingService.class);
+                });
+    }
+
+    /**
+     * And the half that must NOT be softened. Having something to resolve is not having a model:
+     * the placeholder refuses to report a dimension, so a consumer that provisions a vector index
+     * cannot build one at a guessed shape. It is expected to check the marker and skip — this pins
+     * what happens to one that does not.
+     */
+    @Test
+    void theResolvedPlaceholderStillRefusesToReportADimension() {
+        contextRunner
+                .withUserConfiguration(TestableModelProviderConfiguration.class)
+                .run(context -> {
+                    var embeddingService = context.getBean(ModelProvider.class)
+                            .getEmbeddingService(DefaultModelSelectionCriteria.INSTANCE);
+                    assertThatThrownBy(embeddingService::getDimensions)
+                            .isInstanceOf(NoEmbeddingServiceConfiguredException.class);
+                });
+    }
+
+    /**
+     * A consumer that reads the marker before provisioning: it skips, and the application starts
+     * with its index simply not created yet. This is the contract the marker exists for, so it is
+     * worth pinning as the worked example rather than leaving it to prose.
+     */
+    @Test
+    void aConsumerThatChecksTheMarkerSkipsProvisioningInsteadOfGuessing() {
+        contextRunner
+                .withUserConfiguration(TestableModelProviderConfiguration.class, IndexProvisioningConsumer.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    var consumer = context.getBean(IndexProvisioningConsumer.Consumer.class);
+                    assertThat(consumer.provisioned)
+                            .describedAs("provisioned an index with no embedding model")
+                            .isFalse();
+                    assertThat(consumer.skippedBecausePlaceholder).isTrue();
+                });
+    }
+
+    /**
+     * The realistic BYOK configuration, and the one the tests above do NOT exercise: the operator
+     * has already named the embedding model they intend to use, and simply has no key for it yet,
+     * so nothing registered it. Naming the placeholder directly (as the other tests do) resolves it
+     * by name and never reaches the fallback — this is the case that does.
+     */
+    @Test
+    void startsWhenTheConfiguredEmbeddingModelIsNamedButNotYetRegistered() {
+        contextRunner
+                .withPropertyValues("embabel.models.default-embedding-model=text-embedding-3-small")
+                .withUserConfiguration(TestableModelProviderConfiguration.class, EagerEmbeddingConsumer.class)
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBean(EagerEmbeddingConsumer.Consumer.class).resolved)
+                            .describedAs("fell back to the placeholder rather than failing to start")
+                            .isInstanceOf(PlaceholderEmbeddingService.class);
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class EagerEmbeddingConsumer {
+
+        static class Consumer {
+            final EmbeddingService resolved;
+
+            Consumer(ModelProvider modelProvider) {
+                // The whole point: resolution happens HERE, during bean creation.
+                this.resolved = modelProvider.getEmbeddingService(DefaultModelSelectionCriteria.INSTANCE);
+            }
+        }
+
+        @Bean
+        Consumer eagerEmbeddingConsumer(ModelProvider modelProvider) {
+            return new Consumer(modelProvider);
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class IndexProvisioningConsumer {
+
+        static class Consumer {
+            boolean provisioned;
+            boolean skippedBecausePlaceholder;
+
+            Consumer(ModelProvider modelProvider) {
+                var embeddingService = modelProvider.getEmbeddingService(DefaultModelSelectionCriteria.INSTANCE);
+                if (embeddingService instanceof PlaceholderEmbeddingService) {
+                    skippedBecausePlaceholder = true;
+                } else {
+                    var ignored = embeddingService.getDimensions();
+                    provisioned = true;
+                }
+            }
+        }
+
+        @Bean
+        Consumer indexProvisioningConsumer(ModelProvider modelProvider) {
+            return new Consumer(modelProvider);
+        }
+    }
+
     /**
      * Builds the model provider the same way the platform autoconfiguration does — from the
      * {@code LlmService} beans present in the context — so the assertion above exercises the real
@@ -98,16 +234,20 @@ class ByokStarterBootTest {
 
         @Bean
         ModelProvider modelProvider(ApplicationContext applicationContext,
-                                    @Value("${embabel.models.default-llm}") String defaultLlm) {
+                                    @Value("${embabel.models.default-llm}") String defaultLlm,
+                                    @Value("${embabel.models.default-embedding-model}") String defaultEmbeddingModel) {
             var properties = new ConfigurableModelProviderProperties();
             properties.setDefaultLlm(defaultLlm);
+            properties.setDefaultEmbeddingModel(defaultEmbeddingModel);
             // LlmService is F-bounded (LlmService<THIS : LlmService<THIS>>), so a wildcard capture
             // from a stream will not fit the constructor. Collect through the raw type instead.
             List<LlmService<?>> llms = new ArrayList<>();
             for (LlmService<?> llm : applicationContext.getBeansOfType(LlmService.class).values()) {
                 llms.add(llm);
             }
-            return new ConfigurableModelProvider(llms, List.<EmbeddingService>of(), properties);
+            List<EmbeddingService> embeddingServices =
+                    new ArrayList<>(applicationContext.getBeansOfType(EmbeddingService.class).values());
+            return new ConfigurableModelProvider(llms, embeddingServices, properties);
         }
     }
 }


### PR DESCRIPTION
Closes #1909.

## What

`PlaceholderEmbeddingService` in `com.embabel.agent.spi`, next to `PlaceholderLlmService` so `ConfigurableModelProvider` can recognise a placeholder without depending on the BYOK module. `SetupRequiredEmbedding` implements it in `embabel-agent-byok-autoconfigure`, registered by `SetupRequiredEmbeddingConfig` and imported by `AgentByokAutoConfiguration`. `defaultEmbeddingService()` falls back to it exactly as `defaultLlm` already does.

```yaml
embabel:
  models:
    default-llm: setup-required
    default-embedding-model: setup-required-embedding
```

## The dimension

The placeholder refuses to report one, and that is the design rather than an omission — the issue makes the case better than I can restate it. Any number would become the shape of a vector index, writes would succeed, and a real model configured later would silently disagree with everything already stored. That failure surfaces as bad search results, not as an error, which is the worst kind.

So `dimensions` throws like every other member. That is what makes the marker load-bearing: a consumer provisioning a vector index tests for `PlaceholderEmbeddingService` and skips, rather than calling `dimensions` and handling the exception. Catching means deciding from a failure, and a failure can't be told apart from a provider that is merely unreachable right now. Skipping is recoverable — the check is a type test, so it costs nothing to repeat once a real model registers.

## What the fallback does not change

- A deployment holding a key resolves its real model and is never degraded to the placeholder, even with the placeholder registered alongside — which is what the BYOK starter next to a provider starter looks like.
- A deployment carrying no placeholder still fails fast on a `default-embedding-model` that resolves to nothing, because there it is a typo.
- Role-based resolution is untouched. `embeddingServices[role]` still throws `NoSuitableModelException` for an unregistered role — the existing gate in `init` already decides whether that is fatal or expected, and this doesn't widen it.

## Tests

`SetupRequiredEmbeddingTest`, 7 cases: the marker is carried; `dimensions` fails rather than answering; both `embed` overloads fail actionably; a provider holding only the placeholder resolves it; an unregistered default falls back to it; a registered model is preferred over it; and without a placeholder an unresolvable name still throws.

Green alongside the existing suites — `ConfigurableModelProviderTest` (including `SetupRequiredMode` and `Embeddings`), `ConfigurableModelProviderIntegrationTest`, `SetupRequiredLlmTest`, `PureByokWithRolesTest`, `AgentByokAutoConfigurationTest`: 32 in `embabel-agent-api`, 26 in the BYOK module, 0 failures.

## Follow-on, not in this PR

Two things came out of using this from a consumer that provisions an entity vector index (`embabel-agent-rag-graph`), worth recording:

1. **The issue's recovery model is "the index is created on the next boot".** A deployment that takes its key from a config screen never reboots, so a consumer may want to re-check at runtime. The marker supports that already — it's a type test, not a call — but it's worth saying so, since "next boot" reads as the only path.
2. **A *changed* model is the sibling case this doesn't cover.** The marker answers "is there a model yet"; it doesn't help when a real model is later swapped for one with a different dimension. Today that surfaces as index drift, which consumers typically log and leave in place, so the wrong-dimension index survives. A schema version keyed to the embedding model's identity is the fix on the consumer side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
