### PR TITLE
Change log level from warn to info for tool call

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolDecorators.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolDecorators.kt
@@ -78,7 +78,7 @@ class ObservabilityTool(
         }
         val currentObservation = observationRegistry.currentObservation
         if (currentObservation == null) {
-            loggerFor<ObservabilityTool>().warn(
+            loggerFor<ObservabilityTool>().info(
                 "No parent observation for tool call {} with input: {}, observation registry: {}",
                 delegate.definition.name,
                 input,


### PR DESCRIPTION
This pull request makes a minor change to the logging level in the `ObservabilityTool` class. The log message for missing parent observations is now logged at the `info` level instead of `warn`.