### PR TITLE
Make the readSection anti-blending guard fire: promote the root document title

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/ContentChunker.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/ContentChunker.kt
@@ -74,6 +74,9 @@ interface ContentChunker {
         /** Metadata key for the unique identifier of the root document */
         const val ROOT_DOCUMENT_ID = ChunkStructure.ROOT_DOCUMENT_ID
 
+        /** Metadata key for the human-readable title of the root document */
+        const val ROOT_DOCUMENT_TITLE = ChunkStructure.ROOT_DOCUMENT_TITLE
+
         /** Metadata key for the unique identifier of the container section */
         const val CONTAINER_SECTION_ID = ChunkStructure.CONTAINER_SECTION_ID
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/InMemoryContentChunker.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/ingestion/InMemoryContentChunker.kt
@@ -23,6 +23,7 @@ import com.embabel.agent.rag.ingestion.ContentChunker.Companion.LEAF_SECTION_ID
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.LEAF_SECTION_TITLE
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.LEAF_SECTION_URL
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.ROOT_DOCUMENT_ID
+import com.embabel.agent.rag.ingestion.ContentChunker.Companion.ROOT_DOCUMENT_TITLE
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.SEQUENCE_NUMBER
 import com.embabel.agent.rag.ingestion.ContentChunker.Companion.TOTAL_CHUNKS
 import com.embabel.agent.rag.model.*
@@ -44,11 +45,15 @@ class InMemoryContentChunker(
         val leaves = section.leaves().toList()
         val totalContentLength = leaves.sumOf { it.content.length + it.title.length + 1 } // +1 for newline after title
 
-        // Determine root document ID: if section is a ContentRoot, use its ID, otherwise try to get from metadata
-        val rootId = if (section is ContentRoot) {
-            section.id
+        // Determine the root document: if section is a ContentRoot, use its own id and title,
+        // otherwise inherit whatever provenance the caller propagated through metadata.
+        val root = if (section is ContentRoot) {
+            RootDocument(id = section.id, title = section.title)
         } else {
-            section.metadata[ROOT_DOCUMENT_ID] as? String ?: section.id
+            RootDocument(
+                id = section.metadata[ROOT_DOCUMENT_ID] as? String ?: section.id,
+                title = section.metadata[ROOT_DOCUMENT_TITLE] as? String,
+            )
         }
 
         // Determine the document for transformation context
@@ -60,14 +65,14 @@ class InMemoryContentChunker(
                 "Creating single chunk for container section '{}' with {} leaves (total length: {} <= max: {})",
                 section.title, leaves.size, totalContentLength, config.maxChunkSize
             )
-            listOf(createSingleChunkFromContainer(section, leaves, rootId))
+            listOf(createSingleChunkFromContainer(section, leaves, root))
         } else {
             // Strategy 2: Try to group leaves intelligently before splitting
             logger.debug(
                 "Total content ({} chars) exceeds maxChunkSize ({}), attempting intelligent grouping",
                 totalContentLength, config.maxChunkSize
             )
-            chunkLeavesIntelligently(section, leaves, rootId)
+            chunkLeavesIntelligently(section, leaves, root)
         }
 
         // Apply transformer if configured
@@ -96,7 +101,7 @@ class InMemoryContentChunker(
     private fun createSingleChunkFromContainer(
         section: NavigableContainerSection,
         leaves: List<LeafSection>,
-        rootId: String,
+        root: RootDocument,
     ): Chunk {
         val combinedContent = leaves.joinToString("\n\n") { leaf ->
             if (leaf.title.isNotBlank()) "${leaf.title}\n${leaf.content}" else leaf.content
@@ -104,7 +109,7 @@ class InMemoryContentChunker(
 
         val combinedMetadata = mutableMapOf<String, Any?>()
         combinedMetadata.putAll(section.metadata)
-        combinedMetadata[ROOT_DOCUMENT_ID] = rootId
+        combinedMetadata.putAll(root.metadata())
         combinedMetadata[CONTAINER_SECTION_ID] = section.id
         combinedMetadata[CONTAINER_SECTION_TITLE] = section.title
         combinedMetadata[CONTAINER_SECTION_URL] = section.uri
@@ -123,7 +128,7 @@ class InMemoryContentChunker(
     private fun chunkLeavesIntelligently(
         containerSection: NavigableContainerSection,
         leaves: List<LeafSection>,
-        rootId: String,
+        root: RootDocument,
     ): List<Chunk> {
         val allChunks = mutableListOf<Chunk>()
         val leafGroups = groupLeavesForOptimalChunking(leaves)
@@ -140,10 +145,10 @@ class InMemoryContentChunker(
 
                     if (leafContentSize <= config.maxChunkSize) {
                         // Small enough for single chunk
-                        allChunks.add(createSingleLeafChunk(containerSection, leaf, rootId, sequenceNumber++))
+                        allChunks.add(createSingleLeafChunk(containerSection, leaf, root, sequenceNumber++))
                     } else {
                         // Too large, split it
-                        val chunks = splitLeafIntoMultipleChunks(containerSection, leaf, rootId, sequenceNumber)
+                        val chunks = splitLeafIntoMultipleChunks(containerSection, leaf, root, sequenceNumber)
                         sequenceNumber += chunks.size
                         allChunks.addAll(chunks)
                     }
@@ -151,7 +156,7 @@ class InMemoryContentChunker(
 
                 else -> {
                     // Multi-leaf group - create combined chunk
-                    allChunks.add(createCombinedLeafChunk(containerSection, group, rootId, sequenceNumber++))
+                    allChunks.add(createCombinedLeafChunk(containerSection, group, root, sequenceNumber++))
                 }
             }
         }
@@ -200,7 +205,7 @@ class InMemoryContentChunker(
     private fun createCombinedLeafChunk(
         containerSection: NavigableContainerSection,
         leaves: List<LeafSection>,
-        rootId: String,
+        root: RootDocument,
         sequenceNumber: Int,
     ): Chunk {
         val combinedContent = leaves.joinToString("\n\n") { leaf ->
@@ -209,7 +214,7 @@ class InMemoryContentChunker(
 
         val combinedMetadata = mutableMapOf<String, Any?>()
         combinedMetadata.putAll(containerSection.metadata)
-        combinedMetadata[ROOT_DOCUMENT_ID] = rootId
+        combinedMetadata.putAll(root.metadata())
         combinedMetadata[CONTAINER_SECTION_ID] = containerSection.id
         combinedMetadata[CONTAINER_SECTION_TITLE] = containerSection.title
         combinedMetadata[CONTAINER_SECTION_URL] = containerSection.uri
@@ -228,7 +233,7 @@ class InMemoryContentChunker(
     private fun createSingleLeafChunk(
         containerSection: NavigableContainerSection,
         leaf: LeafSection,
-        rootId: String,
+        root: RootDocument,
         sequenceNumber: Int,
     ): Chunk {
         val content = if (leaf.title.isNotBlank()) "${leaf.title}\n${leaf.content}" else leaf.content
@@ -236,8 +241,7 @@ class InMemoryContentChunker(
         return Chunk.Companion(
             id = UUID.randomUUID().toString(),
             text = content.trim(),
-            metadata = leaf.metadata + mapOf(
-                ROOT_DOCUMENT_ID to rootId,
+            metadata = leaf.metadata + root.metadata() + mapOf(
                 CONTAINER_SECTION_ID to containerSection.id,
                 CONTAINER_SECTION_TITLE to containerSection.title,
                 LEAF_SECTION_ID to leaf.id,
@@ -254,7 +258,7 @@ class InMemoryContentChunker(
     private fun splitLeafIntoMultipleChunks(
         containerSection: NavigableContainerSection,
         leaf: LeafSection,
-        rootId: String,
+        root: RootDocument,
         startingSequenceNumber: Int,
     ): List<Chunk> {
         val chunks = mutableListOf<Chunk>()
@@ -267,8 +271,7 @@ class InMemoryContentChunker(
             val chunk = Chunk.Companion(
                 id = UUID.randomUUID().toString(),
                 text = textChunk.trim(),
-                metadata = leaf.metadata + mapOf(
-                    ROOT_DOCUMENT_ID to rootId,
+                metadata = leaf.metadata + root.metadata() + mapOf(
                     CONTAINER_SECTION_ID to containerSection.id,
                     CONTAINER_SECTION_TITLE to containerSection.title,
                     LEAF_SECTION_ID to leaf.id,
@@ -570,4 +573,20 @@ class InMemoryContentChunker(
         return lines.isNotEmpty() && lines.all { isTableLine(it) }
     }
 
+}
+
+/**
+ * Provenance of the document a chunk came from: its stable id, and its human-readable title
+ * where the source has one. The title travels with every chunk because `readSection` shows it
+ * to the model when one section name matches more than one document.
+ */
+private data class RootDocument(
+    val id: String,
+    val title: String? = null,
+) {
+
+    fun metadata(): Map<String, Any?> = buildMap {
+        put(ROOT_DOCUMENT_ID, id)
+        title?.let { put(ROOT_DOCUMENT_TITLE, it) }
+    }
 }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/ChunkStructure.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/model/ChunkStructure.kt
@@ -24,6 +24,7 @@ package com.embabel.agent.rag.model
  */
 data class ChunkStructure(
     val rootDocumentId: String? = null,
+    val rootDocumentTitle: String? = null,
     val containerSectionId: String? = null,
     val containerSectionTitle: String? = null,
     val containerSectionUrl: String? = null,
@@ -44,6 +45,7 @@ data class ChunkStructure(
         if (isEmpty()) return emptyMap()
         val result = LinkedHashMap<String, Any?>(KEYS.size)
         rootDocumentId?.let { result[ROOT_DOCUMENT_ID] = it }
+        rootDocumentTitle?.let { result[ROOT_DOCUMENT_TITLE] = it }
         containerSectionId?.let { result[CONTAINER_SECTION_ID] = it }
         containerSectionTitle?.let { result[CONTAINER_SECTION_TITLE] = it }
         containerSectionUrl?.let { result[CONTAINER_SECTION_URL] = it }
@@ -61,6 +63,7 @@ data class ChunkStructure(
      */
     fun merge(other: ChunkStructure): ChunkStructure = ChunkStructure(
         rootDocumentId = other.rootDocumentId ?: rootDocumentId,
+        rootDocumentTitle = other.rootDocumentTitle ?: rootDocumentTitle,
         containerSectionId = other.containerSectionId ?: containerSectionId,
         containerSectionTitle = other.containerSectionTitle ?: containerSectionTitle,
         containerSectionUrl = other.containerSectionUrl ?: containerSectionUrl,
@@ -78,6 +81,7 @@ data class ChunkStructure(
         const val TOTAL_CHUNKS = "total_chunks"
         const val SEQUENCE_NUMBER = "sequence_number"
         const val ROOT_DOCUMENT_ID = "root_document_id"
+        const val ROOT_DOCUMENT_TITLE = "root_document_title"
         const val CONTAINER_SECTION_ID = "container_section_id"
         const val CONTAINER_SECTION_TITLE = "container_section_title"
         const val CONTAINER_SECTION_URL = "container_section_url"
@@ -90,6 +94,7 @@ data class ChunkStructure(
             TOTAL_CHUNKS,
             SEQUENCE_NUMBER,
             ROOT_DOCUMENT_ID,
+            ROOT_DOCUMENT_TITLE,
             CONTAINER_SECTION_ID,
             CONTAINER_SECTION_TITLE,
             CONTAINER_SECTION_URL,
@@ -107,6 +112,7 @@ data class ChunkStructure(
             }
             return ChunkStructure(
                 rootDocumentId = stringOrNull(metadata[ROOT_DOCUMENT_ID]),
+                rootDocumentTitle = stringOrNull(metadata[ROOT_DOCUMENT_TITLE]),
                 containerSectionId = stringOrNull(metadata[CONTAINER_SECTION_ID]),
                 containerSectionTitle = stringOrNull(metadata[CONTAINER_SECTION_TITLE]),
                 containerSectionUrl = stringOrNull(metadata[CONTAINER_SECTION_URL]),

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -203,8 +203,10 @@ internal class ResultExpanderTools @JvmOverloads constructor(
     fun zoomOut(
         @LlmTool.Param(description = "id of the content element to expand") id: String,
     ): String {
-        val embeddables = resultExpander.expandResult(id, ResultExpander.Method.ZOOM_OUT, 1)
-         .filter { it is Embeddable }
+        val (embeddables, ms) = time {
+            resultExpander.expandResult(id, ResultExpander.Method.ZOOM_OUT, 1)
+                .filter { it is Embeddable }
+        }
         if (embeddables.isEmpty()) return "No parent section found."
         // Same observability contract as broadenChunk for whatever is Retrievable.
         val retrievables = embeddables.filterIsInstance<Retrievable>()
@@ -214,7 +216,7 @@ internal class ResultExpanderTools @JvmOverloads constructor(
                     this,
                     "zoomOut: $id",
                     retrievables.map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) },
-                    Duration.ZERO,
+                    Duration.ofMillis(ms),
                 ),
             )
         }
@@ -310,25 +312,65 @@ internal class SectionReadingTools @JvmOverloads constructor(
         // documents hands the model the WRONG one to quote from — measured 2026-08-14
         // (CUAD): governing-law answers cited a different contract's clause at full
         // confidence. Ambiguity is surfaced as a choice, not merged.
+        //
+        // Provenance comes from the chunk's structural fields, which the chunker always
+        // populates: keying off a free-form metadata key nobody writes would leave every
+        // chunk indistinguishable and silently re-enable the blending this prevents.
         val documents = chunks
-            .map { it.metadata["root_document_title"] as? String ?: it.metadata["root_document_uri"] as? String }
+            .map { DocumentProvenance(it.structure.rootDocumentId, it.structure.rootDocumentTitle) }
             .distinct()
-        if (documents.size > 1 && documents.none { it == null }) {
+        // Unknown provenance FAILS CLOSED: a chunk we cannot attribute is the least safe
+        // input to concatenate, not an excuse to skip the check.
+        if (documents.size > 1) {
             return "Section '$sectionTitle' exists in ${documents.size} documents: " +
-                documents.joinToString("; ") { "'$it'" } +
-                ". Call readSection again with a documentTitle to pick ONE."
+                documents.joinToString("; ") { it.describe() } +
+                (documentTitle?.let {
+                    ". The documentTitle '$it' still matches more than one — pass a longer, " +
+                        "more specific substring"
+                } ?: ". Call readSection again with a documentTitle") +
+                " to pick ONE."
         }
-        // Full score: the model asked for this section by name; every chunk of it is evidence
-        // the observer must see, exactly as it would see a search hit.
-        val results = chunks.map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) }
+        val rendered = chunks.map { "Chunk ID: ${it.id}\nContent: ${it.text}\n" }
+        // Truncate at a chunk boundary, and report ONLY the chunks that survived it. Full score:
+        // the model asked for this section by name, so what it was shown is evidence exactly as a
+        // search hit is — but reporting a chunk it never saw lets an attribution check treat an
+        // ungrounded quote as grounded, which is the same failure in the other direction.
+        val shown = rendered
+            .runningFold(0) { chars, chunkText -> chars + chunkText.length + 1 }
+            .drop(1)
+            .takeWhile { it <= maxReadSectionChars }
+            .size
+            .coerceAtLeast(1)
+        val results = chunks.take(shown).map { SimpleSimilaritySearchResult<Retrievable>(it, 1.0) }
         resultsListener?.onResultsEvent(ResultsEvent(this, "readSection: $sectionTitle", results, Duration.ofMillis(ms)))
-        val rendered = chunks.joinToString("\n") { "Chunk ID: ${it.id}\nContent: ${it.text}\n" }
-        if (rendered.length > maxReadSectionChars) {
-            return rendered.take(maxReadSectionChars) +
-                "\n\n[TRUNCATED — section is ${rendered.length} chars. The chunks above are in document order; " +
+        val text = rendered.take(shown).joinToString("\n")
+        if (shown < chunks.size || text.length > maxReadSectionChars) {
+            val what = if (shown < chunks.size) {
+                "showing $shown of ${chunks.size} chunks"
+            } else {
+                // A single chunk over the cap: the model sees part of a chunk reported whole.
+                "one chunk of ${text.length} chars cut at $maxReadSectionChars"
+            }
+            return text.take(maxReadSectionChars) +
+                "\n\n[TRUNCATED — $what. The chunks above are in document order; " +
                 "use vectorSearch or textSearch for the rest, or broadenChunk from the last chunk shown.]"
         }
-        return rendered
+        return text
+    }
+
+    /**
+     * Which document a section's chunks came from. Identity is the root document id — the
+     * title is what the model is shown, but two documents may legitimately share one.
+     */
+    private data class DocumentProvenance(
+        val id: String?,
+        val title: String?,
+    ) {
+        fun describe(): String = when {
+            title != null -> "'$title'"
+            id != null -> "document $id"
+            else -> "an unattributed document"
+        }
     }
 
     companion object {

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -101,6 +101,7 @@ data class ToolishRag @JvmOverloads constructor(
     val metadataFilter: PropertyFilter? = null,
     val entityFilter: EntityFilter? = null,
     val maxZoomOutChars: Int = ResultExpanderTools.DEFAULT_MAX_ZOOM_OUT_CHARS,
+    val maxReadSectionChars: Int = SectionReadingTools.DEFAULT_MAX_READ_SECTION_CHARS,
     /**
      * Progressively-disclosed guidance appended to the unfold response when
      * the LLM invokes this tool. Right home for search-strategy notes
@@ -183,7 +184,7 @@ data class ToolishRag @JvmOverloads constructor(
             }
             if (searchOperations is SectionReader) {
                 logger.debug("Adding SectionReadingTools to ToolishRag '{}'", name)
-                add(SectionReadingTools(searchOperations, listener))
+                add(SectionReadingTools(searchOperations, listener, maxReadSectionChars))
             }
             if (searchOperations is RegexSearchOperations) {
                 logger.debug("Adding RegexSearchTools to ToolishRag '{}'", name)
@@ -254,6 +255,13 @@ data class ToolishRag @JvmOverloads constructor(
      */
     fun withMaxZoomOutChars(maxChars: Int): ToolishRag =
         copy(maxZoomOutChars = maxChars)
+
+    /**
+     * Set the maximum number of characters a single readSection result may return
+     * before it is truncated at a chunk boundary.
+     */
+    fun withMaxReadSectionChars(maxChars: Int): ToolishRag =
+        copy(maxReadSectionChars = maxChars)
 
     /**
      * Set the similarity floors applied when the LLM omits the optional `threshold`

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/ingestion/ContentChunkerRootDocumentTitleTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/ingestion/ContentChunkerRootDocumentTitleTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.ingestion
+
+import com.embabel.agent.rag.model.ChunkStructure
+import com.embabel.agent.rag.model.LeafSection
+import com.embabel.agent.rag.model.MaterializedDocument
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * Every chunk must carry the title of the document it came from.
+ *
+ * `readSection` refuses to concatenate a section title that matches more than one document,
+ * and the only way it can tell one document from another is this field. A chunker that stops
+ * writing it turns that guard into a no-op — the model is handed two contracts' clauses as one
+ * section, with nothing in the output to say so.
+ */
+class ContentChunkerRootDocumentTitleTest {
+
+    private val chunker = ContentChunker(ContentChunker.Config(), ChunkTransformer.NO_OP)
+
+    private fun document(title: String, sections: Int, textLength: Int): MaterializedDocument {
+        val rootId = UUID.randomUUID().toString()
+        return MaterializedDocument(
+            id = rootId,
+            uri = "test://doc",
+            title = title,
+            children = (1..sections).map {
+                LeafSection(
+                    id = UUID.randomUUID().toString(),
+                    uri = "test://doc#$it",
+                    title = "Section $it",
+                    text = "word ".repeat(textLength),
+                    parentId = rootId,
+                )
+            },
+        )
+    }
+
+    @Test
+    fun `a document small enough for one chunk carries its title`() {
+        val chunks = chunker.chunk(document("Acme License", sections = 1, textLength = 5)).toList()
+
+        assertTrue(chunks.isNotEmpty())
+        chunks.forEach {
+            assertEquals("Acme License", it.structure.rootDocumentTitle, "chunk ${it.id}")
+        }
+    }
+
+    @Test
+    fun `a document split across many chunks carries its title on every one`() {
+        // Large enough to exercise leaf grouping and leaf splitting, not just the single-chunk path.
+        val chunks = chunker.chunk(document("Widget License", sections = 12, textLength = 400)).toList()
+
+        assertTrue(chunks.size > 1, "expected a split document, got ${chunks.size} chunk(s)")
+        chunks.forEach {
+            assertEquals("Widget License", it.structure.rootDocumentTitle, "chunk ${it.id}")
+        }
+    }
+
+    @Test
+    fun `the title is readable through the metadata compatibility view`() {
+        val chunk = chunker.chunk(document("Acme License", sections = 1, textLength = 5)).first()
+
+        assertEquals("Acme License", chunk.metadata[ChunkStructure.ROOT_DOCUMENT_TITLE])
+    }
+
+    @Test
+    fun `two documents sharing a section name stay distinguishable`() {
+        val acme = chunker.chunk(document("Acme License", sections = 1, textLength = 5)).toList()
+        val widget = chunker.chunk(document("Widget License", sections = 1, textLength = 5)).toList()
+
+        val titles = (acme + widget).map { it.structure.rootDocumentTitle }.distinct()
+        assertEquals(listOf("Acme License", "Widget License"), titles)
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChunkStructureTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/model/ChunkStructureTest.kt
@@ -35,6 +35,7 @@ class ChunkStructureTest {
             val structure = ChunkStructure.fromMetadata(
                 mapOf(
                     ChunkStructure.ROOT_DOCUMENT_ID to "doc-1",
+                    ChunkStructure.ROOT_DOCUMENT_TITLE to "Acme 10-K",
                     ChunkStructure.CONTAINER_SECTION_ID to "sec-1",
                     ChunkStructure.CONTAINER_SECTION_TITLE to "Intro",
                     ChunkStructure.CONTAINER_SECTION_URL to "https://example.com",
@@ -49,6 +50,7 @@ class ChunkStructureTest {
             )
 
             assertEquals("doc-1", structure.rootDocumentId)
+            assertEquals("Acme 10-K", structure.rootDocumentTitle)
             assertEquals("sec-1", structure.containerSectionId)
             assertEquals("Intro", structure.containerSectionTitle)
             assertEquals("https://example.com", structure.containerSectionUrl)
@@ -67,6 +69,7 @@ class ChunkStructureTest {
                 ChunkStructure.SEQUENCE_NUMBER to 1,
                 "author" to "alice",
                 ChunkStructure.ROOT_DOCUMENT_ID to "doc",
+                ChunkStructure.ROOT_DOCUMENT_TITLE to "Acme 10-K",
             )
             val freeform = ChunkStructure.withoutStructuralKeys(original)
             assertEquals(mapOf("author" to "alice"), freeform)
@@ -80,6 +83,7 @@ class ChunkStructureTest {
         fun `round trips non-null fields`() {
             val structure = ChunkStructure(
                 rootDocumentId = "doc-1",
+                rootDocumentTitle = "Acme 10-K",
                 containerSectionId = "sec-1",
                 sequenceNumber = 3,
                 chunkIndex = 0,
@@ -101,10 +105,11 @@ class ChunkStructureTest {
 
         @Test
         fun `prefers non-null values from other`() {
-            val base = ChunkStructure(rootDocumentId = "doc", sequenceNumber = 1)
+            val base = ChunkStructure(rootDocumentId = "doc", rootDocumentTitle = "Acme 10-K", sequenceNumber = 1)
             val other = ChunkStructure(sequenceNumber = 9, containerSectionId = "c1")
             val merged = base.merge(other)
             assertEquals("doc", merged.rootDocumentId)
+            assertEquals("Acme 10-K", merged.rootDocumentTitle)
             assertEquals(9, merged.sequenceNumber)
             assertEquals("c1", merged.containerSectionId)
         }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingProvenanceTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingProvenanceTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.rag.tools
+
+import com.embabel.agent.rag.ingestion.ChunkTransformer
+import com.embabel.agent.rag.ingestion.ContentChunker
+import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.LeafSection
+import com.embabel.agent.rag.model.MaterializedDocument
+import com.embabel.agent.rag.service.SectionSummary
+import com.embabel.agent.rag.service.SectionReader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * The anti-blending guard, exercised over chunks the REAL chunker produced.
+ *
+ * The unit tests in [SectionReadingToolsTest] hand the guard its provenance. That is exactly how
+ * the defect this covers survived: the guard read metadata keys no chunker wrote, so it passed a
+ * test that supplied them and did nothing at all against a store. Here nothing is hand-written —
+ * two contracts are ingested through [ContentChunker], and the store below matches section titles
+ * the way a real [SectionReader] must. If chunker and guard ever stop agreeing on where document
+ * provenance lives, these fail.
+ */
+class SectionReadingProvenanceTest {
+
+    private val chunker = ContentChunker(ContentChunker.Config(), ChunkTransformer.NO_OP)
+
+    /**
+     * The minimum a store must do to satisfy [SectionReader]: match a section title
+     * case-insensitively across everything it holds, in ingestion order. Deliberately NOT
+     * document-aware — telling the documents apart is the tools' job, which is what is under test.
+     */
+    private class IngestedSections(chunks: List<Chunk>) : SectionReader {
+
+        private val chunks: List<Chunk> = chunks.sortedBy { it.structure.sequenceNumber ?: 0 }
+
+        override fun listSections(documentTitle: String?): List<SectionSummary> = chunks
+            .filter { it.matchesDocument(documentTitle) }
+            .groupBy { (it.structure.rootDocumentTitle ?: "") to it.sectionTitle() }
+            .map { (key, group) -> SectionSummary(key.second, key.first, group.size) }
+
+        override fun readSection(sectionTitle: String, documentTitle: String?): List<Chunk> = chunks
+            .filter { it.sectionTitle().equals(sectionTitle, ignoreCase = true) }
+            .filter { it.matchesDocument(documentTitle) }
+
+        /** A chunk is filed under its leaf section where it has one, else its container. */
+        private fun Chunk.sectionTitle(): String =
+            structure.leafSectionTitle ?: structure.containerSectionTitle ?: ""
+
+        private fun Chunk.matchesDocument(documentTitle: String?): Boolean =
+            documentTitle == null || structure.rootDocumentTitle.orEmpty().contains(documentTitle, true)
+    }
+
+    /** Long enough that the chunker takes its per-leaf path rather than folding the document into one chunk. */
+    private fun clause(text: String): String = text + " " + "The parties acknowledge the foregoing. ".repeat(30)
+
+    private fun contract(title: String, governingLaw: String) = MaterializedDocument(
+        id = UUID.randomUUID().toString(),
+        uri = "test://${title.replace(' ', '-')}",
+        title = title,
+        children = listOf(
+            LeafSection(
+                id = UUID.randomUUID().toString(),
+                uri = "test://${title.replace(' ', '-')}#gl",
+                title = "Governing Law",
+                text = clause(governingLaw),
+                parentId = title,
+            ),
+            LeafSection(
+                id = UUID.randomUUID().toString(),
+                uri = "test://${title.replace(' ', '-')}#term",
+                title = "Term and Termination",
+                text = clause("This agreement runs for three years."),
+                parentId = title,
+            ),
+        ),
+    )
+
+    private fun ingest(vararg documents: MaterializedDocument) =
+        IngestedSections(documents.flatMap { chunker.chunk(it) })
+
+    @Test
+    fun `two ingested contracts sharing a section name are not concatenated`() {
+        val store = ingest(
+            contract("Acme License", "This agreement is governed by the laws of Nevada."),
+            contract("Widget License", "This agreement is governed by the laws of Ontario."),
+        )
+
+        val out = SectionReadingTools(store).readSection("Governing Law")
+
+        // The measured CUAD failure: one contract's clause quoted as the other's.
+        assertFalse(out.contains("Nevada"), "must not return one contract's clause: $out")
+        assertFalse(out.contains("Ontario"), "must not return the other contract's clause: $out")
+        assertTrue(out.contains("2 documents"), out)
+        assertTrue(out.contains("Acme License"), out)
+        assertTrue(out.contains("Widget License"), out)
+    }
+
+    @Test
+    fun `naming the document reads that one whole`() {
+        val store = ingest(
+            contract("Acme License", "This agreement is governed by the laws of Nevada."),
+            contract("Widget License", "This agreement is governed by the laws of Ontario."),
+        )
+
+        val out = SectionReadingTools(store).readSection("Governing Law", documentTitle = "Acme")
+
+        assertTrue(out.contains("Nevada"), out)
+        assertFalse(out.contains("Ontario"), out)
+    }
+
+    @Test
+    fun `a section of one ingested document is read whole`() {
+        val store = ingest(contract("Acme License", "This agreement is governed by the laws of Nevada."))
+
+        val out = SectionReadingTools(store).readSection("Governing Law")
+
+        assertTrue(out.contains("Nevada"), out)
+        assertFalse(out.contains("2 documents"), out)
+    }
+
+    @Test
+    fun `listSections attributes each section to the document it came from`() {
+        val store = ingest(contract("Acme License", "Nevada."), contract("Widget License", "Ontario."))
+
+        val out = SectionReadingTools(store).listSections()
+
+        assertTrue(out.contains("Document: Acme License"), out)
+        assertTrue(out.contains("Document: Widget License"), out)
+    }
+
+    @Test
+    fun `the chunker is the only source of provenance in this test`() {
+        // Guards the guard: if the chunker stops writing the title, the ambiguity check above
+        // silently degrades to "one unattributed document" and would blend again.
+        val chunks = chunker.chunk(contract("Acme License", "This agreement is governed by the laws of Nevada."))
+            .toList()
+
+        assertTrue(chunks.isNotEmpty())
+        chunks.forEach {
+            assertEquals("Acme License", it.structure.rootDocumentTitle, "chunk ${it.id}")
+        }
+        assertEquals(
+            setOf("Governing Law", "Term and Termination"),
+            chunks.mapNotNull { it.structure.leafSectionTitle }.toSet(),
+        )
+    }
+}

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingToolsTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/SectionReadingToolsTest.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.rag.tools
 
 import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.ChunkStructure
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.SectionReader
 import com.embabel.agent.rag.service.SectionSummary
@@ -32,6 +33,9 @@ class SectionReadingToolsTest {
 
     private fun chunk(id: String, text: String): Chunk =
         Chunk(id = id, text = text, parentId = "parent", metadata = emptyMap())
+
+    private fun chunkOf(id: String, text: String, structure: ChunkStructure): Chunk =
+        Chunk.create(text = text, parentId = "parent", id = id, structure = structure)
 
     private class FakeSectionReader(
         private val sections: List<SectionSummary> = emptyList(),
@@ -112,8 +116,8 @@ class SectionReadingToolsTest {
     fun `readSection refuses to blend documents - ambiguity returns a choice, not merged content`() {
         var fired = false
         val chunks = listOf(
-            Chunk(id = "a1", text = "Nevada law", parentId = "p", metadata = mapOf("root_document_title" to "Acme License")),
-            Chunk(id = "b1", text = "Ontario law", parentId = "p", metadata = mapOf("root_document_title" to "Widget License")),
+            chunkOf("a1", "Nevada law", ChunkStructure(rootDocumentId = "doc-a", rootDocumentTitle = "Acme License")),
+            chunkOf("b1", "Ontario law", ChunkStructure(rootDocumentId = "doc-b", rootDocumentTitle = "Widget License")),
         )
         val tools = SectionReadingTools(
             FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)),
@@ -128,6 +132,63 @@ class SectionReadingToolsTest {
     }
 
     @Test
+    fun `provenance the chunker writes as metadata reaches the guard as structure`() {
+        // The chunker writes root_document_title into metadata; the Chunk factory lifts it into
+        // ChunkStructure. If the two ever stop agreeing, the guard silently stops firing.
+        val chunks = listOf(
+            Chunk(
+                id = "a1", text = "Nevada law", parentId = "p",
+                metadata = mapOf(ChunkStructure.ROOT_DOCUMENT_TITLE to "Acme License"),
+            ),
+            Chunk(
+                id = "b1", text = "Ontario law", parentId = "p",
+                metadata = mapOf(ChunkStructure.ROOT_DOCUMENT_TITLE to "Widget License"),
+            ),
+        )
+        assertEquals("Acme License", chunks.first().structure.rootDocumentTitle)
+        val out = SectionReadingTools(FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)))
+            .readSection("Governing Law")
+        assertTrue(out.contains("2 documents"), out)
+    }
+
+    @Test
+    fun `unknown provenance fails closed - a chunk we cannot attribute is not blended in`() {
+        val chunks = listOf(
+            chunkOf("a1", "Nevada law", ChunkStructure(rootDocumentId = "doc-a", rootDocumentTitle = "Acme License")),
+            chunk("b1", "Ontario law"),
+        )
+        val out = SectionReadingTools(FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)))
+            .readSection("Governing Law")
+        assertFalse(out.contains("Nevada"), "unattributed chunks must not be blended in: $out")
+        assertTrue(out.contains("2 documents"), out)
+        assertTrue(out.contains("unattributed"), out)
+    }
+
+    @Test
+    fun `an already-filtered ambiguous read says the filter was not specific enough`() {
+        val chunks = listOf(
+            chunkOf("a1", "Nevada law", ChunkStructure(rootDocumentId = "a", rootDocumentTitle = "Acme License 2024")),
+            chunkOf("b1", "Ontario law", ChunkStructure(rootDocumentId = "b", rootDocumentTitle = "Acme License 2025")),
+        )
+        val out = SectionReadingTools(FakeSectionReader(chunksByTitle = mapOf("Governing Law" to chunks)))
+            .readSection("Governing Law", documentTitle = "Acme")
+        assertTrue(out.contains("still matches more than one"), out)
+        assertTrue(out.contains("Acme"), out)
+    }
+
+    @Test
+    fun `chunks a single document owns are read whole, not treated as ambiguous`() {
+        val chunks = listOf(
+            chunkOf("a1", "header row", ChunkStructure(rootDocumentId = "doc-a", rootDocumentTitle = "Acme 10-K")),
+            chunkOf("a2", "cash 2,366", ChunkStructure(rootDocumentId = "doc-a", rootDocumentTitle = "Acme 10-K")),
+        )
+        val out = SectionReadingTools(FakeSectionReader(chunksByTitle = mapOf("Balance Sheets" to chunks)))
+            .readSection("Balance Sheets")
+        assertTrue(out.contains("header row"), out)
+        assertTrue(out.contains("cash 2,366"), out)
+    }
+
+    @Test
     fun `readSection output over the cap is truncated with guidance, in order`() {
         val big = (1..50).map { chunk("c$it", "x".repeat(1000)) }
         val tools = SectionReadingTools(
@@ -138,6 +199,37 @@ class SectionReadingToolsTest {
         assertTrue(out.length < 6_000, "capped: ${out.length}")
         assertTrue(out.contains("TRUNCATED"), out)
         assertTrue(out.contains("document order"), out)
+    }
+
+    @Test
+    fun `only the chunks that survive truncation are reported as evidence`() {
+        // A chunk the model never saw must not be observable evidence: an attribution check
+        // would then read a figure that only exists in the cut-away text as grounded.
+        var observed: List<SimilarityResult<out Retrievable>>? = null
+        val big = (1..50).map { chunk("c$it", "x".repeat(1000)) }
+        val tools = SectionReadingTools(
+            FakeSectionReader(chunksByTitle = mapOf("Big" to big)),
+            resultsListener = { observed = it.results },
+            maxReadSectionChars = 5_000,
+        )
+        val out = tools.readSection("Big")
+        val reported = observed!!.map { it.match.id }
+        assertTrue(reported.size < big.size, "must not report all 50: ${reported.size}")
+        reported.forEach { id ->
+            assertTrue(out.contains("Chunk ID: $id"), "reported $id but it is not in the output")
+        }
+        assertTrue(out.contains("showing ${reported.size} of 50 chunks"), out)
+    }
+
+    @Test
+    fun `a single chunk larger than the cap is still cut, and says so`() {
+        val tools = SectionReadingTools(
+            FakeSectionReader(chunksByTitle = mapOf("Huge" to listOf(chunk("c1", "x".repeat(10_000))))),
+            maxReadSectionChars = 5_000,
+        )
+        val out = tools.readSection("Huge")
+        assertTrue(out.contains("TRUNCATED"), out)
+        assertTrue(out.contains("cut at 5000"), out)
     }
 
     @Test


### PR DESCRIPTION
Review feedback on #1928, as code. Targets `section-reader-1.5.0-local`, so it can be merged into that branch before it goes to main.

The `SectionReader` design is right and the anti-blending guard is the correct call. Two defects stop it working as written, both found by reading the diff — not observed in a run.

## The guard never fires

```kotlin
.map { it.metadata["root_document_title"] as? String ?: it.metadata["root_document_uri"] as? String }
```

Neither key is written anywhere in this repo or in `embabel-agent-rag-graph`. The chunk vocabulary is `ChunkStructure.KEYS` — `root_document_id`, `container_section_*`, `leaf_section_*`, `sequence_number` — and `root_document_uri` has no producer and no test at all. Against a real store every chunk maps to `null`, `documents` collapses to a single element, and the CUAD failure the comment describes happens exactly as before. `SectionReadingToolsTest` passed because it supplied `root_document_title` by hand.

`SectionReadingProvenanceTest` demonstrates it end to end: two contracts sharing a `Governing Law` section, ingested through the real `ContentChunker`, read back through a store that matches section titles without knowing about documents. On this PR's parent it fails with both clauses concatenated.

That test also sharpens the diagnosis: the key lookup was not independently wrong, because `toMetadata()` merges promoted fields back into `Chunk.metadata`, so the original guard finds the title once the chunker writes it. The defect is the missing producer. Reading through `ChunkStructure` is then a robustness choice — `Chunk.metadata` is a deprecation shim, and a guard reading through it stops working silently when the shim goes.

Rather than key the guard off the id and show the model an opaque uuid, this promotes the title into the structural vocabulary, which is where it belongs: `ChunkStructure.rootDocumentTitle`, written by `InMemoryContentChunker` from the `ContentRoot` it is chunking. Every chunk now says which document it came from, and the guard reads it through the typed accessor.

## The guard is disabled by the case it should fail closed on

```kotlin
if (documents.size > 1 && documents.none { it == null })
```

One chunk with missing provenance skipped the ambiguity check and blended the documents. Unknown provenance is the least safe input, not the most. Now `documents.size > 1`, with unattributed chunks named as such in the choice offered back.

A store that attributes *nothing* still cannot be checked — every chunk looks alike. That is an argument for the graph column landing too (below), not for the old condition.

## Also in here

- **Only the chunks the model saw are reported as evidence.** The `ResultsEvent` was emitted before the `maxReadSectionChars` truncation, so a 60k-char section reported all its chunks at score 1.0 while the model saw 25k. An attribution check then treats a figure that only exists in the cut-away text as grounded — the inverse of the false positive this PR set out to fix. Truncation now cuts at a chunk boundary and only the rendered chunks are reported.
- **`zoomOut` reports real elapsed time** instead of `Duration.ZERO`, matching `broadenChunk` and `readSection`.
- **`maxReadSectionChars` is configurable** through `ToolishRag`, as `maxZoomOutChars` already is; it was reachable only from tests.
- **An already-filtered ambiguous read** now says the supplied `documentTitle` was not specific enough, instead of repeating the same instruction that just failed.

## Not addressed here — your call

`SectionReadingTools(searchOperations, listener)` receives neither `metadataFilter` nor `entityFilter`, while the vector, text and regex tools all do. The KDoc says implementations must scope to their own tenant, but a single store partitioned by metadata filter is a real deployment shape — it is how `me` scopes its RAG services — and there `listSections` / `readSection` would return every tenant's section titles and content. Threading the filter through `SectionReader` changes the interface, so I have left it to you.

## Follow-on

`ChunkNode` in `embabel-agent-rag-graph` needs the matching `@GraphProperty("root_document_title")`, or graph-persisted chunks lose the value in both directions: `from()` maps structure field by field, and `toCoreType()` passes an explicit `structure`, so `Chunk.create`'s `structure ?: fromMetadata(metadata)` never reads the bag while `withoutStructuralKeys` now strips the key from it. PR to follow there.

## Tests

`ContentChunkerRootDocumentTitleTest` (new) — the title is on every chunk of a single-chunk document and of one split across leaf grouping and leaf splitting, readable through the metadata compat view, and two documents stay distinguishable.

`SectionReadingToolsTest` — the ambiguity case now builds chunks through `ChunkStructure`, plus: metadata written by the chunker reaches the guard as structure; one unattributed chunk fails closed; an already-filtered ambiguous read says so; a single document is still read whole; only surviving chunks are reported as evidence; a single over-cap chunk is cut and says so.

`./mvnw test -pl embabel-agent-rag/embabel-agent-rag-core,embabel-agent-rag/embabel-agent-rag-pipeline,embabel-agent-rag/embabel-agent-rag-lucene` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

