### PR TITLE
Fix Bedrock chat options conversion

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/bedrock/BedrockModelsConfig.kt
@@ -40,7 +40,6 @@ import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionCo
 import org.springframework.ai.model.bedrock.autoconfigure.BedrockAwsConnectionProperties
 import org.springframework.ai.model.bedrock.cohere.autoconfigure.BedrockCohereEmbeddingProperties
 import org.springframework.ai.model.bedrock.titan.autoconfigure.BedrockTitanEmbeddingProperties
-import org.springframework.ai.model.tool.ToolCallingChatOptions
 import org.springframework.ai.model.tool.ToolCallingManager
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
@@ -299,7 +298,7 @@ class BedrockModelsConfig(
 
 object BedrockOptionsConverter : OptionsConverter {
     override fun convertOptions(options: LlmOptions, model: String): ChatOptions =
-        ToolCallingChatOptions.builder()
+        BedrockChatOptions.builder()
             .model(model)
             .temperature(options.temperature)
             .topP(options.topP)

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/bedrock/BedrockOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/bedrock/BedrockOptionsConverterTest.kt
@@ -15,12 +15,20 @@
  */
 package com.embabel.agent.config.models.bedrock
 
-//import com.embabel.agent.config.models.OptionsConverterTestSupport
-//import org.springframework.ai.model.tool.ToolCallingChatOptions
-//// TODO: need a place to access OptionsConverterTestSupport from api and autoconfiguration
-//class BedrockOptionsConverterTest : OptionsConverterTestSupport<ToolCallingChatOptions>(
-//    optionsConverter = BedrockOptionsConverter
-//) {
-//
-//
-//}
+import com.embabel.agent.test.models.OptionsConverterTestSupport
+import com.embabel.common.ai.model.LlmOptions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.ai.bedrock.converse.BedrockChatOptions
+
+class BedrockOptionsConverterTest : OptionsConverterTestSupport(
+    optionsConverter = BedrockOptionsConverter
+) {
+
+    @Test
+    fun `should create provider-specific options`() {
+        val options = optionsConverter.convertOptions(LlmOptions(), "test-model")
+
+        assertThat(options).isInstanceOf(BedrockChatOptions::class.java)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1923.

- Return `BedrockChatOptions` from `BedrockOptionsConverter`.
- Restore the Bedrock options converter test.
- Add regression coverage verifying the provider-specific options type.
- Preserve the existing conversion of model, temperature, token, and sampling settings.

## Problem

`BedrockOptionsConverter` created generic `ToolCallingChatOptions`. Spring AI 2.0’s `BedrockProxyChatModel` expects `BedrockChatOptions` and casts the request options accordingly, causing:

```text
ClassCastException: DefaultToolCallingChatOptions cannot be cast to BedrockChatOptions
```

## Solution

Build `BedrockChatOptions` directly in the provider-specific converter. The existing tool-callback flow uses `mutate()`, so the Bedrock-specific subtype is preserved when tools are attached.

## Testing

```bash
./mvnw -pl embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure \
  -am \
  -Dtest=BedrockOptionsConverterTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```