### PR TITLE
Feat: support OpenAI response continuation

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModel.kt
@@ -58,6 +58,12 @@ import reactor.core.publisher.Flux
 import java.util.function.Supplier
 import com.openai.models.responses.Response as OpenAiResponse
 
+/** Options specific to models served through OpenAI's Responses API. */
+object OpenAiResponsesOptions {
+    /** Key used in [OpenAiChatOptions.extraBody] to continue a stored conversation. */
+    const val PREVIOUS_RESPONSE_ID = "previous_response_id"
+}
+
 /**
  * Spring AI [ChatModel] backed by the OpenAI Responses API, which serves the `*-pro` models.
  *
@@ -120,6 +126,7 @@ class OpenAiResponsesChatModel(
                     .flatMap(::toInputItems)
             )
         instructionsOf(prompt)?.let(builder::instructions)
+        previousResponseIdOf(options)?.let(builder::previousResponseId)
         maxOutputTokensOf(options)?.let { builder.maxOutputTokens(it.toLong()) }
         toolsOf(options).takeIf { it.isNotEmpty() }?.let(builder::tools)
         textConfigOf(options)?.let(builder::text)
@@ -128,6 +135,12 @@ class OpenAiResponsesChatModel(
         // dropped here rather than refused by the endpoint.
         return builder.build()
     }
+
+    private fun previousResponseIdOf(options: ChatOptions?): String? =
+        ((options as? OpenAiChatOptions)?.extraBody?.get(OpenAiResponsesOptions.PREVIOUS_RESPONSE_ID)
+            ?: defaultOptions.extraBody?.get(OpenAiResponsesOptions.PREVIOUS_RESPONSE_ID))
+            ?.toString()
+            ?.takeIf { it.isNotBlank() }
 
     /**
      * Since #1857 the provider converters stamp the configured model themselves, so a request built
@@ -316,6 +329,7 @@ class OpenAiResponsesChatModel(
             DefaultUsage(it.inputTokens().toInt(), it.outputTokens().toInt(), it.totalTokens().toInt(), it)
         }
         val metadata = ChatResponseMetadata.builder()
+            .id(response.id())
             .model(modelNameOf(response.model()))
             .usage(usage)
             .build()

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
@@ -91,6 +91,21 @@ class OpenAiResponsesChatModelTest {
     @Nested
     inner class RequestMapping {
 
+        @Test
+        fun `previous response id is forwarded from OpenAI extra body options`() {
+            val params = capture(
+                Prompt(
+                    listOf(UserMessage("Continue")),
+                    OpenAiChatOptions.builder()
+                        .model("gpt-5-pro")
+                        .extraBody(mapOf(OpenAiResponsesOptions.PREVIOUS_RESPONSE_ID to "resp_previous"))
+                        .build(),
+                )
+            )
+
+            assertEquals("resp_previous", params.previousResponseId().orElse(null))
+        }
+
         /**
          * The Responses API has no system role: a system message carried as an input item is
          * treated as ordinary user text, quietly losing its authority over the model.
@@ -416,6 +431,13 @@ class OpenAiResponsesChatModelTest {
 
     @Nested
     inner class ResponseMapping {
+
+        @Test
+        fun `response id is reported in standard response metadata`() {
+            respondWith(textResponse("ok"))
+
+            assertEquals("resp_1", model.call(Prompt("Hi")).metadata.id)
+        }
 
         @Test
         fun `text output becomes the assistant message`() {

--- a/embabel-agent-docs/src/main/asciidoc/reference/llms/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/llms/page.adoc
@@ -39,6 +39,35 @@ Smaller chat models behave differently from frontier models in ways that the fra
 These settings are off-by-default so existing deployments using strong models behave exactly as before.
 Turn them on per-deployment when the model you've picked benefits from them.
 
+[[reference.llms.openai-responses-continuation]]
+==== Continuing an OpenAI Responses API conversation
+
+Models routed through OpenAI's Responses API return a response ID that can be used to continue the
+server-side conversation without resending its earlier turns. The ID is available as the standard
+Spring AI `ChatResponseMetadata.id` value.
+
+Pass that value on the next call through `OpenAiChatOptions.extraBody` using
+`OpenAiResponsesOptions.PREVIOUS_RESPONSE_ID`:
+
+[source,kotlin]
+----
+val firstResponse = model.call(Prompt("Tell me a short story"))
+
+val nextOptions = OpenAiChatOptions.builder()
+    .model("gpt-5-pro")
+    .extraBody(mapOf(OpenAiResponsesOptions.PREVIOUS_RESPONSE_ID to firstResponse.metadata.id))
+    .build()
+
+val nextResponse = model.call(Prompt(listOf(UserMessage("Give it a happier ending")), nextOptions))
+----
+
+Send only the new input when using a previous response ID. Resending the complete local history
+would duplicate context already retained by OpenAI. Applications are responsible for persisting the
+latest response ID and should apply their OpenAI account's data-retention requirements to it.
+
+This option applies only to models whose catalog entry selects the Responses API. It does not add
+server-side tool execution; Embabel continues to own and execute the tool loop.
+
 
 [[reference.llms.custom-integration]]
 ==== Advanced: Custom LLM Integration
@@ -1430,4 +1459,3 @@ static class MonthItem {
 - **Streaming**: Native structured output is not supported for streaming by Spring AI currently
 - **`ifPossible` APIs**: `createObjectIfPossible` and related paths use `MaybeReturn` semantics and stay on Embabel's fallback object construction path.
 - **Provider coverage**: OpenAI-compatible `response_format` is the primary supported path. Anthropic native structured output is currently disabled by default until its semantics are verified.
-


### PR DESCRIPTION
## Summary

Add OpenAI Responses API conversation continuation support using `previous_response_id`.

## Changes

- Forward `previous_response_id` from `OpenAiChatOptions.extraBody`.
- Add `OpenAiResponsesOptions.PREVIOUS_RESPONSE_ID` as the supported option key.
- Expose the returned OpenAI response ID through `ChatResponseMetadata.id`.
- Document how to persist and reuse response IDs.
- Clarify that callers should send only new input when continuing a stored conversation.
- Add unit coverage for request and response ID mapping.

## Example

```kotlin
val firstResponse = model.call(Prompt("Tell me a short story"))

val nextOptions = OpenAiChatOptions.builder()
    .model("gpt-5-pro")
    .extraBody(
        mapOf(
            OpenAiResponsesOptions.PREVIOUS_RESPONSE_ID to firstResponse.metadata.id
        )
    )
    .build()

val nextResponse = model.call(
    Prompt(
        listOf(UserMessage("Give it a happier ending")),
        nextOptions,
    )
)
```

## Scope

This change supports server-side conversation continuation for models routed through the Responses API. It does not enable server-side tool execution. Embabel continues to own the tool loop.

## Testing

```powershell
./mvnw -pl embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure `
  -Dtest=OpenAiResponsesChatModelTest test
```

Closes #1610.