### PR TITLE
Add embedding-driven skills

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/agent_skills/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/agent_skills/page.adoc
@@ -200,6 +200,56 @@ The `Skills` class exposes three LLM tools:
 * `listResources(skillName, resourceType)` - List files in scripts/references/assets
 * `readResource(skillName, resourceType, fileName)` - Read a resource file
 
+===== Selecting Skills by Embedding
+
+Lazy activation asks the model to choose: it reads the descriptions, decides a skill is
+relevant, and calls `activate`.
+This is appropriate for procedural skills.
+For skills that carry *reference knowledge* — domain conventions, formulas, terminology a
+model may misread — the decision is the weak point, because a model confident in a wrong
+answer never reaches for help.
+
+`EmbeddingSkillSelector` offers a second activation mode: choose skills by similarity
+between the query and each skill's `description`, and inject the instructions directly.
+No tool call, no model decision, one embedding call.
+
+A skill opts in through the specification's open `metadata` map, so it stays portable —
+other Agent Skills runtimes ignore the key:
+
+[source,markdown]
+----
+---
+name: financial-metric-formulas
+description: Derived financial metrics and how to compute them from statement line items -
+  quick ratio, current ratio, EBITDA, operating and gross margin, CAGR, free cash flow.
+metadata:
+  activation: embedding
+---
+
+Quick ratio = (cash and equivalents + short-term investments + receivables) / current liabilities...
+----
+
+[source,kotlin]
+----
+val selector = EmbeddingSkillSelector(embeddingService)
+val guidance = selector.select(userQuestion, skills.skills)
+    .joinToString("\n\n") { it.skill.instructions.orEmpty() }
+----
+
+Notes:
+
+* Skills without `activation: embedding` are never selected this way, so existing skill
+libraries are unaffected.
+* Similarity discriminates by subject, not by difficulty.
+A skill selected this way is injected for every question in its subject area, so its
+instructions must be safe to inject whenever the subject matches.
+* `description` is what gets embedded: write it in the vocabulary of the questions the
+skill serves.
+* The default threshold (`0.30`) and maximum (2 skills) are constructor parameters.
+Similarity scores are not calibrated across embedding models — tune the threshold if you
+change the model.
+* Selection is fail-open: an embedding failure yields no skills rather than an error.
+
 ==== Combining Skills with Other References
 
 Skills can be combined with other `LlmReference` implementations:

--- a/embabel-agent-docs/src/main/asciidoc/reference/agent_skills/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/agent_skills/page.adoc
@@ -229,12 +229,40 @@ metadata:
 Quick ratio = (cash and equivalents + short-term investments + receivables) / current liabilities...
 ----
 
+The natural way to use it with a `PromptRunner` is as a `PromptContributor`:
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+var selector = new EmbeddingSkillSelector(embeddingService);
+
+var response = context.ai()
+    .withLlm(llm)
+    .withPromptContributor(selector.contributorFor(question, skills))
+    .respond(conversation.getMessages());
+----
+
+Kotlin::
++
 [source,kotlin]
 ----
 val selector = EmbeddingSkillSelector(embeddingService)
-val guidance = selector.select(userQuestion, skills.skills)
-    .joinToString("\n\n") { it.skill.instructions.orEmpty() }
+
+val response = context.ai()
+    .withLlm(llm)
+    .withPromptContributor(selector.contributorFor(question, skills))
+    .respond(conversation.messages)
 ----
+====
+
+The contributor is lazy: selection happens when the prompt is assembled, so a runner that
+is configured and never used costs no embedding call.
+Callers assembling a prompt by hand — rendering into a template, for example — can use
+`guidanceFor(query, skills)` for the same content as a string, or `select(...)` for the
+chosen skills and their scores.
 
 Notes:
 

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/EmbeddingSkillSelector.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/EmbeddingSkillSelector.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills
+
+import com.embabel.agent.skills.support.LoadedSkill
+import com.embabel.common.ai.model.EmbeddingService
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * A skill chosen by similarity to a query, with the score that chose it.
+ */
+data class RetrievedSkill(
+    val skill: LoadedSkill,
+    val score: Double,
+)
+
+/**
+ * Chooses skills by SEMANTIC SIMILARITY, for callers that want to inject a skill's
+ * instructions into a prompt rather than offer the skill to the model as a tool.
+ *
+ * The existing activation path ([Skills.asIndividualReferences]) is a decision the LLM
+ * makes: it reads skill descriptions, picks one, calls it, then reads the body. That
+ * costs a turn and a judgement — and the judgement is exactly what a small model gets
+ * wrong, because a model confident in a wrong answer never reaches for help. Selecting
+ * by embedding removes the decision: the skill whose description matches the query
+ * arrives already open, at the cost of one embedding call and no LLM work.
+ *
+ * OPT-IN AND ADDITIVE. Nothing selects this way unless a caller constructs this class,
+ * and only skills that ASK for it ([activatesByEmbedding]) are eligible, so an existing
+ * skill library behaves exactly as before.
+ *
+ * Similarity discriminates by SUBJECT, not by difficulty: it can tell a contract question
+ * from a financial one, but not a hard question from an easy one. A skill selected this
+ * way must therefore be safe to inject on every question in its subject area, since that
+ * is what will happen.
+ */
+class EmbeddingSkillSelector @JvmOverloads constructor(
+    private val embeddingService: EmbeddingService,
+    private val threshold: Double = DEFAULT_THRESHOLD,
+    private val maxSkills: Int = DEFAULT_MAX_SKILLS,
+) {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Skill description embeddings, keyed by the description itself so an edited skill
+     * re-embeds and an unchanged one never does. Bounded by the skill library's size.
+     */
+    private val cache = ConcurrentHashMap<String, FloatArray>()
+
+    /**
+     * The eligible skills whose descriptions match [query], best first, at most
+     * [maxSkills]. Empty when nothing clears [threshold].
+     *
+     * Fail-open: an embedding failure yields no skills and is logged, because guidance
+     * is an enhancement and must never be the reason an answer does not happen.
+     */
+    fun select(query: String, skills: List<LoadedSkill>): List<RetrievedSkill> {
+        val eligible = skills.filter { it.activatesByEmbedding() }
+        if (eligible.isEmpty() || query.isBlank()) return emptyList()
+        return try {
+            val queryVector = embeddingService.embed(query)
+            eligible
+                .map { RetrievedSkill(it, cosine(queryVector, vectorFor(it))) }
+                .filter { it.score >= threshold }
+                .sortedByDescending { it.score }
+                .take(maxSkills)
+                .also { selected ->
+                    if (selected.isNotEmpty()) {
+                        logger.debug(
+                            "Selected {} skill(s) by embedding for '{}': {}",
+                            selected.size, query.take(60),
+                            selected.joinToString { "${it.skill.name}=${"%.3f".format(it.score)}" },
+                        )
+                    }
+                }
+        } catch (e: Exception) {
+            logger.warn("Embedding skill selection failed, continuing without: {}", e.message)
+            emptyList()
+        }
+    }
+
+    private fun vectorFor(skill: LoadedSkill): FloatArray =
+        cache.computeIfAbsent(skill.description) { embeddingService.embed(it) }
+
+    private fun cosine(a: FloatArray, b: FloatArray): Double {
+        if (a.size != b.size) return 0.0
+        var dot = 0.0
+        var na = 0.0
+        var nb = 0.0
+        for (i in a.indices) {
+            dot += a[i] * b[i]
+            na += a[i] * a[i]
+            nb += b[i] * b[i]
+        }
+        return if (na == 0.0 || nb == 0.0) 0.0 else dot / (Math.sqrt(na) * Math.sqrt(nb))
+    }
+
+    companion object {
+
+        /**
+         * Frontmatter key, inside the spec's open `metadata` map, by which a skill asks to
+         * be selected by embedding. Unknown metadata keys are ignored by other Agent Skills
+         * runtimes, so a skill carrying this stays portable.
+         */
+        const val ACTIVATION_KEY = "activation"
+
+        /** [ACTIVATION_KEY] value that opts a skill into embedding selection. */
+        const val ACTIVATION_EMBEDDING = "embedding"
+
+        /**
+         * Sits between the similarity a description shows for questions in its own subject
+         * area and the similarity it shows for other subjects. Tune per embedding model:
+         * scores are not calibrated across them.
+         */
+        const val DEFAULT_THRESHOLD = 0.30
+
+        /** Injected guidance competes with retrieved evidence for the model's attention. */
+        const val DEFAULT_MAX_SKILLS = 2
+    }
+}
+
+/**
+ * Does this skill ask to be selected by embedding similarity and injected, rather than
+ * offered to the model as a callable tool? False unless the skill says so, so existing
+ * skills are unaffected.
+ */
+fun LoadedSkill.activatesByEmbedding(): Boolean =
+    metadata?.get(EmbeddingSkillSelector.ACTIVATION_KEY)
+        ?.equals(EmbeddingSkillSelector.ACTIVATION_EMBEDDING, ignoreCase = true) == true

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/EmbeddingSkillSelector.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/EmbeddingSkillSelector.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.skills
 
 import com.embabel.agent.skills.support.LoadedSkill
 import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.ai.prompt.PromptContributor
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
@@ -94,6 +95,45 @@ class EmbeddingSkillSelector @JvmOverloads constructor(
         }
     }
 
+    /**
+     * The selected skills' instructions, rendered as one block, or empty when nothing
+     * matches. For callers assembling a prompt themselves.
+     */
+    @JvmOverloads
+    fun guidanceFor(query: String, skills: List<LoadedSkill>, heading: (String) -> String = { "## $it" }): String =
+        select(query, skills).joinToString("\n\n") { retrieved ->
+            "${heading(retrieved.skill.name)}\n${retrieved.skill.instructions.orEmpty().trim()}"
+        }
+
+    /**
+     * A [PromptContributor] carrying whatever this selector chooses for [query] — the
+     * natural way to use skill guidance with a `PromptRunner`:
+     *
+     * ```kotlin
+     * ai.withLlm(llm)
+     *     .withPromptContributor(selector.contributorFor(question, skills))
+     *     .respond(messages)
+     * ```
+     *
+     * Selection is DEFERRED to prompt assembly, so a runner that is configured and never
+     * used costs no embedding call, and the contribution reflects the skills as they are
+     * when the prompt is built. Contributes an empty string when nothing matches.
+     */
+    @JvmOverloads
+    fun contributorFor(
+        query: String,
+        skills: List<LoadedSkill>,
+        role: String = GUIDANCE_ROLE,
+    ): PromptContributor = PromptContributor.dynamic({ guidanceFor(query, skills) }, role)
+
+    /** As [contributorFor], over a whole [Skills] library. */
+    @JvmOverloads
+    fun contributorFor(
+        query: String,
+        skills: Skills,
+        role: String = GUIDANCE_ROLE,
+    ): PromptContributor = contributorFor(query, skills.skills, role)
+
     private fun vectorFor(skill: LoadedSkill): FloatArray =
         cache.computeIfAbsent(skill.description) { embeddingService.embed(it) }
 
@@ -131,6 +171,9 @@ class EmbeddingSkillSelector @JvmOverloads constructor(
 
         /** Injected guidance competes with retrieved evidence for the model's attention. */
         const val DEFAULT_MAX_SKILLS = 2
+
+        /** Role stamped on the contribution, so assembled prompts stay identifiable. */
+        const val GUIDANCE_ROLE = "skill_guidance"
     }
 }
 

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/EmbeddingSkillSelectorTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/EmbeddingSkillSelectorTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills
+
+import com.embabel.agent.skills.spec.SkillDefinition
+import com.embabel.agent.skills.support.LoadedSkill
+import com.embabel.common.ai.model.EmbeddingService
+import com.embabel.common.ai.model.PricingModel
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class EmbeddingSkillSelectorTest {
+
+    /** Deterministic stand-in: each text embeds to the axis named by its first word. */
+    private class AxisEmbedder(val fail: Boolean = false) : EmbeddingService {
+        var calls = 0
+        override fun embed(text: String): FloatArray {
+            calls++
+            if (fail) throw IllegalStateException("embedding backend down")
+            val axis = when (text.substringBefore(' ').lowercase()) {
+                "contract" -> 0
+                "finance" -> 1
+                else -> 2
+            }
+            return FloatArray(3) { if (it == axis) 1f else 0f }
+        }
+
+        override fun embed(texts: List<String>): List<FloatArray> = texts.map { embed(it) }
+        override val dimensions: Int = 3
+        override val name: String = "axis"
+        override val provider: String = "test"
+        override val pricingModel: PricingModel = PricingModel.ALL_YOU_CAN_EAT
+        override fun infoString(verbose: Boolean?, indent: Int): String = "axis"
+    }
+
+    private fun skill(name: String, description: String, activation: String? = "embedding") = LoadedSkill(
+        skillMetadata = SkillDefinition(
+            name = name,
+            description = description,
+            metadata = activation?.let { mapOf("activation" to it) },
+            instructions = "guidance body for $name",
+        ),
+        basePath = Path.of("/tmp/$name"),
+    )
+
+    private val contractSkill = skill("contract-negation", "contract confidentiality carve-outs")
+    private val financeSkill = skill("metric-formulas", "finance derived metric formulas")
+
+    @Test
+    fun `selects the matching-domain skill and rejects the other`() {
+        val selected = EmbeddingSkillSelector(AxisEmbedder())
+            .select("contract question about carve-outs", listOf(contractSkill, financeSkill))
+        assertEquals(listOf("contract-negation"), selected.map { it.skill.name })
+        assertEquals(1.0, selected.single().score, 1e-9)
+    }
+
+    @Test
+    fun `a skill that does not opt in is never selected — existing libraries are unaffected`() {
+        val optedOut = skill("contract-negation", "contract confidentiality carve-outs", activation = null)
+        val selected = EmbeddingSkillSelector(AxisEmbedder()).select("contract question", listOf(optedOut))
+        assertTrue(selected.isEmpty())
+    }
+
+    @Test
+    fun `an unrelated query clears no skill`() {
+        val selected = EmbeddingSkillSelector(AxisEmbedder())
+            .select("weather forecast for tomorrow", listOf(contractSkill, financeSkill))
+        assertTrue(selected.isEmpty(), "orthogonal query must score 0, below threshold")
+    }
+
+    @Test
+    fun `at most maxSkills are returned, best first`() {
+        val alsoContract = skill("contract-terms", "contract duration and termination")
+        val selected = EmbeddingSkillSelector(AxisEmbedder(), maxSkills = 1)
+            .select("contract question", listOf(contractSkill, alsoContract))
+        assertEquals(1, selected.size)
+    }
+
+    @Test
+    fun `description embeddings are cached across calls`() {
+        val embedder = AxisEmbedder()
+        val selector = EmbeddingSkillSelector(embedder)
+        selector.select("contract one", listOf(contractSkill, financeSkill))
+        val afterFirst = embedder.calls
+        selector.select("contract two", listOf(contractSkill, financeSkill))
+        // Second call embeds only the query: both skill descriptions are cached.
+        assertEquals(afterFirst + 1, embedder.calls)
+    }
+
+    @Test
+    fun `an embedding failure yields no skills rather than breaking the caller`() {
+        val selected = EmbeddingSkillSelector(AxisEmbedder(fail = true))
+            .select("contract question", listOf(contractSkill))
+        assertTrue(selected.isEmpty())
+    }
+}

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/EmbeddingSkillSelectorTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/EmbeddingSkillSelectorTest.kt
@@ -103,6 +103,32 @@ class EmbeddingSkillSelectorTest {
     }
 
     @Test
+    fun `contributorFor defers selection until the prompt is assembled`() {
+        val embedder = AxisEmbedder()
+        val contributor = EmbeddingSkillSelector(embedder)
+            .contributorFor("contract question", listOf(contractSkill, financeSkill))
+        assertEquals(0, embedder.calls, "configuring a runner must not embed anything")
+        val contribution = contributor.contribution()
+        assertTrue(contribution.contains("## contract-negation"), contribution)
+        assertTrue(contribution.contains("guidance body for contract-negation"), contribution)
+        assertTrue(embedder.calls > 0, "assembly embeds")
+    }
+
+    @Test
+    fun `a contributor with no match contributes nothing`() {
+        val contributor = EmbeddingSkillSelector(AxisEmbedder())
+            .contributorFor("weather tomorrow", listOf(contractSkill))
+        assertTrue(contributor.contribution().isEmpty())
+    }
+
+    @Test
+    fun `the contribution carries the guidance role`() {
+        val contributor = EmbeddingSkillSelector(AxisEmbedder())
+            .contributorFor("contract question", listOf(contractSkill))
+        assertEquals(EmbeddingSkillSelector.GUIDANCE_ROLE, contributor.promptContribution().role)
+    }
+
+    @Test
     fun `an embedding failure yields no skills rather than breaking the caller`() {
         val selected = EmbeddingSkillSelector(AxisEmbedder(fail = true))
             .select("contract question", listOf(contractSkill))


### PR DESCRIPTION
Existing skills exposure is tool-based: The LLM is given the opportunity to load a skill depending on its own judgment.

This PR adds embedding-driven skill exposure, whereby skills can 

This is particularly beneficial for small models, and in specialized tasks such as RAG.

Usage is aligned with `PromptContributor` and hence natural on a `PromptRunner`.