### PR TITLE
fix: ship credential LLM service factories

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/RoleResolver.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/ai/model/RoleResolver.kt
@@ -87,10 +87,10 @@ fun interface RoleResolver {
 /**
  * Builds an [LlmService] from a user-supplied key.
  *
- * No implementation ships with the platform yet, so an application returning
- * [RoleResolution.Credential] must register one - otherwise the role fails with
- * [NoSuitableModelException] and a log line naming the provider nothing handled. It is a one-liner
- * over the provider's own BYOK factory:
+ * The BYOK starter supplies implementations for OpenAI and Anthropic. Applications using another
+ * provider must register one - otherwise [RoleResolution.Credential] fails with
+ * [NoSuitableModelException] and a log line naming the provider nothing handled. An implementation
+ * is a one-liner over the provider's own BYOK factory:
  *
  * ```kotlin
  * @Bean
@@ -104,9 +104,8 @@ fun interface RoleResolver {
  * The platform caches what this returns, per (provider, key, model), so an implementation should
  * build rather than maintain a cache of its own.
  *
- * Provider-supplied implementations are follow-up work: they belong with the provider modules, and
- * a pure bring-your-own-key deployment deliberately has no provider autoconfiguration on the
- * classpath to carry them.
+ * A bean with the same name as a starter-supplied implementation replaces it, allowing an
+ * application to customize details such as the base URL or proxy.
  */
 fun interface CredentialLlmServiceFactory {
 

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/pom.xml
@@ -33,6 +33,18 @@
 
         <dependency>
             <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-anthropic</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-openai</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
             <artifactId>embabel-agent-test-internal</artifactId>
             <scope>test</scope>
         </dependency>

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfiguration.java
@@ -15,6 +15,8 @@
  */
 package com.embabel.agent.autoconfigure.models.byok;
 
+import com.embabel.agent.config.models.byok.AnthropicCredentialLlmServiceFactoryConfig;
+import com.embabel.agent.config.models.byok.OpenAiCredentialLlmServiceFactoryConfig;
 import com.embabel.agent.config.models.byok.SetupRequiredEmbeddingConfig;
 import com.embabel.agent.config.models.byok.SetupRequiredLlmConfig;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -25,10 +27,11 @@ import org.springframework.context.annotation.Import;
  * Autoconfiguration for Bring Your Own Key deployments.
  * <p>
  * Unlike the provider autoconfigurations, this registers no real models and requires no API key.
- * It contributes only the {@code setup-required} placeholder LLM and its embedding counterpart,
- * which let a deployment holding no provider key start up and resolve
- * {@code embabel.models.default-llm} and {@code embabel.models.default-embedding-model}. Keys arrive
- * at runtime and reach a call through {@code PromptRunner.withLlmService(...)}.
+ * It contributes the {@code setup-required} placeholders and credential-backed LLM service
+ * factories for supported providers on the classpath. The placeholders let a deployment holding
+ * no provider key start up and resolve
+ * {@code embabel.models.default-llm} and {@code embabel.models.default-embedding-model}. Keys can
+ * arrive at runtime through role resolution or an explicitly built service.
  * <p>
  * The embedding placeholder never reports a dimension: a vector index built at a guessed dimension
  * would accept writes and disagree with the real model later, so anything provisioning one must
@@ -39,6 +42,11 @@ import org.springframework.context.annotation.Import;
  */
 @AutoConfiguration
 @AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
-@Import({SetupRequiredLlmConfig.class, SetupRequiredEmbeddingConfig.class})
+@Import({
+        SetupRequiredLlmConfig.class,
+        SetupRequiredEmbeddingConfig.class,
+        AnthropicCredentialLlmServiceFactoryConfig.class,
+        OpenAiCredentialLlmServiceFactoryConfig.class
+})
 public class AgentByokAutoConfiguration {
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/CredentialLlmServiceFactoryConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/CredentialLlmServiceFactoryConfig.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.byok
+
+import com.embabel.agent.anthropic.AnthropicModelFactory
+import com.embabel.agent.api.models.AnthropicModels
+import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.openai.OpenAiCompatibleModelFactory
+import com.embabel.common.ai.model.CredentialLlmServiceFactory
+import com.embabel.common.ai.model.PricingModel
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(AnthropicModelFactory::class)
+class AnthropicCredentialLlmServiceFactoryConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["anthropicCredentialLlmServiceFactory"])
+    fun anthropicCredentialLlmServiceFactory() = CredentialLlmServiceFactory { credential, model ->
+        if (!credential.provider.equals(AnthropicModels.PROVIDER, ignoreCase = true)) null
+        else AnthropicModelFactory(apiKey = credential.apiKey).build(model)
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(OpenAiCompatibleModelFactory::class)
+class OpenAiCredentialLlmServiceFactoryConfig {
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["openAiCredentialLlmServiceFactory"])
+    fun openAiCredentialLlmServiceFactory() = CredentialLlmServiceFactory { credential, model ->
+        if (!credential.provider.equals(OpenAiModels.PROVIDER, ignoreCase = true)) null
+        else OpenAiCompatibleModelFactory(baseUrl = null, apiKey = credential.apiKey)
+            .openAiCompatibleLlm(
+                model = model,
+                pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+                provider = OpenAiModels.PROVIDER,
+                knowledgeCutoffDate = null,
+            )
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/byok/AgentByokAutoConfigurationTest.java
@@ -15,11 +15,15 @@
  */
 package com.embabel.agent.autoconfigure.models.byok;
 
+import com.embabel.agent.api.models.AnthropicModels;
+import com.embabel.agent.api.models.OpenAiModels;
 import com.embabel.agent.config.models.byok.SetupRequiredEmbedding;
 import com.embabel.agent.config.models.byok.SetupRequiredLlm;
 import com.embabel.agent.spi.LlmService;
 import com.embabel.agent.spi.PlaceholderEmbeddingService;
+import com.embabel.common.ai.model.CredentialLlmServiceFactory;
 import com.embabel.common.ai.model.EmbeddingService;
+import com.embabel.common.ai.model.ProviderCredential;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -72,5 +76,43 @@ class AgentByokAutoConfigurationTest {
         contextRunner.run(context ->
                 assertThat(context.getBeansOfType(EmbeddingService.class))
                         .containsOnlyKeys(SetupRequiredEmbedding.NAME));
+    }
+
+    @Test
+    void registersCredentialFactoriesForProvidersOnTheClasspath() {
+        contextRunner.run(context -> assertThat(context.getBeansOfType(CredentialLlmServiceFactory.class))
+                .containsOnlyKeys("anthropicCredentialLlmServiceFactory", "openAiCredentialLlmServiceFactory"));
+    }
+
+    @Test
+    void credentialFactoriesOnlyHandleTheirProvider() {
+        contextRunner.run(context -> {
+            var factories = context.getBeansOfType(CredentialLlmServiceFactory.class);
+            var anthropic = factories.get("anthropicCredentialLlmServiceFactory");
+            var openAi = factories.get("openAiCredentialLlmServiceFactory");
+            var anthropicService = anthropic.createLlmService(
+                    new ProviderCredential("ANTHROPIC", "key"), "claude-test");
+            var openAiService = openAi.createLlmService(
+                    new ProviderCredential("OPENAI", "key"), "gpt-test");
+
+            assertThat(anthropicService).isNotNull();
+            assertThat(anthropicService.getProvider()).isEqualTo(AnthropicModels.PROVIDER);
+            assertThat(anthropic.createLlmService(new ProviderCredential("openai", "key"), "gpt-test"))
+                    .isNull();
+            assertThat(openAiService).isNotNull();
+            assertThat(openAiService.getProvider()).isEqualTo(OpenAiModels.PROVIDER);
+            assertThat(openAi.createLlmService(new ProviderCredential("anthropic", "key"), "claude-test"))
+                    .isNull();
+        });
+    }
+
+    @Test
+    void applicationFactoryWithTheProviderBeanNameWins() {
+        CredentialLlmServiceFactory custom = (credential, model) -> null;
+
+        contextRunner
+                .withBean("openAiCredentialLlmServiceFactory", CredentialLlmServiceFactory.class, () -> custom)
+                .run(context -> assertThat(context.getBean("openAiCredentialLlmServiceFactory"))
+                        .isSameAs(custom));
     }
 }

--- a/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/customizing/page.adoc
@@ -448,6 +448,13 @@ The name is available as the constant `SetupRequiredLlm.NAME`. Opting in through
 deliberate — the placeholder is registered unconditionally but is only ever selected if you name it,
 so adding the starter alongside a real provider changes nothing.
 
+The starter also registers `CredentialLlmServiceFactory` beans for OpenAI and Anthropic. A
+`RoleResolver` can therefore return `RoleResolution.Credential` for either provider without any
+application factory code; the platform builds the requested model and caches it per provider, key,
+and model. Provider names are matched case-insensitively. To use a custom base URL or proxy, register
+a factory under `openAiCredentialLlmServiceFactory` or `anthropicCredentialLlmServiceFactory`; the
+starter backs off when a bean with that name exists.
+
 The placeholder completes nothing. Any call that reaches it throws `NoLlmConfiguredException`, so a
 missing key surfaces as an actionable error rather than a silently empty answer. Catch it to render
 your own "add an API key" experience:
@@ -535,8 +542,8 @@ is a different problem: the existing index keeps its original dimension, and vec
 the new model disagree with everything already stored. That is drift, and it needs the corpus
 re-embedded — see the note under <<Embedding services>> above.
 
-NOTE: The starter stops at the factories and the placeholder. Key storage and lifecycle remain the
-application's responsibility, as described under <<reference.customizing.byok>> above.
+NOTE: The starter stops at model construction and the placeholders. Key storage and lifecycle remain
+the application's responsibility, as described under <<reference.customizing.byok>> above.
 
 ===== Error handling
 
@@ -617,4 +624,3 @@ embabel.agent.logging.personality=severance
 Remove the `embabel.agent.logging.personality` key to disable personality-based logging.
 
 As all logging results from listening to events via an `AgenticEventListener`, you can also easily create your own customized logging.
-

--- a/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
+++ b/embabel-agent-starters/embabel-agent-starter-byok/src/test/java/com/embabel/agent/starter/byok/ByokStarterBootTest.java
@@ -23,6 +23,7 @@ import com.embabel.agent.spi.LlmService;
 import com.embabel.agent.spi.PlaceholderEmbeddingService;
 import com.embabel.common.ai.model.ConfigurableModelProvider;
 import com.embabel.common.ai.model.ConfigurableModelProviderProperties;
+import com.embabel.common.ai.model.CredentialLlmServiceFactory;
 import com.embabel.common.ai.model.DefaultModelSelectionCriteria;
 import com.embabel.common.ai.model.EmbeddingService;
 import com.embabel.common.ai.model.ModelProvider;
@@ -80,6 +81,12 @@ class ByokStarterBootTest {
             assertThat(context).hasNotFailed();
             assertThat(context).hasBean(SetupRequiredLlm.NAME);
         });
+    }
+
+    @Test
+    void shipsCredentialFactoriesForItsProviderDependencies() {
+        contextRunner.run(context -> assertThat(context.getBeansOfType(CredentialLlmServiceFactory.class))
+                .containsOnlyKeys("anthropicCredentialLlmServiceFactory", "openAiCredentialLlmServiceFactory"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds built-in `CredentialLlmServiceFactory` beans for OpenAI and Anthropic when using `embabel-agent-starter-byok`.

This allows `RoleResolution.Credential` to work without requiring applications to duplicate provider-specific factory wiring.

## Changes

- Add classpath-conditional credential factories for OpenAI and Anthropic.
- Match provider names case-insensitively.
- Allow applications to override either factory by registering a bean with the corresponding name.
- Keep provider dependencies optional in the BYOK autoconfiguration module.
- Update the BYOK guide and `CredentialLlmServiceFactory` documentation.
- Add autoconfiguration and starter-level regression coverage.

## Motivation

The BYOK starter already includes the OpenAI and Anthropic provider factory modules, but it did not expose them through `CredentialLlmServiceFactory`.

As a result, a resolver returning `RoleResolution.Credential` failed with `NoSuitableModelException` unless every application supplied its own adapter bean.

## Testing

```bash
mvn -pl embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure -am \
  -Dtest=AgentByokAutoConfigurationTest \
  -Dsurefire.failIfNoSpecifiedTests=false test

mvn -pl embabel-agent-starters/embabel-agent-starter-byok -am \
  -Dtest=ByokStarterBootTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

Closes #1935.