### PR TITLE
fix(openai): use versioned Mistral base URL

### DIFF
--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -114,7 +114,7 @@ open class OpenAiCompatibleModelFactory(
          * Note: uses the OpenAI wire protocol, not the native Spring AI Mistral client.
          */
         fun mistral(apiKey: String): ByokSpec =
-            ByokSpec("https://api.mistral.ai", apiKey, MistralAiModels.MINISTRAL_8B, MistralAiModels.PROVIDER)
+            ByokSpec("https://api.mistral.ai/v1", apiKey, MistralAiModels.MINISTRAL_8B, MistralAiModels.PROVIDER)
 
         /**
          * Returns a [ByokSpec] for Google Gemini (OpenAI-compatible endpoint).

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
@@ -21,6 +21,7 @@ import com.embabel.agent.api.models.GoogleGenAiModels
 import com.embabel.agent.api.models.MistralAiModels
 import com.embabel.agent.api.models.OpenAiModels
 import com.embabel.common.byok.ByokFactory
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
 
@@ -38,7 +39,11 @@ class OpenAiCompatibleModelFactoryByokSpecTest {
 
     @Test
     fun `mistral returns ByokFactory`() {
-        assertInstanceOf(ByokFactory::class.java, OpenAiCompatibleModelFactory.mistral("key"))
+        val spec = OpenAiCompatibleModelFactory.mistral("key")
+
+        assertInstanceOf(ByokFactory::class.java, spec)
+        val baseUrl = spec.javaClass.getDeclaredField("baseUrl").apply { isAccessible = true }.get(spec)
+        assertEquals("https://api.mistral.ai/v1", baseUrl)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #1937 by updating the Mistral OpenAI-compatible base URL from:

```text
https://api.mistral.ai
```

to:

```text
https://api.mistral.ai/v1
```

The OpenAI Java client appends `/chat/completions`, so Mistral requests now target the correct endpoint:

```text
https://api.mistral.ai/v1/chat/completions
```

The change is provider-specific; generic and other named provider URLs remain unchanged.

## Testing

- Added regression coverage for the Mistral factory’s exact base URL.
- Ran the focused factory and validation tests.
- 12 tests passed with no failures or errors.
- `git diff --check` passed.

## Test disclaimer

The live Mistral BYOK integration test was not run because `MISTRAL_API_KEY` was unavailable. It should be run with a valid credential before merging:

```bash
MISTRAL_API_KEY=<key> mvn -pl embabel-agent-openai \
  -Dtest=OpenAiCompatibleModelFactoryByokIT \
  test
```