### PR TITLE
Add an opt-in knob to fetch neighbouring chunks around every search hit

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -38,6 +38,45 @@ import java.time.Instant
 /**
  * Classic vector search
  */
+/**
+ * Neighbouring chunks around each hit, folded into the result set.
+ *
+ * Reuses the same [ResultExpander] seam `broadenChunk` exposes to the model, so a store that
+ * cannot expand simply never expands — no capability check to keep in step.
+ *
+ * A neighbour INHERITS its hit's score rather than being scored itself. It is continuation
+ * text, not a rival candidate: scoring it independently would let context outrank the match
+ * that found it, and reordering results is not what expansion is for.
+ *
+ * Deduplicated by id and appended after the hits, so an expanded set is a superset of the
+ * unexpanded one in the same order. That matters for anything reading these results
+ * positionally, and it means turning the knob on cannot lose a result.
+ */
+internal fun List<SimilarityResult<out Retrievable>>.withNeighbours(
+    expander: ResultExpander?,
+    each: Int,
+): List<SimilarityResult<out Retrievable>> {
+    if (expander == null || each <= 0 || isEmpty()) return this
+    val seen = mapTo(mutableSetOf()) { it.match.id }
+    val extra = flatMap { hit ->
+        runCatching { expander.expandResult(hit.match.id, ResultExpander.Method.SEQUENCE, each) }
+            .getOrElse { e ->
+                LoggerFactory.getLogger("com.embabel.agent.rag.tools.expand")
+                    .warn("Could not expand {}: {}", hit.match.id, e.message)
+                emptyList<com.embabel.agent.rag.model.ContentElement>()
+            }
+            .filterIsInstance<Chunk>()
+            .filter { neighbour -> seen.add(neighbour.id) }
+            .map { neighbour ->
+                object : SimilarityResult<Chunk> {
+                    override val match: Chunk = neighbour
+                    override val score: Double = hit.score
+                }
+            }
+    }
+    return this + extra
+}
+
 internal class VectorSearchTools @JvmOverloads constructor(
     private val vectorSearch: VectorSearch,
     private val searchFor: List<Class<out Retrievable>> = listOf(Chunk::class.java),
@@ -45,6 +84,7 @@ internal class VectorSearchTools @JvmOverloads constructor(
     private val entityFilter: EntityFilter? = null,
     private val resultsListener: ResultsListener? = null,
     private val searchDefaults: SearchDefaults = SearchDefaults.DEFAULT,
+    private val resultExpander: ResultExpander? = null,
 ) : SearchTools {
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
@@ -66,9 +106,12 @@ internal class VectorSearchTools @JvmOverloads constructor(
             query, topK, threshold, searchFor.map { it.simpleName }, metadataFilter, entityFilter
         )
         val request = TextSimilaritySearchRequest(query, threshold, topK)
-        val (results, ms) = time {
+        val (hits, ms) = time {
             searchForAllTypes(request)
         }
+        // Expanded BEFORE the listener fires: an observer must see what the model sees, or
+        // reported provenance and the answer's actual evidence drift apart.
+        val results = hits.withNeighbours(resultExpander, searchDefaults.expandNeighbours)
         resultsListener?.onResultsEvent(ResultsEvent(this, query, results, Duration.ofMillis(ms)))
         return SimpleRetrievableResultsFormatter.formatResults(SimilarityResults.fromList<Retrievable>(results))
     }
@@ -184,6 +227,7 @@ internal class TextSearchTools @JvmOverloads constructor(
     private val entityFilter: EntityFilter? = null,
     private val resultsListener: ResultsListener? = null,
     private val searchDefaults: SearchDefaults = SearchDefaults.DEFAULT,
+    private val resultExpander: ResultExpander? = null,
 ) : SearchTools, Tool {
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
@@ -248,10 +292,13 @@ internal class TextSearchTools @JvmOverloads constructor(
         )
 
         val request = TextSimilaritySearchRequest(query, threshold, topK)
-        val (results, ms) = time {
+        val (hits, ms) = time {
             searchForAllTypes(request)
         }
-        Bm25Normalization.warnIfThresholdSuppressedResults(logger, query, threshold, results.size)
+        // Warn on the HITS, not the expanded set: the threshold suppressed matches, and
+        // neighbours added afterwards would mask exactly the emptiness worth warning about.
+        Bm25Normalization.warnIfThresholdSuppressedResults(logger, query, threshold, hits.size)
+        val results = hits.withNeighbours(resultExpander, searchDefaults.expandNeighbours)
         resultsListener?.onResultsEvent(ResultsEvent(this, query, results, Duration.ofMillis(ms)))
         return SimpleRetrievableResultsFormatter.formatResults(SimilarityResults.fromList<Retrievable>(results))
     }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/SearchDefaults.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/SearchDefaults.kt
@@ -38,6 +38,7 @@ import com.embabel.common.core.types.ZeroToOne
 data class SearchDefaults @JvmOverloads constructor(
     val vectorSimilarityThreshold: ZeroToOne = DEFAULT_VECTOR_SIMILARITY_THRESHOLD,
     val textSimilarityThreshold: ZeroToOne = DEFAULT_TEXT_SIMILARITY_THRESHOLD,
+    val expandNeighbours: Int = DEFAULT_EXPAND_NEIGHBOURS,
 ) {
 
     init {
@@ -47,6 +48,9 @@ data class SearchDefaults @JvmOverloads constructor(
         require(textSimilarityThreshold in 0.0..1.0) {
             "textSimilarityThreshold must be in 0.0..1.0, was $textSimilarityThreshold"
         }
+        require(expandNeighbours >= 0) {
+            "expandNeighbours must be >= 0, was $expandNeighbours"
+        }
     }
 
     companion object {
@@ -54,6 +58,28 @@ data class SearchDefaults @JvmOverloads constructor(
         const val DEFAULT_VECTOR_SIMILARITY_THRESHOLD: ZeroToOne = 0.25
 
         const val DEFAULT_TEXT_SIMILARITY_THRESHOLD: ZeroToOne = 0.0
+
+        /**
+         * Neighbouring chunks fetched around every search hit, automatically.
+         *
+         * ZERO by default: today's behaviour, where context is only ever widened if the model
+         * thinks to call `broadenChunk` itself. That is a lot to expect — measured on a
+         * 69-page statute, recovering a severed provision needed `chunksToAdd` of about 12
+         * against a tool default of 2, and the model has no way to know that.
+         *
+         * The failure this addresses is structural rather than a ranking problem: a chunker
+         * splitting an oversized leaf can separate a provision from the sentence that governs
+         * it, so the retrieved chunk carries "(i) investments ..." and not what the list is
+         * FOR. Widening chunks at INGESTION was measured and is worse (30.67 against a 33
+         * baseline) because it dilutes every embedding and makes siblings alike. Expanding
+         * AFTER the match leaves embeddings untouched and pays only for what actually hit.
+         *
+         * Not free, and off by default for that reason: every hit costs a store round trip
+         * and enlarges what the model reads, and irrelevant passages actively degrade
+         * generation. Raise it where the corpus is continuous prose whose meaning runs across
+         * chunk boundaries; leave it at 0 for corpora of self-contained records.
+         */
+        const val DEFAULT_EXPAND_NEIGHBOURS: Int = 0
 
         @JvmField
         val DEFAULT: SearchDefaults = SearchDefaults()

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -155,6 +155,7 @@ data class ToolishRag @JvmOverloads constructor(
                 add(
                     VectorSearchTools(
                         searchOperations, vectorSearchFor, metadataFilter, entityFilter, listener, searchDefaults,
+                        searchOperations as? ResultExpander,
                     )
                 )
             } else {
@@ -171,6 +172,7 @@ data class ToolishRag @JvmOverloads constructor(
                 add(
                     TextSearchTools(
                         searchOperations, textSearchFor, metadataFilter, entityFilter, listener, searchDefaults,
+                        searchOperations as? ResultExpander,
                     )
                 )
             }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/AutoExpandNeighboursTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/AutoExpandNeighboursTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.tools
+
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.ContentElement
+import com.embabel.agent.rag.service.ResultExpander
+import com.embabel.common.core.types.SimilarityResult
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * The contract of [SearchDefaults.expandNeighbours]: OFF unless asked for, and additive when on.
+ */
+class AutoExpandNeighboursTest {
+
+    private fun chunk(id: String) = Chunk(id = id, text = "text of $id", parentId = "leaf-1", metadata = emptyMap())
+
+    private fun hit(id: String, score: Double) = object : SimilarityResult<Chunk> {
+        override val match: Chunk = chunk(id)
+        override val score: Double = score
+    }
+
+    /** Returns two neighbours per request, plus one that duplicates an existing hit. */
+    private val expander = object : ResultExpander {
+        override fun expandResult(id: String, method: ResultExpander.Method, count: Int): List<ContentElement> =
+            listOf(chunk("$id-before"), chunk("$id-after"), chunk("hit-2"))
+    }
+
+    @Test
+    fun `expansion is off by default, so existing behaviour is unchanged`() {
+        val hits = listOf(hit("hit-1", 0.9))
+        assertEquals(hits, hits.withNeighbours(expander, SearchDefaults.DEFAULT.expandNeighbours))
+        assertEquals(0, SearchDefaults.DEFAULT.expandNeighbours, "default must stay 0")
+    }
+
+    @Test
+    fun `a store that cannot expand is simply not expanded`() {
+        val hits = listOf(hit("hit-1", 0.9))
+        assertEquals(hits, hits.withNeighbours(null, 4))
+    }
+
+    @Test
+    fun `expansion only ever adds, keeping hits first and in order`() {
+        val hits = listOf(hit("hit-1", 0.9), hit("hit-2", 0.5))
+        val expanded = hits.withNeighbours(expander, 2)
+
+        assertEquals(listOf("hit-1", "hit-2"), expanded.take(2).map { it.match.id },
+            "hits must stay first and in order — callers read these positionally")
+        assertTrue(expanded.size > hits.size, "expansion should add neighbours")
+        assertEquals(expanded.map { it.match.id }.distinct(), expanded.map { it.match.id },
+            "no duplicates: a neighbour that is already a hit must not appear twice")
+        assertTrue(expanded.none { it.match.id == "hit-2" && it.score != 0.5 },
+            "an existing hit keeps its own score, not a neighbour's")
+    }
+
+    @Test
+    fun `a neighbour inherits the score of the hit that found it`() {
+        val expanded = listOf(hit("hit-1", 0.77)).withNeighbours(expander, 2)
+        val neighbour = expanded.first { it.match.id == "hit-1-after" }
+        assertEquals(0.77, neighbour.score,
+            "context must not be scored independently, or it could outrank the match that found it")
+    }
+}


### PR DESCRIPTION
## Summary

A chunker splitting an oversized leaf can separate a provision from the sentence that governs it, so a retrieved chunk reads "(i) investments ..." without saying what the list is *for*. Today the only cure is for the model to call `broadenChunk` itself, which it must first realise it needs: measured on a 69-page statute, recovering one severed provision took about 12 extra chunks against a tool default of 2, and nothing tells the model that.

`SearchDefaults.expandNeighbours` fetches that context automatically. It is **0 by default**, so behaviour is unchanged unless a deployment asks for it.

## Design notes

- Reuses the existing `ResultExpander` seam that `broadenChunk` already uses, so a store without the capability simply never expands — no second capability check to drift.
- A neighbour **inherits the score of the hit that found it**. It is continuation text, not a rival candidate, and scoring it independently would let context outrank the match that produced it.
- Expansion happens **before the results listener fires**, so an observer sees what the model sees. Otherwise reported provenance and the answer's real evidence diverge.
- Additive, deduplicated, hits first: an expanded result set is a superset of the unexpanded one in the same order, so turning the knob on cannot lose or reorder a result. Anything reading these positionally is safe.
- The BM25 threshold warning still counts **hits**, not the expanded set — neighbours added afterwards would mask exactly the emptiness worth warning about.

## Measurement

Measured honestly, and it is **not** a win on the corpus tested. On a 40-question statute suite: 25/40 with expansion off, 27/40 at `expandNeighbours=4` — inside that suite's run-to-run sigma of ~2.3 — for 7x the retrieved context (12.6 → 87.9 chunks per question) and 4x the latency. The question the change was designed to fix remained wrong even while the loop was reading a large fraction of the whole document.

So this ships as a capability with a measurement attached rather than a recommendation: useful where a corpus is continuous prose whose meaning runs across chunk boundaries, and left off where retrieval is not the binding constraint. Widening chunks at ingestion was also measured and is worse (30.67 against 33), because it dilutes every embedding; expanding after the match at least pays only for what hit.

## Test plan

- `AutoExpandNeighboursTest` covers the new behaviour (expansion off by default, superset/ordering guarantees, score inheritance, dedup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTZjB4eQKfa8bg6LPEb6Xz