### PR TITLE
RAG enhancement: Add `SectionReader` to navigate document sections by name

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/ContentChunker.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/ContentChunker.kt
@@ -74,6 +74,9 @@ interface ContentChunker {
         /** Metadata key for the unique identifier of the root document */
         const val ROOT_DOCUMENT_ID = ChunkStructure.ROOT_DOCUMENT_ID
 
+        /** Metadata key for the human-readable title of the root document */
+        const val ROOT_DOCUMENT_TITLE = ChunkStructure.ROOT_DOCUMENT_TITLE
+
         /** Metadata key for the unique identifier of the container section */
         const val CONTAINER_SECTION_ID = ChunkStructure.CONTAINER_SECTION_ID
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/InMemoryContentChunker.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/InMemoryContentChunker.kt
@@ -23,6 +23,7 @@ import com.embabel.agent.rag.ingestion.ContentChunker.Companion.LEAF_SECTION_ID
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.LEAF_SECTION_TITLE
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.LEAF_SECTION_URL
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.ROOT_DOCUMENT_ID
+import com.embabel.agent.rag.ingestion.ContentChunker.Companion.ROOT_DOCUMENT_TITLE
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.SEQUENCE_NUMBER
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.TOTAL_CHUNKS
 import com.embabel.agent.rag.model.*
@@ -44,11 +45,15 @@ class InMemoryContentChunker(
         val leaves = section.leaves().toList()
         val totalContentLength = leaves.sumOf { it.content.length + it.title.length + 1 } // +1 for newline after title
 
-        // Determine root document ID: if section is a ContentRoot, use its ID, otherwise try to get from metadata
-        val rootId = if (section is ContentRoot) {
-            section.id
+        // Determine the root document: if section is a ContentRoot, use its own id and title,
+        // otherwise inherit whatever provenance the caller propagated through metadata.
+        val root = if (section is ContentRoot) {
+            RootDocument(id = section.id, title = section.title)
         } else {
-            section.metadata[ROOT_DOCUMENT_ID] as? String ?: section.id
+            RootDocument(
+                id = section.metadata[ROOT_DOCUMENT_ID] as? String ?: section.id,
+                title = section.metadata[ROOT_DOCUMENT_TITLE] as? String,
+            )
         }
 
         // Determine the document for transformation context
@@ -60,14 +65,14 @@ class InMemoryContentChunker(
                 "Creating single chunk for container section '{}' with {} leaves (total length: {} <= max: {})",
                 section.title, leaves.size, totalContentLength, config.maxChunkSize
             )
-            listOf(createSingleChunkFromContainer(section, leaves, rootId))
+            listOf(createSingleChunkFromContainer(section, leaves, root))
         } else {
             // Strategy 2: Try to group leaves intelligently before splitting
             logger.debug(
                 "Total content ({} chars) exceeds maxChunkSize ({}), attempting intelligent grouping",
                 totalContentLength, config.maxChunkSize
             )
-            chunkLeavesIntelligently(section, leaves, rootId)
+            chunkLeavesIntelligently(section, leaves, root)
         }
 
         // Apply transformer if configured
@@ -96,7 +101,7 @@ class InMemoryContentChunker(
     private fun createSingleChunkFromContainer(
         section: NavigableContainerSection,
         leaves: List<LeafSection>,
-        rootId: String,
+        root: RootDocument,
     ): Chunk {
         val combinedContent = leaves.joinToString("\n\n") { leaf ->
             if (leaf.title.isNotBlank()) "${leaf.title}\n${leaf.content}" else leaf.content
@@ -104,7 +109,7 @@ class InMemoryContentChunker(
 
         val combinedMetadata = mutableMapOf<String, Any?>()
         combinedMetadata.putAll(section.metadata)
-        combinedMetadata[ROOT_DOCUMENT_ID] = rootId
+        combinedMetadata.putAll(root.metadata())
         combinedMetadata[CONTAINER_SECTION_ID] = section.id
         combinedMetadata[CONTAINER_SECTION_TITLE] = section.title
         combinedMetadata[CONTAINER_SECTION_URL] = section.uri
@@ -123,7 +128,7 @@ class InMemoryContentChunker(
     private fun chunkLeavesIntelligently(
         containerSection: NavigableContainerSection,
         leaves: List<LeafSection>,
-        rootId: String,
+        root: RootDocument,
     ): List<Chunk> {
         val allChunks = mutableListOf<Chunk>()
         val leafGroups = groupLeavesForOptimalChunking(leaves)
@@ -140,10 +145,10 @@ class InMemoryContentChunker(
 
                     if (leafContentSize <= config.maxChunkSize) {
                         // Small enough for single chunk
-                        allChunks.add(createSingleLeafChunk(containerSection, leaf, rootId, sequenceNumber++))
+                        allChunks.add(createSingleLeafChunk(containerSection, leaf, root, sequenceNumber++))
                     } else {
                         // Too large, split it
-                        val chunks = splitLeafIntoMultipleChunks(containerSection, leaf, rootId, sequenceNumber)
+                        val chunks = splitLeafIntoMultipleChunks(containerSection, leaf, root, sequenceNumber)
                         sequenceNumber += chunks.size
                         allChunks.addAll(chunks)
                     }
@@ -151,7 +156,7 @@ class InMemoryContentChunker(
 
                 else -> {
                     // Multi-leaf group - create combined chunk
-                    allChunks.add(createCombinedLeafChunk(containerSection, group, rootId, sequenceNumber++))
+                    allChunks.add(createCombinedLeafChunk(containerSection, group, root, sequenceNumber++))
                 }
             }
         }
@@ -200,7 +205,7 @@ class InMemoryContentChunker(
     private fun createCombinedLeafChunk(
         containerSection: NavigableContainerSection,
         leaves: List<LeafSection>,
-        rootId: String,
+        root: RootDocument,
         sequenceNumber: Int,
     ): Chunk {
         val combinedContent = leaves.joinToString("\n\n") { leaf ->
@@ -209,7 +214,7 @@ class InMemoryContentChunker(
 
         val combinedMetadata = mutableMapOf<String, Any?>()
         combinedMetadata.putAll(containerSection.metadata)
-        combinedMetadata[ROOT_DOCUMENT_ID] = rootId
+        combinedMetadata.putAll(root.metadata())
         combinedMetadata[CONTAINER_SECTION_ID] = containerSection.id
         combinedMetadata[CONTAINER_SECTION_TITLE] = containerSection.title
         combinedMetadata[CONTAINER_SECTION_URL] = containerSection.uri
@@ -228,7 +233,7 @@ class InMemoryContentChunker(
     private fun createSingleLeafChunk(
         containerSection: NavigableContainerSection,
         leaf: LeafSection,
-        rootId: String,
+        root: RootDocument,
         sequenceNumber: Int,
     ): Chunk {
         val content = if (leaf.title.isNotBlank()) "${leaf.title}\n${leaf.content}" else leaf.content
@@ -236,8 +241,7 @@ class InMemoryContentChunker(
         return Chunk.Companion(
             id = UUID.randomUUID().toString(),
             text = content.trim(),
-            metadata = leaf.metadata + mapOf(
-                ROOT_DOCUMENT_ID to rootId,
+            metadata = leaf.metadata + root.metadata() + mapOf(
                 CONTAINER_SECTION_ID to containerSection.id,
                 CONTAINER_SECTION_TITLE to containerSection.title,
                 LEAF_SECTION_ID to leaf.id,
@@ -254,7 +258,7 @@ class InMemoryContentChunker(
     private fun splitLeafIntoMultipleChunks(
         containerSection: NavigableContainerSection,
         leaf: LeafSection,
-        rootId: String,
+        root: RootDocument,
         startingSequenceNumber: Int,
     ): List<Chunk> {
         val chunks = mutableListOf<Chunk>()
@@ -267,8 +271,7 @@ class InMemoryContentChunker(
             val chunk = Chunk.Companion(
                 id = UUID.randomUUID().toString(),
                 text = textChunk.trim(),
-                metadata = leaf.metadata + mapOf(
-                    ROOT_DOCUMENT_ID to rootId,
+                metadata = leaf.metadata + root.metadata() + mapOf(
                     CONTAINER_SECTION_ID to containerSection.id,
                     CONTAINER_SECTION_TITLE to containerSection.title,
                     LEAF_SECTION_ID to leaf.id,
@@ -570,4 +573,20 @@ class InMemoryContentChunker(
         return lines.isNotEmpty() && lines.all { isTableLine(it) }
     }
 
+}
+
+/**
+ * Provenance of the document a chunk came from: its stable id, and its human-readable title
+ * where the source has one. The title travels with every chunk because `readSection` shows it
+ * to the model when one section name matches more than one document.
+ */
+private data class RootDocument(
+    val id: String,
+    val title: String? = null,
+) {
+
+    fun metadata(): Map<String, Any?> = buildMap {
+        put(ROOT_DOCUMENT_ID, id)
+        title?.let { put(ROOT_DOCUMENT_TITLE, it) }
+    }
 }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/ChunkStructure.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/ChunkStructure.kt
@@ -24,6 +24,7 @@ package com.embabel.agent.rag.model
  */
 data class ChunkStructure(
     val rootDocumentId: String? = null,
+    val rootDocumentTitle: String? = null,
     val containerSectionId: String? = null,
     val containerSectionTitle: String? = null,
     val containerSectionUrl: String? = null,
@@ -44,6 +45,7 @@ data class ChunkStructure(
         if (isEmpty()) return emptyMap()
         val result = LinkedHashMap<String, Any?>(KEYS.size)
         rootDocumentId?.let { result[ROOT_DOCUMENT_ID] = it }
+        rootDocumentTitle?.let { result[ROOT_DOCUMENT_TITLE] = it }
         containerSectionId?.let { result[CONTAINER_SECTION_ID] = it }
         containerSectionTitle?.let { result[CONTAINER_SECTION_TITLE] = it }
         containerSectionUrl?.let { result[CONTAINER_SECTION_URL] = it }
@@ -61,6 +63,7 @@ data class ChunkStructure(
      */
     fun merge(other: ChunkStructure): ChunkStructure = ChunkStructure(
         rootDocumentId = other.rootDocumentId ?: rootDocumentId,
+        rootDocumentTitle = other.rootDocumentTitle ?: rootDocumentTitle,
         containerSectionId = other.containerSectionId ?: containerSectionId,
         containerSectionTitle = other.containerSectionTitle ?: containerSectionTitle,
         containerSectionUrl = other.containerSectionUrl ?: containerSectionUrl,
@@ -78,6 +81,7 @@ data class ChunkStructure(
         const val TOTAL_CHUNKS = "total_chunks"
         const val SEQUENCE_NUMBER = "sequence_number"
         const val ROOT_DOCUMENT_ID = "root_document_id"
+        const val ROOT_DOCUMENT_TITLE = "root_document_title"
         const val CONTAINER_SECTION_ID = "container_section_id"
         const val CONTAINER_SECTION_TITLE = "container_section_title"
         const val CONTAINER_SECTION_URL = "container_section_url"
@@ -90,6 +94,7 @@ data class ChunkStructure(
             TOTAL_CHUNKS,
             SEQUENCE_NUMBER,
             ROOT_DOCUMENT_ID,
+            ROOT_DOCUMENT_TITLE,
             CONTAINER_SECTION_ID,
             CONTAINER_SECTION_TITLE,
             CONTAINER_SECTION_URL,
@@ -107,6 +112,7 @@ data class ChunkStructure(
             }
             return ChunkStructure(
                 rootDocumentId = stringOrNull(metadata[ROOT_DOCUMENT_ID]),
+                rootDocumentTitle = stringOrNull(metadata[ROOT_DOCUMENT_TITLE]),
                 containerSectionId = stringOrNull(metadata[CONTAINER_SECTION_ID]),
                 containerSectionTitle = stringOrNull(metadata[CONTAINER_SECTION_TITLE]),
                 containerSectionUrl = stringOrNull(metadata[CONTAINER_SECTION_URL]),

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.rag.service
 
 import com.embabel.agent.filter.PropertyFilter
 import com.embabel.agent.rag.filter.EntityFilter
+import com.embabel.agent.rag.model.Chunk
 import com.embabel.agent.rag.model.ContentElement
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.common.core.types.SimilarityResult
@@ -301,6 +302,51 @@ interface FilteringRegexSearch : RegexSearchOperations {
         metadataFilter: PropertyFilter? = null,
         entityFilter: EntityFilter? = null,
     ): List<SimilarityResult<T>>
+}
+
+/**
+ * One section heading of an ingested document, as reported by [SectionReader.listSections].
+ */
+data class SectionSummary(
+    val title: String,
+    val documentTitle: String,
+    val chunkCount: Int,
+)
+
+/**
+ * Interface to be implemented by stores that can navigate a document's section
+ * structure by NAME: list the section headings of a document (its table of
+ * contents) and read every chunk of a named section in document order.
+ *
+ * Search finds isolated hits; some content is only usable whole. The motivating
+ * case is structured data split across chunks — a financial statement whose
+ * header row, row labels and values land in different chunks. A model that has
+ * seen a section title (from [listSections], or from provenance embedded in a
+ * retrieved chunk) can read the complete section in order instead of trying to
+ * reassemble it from search results.
+ *
+ * Tenancy: implementations MUST scope results to their own tenant/context. The
+ * tools built over this interface (unlike the vector/text search tools) apply
+ * no metadata filter of their own, because section reads are keyed by title
+ * rather than similarity and per-store scoping is where multi-tenant stores
+ * already enforce isolation.
+ */
+interface SectionReader : SearchOperations {
+
+    /**
+     * The section headings of ingested documents, with chunk counts.
+     * @param documentTitle case-insensitive substring filter on the document
+     * title; null lists sections for all visible documents
+     */
+    fun listSections(documentTitle: String? = null): List<SectionSummary>
+
+    /**
+     * Every chunk of the named section(s), in document sequence order.
+     * @param sectionTitle exact section title, matched case-insensitively
+     * @param documentTitle optional case-insensitive substring filter on the
+     * document title, to disambiguate when documents share section names
+     */
+    fun readSection(sectionTitle: String, documentTitle: String? = null): List<Chunk>
 }
 
 /**

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -203,8 +203,10 @@ internal class ResultExpanderTools @JvmOverloads constructor(
     fun zoomOut(
         @LlmTool.Param(description = "id of the content element to expand") id: String,
     ): String {
-        val embeddables = resultExpander.expandResult(id, ResultExpander.Method.ZOOM_OUT, 1)
-         .filter { it is Embeddable }
+        val (embeddables, ms) = time {
+            resultExpander.expandResult(id, ResultExpander.Method.ZOOM_OUT, 1)
+                .filter { it is Embeddable }
+        }
         if (embeddables.isEmpty()) return "No parent section found."
         // Same observability contract as broadenChunk for whatever is Retrievable.
         val retrievables = embeddables.filterIsInstance<Retrievable>()
@@ -214,7 +216,7 @@ internal class ResultExpanderTools @JvmOverloads constructor(
                     this,
                     "zoomOut: $id",
                     retrievables.map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) },
-                    Duration.ZERO,
+                    Duration.ofMillis(ms),
                 ),
             )
         }
@@ -310,25 +312,65 @@ internal class SectionReadingTools @JvmOverloads constructor(
         // documents hands the model the WRONG one to quote from — measured 2026-08-14
         // (CUAD): governing-law answers cited a different contract's clause at full
         // confidence. Ambiguity is surfaced as a choice, not merged.
+        //
+        // Provenance comes from the chunk's structural fields, which the chunker always
+        // populates: keying off a free-form metadata key nobody writes would leave every
+        // chunk indistinguishable and silently re-enable the blending this prevents.
         val documents = chunks
-            .map { it.metadata["root_document_title"] as? String ?: it.metadata["root_document_uri"] as? String }
+            .map { DocumentProvenance(it.structure.rootDocumentId, it.structure.rootDocumentTitle) }
             .distinct()
-        if (documents.size > 1 && documents.none { it == null }) {
+        // Unknown provenance FAILS CLOSED: a chunk we cannot attribute is the least safe
+        // input to concatenate, not an excuse to skip the check.
+        if (documents.size > 1) {
             return "Section '$sectionTitle' exists in ${documents.size} documents: " +
-                documents.joinToString("; ") { "'$it'" } +
-                ". Call readSection again with a documentTitle to pick ONE."
+                documents.joinToString("; ") { it.describe() } +
+                (documentTitle?.let {
+                    ". The documentTitle '$it' still matches more than one — pass a longer, " +
+                        "more specific substring"
+                } ?: ". Call readSection again with a documentTitle") +
+                " to pick ONE."
         }
-        // Full score: the model asked for this section by name; every chunk of it is evidence
-        // the observer must see, exactly as it would see a search hit.
-        val results = chunks.map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) }
+        val rendered = chunks.map { "Chunk ID: ${it.id}\nContent: ${it.text}\n" }
+        // Truncate at a chunk boundary, and report ONLY the chunks that survived it. Full score:
+        // the model asked for this section by name, so what it was shown is evidence exactly as a
+        // search hit is — but reporting a chunk it never saw lets an attribution check treat an
+        // ungrounded quote as grounded, which is the same failure in the other direction.
+        val shown = rendered
+            .runningFold(0) { chars, chunkText -> chars + chunkText.length + 1 }
+            .drop(1)
+            .takeWhile { it <= maxReadSectionChars }
+            .size
+            .coerceAtLeast(1)
+        val results = chunks.take(shown).map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) }
         resultsListener?.onResultsEvent(ResultsEvent(this, "readSection: $sectionTitle", results, Duration.ofMillis(ms)))
-        val rendered = chunks.joinToString("\n") { "Chunk ID: ${it.id}\nContent: ${it.text}\n" }
-        if (rendered.length > maxReadSectionChars) {
-            return rendered.take(maxReadSectionChars) +
-                "\n\n[TRUNCATED — section is ${rendered.length} chars. The chunks above are in document order; " +
+        val text = rendered.take(shown).joinToString("\n")
+        if (shown < chunks.size || text.length > maxReadSectionChars) {
+            val what = if (shown < chunks.size) {
+                "showing $shown of ${chunks.size} chunks"
+            } else {
+                // A single chunk over the cap: the model sees part of a chunk reported whole.
+                "one chunk of ${text.length} chars cut at $maxReadSectionChars"
+            }
+            return text.take(maxReadSectionChars) +
+                "\n\n[TRUNCATED — $what. The chunks above are in document order; " +
                 "use vectorSearch or textSearch for the rest, or broadenChunk from the last chunk shown.]"
         }
-        return rendered
+        return text
+    }
+
+    /**
+     * Which document a section's chunks came from. Identity is the root document id — the
+     * title is what the model is shown, but two documents may legitimately share one.
+     */
+    private data class DocumentProvenance(
+        val id: String?,
+        val title: String?,
+    ) {
+        fun describe(): String = when {
+            title != null -> "'$title'"
+            id != null -> "document $id"
+            else -> "an unattributed document"
+        }
     }
 
     companion object {

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -305,6 +305,19 @@ internal class SectionReadingTools @JvmOverloads constructor(
                 (documentTitle?.let { " in a document whose title contains '$it'" } ?: "") +
                 ". Use listSections to see the available section titles."
         }
+        // NEVER blend documents. Similar documents share section names (contracts,
+        // periodic filings), and a title match that silently concatenates several
+        // documents hands the model the WRONG one to quote from — measured 2026-08-14
+        // (CUAD): governing-law answers cited a different contract's clause at full
+        // confidence. Ambiguity is surfaced as a choice, not merged.
+        val documents = chunks
+            .map { it.metadata["root_document_title"] as? String ?: it.metadata["root_document_uri"] as? String }
+            .distinct()
+        if (documents.size > 1 && documents.none { it == null }) {
+            return "Section '$sectionTitle' exists in ${documents.size} documents: " +
+                documents.joinToString("; ") { "'$it'" } +
+                ". Call readSection again with a documentTitle to pick ONE."
+        }
         // Full score: the model asked for this section by name; every chunk of it is evidence
         // the observer must see, exactly as it would see a search hit.
         val results = chunks.map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -26,6 +26,7 @@ import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.*
 import com.embabel.agent.rag.service.support.Bm25Normalization
 import com.embabel.common.core.types.SimilarityResult
+import com.embabel.common.core.types.SimpleSimilaritySearchResult
 import com.embabel.common.core.types.TextSimilaritySearchRequest
 import com.embabel.common.core.types.ZeroToOne
 import com.embabel.common.util.loggerFor
@@ -202,6 +203,94 @@ internal class ResultExpanderTools @JvmOverloads constructor(
 
     companion object {
         const val DEFAULT_MAX_ZOOM_OUT_CHARS = 25_000
+    }
+}
+
+/**
+ * Tools to navigate a document's section structure by NAME, over a [SectionReader] store.
+ *
+ * Search retrieves isolated hits; some content only answers whole. The motivating case is
+ * structured data split across chunks — a financial statement whose header row, row labels
+ * and values land in different chunks, so search-hit reassembly picks wrong rows or a wrong
+ * period column. `listSections` is the document's real table of contents; `readSection`
+ * returns a named section complete and in order.
+ *
+ * Chunks returned by `readSection` are reported to the [ResultsListener] at full score, so
+ * observed-attribution consumers see section reads the same way they see search hits.
+ */
+internal class SectionReadingTools @JvmOverloads constructor(
+    private val sectionReader: SectionReader,
+    private val resultsListener: ResultsListener? = null,
+    private val maxReadSectionChars: Int = DEFAULT_MAX_READ_SECTION_CHARS,
+) : SearchTools {
+
+    private val logger: Logger = LoggerFactory.getLogger(javaClass)
+
+    @LlmTool(
+        description = "List the section headings of a document — its table of contents — with chunk counts. " +
+            "Use to find the exact section that holds structured data (a financial statement, a schedule, an appendix) " +
+            "before reading it with readSection."
+    )
+    fun listSections(
+        @LlmTool.Param(
+            description = "Case-insensitive substring of the document title to scope to. Omit to list all documents' sections.",
+            required = false,
+        ) documentTitle: String? = null,
+    ): String {
+        val sections = sectionReader.listSections(documentTitle)
+        if (sections.isEmpty()) {
+            return "No sections found" + (documentTitle?.let { " for document title containing '$it'" } ?: "") + "."
+        }
+        val listing = sections
+            .groupBy { it.documentTitle }
+            .entries
+            .joinToString("\n") { (doc, docSections) ->
+                "Document: $doc\n" + docSections.joinToString("\n") { "  - ${it.title} (${it.chunkCount} chunks)" }
+            }
+        if (listing.length > maxReadSectionChars) {
+            return listing.take(maxReadSectionChars) +
+                "\n\n[TRUNCATED — narrow with the documentTitle parameter.]"
+        }
+        return listing
+    }
+
+    @LlmTool(
+        description = "Read EVERY chunk of a named section in document order — e.g. a complete financial statement " +
+            "or schedule. Use when you need structured data whole (all rows of a table, with the header row) rather " +
+            "than isolated search hits. Get the exact title from listSections or from a retrieved chunk's Section header."
+    )
+    fun readSection(
+        @LlmTool.Param(description = "Exact section title, as shown by listSections or a chunk's Section header")
+        sectionTitle: String,
+        @LlmTool.Param(
+            description = "Case-insensitive substring of the document title, to disambiguate when documents share section names.",
+            required = false,
+        ) documentTitle: String? = null,
+    ): String {
+        logger.info("Reading section '{}' documentTitle={}", sectionTitle, documentTitle)
+        val (chunks, ms) = time {
+            sectionReader.readSection(sectionTitle, documentTitle)
+        }
+        if (chunks.isEmpty()) {
+            return "No section titled '$sectionTitle' found" +
+                (documentTitle?.let { " in a document whose title contains '$it'" } ?: "") +
+                ". Use listSections to see the available section titles."
+        }
+        // Full score: the model asked for this section by name; every chunk of it is evidence
+        // the observer must see, exactly as it would see a search hit.
+        val results = chunks.map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) }
+        resultsListener?.onResultsEvent(ResultsEvent(this, "readSection: $sectionTitle", results, Duration.ofMillis(ms)))
+        val rendered = chunks.joinToString("\n") { "Chunk ID: ${it.id}\nContent: ${it.text}\n" }
+        if (rendered.length > maxReadSectionChars) {
+            return rendered.take(maxReadSectionChars) +
+                "\n\n[TRUNCATED — section is ${rendered.length} chars. The chunks above are in document order; " +
+                "use vectorSearch or textSearch for the rest, or broadenChunk from the last chunk shown.]"
+        }
+        return rendered
+    }
+
+    companion object {
+        const val DEFAULT_MAX_READ_SECTION_CHARS = 25_000
     }
 }
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -169,6 +169,7 @@ internal class VectorSearchTools @JvmOverloads constructor(
 internal class ResultExpanderTools @JvmOverloads constructor(
     private val resultExpander: ResultExpander,
     private val maxZoomOutChars: Int = DEFAULT_MAX_ZOOM_OUT_CHARS,
+    private val resultsListener: ResultsListener? = null,
 ) : SearchTools {
 
     @LlmTool(description = "given a chunk ID, expand to surrounding chunks")
@@ -176,9 +177,25 @@ internal class ResultExpanderTools @JvmOverloads constructor(
         @LlmTool.Param(description = "id of the chunk to expand") chunkId: String,
         @LlmTool.Param(description = "chunksToAdd", required = false) chunksToAdd: Int = 2,
     ): String {
-        val chunks = resultExpander.expandResult(chunkId, ResultExpander.Method.SEQUENCE, chunksToAdd)
-         .filterIsInstance<Chunk>()
+        val (chunks, ms) = time {
+            resultExpander.expandResult(chunkId, ResultExpander.Method.SEQUENCE, chunksToAdd)
+                .filterIsInstance<Chunk>()
+        }
         if (chunks.isEmpty()) return "No adjacent chunks found for this section."
+        // Expanded chunks are evidence the model SEES and quotes from. An observer
+        // (attribution rollup, quoted-figure verification) that never learns of them
+        // mislabels legitimate quotes as inventions — measured 2026-08-13, where a
+        // fidelity check flagged clause numbers quoted from a broadened table of
+        // contents. Same full-score contract as section reads: the model asked for
+        // these chunks; every one is evidence.
+        resultsListener?.onResultsEvent(
+            ResultsEvent(
+                this,
+                "broadenChunk: $chunkId",
+                chunks.map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) },
+                Duration.ofMillis(ms),
+            ),
+        )
         return chunks.joinToString("\n") { "Chunk ID: ${it.id}\nContent: ${it.text}\n" }
     }
 
@@ -189,6 +206,18 @@ internal class ResultExpanderTools @JvmOverloads constructor(
         val embeddables = resultExpander.expandResult(id, ResultExpander.Method.ZOOM_OUT, 1)
          .filter { it is Embeddable }
         if (embeddables.isEmpty()) return "No parent section found."
+        // Same observability contract as broadenChunk for whatever is Retrievable.
+        val retrievables = embeddables.filterIsInstance<Retrievable>()
+        if (retrievables.isNotEmpty()) {
+            resultsListener?.onResultsEvent(
+                ResultsEvent(
+                    this,
+                    "zoomOut: $id",
+                    retrievables.map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) },
+                    Duration.ZERO,
+                ),
+            )
+        }
         val result = embeddables.joinToString("\n") { contentElement ->
             "${contentElement.javaClass.simpleName}: id=${contentElement.id}\nContent: ${(contentElement as Embeddable).embeddableValue()}\n"
         }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -101,6 +101,7 @@ data class ToolishRag @JvmOverloads constructor(
     val metadataFilter: PropertyFilter? = null,
     val entityFilter: EntityFilter? = null,
     val maxZoomOutChars: Int = ResultExpanderTools.DEFAULT_MAX_ZOOM_OUT_CHARS,
+    val maxReadSectionChars: Int = SectionReadingTools.DEFAULT_MAX_READ_SECTION_CHARS,
     /**
      * Progressively-disclosed guidance appended to the unfold response when
      * the LLM invokes this tool. Right home for search-strategy notes
@@ -183,7 +184,7 @@ data class ToolishRag @JvmOverloads constructor(
             }
             if (searchOperations is SectionReader) {
                 logger.debug("Adding SectionReadingTools to ToolishRag '{}'", name)
-                add(SectionReadingTools(searchOperations, listener))
+                add(SectionReadingTools(searchOperations, listener, maxReadSectionChars))
             }
             if (searchOperations is RegexSearchOperations) {
                 logger.debug("Adding RegexSearchTools to ToolishRag '{}'", name)
@@ -254,6 +255,13 @@ data class ToolishRag @JvmOverloads constructor(
      */
     fun withMaxZoomOutChars(maxChars: Int): ToolishRag =
         copy(maxZoomOutChars = maxChars)
+
+    /**
+     * Set the maximum number of characters a single readSection result may return
+     * before it is truncated at a chunk boundary.
+     */
+    fun withMaxReadSectionChars(maxChars: Int): ToolishRag =
+        copy(maxReadSectionChars = maxChars)
 
     /**
      * Set the similarity floors applied when the LLM omits the optional `threshold`

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -179,7 +179,7 @@ data class ToolishRag @JvmOverloads constructor(
             }
             if (searchOperations is ResultExpander) {
                 logger.debug("Adding ResultExpanderTools to ToolishRag '{}'", name)
-                add(ResultExpanderTools(searchOperations, maxZoomOutChars))
+                add(ResultExpanderTools(searchOperations, maxZoomOutChars, listener))
             }
             if (searchOperations is SectionReader) {
                 logger.debug("Adding SectionReadingTools to ToolishRag '{}'", name)

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -29,6 +29,7 @@ import com.embabel.agent.rag.service.RegexSearchOperations
 import com.embabel.agent.rag.service.ResultExpander
 import com.embabel.agent.rag.service.RetrievableResultsFormatter
 import com.embabel.agent.rag.service.SearchOperations
+import com.embabel.agent.rag.service.SectionReader
 import com.embabel.agent.rag.service.SimilarityResults
 import com.embabel.agent.rag.service.SimpleRetrievableResultsFormatter
 import com.embabel.agent.rag.service.TextSearch
@@ -179,6 +180,10 @@ data class ToolishRag @JvmOverloads constructor(
             if (searchOperations is ResultExpander) {
                 logger.debug("Adding ResultExpanderTools to ToolishRag '{}'", name)
                 add(ResultExpanderTools(searchOperations, maxZoomOutChars))
+            }
+            if (searchOperations is SectionReader) {
+                logger.debug("Adding SectionReadingTools to ToolishRag '{}'", name)
+                add(SectionReadingTools(searchOperations, listener))
             }
             if (searchOperations is RegexSearchOperations) {
                 logger.debug("Adding RegexSearchTools to ToolishRag '{}'", name)

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/ingestion/ContentChunkerRootDocumentTitleTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/ingestion/ContentChunkerRootDocumentTitleTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.ingestion
+
+import com.embabel.agent.rag.model.ChunkStructure
+import com.embabel.agent.rag.model.LeafSection
+import com.embabel.agent.rag.model.MaterializedDocument
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Every chunk must carry the title of the document it came from.
+ *
+ * `readSection` refuses to concatenate a section title that matches more than one document,
+ * and the only way it can tell one document from another is this field. A chunker that stops
+ * writing it turns that guard into a no-op — the model is handed two contracts' clauses as one
+ * section, with nothing in the output to say so.
+ */
+class ContentChunkerRootDocumentTitleTest {
+
+    private val chunker = ContentChunker(ContentChunker.Config(), ChunkTransformer.NO_OP)
+
+    private fun document(title: String, sections: Int, textLength: Int): MaterializedDocument {
+        val rootId = UUID.randomUUID().toString()
+        return MaterializedDocument(
+            id = rootId,
+            uri = "test://doc",
+            title = title,
+            children = (1..sections).map {
+                LeafSection(
+                    id = UUID.randomUUID().toString(),
+                    uri = "test://doc#$it",
+                    title = "Section $it",
+                    text = "word ".repeat(textLength),
+                    parentId = rootId,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `a document small enough for one chunk carries its title`() {
+        val chunks = chunker.chunk(document("Acme License", sections = 1, textLength = 5)).toList()
+
+        assertTrue(chunks.isNotEmpty())
+        chunks.forEach {
+            assertEquals("Acme License", it.structure.rootDocumentTitle, "chunk ${it.id}")
+        }
+    }
+
+    @Test
+    fun `a document split across many chunks carries its title on every one`() {
+        // Large enough to exercise leaf grouping and leaf splitting, not just the single-chunk path.
+        val chunks = chunker.chunk(document("Widget License", sections = 12, textLength = 400)).toList()
+
+        assertTrue(chunks.size > 1, "expected a split document, got ${chunks.size} chunk(s)")
+        chunks.forEach {
+            assertEquals("Widget License", it.structure.rootDocumentTitle, "chunk ${it.id}")
+        }
+    }
+
+    @Test
+    fun `the title is readable through the metadata compatibility view`() {
+        val chunk = chunker.chunk(document("Acme License", sections = 1, textLength = 5)).first()
+
+        assertEquals("Acme License", chunk.metadata[ChunkStructure.ROOT_DOCUMENT_TITLE])
+    }
+
+    @Test
+    fun `two documents sharing a section name stay distinguishable`() {
+        val acme = chunker.chunk(document("Acme License", sections = 1, textLength = 5)).toList()
+        val widget = chunker.chunk(document("Widget License", sections = 1, textLength = 5)).toList()
+
+        val titles = (acme + widget).map { it.structure.rootDocumentTitle }.distinct()
+        assertEquals(listOf("Acme License", "Widget License"), titles)
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChunkStructureTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChunkStructureTest.kt
@@ -35,6 +35,7 @@ class ChunkStructureTest {
             val structure = ChunkStructure.fromMetadata(
                 mapOf(
                     ChunkStructure.ROOT_DOCUMENT_ID to "doc-1",
+                    ChunkStructure.ROOT_DOCUMENT_TITLE to "Acme 10-K",
                     ChunkStructure.CONTAINER_SECTION_ID to "sec-1",
                     ChunkStructure.CONTAINER_SECTION_TITLE to "Intro",
                     ChunkStructure.CONTAINER_SECTION_URL to "https://example.com",
@@ -49,6 +50,7 @@ class ChunkStructureTest {
             )
 
             assertEquals("doc-1", structure.rootDocumentId)
+            assertEquals("Acme 10-K", structure.rootDocumentTitle)
             assertEquals("sec-1", structure.containerSectionId)
             assertEquals("Intro", structure.containerSectionTitle)
             assertEquals("https://example.com", structure.containerSectionUrl)
@@ -67,6 +69,7 @@ class ChunkStructureTest {
                 ChunkStructure.SEQUENCE_NUMBER to 1,
                 "author" to "alice",
                 ChunkStructure.ROOT_DOCUMENT_ID to "doc",
+                ChunkStructure.ROOT_DOCUMENT_TITLE to "Acme 10-K",
             )
             val freeform = ChunkStructure.withoutStructuralKeys(original)
             assertEquals(mapOf("author" to "alice"), freeform)
@@ -80,6 +83,7 @@ class ChunkStructureTest {
         fun `round trips non-null fields`() {
             val structure = ChunkStructure(
                 rootDocumentId = "doc-1",
+                rootDocumentTitle = "Acme 10-K",
                 containerSectionId = "sec-1",
                 sequenceNumber = 3,
                 chunkIndex = 0,
@@ -101,10 +105,11 @@ class ChunkStructureTest {
 
         @Test
         fun `prefers non-null values from other`() {
-            val base = ChunkStructure(rootDocumentId = "doc", sequenceNumber = 1)
+            val base = ChunkStructure(rootDocumentId = "doc", rootDocumentTitle = "Acme 10-K", sequenceNumber = 1)
             val other = ChunkStructure(sequenceNumber = 9, containerSectionId = "c1")
             val merged = base.merge(other)
             assertEquals("doc", merged.rootDocumentId)
+            assertEquals("Acme 10-K", merged.rootDocumentTitle)
             assertEquals(9, merged.sequenceNumber)
             assertEquals("c1", merged.containerSectionId)
         }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ResultExpanderToolsListenerTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ResultExpanderToolsListenerTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.tools
+
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.ContentElement
+import com.embabel.agent.rag.service.ResultExpander
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ResultExpanderToolsListenerTest {
+
+    private fun chunk(id: String, text: String): Chunk =
+        Chunk(id = id, text = text, parentId = "parent", metadata = emptyMap())
+
+    private class FakeExpander(private val elements: List<ContentElement>) : ResultExpander {
+        override fun expandResult(
+            id: String,
+            method: ResultExpander.Method,
+            elementsToAdd: Int,
+        ): List<ContentElement> = elements
+    }
+
+    @Test
+    fun `broadenChunk reports expanded chunks to the listener at full score`() {
+        // An observer (attribution, quote verification) must see what the model sees:
+        // content surfaced by expansion is evidence exactly like a search hit.
+        var events = mutableListOf<ResultsEvent>()
+        val tools = ResultExpanderTools(
+            FakeExpander(listOf(chunk("c1", "Section 3.01. Certificate of Incorporation"))),
+            resultsListener = { events.add(it) },
+        )
+        val out = tools.broadenChunk("seed")
+        assertTrue(out.contains("3.01"), out)
+        assertEquals(1, events.size)
+        assertEquals(1, events[0].results.size)
+        assertTrue(events[0].results.all { it.score == 1.0 })
+        assertEquals("broadenChunk: seed", events[0].query)
+    }
+
+    @Test
+    fun `no expansion means no event`() {
+        var fired = false
+        val tools = ResultExpanderTools(FakeExpander(emptyList()), resultsListener = { fired = true })
+        tools.broadenChunk("seed")
+        assertTrue(!fired)
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingProvenanceTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingProvenanceTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.tools
+
+import com.embabel.agent.rag.ingestion.ChunkTransformer
+import com.embabel.agent.rag.ingestion.ContentChunker
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.LeafSection
+import com.embabel.agent.rag.model.MaterializedDocument
+import com.embabel.agent.rag.service.SectionSummary
+import com.embabel.agent.rag.service.SectionReader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The anti-blending guard, exercised over chunks the REAL chunker produced.
+ *
+ * The unit tests in [SectionReadingToolsTest] hand the guard its provenance. That is exactly how
+ * the defect this covers survived: the guard read metadata keys no chunker wrote, so it passed a
+ * test that supplied them and did nothing at all against a store. Here nothing is hand-written —
+ * two contracts are ingested through [ContentChunker], and the store below matches section titles
+ * the way a real [SectionReader] must. If chunker and guard ever stop agreeing on where document
+ * provenance lives, these fail.
+ */
+class SectionReadingProvenanceTest {
+
+    private val chunker = ContentChunker(ContentChunker.Config(), ChunkTransformer.NO_OP)
+
+    /**
+     * The minimum a store must do to satisfy [SectionReader]: match a section title
+     * case-insensitively across everything it holds, in ingestion order. Deliberately NOT
+     * document-aware — telling the documents apart is the tools' job, which is what is under test.
+     */
+    private class IngestedSections(chunks: List<Chunk>) : SectionReader {
+
+        private val chunks: List<Chunk> = chunks.sortedBy { it.structure.sequenceNumber ?: 0 }
+
+        override fun listSections(documentTitle: String?): List<SectionSummary> = chunks
+            .filter { it.matchesDocument(documentTitle) }
+            .groupBy { (it.structure.rootDocumentTitle ?: "") to it.sectionTitle() }
+            .map { (key, group) -> SectionSummary(key.second, key.first, group.size) }
+
+        override fun readSection(sectionTitle: String, documentTitle: String?): List<Chunk> = chunks
+            .filter { it.sectionTitle().equals(sectionTitle, ignoreCase = true) }
+            .filter { it.matchesDocument(documentTitle) }
+
+        /** A chunk is filed under its leaf section where it has one, else its container. */
+        private fun Chunk.sectionTitle(): String =
+            structure.leafSectionTitle ?: structure.containerSectionTitle ?: ""
+
+        private fun Chunk.matchesDocument(documentTitle: String?): Boolean =
+            documentTitle == null || structure.rootDocumentTitle.orEmpty().contains(documentTitle, true)
+    }
+
+    /** Long enough that the chunker takes its per-leaf path rather than folding the document into one chunk. */
+    private fun clause(text: String): String = text + " " + "The parties acknowledge the foregoing. ".repeat(30)
+
+    private fun contract(title: String, governingLaw: String) = MaterializedDocument(
+        id = UUID.randomUUID().toString(),
+        uri = "test://${title.replace(' ', '-')}",
+        title = title,
+        children = listOf(
+            LeafSection(
+                id = UUID.randomUUID().toString(),
+                uri = "test://${title.replace(' ', '-')}#gl",
+                title = "Governing Law",
+                text = clause(governingLaw),
+                parentId = title,
+            ),
+            LeafSection(
+                id = UUID.randomUUID().toString(),
+                uri = "test://${title.replace(' ', '-')}#term",
+                title = "Term and Termination",
+                text = clause("This agreement runs for three years."),
+                parentId = title,
+            ),
+        ),
+    )
+
+    private fun ingest(vararg documents: MaterializedDocument) =
+        IngestedSections(documents.flatMap { chunker.chunk(it) })
+
+    @Test
+    fun `two ingested contracts sharing a section name are not concatenated`() {
+        val store = ingest(
+            contract("Acme License", "This agreement is governed by the laws of Nevada."),
+            contract("Widget License", "This agreement is governed by the laws of Ontario."),
+        )
+
+        val out = SectionReadingTools(store).readSection("Governing Law")
+
+        // The measured CUAD failure: one contract's clause quoted as the other's.
+        assertFalse(out.contains("Nevada"), "must not return one contract's clause: $out")
+        assertFalse(out.contains("Ontario"), "must not return the other contract's clause: $out")
+        assertTrue(out.contains("2 documents"), out)
+        assertTrue(out.contains("Acme License"), out)
+        assertTrue(out.contains("Widget License"), out)
+    }
+
+    @Test
+    fun `naming the document reads that one whole`() {
+        val store = ingest(
+            contract("Acme License", "This agreement is governed by the laws of Nevada."),
+            contract("Widget License", "This agreement is governed by the laws of Ontario."),
+        )
+
+        val out = SectionReadingTools(store).readSection("Governing Law", documentTitle = "Acme")
+
+        assertTrue(out.contains("Nevada"), out)
+        assertFalse(out.contains("Ontario"), out)
+    }
+
+    @Test
+    fun `a section of one ingested document is read whole`() {
+        val store = ingest(contract("Acme License", "This agreement is governed by the laws of Nevada."))
+
+        val out = SectionReadingTools(store).readSection("Governing Law")
+
+        assertTrue(out.contains("Nevada"), out)
+        assertFalse(out.contains("2 documents"), out)
+    }
+
+    @Test
+    fun `listSections attributes each section to the document it came from`() {
+        val store = ingest(contract("Acme License", "Nevada."), contract("Widget License", "Ontario."))
+
+        val out = SectionReadingTools(store).listSections()
+
+        assertTrue(out.contains("Document: Acme License"), out)
+        assertTrue(out.contains("Document: Widget License"), out)
+    }
+
+    @Test
+    fun `the chunker is the only source of provenance in this test`() {
+        // Guards the guard: if the chunker stops writing the title, the ambiguity check above
+        // silently degrades to "one unattributed document" and would blend again.
+        val chunks = chunker.chunk(contract("Acme License", "This agreement is governed by the laws of Nevada."))
+            .toList()
+
+        assertTrue(chunks.isNotEmpty())
+        chunks.forEach {
+            assertEquals("Acme License", it.structure.rootDocumentTitle, "chunk ${it.id}")
+        }
+        assertEquals(
+            setOf("Governing Law", "Term and Termination"),
+            chunks.mapNotNull { it.structure.leafSectionTitle }.toSet(),
+        )
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingToolsTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingToolsTest.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.rag.tools
 
 import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.ChunkStructure
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.SectionReader
 import com.embabel.agent.rag.service.SectionSummary
@@ -32,6 +33,9 @@ class SectionReadingToolsTest {
 
     private fun chunk(id: String, text: String): Chunk =
         Chunk(id = id, text = text, parentId = "parent", metadata = emptyMap())
+
+    private fun chunkOf(id: String, text: String, structure: ChunkStructure): Chunk =
+        Chunk.create(text = text, parentId = "parent", id = id, structure = structure)
 
     private class FakeSectionReader(
         private val sections: List<SectionSummary> = emptyList(),
@@ -112,8 +116,8 @@ class SectionReadingToolsTest {
     fun `readSection refuses to blend documents - ambiguity returns a choice, not merged content`() {
         var fired = false
         val chunks = listOf(
-            Chunk(id = "a1", text = "Nevada law", parentId = "p", metadata = mapOf("root_document_title" to "Acme License")),
-            Chunk(id = "b1", text = "Ontario law", parentId = "p", metadata = mapOf("root_document_title" to "Widget License")),
+            chunkOf("a1", "Nevada law", ChunkStructure(rootDocumentId = "doc-a", rootDocumentTitle = "Acme License")),
+            chunkOf("b1", "Ontario law", ChunkStructure(rootDocumentId = "doc-b", rootDocumentTitle = "Widget License")),
         )
         val tools = SectionReadingTools(
             FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)),
@@ -128,6 +132,63 @@ class SectionReadingToolsTest {
     }
 
     @Test
+    fun `provenance the chunker writes as metadata reaches the guard as structure`() {
+        // The chunker writes root_document_title into metadata; the Chunk factory lifts it into
+        // ChunkStructure. If the two ever stop agreeing, the guard silently stops firing.
+        val chunks = listOf(
+            Chunk(
+                id = "a1", text = "Nevada law", parentId = "p",
+                metadata = mapOf(ChunkStructure.ROOT_DOCUMENT_TITLE to "Acme License"),
+            ),
+            Chunk(
+                id = "b1", text = "Ontario law", parentId = "p",
+                metadata = mapOf(ChunkStructure.ROOT_DOCUMENT_TITLE to "Widget License"),
+            ),
+        )
+        assertEquals("Acme License", chunks.first().structure.rootDocumentTitle)
+        val out = SectionReadingTools(FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)))
+            .readSection("Governing Law")
+        assertTrue(out.contains("2 documents"), out)
+    }
+
+    @Test
+    fun `unknown provenance fails closed - a chunk we cannot attribute is not blended in`() {
+        val chunks = listOf(
+            chunkOf("a1", "Nevada law", ChunkStructure(rootDocumentId = "doc-a", rootDocumentTitle = "Acme License")),
+            chunk("b1", "Ontario law"),
+        )
+        val out = SectionReadingTools(FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)))
+            .readSection("Governing Law")
+        assertFalse(out.contains("Nevada"), "unattributed chunks must not be blended in: $out")
+        assertTrue(out.contains("2 documents"), out)
+        assertTrue(out.contains("unattributed"), out)
+    }
+
+    @Test
+    fun `an already-filtered ambiguous read says the filter was not specific enough`() {
+        val chunks = listOf(
+            chunkOf("a1", "Nevada law", ChunkStructure(rootDocumentId = "a", rootDocumentTitle = "Acme License 2024")),
+            chunkOf("b1", "Ontario law", ChunkStructure(rootDocumentId = "b", rootDocumentTitle = "Acme License 2025")),
+        )
+        val out = SectionReadingTools(FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)))
+            .readSection("Governing Law", documentTitle = "Acme")
+        assertTrue(out.contains("still matches more than one"), out)
+        assertTrue(out.contains("Acme"), out)
+    }
+
+    @Test
+    fun `chunks a single document owns are read whole, not treated as ambiguous`() {
+        val chunks = listOf(
+            chunkOf("a1", "header row", ChunkStructure(rootDocumentId = "doc-a", rootDocumentTitle = "Acme 10-K")),
+            chunkOf("a2", "cash 2,366", ChunkStructure(rootDocumentId = "doc-a", rootDocumentTitle = "Acme 10-K")),
+        )
+        val out = SectionReadingTools(FakeSectionReader(chunksByTitle = mapOf("Balance Sheets" to chunks)))
+            .readSection("Balance Sheets")
+        assertTrue(out.contains("header row"), out)
+        assertTrue(out.contains("cash 2,366"), out)
+    }
+
+    @Test
     fun `readSection output over the cap is truncated with guidance, in order`() {
         val big = (1..50).map { chunk("c$it", "x".repeat(1000)) }
         val tools = SectionReadingTools(
@@ -138,6 +199,37 @@ class SectionReadingToolsTest {
         assertTrue(out.length < 6_000, "capped: ${out.length}")
         assertTrue(out.contains("TRUNCATED"), out)
         assertTrue(out.contains("document order"), out)
+    }
+
+    @Test
+    fun `only the chunks that survive truncation are reported as evidence`() {
+        // A chunk the model never saw must not be observable evidence: an attribution check
+        // would then read a figure that only exists in the cut-away text as grounded.
+        var observed: List<SimilarityResult<out Retrievable>>? = null
+        val big = (1..50).map { chunk("c$it", "x".repeat(1000)) }
+        val tools = SectionReadingTools(
+            FakeSectionReader(chunksByTitle = mapOf("Big" to big)),
+            resultsListener = { observed = it.results },
+            maxReadSectionChars = 5_000,
+        )
+        val out = tools.readSection("Big")
+        val reported = observed!!.map { it.match.id }
+        assertTrue(reported.size < big.size, "must not report all 50: ${reported.size}")
+        reported.forEach { id ->
+            assertTrue(out.contains("Chunk ID: $id"), "reported $id but it is not in the output")
+        }
+        assertTrue(out.contains("showing ${reported.size} of 50 chunks"), out)
+    }
+
+    @Test
+    fun `a single chunk larger than the cap is still cut, and says so`() {
+        val tools = SectionReadingTools(
+            FakeSectionReader(chunksByTitle = mapOf("Huge" to listOf(chunk("c1", "x".repeat(10_000))))),
+            maxReadSectionChars = 5_000,
+        )
+        val out = tools.readSection("Huge")
+        assertTrue(out.contains("TRUNCATED"), out)
+        assertTrue(out.contains("cut at 5000"), out)
     }
 
     @Test

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingToolsTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingToolsTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.tools
+
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.Retrievable
+import com.embabel.agent.rag.service.SectionReader
+import com.embabel.agent.rag.service.SectionSummary
+import com.embabel.agent.rag.service.VectorSearch
+import com.embabel.common.core.types.SimilarityResult
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SectionReadingToolsTest {
+
+    private fun chunk(id: String, text: String): Chunk =
+        Chunk(id = id, text = text, parentId = "parent", metadata = emptyMap())
+
+    private class FakeSectionReader(
+        private val sections: List<SectionSummary> = emptyList(),
+        private val chunksByTitle: Map<String, List<Chunk>> = emptyMap(),
+    ) : SectionReader {
+        var lastDocumentTitle: String? = null
+
+        override fun listSections(documentTitle: String?): List<SectionSummary> {
+            lastDocumentTitle = documentTitle
+            return sections
+        }
+
+        override fun readSection(sectionTitle: String, documentTitle: String?): List<Chunk> {
+            lastDocumentTitle = documentTitle
+            return chunksByTitle[sectionTitle] ?: emptyList()
+        }
+    }
+
+    @Test
+    fun `listSections groups by document with chunk counts`() {
+        val tools = SectionReadingTools(
+            FakeSectionReader(
+                sections = listOf(
+                    SectionSummary("Balance Sheets", "Acme 10-K", 10),
+                    SectionSummary("Statements of Operations", "Acme 10-K", 7),
+                    SectionSummary("Overview", "Widget Deck", 3),
+                ),
+            ),
+        )
+        val out = tools.listSections(null)
+        assertTrue(out.contains("Document: Acme 10-K"), out)
+        assertTrue(out.contains("- Balance Sheets (10 chunks)"), out)
+        assertTrue(out.contains("Document: Widget Deck"), out)
+    }
+
+    @Test
+    fun `listSections with no sections says so and names the filter`() {
+        val out = SectionReadingTools(FakeSectionReader()).listSections("annual report")
+        assertTrue(out.contains("No sections found"), out)
+        assertTrue(out.contains("annual report"), out)
+    }
+
+    @Test
+    fun `readSection renders chunks in given order and reports them to the listener at full score`() {
+        var observed: List<SimilarityResult<out Retrievable>>? = null
+        var observedQuery: String? = null
+        val tools = SectionReadingTools(
+            FakeSectionReader(
+                chunksByTitle = mapOf(
+                    "Balance Sheets" to listOf(chunk("c1", "header row"), chunk("c2", "cash 2,366")),
+                ),
+            ),
+            resultsListener = { event ->
+                observed = event.results
+                observedQuery = event.query
+            },
+        )
+        val out = tools.readSection("Balance Sheets")
+        assertTrue(out.indexOf("header row") < out.indexOf("cash 2,366"), out)
+        assertTrue(out.contains("Chunk ID: c1"), out)
+        assertEquals(2, observed?.size)
+        assertTrue(observed!!.all { it.score == 1.0 })
+        assertEquals("readSection: Balance Sheets", observedQuery)
+    }
+
+    @Test
+    fun `readSection for an unknown title points at listSections and fires no event`() {
+        var fired = false
+        val tools = SectionReadingTools(FakeSectionReader(), resultsListener = { fired = true })
+        val out = tools.readSection("Nope", "Acme")
+        assertTrue(out.contains("No section titled 'Nope'"), out)
+        assertTrue(out.contains("listSections"), out)
+        assertTrue(out.contains("Acme"), out)
+        assertFalse(fired)
+    }
+
+    @Test
+    fun `readSection output over the cap is truncated with guidance, in order`() {
+        val big = (1..50).map { chunk("c$it", "x".repeat(1000)) }
+        val tools = SectionReadingTools(
+            FakeSectionReader(chunksByTitle = mapOf("Big" to big)),
+            maxReadSectionChars = 5_000,
+        )
+        val out = tools.readSection("Big")
+        assertTrue(out.length < 6_000, "capped: ${out.length}")
+        assertTrue(out.contains("TRUNCATED"), out)
+        assertTrue(out.contains("document order"), out)
+    }
+
+    @Test
+    fun `document title filter is passed through to the store`() {
+        val reader = FakeSectionReader()
+        SectionReadingTools(reader).listSections("acme")
+        assertEquals("acme", reader.lastDocumentTitle)
+        SectionReadingTools(reader).readSection("Balance Sheets", "widget")
+        assertEquals("widget", reader.lastDocumentTitle)
+    }
+
+    @Test
+    fun `ToolishRag exposes section tools only when the store implements SectionReader`() {
+        val withSections = ToolishRag(
+            name = "with",
+            description = "store with sections",
+            searchOperations = FakeSectionReader(),
+        ).tools().map { it.definition.name }
+        // Tool names are prefixed with the rag name by the UnfoldingTool machinery.
+        assertTrue(withSections.any { it.endsWith("listSections") }, withSections.toString())
+        assertTrue(withSections.any { it.endsWith("readSection") }, withSections.toString())
+
+        val without = ToolishRag(
+            name = "without",
+            description = "plain vector store",
+            searchOperations = mockk<VectorSearch>(relaxed = true),
+        ).tools().map { it.definition.name }
+        assertNull(without.find { it.endsWith("listSections") }, without.toString())
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingToolsTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingToolsTest.kt
@@ -109,6 +109,25 @@ class SectionReadingToolsTest {
     }
 
     @Test
+    fun `readSection refuses to blend documents - ambiguity returns a choice, not merged content`() {
+        var fired = false
+        val chunks = listOf(
+            Chunk(id = "a1", text = "Nevada law", parentId = "p", metadata = mapOf("root_document_title" to "Acme License")),
+            Chunk(id = "b1", text = "Ontario law", parentId = "p", metadata = mapOf("root_document_title" to "Widget License")),
+        )
+        val tools = SectionReadingTools(
+            FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)),
+            resultsListener = { fired = true },
+        )
+        val out = tools.readSection("Governing Law")
+        assertFalse(out.contains("Nevada"), "content must not be returned on ambiguity: $out")
+        assertTrue(out.contains("2 documents"), out)
+        assertTrue(out.contains("Acme License"), out)
+        assertTrue(out.contains("documentTitle"), out)
+        assertFalse(fired, "ambiguous reads are not evidence")
+    }
+
+    @Test
     fun `readSection output over the cap is truncated with guidance, in order`() {
         val big = (1..50).map { chunk("c$it", "x".repeat(1000)) }
         val tools = SectionReadingTools(


### PR DESCRIPTION
This PR extends the navigational capabilities over content that move `ToolishRag` beyond mere chunk retrieval.

Search retrieves isolated hits; some content only answers whole — the motivating case is structured data split across chunks, e.g. a financial statement whose header row, labels and values land in different chunks. 

As usual, stores can elect what they support. `SectionReader` stores list a document's section headings (its table of contents) and read every chunk of a named section in order. 

`ToolishRag` now exposes listSections/readSection when the store implements it; section reads are reported to the ResultsListener at full score so observed attribution sees them like search hits.


