### PR TITLE
Fix broken IT tests due to GPT model deprecation

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt53ChatIntegrationIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/Gpt53ChatIntegrationIT.kt
@@ -50,7 +50,7 @@ class Gpt53ChatTestConfig
 
 @SpringBootTest(
     properties = [
-        "embabel.models.default-llm=gpt-5.3-chat-latest",
+        "embabel.models.default-llm=gpt-5.6-terra",
         "embabel.agent.platform.models.openai.max-attempts=1",
         "spring.main.allow-bean-definition-overriding=true",
     ]
@@ -82,16 +82,16 @@ class Gpt53ChatIntegrationIT(
         val llm = findLlm()
 
         // Verify against OpenAI API
-        val response = sayReady(ai, OpenAiModels.GPT_53_CHAT_LATEST)
+        val response = sayReady(ai, OpenAiModels.GPT_56_TERRA)
 
         assertTrue(response.isNotBlank(), "Expected non-empty response from GPT-5.3 Chat")
         assertTrue(response.contains("READY", ignoreCase = true), "Expected GPT-5.3 Chat to reply with READY, got: $response")
-        assertEquals(OpenAiModels.GPT_53_CHAT_LATEST, llm?.name)
+        assertEquals(OpenAiModels.GPT_56_TERRA, llm?.name)
     }
 
     private fun findLlm(): LlmService<*>? {
 
-        return llms.find { it.name == OpenAiModels.GPT_53_CHAT_LATEST }
+        return llms.find { it.name == OpenAiModels.GPT_56_TERRA }
     }
 
     override fun toString(): String {

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiCatalogIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiCatalogIT.kt
@@ -76,6 +76,7 @@ class BadgeCodeTool {
         // One attempt: a rejected payload is not a transient failure, and retrying it only buries
         // the provider's message under a "Failed after 3 attempt(s)".
         "embabel.agent.platform.models.openai.max-attempts=1",
+        "embabel.agent.platform.llm-operations.data-binding.max-attempts=1",
         "spring.main.allow-bean-definition-overriding=true",
     ]
 )
@@ -92,12 +93,21 @@ class OpenAiCatalogIT(
 
     companion object {
 
+        // Models deprecated by OpenAI and no longer callable — kept in the catalog so users who
+        // reference them by name receive the provider's own deprecation error rather than a silent
+        // "model not found" from Embabel's configuration layer.
+        private val DEPRECATED_MODELS = setOf(
+            "gpt-5.3-chat-latest",
+        )
+
         /**
          * Every chat model the catalog ships, so coverage tracks the YAML instead of a copy of it.
          */
         @JvmStatic
         fun catalogModels(): List<String> =
-            OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels().map { it.modelId }
+            OpenAiModelLoader().loadAutoConfigMetadata().effectiveModels()
+                .map { it.modelId }
+                .filter { it !in DEPRECATED_MODELS }
     }
 
     /**


### PR DESCRIPTION
# OVERVIEW

Model
"gpt-5.3-chat-latest"
Got deprecated.

Replaced by the model recommended by GPT:

"gpt-5.6-terra"