### PR TITLE
Let a text-search implementation say how it reads a query

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
@@ -115,15 +115,77 @@ interface FilteringVectorSearch : VectorSearch {
 }
 
 /**
- * Full-text search using Lucene query syntax
+ * How an implementation interprets the `query` string handed to [TextSearch.textSearch].
+ *
+ * The two are mutually exclusive by design: a surface that escapes *some* of its input is
+ * predictable to nobody, human or model. An implementation declares what it can serve via
+ * [TextSearch.supportedQueryModes], and which it is serving via [TextSearch.queryMode].
+ */
+enum class TextQueryMode {
+
+    /**
+     * The query is **literal text**. The implementation escapes it, so no character can be mistaken
+     * for an operator and no input can fail to parse — a pasted URL, file path or code fragment is
+     * searched for rather than interpreted.
+     *
+     * The caller cannot express required terms, exclusions or phrases, so any precision beyond
+     * ranking has to come from the implementation. What that means varies: an engine-backed store
+     * may escape the text and then ENHANCE it — requiring identifier-shaped tokens on the caller's
+     * behalf — while a substring-matching store simply matches. Both are honest [LITERAL]; the mode
+     * describes how the caller's text is read, not how hard the implementation works afterwards.
+     *
+     * Prefer this for callers that cannot reliably compose an expression, notably small models, for
+     * which a malformed expression is a likelier outcome than a useful one.
+     */
+    LITERAL,
+
+    /**
+     * The query is a **Lucene expression** the caller composes, passed through unaltered. The caller
+     * owns precision, and owns escaping: an unbalanced `/` or a bare `:` is a parse failure, not a
+     * search for those characters.
+     */
+    EXPRESSION,
+}
+
+/**
+ * Full-text search.
+ *
+ * How the `query` string is interpreted depends on [queryMode] — see [TextQueryMode]. Every
+ * implementation historically behaved as [TextQueryMode.EXPRESSION], which remains the default.
  */
 interface TextSearch : TypeRetrievalOperations {
 
     /**
-     * Performs full-text search using Lucene query syntax.
+     * The query modes this implementation can serve. Never empty.
+     *
+     * A capability, not a preference. An implementation backed by substring matching cannot honour
+     * an expression however it is configured, and one backed by an engine whose syntax differs from
+     * Lucene's should not claim [TextQueryMode.EXPRESSION] merely because it has a parser.
+     * Deployments choose among these; they cannot choose outside them.
+     */
+    val supportedQueryModes: Set<TextQueryMode>
+        get() = setOf(TextQueryMode.EXPRESSION)
+
+    /**
+     * The mode currently in effect. Must be a member of [supportedQueryModes].
+     *
+     * [luceneSyntaxNotes] must describe THIS mode. It reaches the model verbatim in the search
+     * tool's description, so a store advertising expression syntax while escaping its input teaches
+     * the model to write queries that cannot work.
+     */
+    val queryMode: TextQueryMode
+        get() = supportedQueryModes.first()
+
+    /**
+     * Performs full-text search.
+     *
+     * The syntax below applies when [queryMode] is [TextQueryMode.EXPRESSION]. Under
+     * [TextQueryMode.LITERAL] the query is escaped and matched as text, so none of these operators
+     * has any effect.
      *
      * Not all implementations will support all capabilities (such as fuzzy matching).
-     * However, the use of quotes for phrases and + / - for required / excluded terms should be widely supported.
+     * However, the use of quotes for phrases and + / - for required / excluded terms should be
+     * widely supported among implementations that declare [TextQueryMode.EXPRESSION].
      *
      * The "query" field of request supports the following syntax:
      *

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/InMemoryNamedEntityDataRepository.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/support/InMemoryNamedEntityDataRepository.kt
@@ -24,6 +24,7 @@ import com.embabel.agent.rag.model.RelationshipDirection
 import com.embabel.agent.rag.service.NamedEntityDataRepository
 import com.embabel.agent.rag.service.NativeFinder
 import com.embabel.agent.rag.service.RelationshipData
+import com.embabel.agent.rag.service.TextQueryMode
 import com.embabel.agent.rag.service.RetrievableIdentifier
 import com.embabel.common.ai.model.EmbeddingService
 import com.embabel.common.core.types.SimilarityResult
@@ -117,6 +118,11 @@ open class InMemoryNamedEntityDataRepository @JvmOverloads constructor(
             .let { InMemoryPropertyFilter.filterResults(it, metadataFilter, entityFilter) }
             .take(request.topK)
     }
+
+    // Substring matching has no query parser, so an expression cannot be honoured however this is
+    // configured — the capability is absent, not merely switched off. Literal text is matched as
+    // given; unlike an engine-backed store there is nothing to enhance it with.
+    override val supportedQueryModes: Set<TextQueryMode> = setOf(TextQueryMode.LITERAL)
 
     override val luceneSyntaxNotes: String = "Basic substring matching only"
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/service/TextQueryModeTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/service/TextQueryModeTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.service
+
+import com.embabel.agent.rag.model.Retrievable
+import com.embabel.common.core.types.SimilarityResult
+import com.embabel.common.core.types.TextSimilaritySearchRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * The contract around [TextQueryMode]: what an implementation gets for free, and the one invariant
+ * that cannot be left to convention.
+ */
+class TextQueryModeTest {
+
+    private open class Stub(
+        override val supportedQueryModes: Set<TextQueryMode> = setOf(TextQueryMode.EXPRESSION),
+    ) : TextSearch {
+        override fun supportsType(type: String) = true
+        override fun <T : Retrievable> textSearch(
+            request: TextSimilaritySearchRequest,
+            clazz: Class<T>,
+        ): List<SimilarityResult<T>> = emptyList()
+    }
+
+    @Test
+    @DisplayName("an implementation that declares nothing behaves as it always has")
+    fun `default is EXPRESSION`() {
+        // Every implementation predating the mode passed the caller's query through untouched.
+        // Defaulting anywhere else would silently change what those stores do with an operator.
+        val store = object : Stub() {}
+        assertEquals(setOf(TextQueryMode.EXPRESSION), store.supportedQueryModes)
+        assertEquals(TextQueryMode.EXPRESSION, store.queryMode)
+    }
+
+    @Test
+    @DisplayName("declaring one supported mode selects it without restating it")
+    fun `single supported mode becomes the active mode`() {
+        val store = object : Stub(setOf(TextQueryMode.LITERAL)) {}
+        assertEquals(TextQueryMode.LITERAL, store.queryMode)
+    }
+
+    @Test
+    @DisplayName("the active mode must be one the implementation can actually serve")
+    fun `queryMode is a member of supportedQueryModes`() {
+        // The invariant worth pinning. A store configured into a mode it cannot serve does not fail
+        // loudly — it quietly stops honouring operators, or starts escaping input the caller
+        // composed, and the tool description tells the model the opposite of what happens.
+        val stores = listOf(
+            object : Stub() {},
+            object : Stub(setOf(TextQueryMode.LITERAL)) {},
+            object : Stub(setOf(TextQueryMode.LITERAL, TextQueryMode.EXPRESSION)) {},
+        )
+        stores.forEach { store ->
+            assertTrue(
+                store.queryMode in store.supportedQueryModes,
+                "active mode ${store.queryMode} not in supported ${store.supportedQueryModes}",
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("supporting both leaves the choice to the deployment")
+    fun `an implementation may serve both modes`() {
+        val store = object : Stub(setOf(TextQueryMode.LITERAL, TextQueryMode.EXPRESSION)) {
+            override val queryMode = TextQueryMode.LITERAL
+        }
+        assertEquals(TextQueryMode.LITERAL, store.queryMode)
+        assertTrue(TextQueryMode.EXPRESSION in store.supportedQueryModes, "still available to configure")
+    }
+}


### PR DESCRIPTION
`TextSearch` documents a Lucene syntax table and states that `+` / `-` and quotes *"should be widely supported"*. That is a promise the interface cannot keep — and there is a second, useful way to serve text search that it has no way to express.

## Two problems

**The syntax promise isn't universal.** Substring-backed implementations have no parser at all; `InMemoryNamedEntityDataRepository` already admits this in prose, through `luceneSyntaxNotes = "Basic substring matching only"`. An engine whose query syntax differs from Lucene's can't honour the table either. Today that's discoverable only by reading a free-text string meant for an LLM.

**There is an unnamed second surface.** Take the caller's words as literal text, escape them, and let the implementation supply precision. Nothing can fail to parse — a pasted URL, file path or code fragment is searched for rather than interpreted. That matters for callers that compose queries unreliably: a small model is likelier to emit a malformed expression than a useful one.

## What this adds

`TextQueryMode` names both surfaces. `supportedQueryModes` declares which an implementation can serve — a **capability, not a preference**, so a deployment chooses among them and cannot choose outside them. `queryMode` is the one in effect, defaulting to the only supported mode.

Both default to `EXPRESSION`, so every existing implementation keeps exactly its current behaviour. The only declaration in this PR is `InMemoryNamedEntityDataRepository`, which declares `LITERAL` only — matching what its own notes have always said.

## Two things the KDoc is explicit about

**The modes are exclusive by design.** Escaping *part* of the input is predictable to nobody, human or model: the same `+` would be an operator in one query and a literal in the next.

**The mode describes how the caller's text is read, not how hard the implementation works afterwards.** Under `LITERAL` an engine-backed store may escape and then *enhance* — requiring identifier-shaped tokens on the caller's behalf — while a substring store simply matches. Both are honest `LITERAL`.

And `luceneSyntaxNotes` must now describe the **active** mode. It reaches the model verbatim in `TextSearchTools`' description, so a store advertising expression syntax while escaping its input teaches the model to write queries that cannot work.

## Why now

Measured on an 851-document corpus, `error code ER20328_23 in the payment service` matched **all 851** documents and scored *above* a genuine exact match elsewhere in the same corpus — BM25 sums per-term contributions, so a question wrapped around an identifier matches everything sharing an ordinary word. Precision has to come from the result set, by requiring the identifier.

Which raises the question this enum answers: who requires it? A capable caller can, given the right tool description — measured at **3/3 on gpt-4.1-mini** with instructions to prefix identifiers, against **0/3** with the syntax notes that ship today. A caller that can't needs the store to do it, on literal input. Both are legitimate; they need different contracts, and an implementation should be able to say which it offers.

The graph store implementation of both modes follows in `embabel-agent-rag-graph`.

## Tests

`TextQueryModeTest` — 4 tests covering the default, single-mode selection, dual support, and the one invariant that can't be left to convention: the active mode must be one the implementation actually serves. A store configured into a mode it can't serve doesn't fail loudly; it quietly stops honouring operators, or starts escaping input the caller composed.

Full `embabel-agent-rag-core` suite: **678 passing, 0 failures.**
