### PR TITLE
Make integration test suite runnable in bulk

### DIFF
--- a/README.md
+++ b/README.md
@@ -952,25 +952,31 @@ mvn test
 
 ### Integration tests
 
-Integration tests (`*IT`) hit real provider APIs and are excluded from the default `mvn test` run.
-To run them, ensure the following environment variables are set:
+Integration tests (`*IT`) are excluded from the default `mvn test` run. Run the complete suite with:
+
+```bash
+mvn -Pintegration-tests test
+```
+
+Tests that require credentials or live services are skipped when their environment variables are absent, so you only
+need to configure the integrations you want to exercise:
 
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
 - `DEEPSEEK_API_KEY`
 - `MISTRAL_API_KEY`
+- `GEMINI_API_KEY`
+- `GOOGLE_GENAI_API_KEY`
+- `DASHSCOPE_API_KEY`
+- `ZAI_API_KEY`
+- `OLLAMA_BASE_URL` for tests using a local Ollama service
+- `EMBABEL_RUN_ONNX_INTEGRATION_TESTS` to opt into the slow Hugging Face model download
 
-Then run:
+Self-contained integration tests still run when none of these variables are set. To run a specific module's
+integration tests, add `-pl`:
 
 ```bash
-mvn -Dtest='*IT,!LLMOllama*IT' -Dsurefire.failIfNoSpecifiedTests=false test
-```
-
-This runs all integration tests except Ollama (which requires a local Ollama server).
-To run a specific module's integration tests, add `-pl`:
-
-```bash
-mvn -Dtest='*IT,!LLMOllama*IT' -Dsurefire.failIfNoSpecifiedTests=false test -pl embabel-agent-openai
+mvn -Pintegration-tests test -pl embabel-agent-openai
 ```
 
 ## Spring profiles

--- a/embabel-agent-api/pom.xml
+++ b/embabel-agent-api/pom.xml
@@ -290,9 +290,7 @@
                 <configuration>
                     <failOnFlakeCount>1</failOnFlakeCount>
                     <rerunFailingTestsCount>1</rerunFailingTestsCount>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                        <exclude>**/*IT.kt</exclude>
+                    <excludes combine.children="append">
                         <exclude>**/architecture/**</exclude>
                     </excludes>
                 </configuration>

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LLMAnthropicGuardRailsIntegrationIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LLMAnthropicGuardRailsIntegrationIT.java
@@ -26,6 +26,7 @@ import com.embabel.common.core.thinking.ThinkingResponse;
 import com.embabel.common.core.validation.ValidationResult;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,6 +82,8 @@ import static org.junit.jupiter.api.Assertions.*;
         }
 )
 @Import({AgentAnthropicAutoConfiguration.class})
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires ANTHROPIC_API_KEY")
 class LLMAnthropicGuardRailsIntegrationIT {
 
     private static final Logger logger = LoggerFactory.getLogger(LLMAnthropicGuardRailsIntegrationIT.class);

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LLMAnthropicStreamingBuilderIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LLMAnthropicStreamingBuilderIT.java
@@ -29,6 +29,7 @@ import com.embabel.common.ai.model.LlmOptions;
 import com.embabel.common.ai.model.Thinking;
 import com.embabel.common.core.streaming.StreamingEvent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,6 +105,8 @@ import static org.junit.jupiter.api.Assertions.*;
         }
 )
 @Import({AgentAnthropicAutoConfiguration.class})
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires ANTHROPIC_API_KEY")
 class LLMAnthropicStreamingBuilderIT {
 
     private static final Logger logger = LoggerFactory.getLogger(LLMAnthropicStreamingBuilderIT.class);
@@ -292,6 +295,4 @@ class LLMAnthropicStreamingBuilderIT {
 
         logger.info("Integration streaming test completed successfully with {} total events", receivedEvents.size());
     }
-
-
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LLMAnthropicThinkingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LLMAnthropicThinkingIT.java
@@ -31,6 +31,7 @@ import com.embabel.common.core.validation.ValidationResult;
 import com.embabel.common.core.validation.ValidationSeverity;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
@@ -102,6 +103,8 @@ import static org.junit.jupiter.api.Assertions.*;
         }
 )
 @Import({AgentAnthropicAutoConfiguration.class})
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires ANTHROPIC_API_KEY")
 class LLMAnthropicThinkingIT {
 
     private static final Logger logger = LoggerFactory.getLogger(LLMAnthropicThinkingIT.class);

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LlmAnthropicCachingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LlmAnthropicCachingIT.java
@@ -29,6 +29,7 @@ import com.embabel.chat.UserMessage;
 import com.embabel.chat.support.InMemoryConversation;
 import com.embabel.common.ai.model.LlmOptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -102,6 +103,8 @@ import static org.junit.jupiter.api.Assertions.*;
         }
 )
 @Import({AgentAnthropicAutoConfiguration.class})
+@EnabledIfEnvironmentVariable(named = "ANTHROPIC_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires ANTHROPIC_API_KEY")
 class LlmAnthropicCachingIT {
 
     private static final Logger logger = LoggerFactory.getLogger(LlmAnthropicCachingIT.class);

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/Opus48IntegrationIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/Opus48IntegrationIT.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.spi.LlmService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.opentest4j.TestAbortedException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
@@ -56,6 +57,11 @@ class Opus48TestConfig
 )
 @ActiveProfiles("opus48-test")
 @Import(Opus48TestConfig::class, AgentAnthropicAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(
+    named = "ANTHROPIC_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires ANTHROPIC_API_KEY",
+)
 class Opus48IntegrationIT(
     @param:Autowired private val ai: Ai,
     @param:Autowired private val llms: List<LlmService<*>>,

--- a/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/bedrock/AgentBedrockAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-bedrock-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/bedrock/AgentBedrockAutoConfigurationTest.java
@@ -33,7 +33,7 @@ import static com.embabel.agent.config.models.bedrock.BedrockModelsConfig.EU_ANT
 import static com.embabel.agent.config.models.bedrock.BedrockModelsConfig.EU_ANTHROPIC_CLAUDE_SONNET_4;
 
 @SpringBootTest(
-        classes = AgentBedrockAutoConfigurationIT.class,
+        classes = AgentBedrockAutoConfigurationTest.class,
         properties = {
                 "embabel.models.default-llm=" + EU_ANTHROPIC_CLAUDE_SONNET_4,
                 "embabel.models.llms.cheapest=" + EU_ANTHROPIC_CLAUDE_SONNET_4,
@@ -44,8 +44,8 @@ import static com.embabel.agent.config.models.bedrock.BedrockModelsConfig.EU_ANT
         })
 @ComponentScan(basePackages = "com.embabel.agent.autoconfigure")
 @ImportAutoConfiguration(classes = {JacksonAutoConfiguration.class, AgentBedrockAutoConfiguration.class})
-        @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-class AgentBedrockAutoConfigurationIT {
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class AgentBedrockAutoConfigurationTest {
 
     @Autowired
     private ApplicationContext applicationContext;

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiChatIntegrationIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/GoogleGenAiChatIntegrationIT.kt
@@ -62,7 +62,7 @@ class GoogleGenAiChatTestConfig
 )
 @ActiveProfiles("google-genai-chat-test")
 @Import(GoogleGenAiChatTestConfig::class, AgentGoogleGenAiAutoConfiguration::class)
-@EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".+", disabledReason = "Integration test requires GOOGLE_API_KEY")
+@EnabledIfEnvironmentVariable(named = "GEMINI_API_KEY", matches = ".+", disabledReason = "Integration test requires GEMINI_API_KEY")
 class GoogleGenAiChatIntegrationIT(
     @param:Autowired private val ai: Ai,
     @param:Autowired private val llms: List<LlmService<*>>,

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/java/com/embabel/agent/config/models/ollama/LLMOllamaStreamingBuilderIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/java/com/embabel/agent/config/models/ollama/LLMOllamaStreamingBuilderIT.java
@@ -24,6 +24,7 @@ import com.embabel.agent.spi.LlmService;
 import com.embabel.agent.spi.support.springai.SpringAiLlmService;
 import com.embabel.common.core.streaming.StreamingEvent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
@@ -100,6 +101,8 @@ import static org.junit.jupiter.api.Assertions.*;
         }
 )
 @Import({AgentOllamaAutoConfiguration.class})
+@EnabledIfEnvironmentVariable(named = "OLLAMA_BASE_URL", matches = ".+",
+        disabledReason = "Integration test requires OLLAMA_BASE_URL")
 class LLMOllamaStreamingBuilderIT {
 
     private static final Logger logger = LoggerFactory.getLogger(LLMOllamaStreamingBuilderIT.class);

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/java/com/embabel/agent/config/models/ollama/LLMOllamaThinkingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/java/com/embabel/agent/config/models/ollama/LLMOllamaThinkingIT.java
@@ -25,6 +25,7 @@ import com.embabel.common.ai.model.Thinking;
 import com.embabel.common.core.thinking.ThinkingBlock;
 import com.embabel.common.core.thinking.ThinkingResponse;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.tool.annotation.Tool;
@@ -92,6 +93,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         }
 )
 @Import({AgentOllamaAutoConfiguration.class})
+@EnabledIfEnvironmentVariable(named = "OLLAMA_BASE_URL", matches = ".+",
+        disabledReason = "Integration test requires OLLAMA_BASE_URL")
 class LLMOllamaThinkingIT {
 
     @SpringBootConfiguration

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/platform/AgentPlatformAutoConfigurationIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/platform/AgentPlatformAutoConfigurationIT.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration;
@@ -37,6 +38,8 @@ import org.springframework.test.annotation.DirtiesContext;
 @ComponentScan(basePackages = "com.embabel.agent.autoconfigure")
 @ImportAutoConfiguration(classes = {JacksonAutoConfiguration.class, AgentPlatformAutoConfiguration.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires OPENAI_API_KEY")
 class AgentPlatformAutoConfigurationIT {
 
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiCostTrackingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiCostTrackingIT.java
@@ -23,6 +23,7 @@ import com.embabel.agent.api.event.LlmInvocationEvent;
 import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,6 +70,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ConfigurationPropertiesScan(basePackages = "com.embabel.agent")
 @ComponentScan(basePackages = "com.embabel.agent")
 @Import({AgentOpenAiAutoConfiguration.class, LLMOpenAiCostTrackingIT.CostListenerConfig.class})
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires OPENAI_API_KEY")
 class LLMOpenAiCostTrackingIT {
 
     private static final Logger logger = LoggerFactory.getLogger(LLMOpenAiCostTrackingIT.class);

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiGuardRailsIntegrationIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiGuardRailsIntegrationIT.java
@@ -40,6 +40,7 @@ import com.openai.models.moderations.ModerationCreateParams;
 import com.openai.models.moderations.ModerationCreateResponse;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.moderation.Moderation;
@@ -338,6 +339,8 @@ class GuardRailConfiguration {
         }
 )
 @Import({AgentOpenAiAutoConfiguration.class, GuardRailConfiguration.class})
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires OPENAI_API_KEY")
 class LLMOpenAiGuardRailsIntegrationIT {
 
     @SpringBootConfiguration

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiStreamingBuilderIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/LLMOpenAiStreamingBuilderIT.java
@@ -23,6 +23,7 @@ import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguratio
 import com.embabel.agent.spi.LlmService;
 import com.embabel.common.core.streaming.StreamingEvent;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -95,6 +96,8 @@ import static org.junit.jupiter.api.Assertions.*;
         }
 )
 @Import({StreamingTestConfig.class, AgentOpenAiAutoConfiguration.class})
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires OPENAI_API_KEY")
 class LLMOpenAiStreamingBuilderIT {
 
     private static final Logger logger = LoggerFactory.getLogger(LLMOpenAiStreamingBuilderIT.class);

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/ParallelToolLoopGuardRailIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/java/com/embabel/agent/config/models/openai/ParallelToolLoopGuardRailIT.java
@@ -28,6 +28,7 @@ import com.embabel.common.core.thinking.ThinkingResponse;
 import com.embabel.common.core.validation.ValidationResult;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,6 +83,8 @@ import static org.junit.jupiter.api.Assertions.*;
         }
 )
 @Import(AgentOpenAiAutoConfiguration.class)
+@EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+",
+        disabledReason = "Integration test requires OPENAI_API_KEY")
 class ParallelToolLoopGuardRailIT {
 
     private static final Logger logger = LoggerFactory.getLogger(ParallelToolLoopGuardRailIT.class);

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/AgentProcessCostAggregationRealLlmIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/AgentProcessCostAggregationRealLlmIT.kt
@@ -30,6 +30,7 @@ import com.embabel.agent.domain.io.UserInput
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration
@@ -73,6 +74,11 @@ import org.springframework.test.context.ActiveProfiles
 )
 @Import(AgentOpenAiAutoConfiguration::class)
 @ImportAutoConfiguration(AgentPlatformAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(
+    named = "OPENAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires OPENAI_API_KEY",
+)
 class AgentProcessCostAggregationRealLlmIT {
 
     private val logger = LoggerFactory.getLogger(AgentProcessCostAggregationRealLlmIT::class.java)

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/LLMStreamingIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/LLMStreamingIT.kt
@@ -27,6 +27,7 @@ import com.embabel.common.core.streaming.StreamingEvent
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import org.slf4j.LoggerFactory
 import org.springframework.ai.tool.annotation.Tool
 import org.springframework.beans.factory.annotation.Autowired
@@ -109,6 +110,11 @@ class SimpleTool {
 )
 @ActiveProfiles("streaming-test")
 @Import(StreamingTestConfig::class, AgentOpenAiAutoConfiguration::class)
+@EnabledIfEnvironmentVariable(
+    named = "OPENAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires OPENAI_API_KEY",
+)
 class LLMStreamingIT(
     @param:Autowired private val autonomy: Autonomy,
     @param:Autowired private val ai: Ai,

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperationsIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperationsIT.kt
@@ -32,6 +32,7 @@ import com.embabel.common.core.validation.ValidationResult
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -45,6 +46,11 @@ import org.springframework.boot.test.context.SpringBootTest
 data class TestPerson(val name: String, val sign: String)
 
 @SpringBootTest
+@EnabledIfEnvironmentVariable(
+    named = "OPENAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires OPENAI_API_KEY",
+)
 internal class ChatClientLlmOperationsIT {
     @Autowired
     @Qualifier("chatClientLlmOperations")

--- a/embabel-agent-docs/src/main/asciidoc/reference/testing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/testing/page.adoc
@@ -819,6 +819,38 @@ class StoryWriterIntegrationTest : EmbabelMockitoIntegrationTest() {
 - Check tool groups: `llm.getToolGroups().isEmpty()`
 - Validate persona and other LLM options
 
+===== Running the Repository Integration Test Suite
+
+Tests whose names end in `IT` are excluded from the default `mvn test` run.
+Run the complete integration test suite with:
+
+[source,bash]
+----
+mvn -Pintegration-tests test
+----
+
+Tests that require credentials or live services are skipped when their environment variables are absent.
+Configure only the integrations you want to exercise:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `DEEPSEEK_API_KEY`
+- `MISTRAL_API_KEY`
+- `GEMINI_API_KEY`
+- `GOOGLE_GENAI_API_KEY`
+- `DASHSCOPE_API_KEY`
+- `ZAI_API_KEY`
+- `OLLAMA_BASE_URL` for tests using a local Ollama service
+- `EMBABEL_RUN_ONNX_INTEGRATION_TESTS` to opt into the slow Hugging Face model download
+
+Self-contained integration tests still run when none of these variables are set.
+Use Maven's `-pl` option to limit the run to a module:
+
+[source,bash]
+----
+mvn -Pintegration-tests test -pl embabel-agent-openai
+----
+
 ===== Integration Tests with LLM
 
 Embabel provides integration tests that exercise complete workflows with real LLM providers to verify end-to-end functionality.

--- a/embabel-agent-onnx/pom.xml
+++ b/embabel-agent-onnx/pom.xml
@@ -95,16 +95,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/*IT.java</exclude>
-                        <exclude>**/*IT.kt</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/embabel-agent-onnx/src/test/kotlin/com/embabel/agent/onnx/embeddings/OnnxEmbeddingServiceIT.kt
+++ b/embabel-agent-onnx/src/test/kotlin/com/embabel/agent/onnx/embeddings/OnnxEmbeddingServiceIT.kt
@@ -22,6 +22,7 @@ import kotlin.system.measureTimeMillis
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
 
 /**
  * IT test that downloads the real all-MiniLM-L6-v2 model and runs inference.
@@ -31,6 +32,11 @@ import org.junit.jupiter.api.TestInstance
  * download-and-cache pipeline end to end, including HTTP redirect handling.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(
+    named = "EMBABEL_RUN_ONNX_INTEGRATION_TESTS",
+    matches = ".+",
+    disabledReason = "Integration test downloads all-MiniLM-L6-v2 from Hugging Face and may be slow",
+)
 class OnnxEmbeddingServiceIT {
 
     companion object {

--- a/pom.xml
+++ b/pom.xml
@@ -224,6 +224,27 @@
     </build>
 
     <profiles>
+        <!-- Run integration tests that follow the *IT naming convention -->
+        <profile>
+            <id>integration-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.*</include>
+                            </includes>
+                            <excludes combine.self="override">
+                                <exclude>none</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <!-- Build Embabel Agent Documentation -->
         <profile>
             <id>embabel-agent-docs</id>


### PR DESCRIPTION
## Summary

- Guard provider-dependent integration tests with their required environment variables
- Skip the ONNX integration test unless its slow Hugging Face download is explicitly enabled
- Keep self-contained integration tests enabled in the full sweep
- Add an `integration-tests` Maven profile for running all `*IT` tests
- Document the profile and supported environment variables
- Correct the Google GenAI disabled reason

## Usage

```bash
mvn -Pintegration-tests test
```

Tests requiring unavailable credentials or services are skipped individually. Self-contained integration tests continue to run.

The ONNX download test requires:

```bash
EMBABEL_RUN_ONNX_INTEGRATION_TESTS=true
```

## Validation

- `git diff --check`
- Root POM XML parsing
- Static audit confirmed only the two self-contained integration-test classes remain unguarded
- Maven tests were not run locally

Closes #1925