### PR TITLE
fix(tool-loop): replace the blank turn before re-prompting

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,6 +990,8 @@ need to configure the integrations you want to exercise:
 - `ZAI_API_KEY`
 - `OLLAMA_BASE_URL` for tests using a local Ollama service
 - `EMBABEL_RUN_ONNX_INTEGRATION_TESTS` to opt into the slow Hugging Face model download
+- `GOOGLE_PROJECT_ID` plus `EMBABEL_RUN_VERTEX_INTEGRATION_TESTS` to opt into the Vertex AI tests, which
+  also need application default credentials (`gcloud auth application-default login`)
 
 Self-contained integration tests still run when none of these variables are set. To run a specific module's
 integration tests, add `-pl`:

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/loop/support/DefaultToolLoop.kt
@@ -39,6 +39,7 @@ import com.embabel.agent.spi.loop.ToolLoop
 import com.embabel.agent.spi.loop.ToolLoopResult
 import com.embabel.agent.spi.loop.ToolNotFoundAction
 import com.embabel.agent.spi.loop.ToolNotFoundPolicy
+import com.embabel.chat.AssistantMessage
 import com.embabel.chat.AssistantMessageWithToolCalls
 import com.embabel.chat.EmptyLlmResponseException
 import com.embabel.chat.Message
@@ -47,6 +48,9 @@ import com.embabel.chat.ToolResultMessage
 import com.embabel.chat.UserMessage
 import tools.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
+
+/** Stands in for an empty assistant turn, which some providers reject. */
+private const val NO_RESPONSE_PLACEHOLDER = "(no response)"
 
 /**
  * Default implementation of [com.embabel.agent.spi.loop.ToolLoop].
@@ -154,6 +158,14 @@ internal open class DefaultToolLoop(
                                 "Empty LLM response at iteration {} — feeding back to model",
                                 state.iterations,
                             )
+                            // The turn we are about to re-prompt on is already in the history. If
+                            // it is truly empty — no text, no tool call — Vertex and Mistral answer
+                            // 400 to it and the nudge below never reaches the model. Replace it
+                            // rather than drop it, so the roles still alternate around the nudge.
+                            if (transformedResponse.content.isEmpty()) {
+                                state.conversationHistory[state.conversationHistory.lastIndex] =
+                                    AssistantMessage(NO_RESPONSE_PLACEHOLDER)
+                            }
                             state.conversationHistory.add(UserMessage(action.message))
                             continue
                         }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/ToolLoopTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/loop/ToolLoopTest.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.core.Blackboard
 import com.embabel.agent.core.ReplanRequestedException
 import com.embabel.agent.core.Usage
+import com.embabel.agent.domain.io.AssistantContent
 import com.embabel.agent.spi.loop.support.DefaultToolLoop
 import com.embabel.chat.AssistantMessage
 import com.embabel.chat.AssistantMessageWithToolCalls
@@ -397,10 +398,14 @@ internal class MockLlmMessageSender(
 
     private var callIndex = 0
 
+    /** The history handed to each call, in order. */
+    val historiesSent = mutableListOf<List<Message>>()
+
     override fun call(messages: List<Message>, tools: List<Tool>): LlmMessageResponse {
         if (callIndex >= responses.size) {
             throw IllegalStateException("MockSingleLlmCaller ran out of responses")
         }
+        historiesSent += messages.toList()
         return responses[callIndex++]
     }
 
@@ -409,6 +414,17 @@ internal class MockLlmMessageSender(
             return LlmMessageResponse(
                 message = AssistantMessage(text),
                 textContent = text,
+            )
+        }
+
+        /**
+         * A turn with no text and no tool call, built the way the real conversion builds it.
+         * Not `textResponse(" ")`: a space is content, and providers accept it.
+         */
+        fun blankResponse(): LlmMessageResponse {
+            return LlmMessageResponse(
+                message = AssistantMessageWithToolCalls(content = "", toolCalls = emptyList()),
+                textContent = "",
             )
         }
 
@@ -1474,6 +1490,132 @@ class ToolLoopAdditionalTests {
             )
 
             assertEquals("Final answer", result.result)
+        }
+
+        /**
+         * Vertex and Mistral answer 400 to a turn with no text and no tool call, so the re-prompt
+         * must not carry it as it is. OpenAI and Anthropic accept it, which is why the loop cannot
+         * leave this to the provider. Each provider module has a live `BlankTurnRePromptIT`.
+         *
+         * The turn is replaced, not removed: removing it would put the nudge straight after the
+         * user question and the roles would stop alternating.
+         */
+        @Test
+        fun `the re-prompt after a blank turn is well formed`() {
+            val mockCaller = MockLlmMessageSender(
+                responses = listOf(
+                    MockLlmMessageSender.blankResponse(),
+                    MockLlmMessageSender.textResponse("Recovered answer"),
+                )
+            )
+
+            val toolLoop = DefaultToolLoop(
+                llmMessageSender = mockCaller,
+                objectMapper = objectMapper,
+                emptyResponsePolicy = RetryWithFeedbackPolicy(maxRetries = 1),
+            )
+
+            val result = toolLoop.execute(
+                initialMessages = listOf(UserMessage("question")),
+                initialTools = emptyList(),
+                outputParser = { it },
+            )
+
+            assertEquals("Recovered answer", result.result)
+            assertEquals(2, mockCaller.historiesSent.size)
+
+            val rePrompt = mockCaller.historiesSent[1]
+            assertTrue(
+                rePrompt.none { it is AssistantContent && it.content.isBlank() },
+                "an empty assistant turn is what the provider rejects: $rePrompt",
+            )
+            val nudgeIndex = rePrompt.indexOfFirst {
+                it is UserMessage && it.content.contains("no response", ignoreCase = true)
+            }
+            assertTrue(nudgeIndex > 0, "the nudge is what the re-prompt is for: $rePrompt")
+            val beforeNudge = rePrompt[nudgeIndex - 1]
+            assertTrue(
+                beforeNudge is AssistantContent && beforeNudge.content.isNotBlank(),
+                "the nudge must follow a sendable assistant turn: $rePrompt",
+            )
+        }
+
+        /**
+         * The case the policy exists for: the model goes blank after a tool call. Some providers
+         * carry a tool result in a user turn, so the nudge must not land straight after one.
+         */
+        @Test
+        fun `a blank turn after a tool call still leaves an assistant turn before the nudge`() {
+            val mockTool = MockTool(
+                name = "get_weather",
+                description = "Get the weather",
+                onCall = { Tool.Result.text("""{"temperature": 72}""") },
+            )
+            val mockCaller = MockLlmMessageSender(
+                responses = listOf(
+                    MockLlmMessageSender.toolCallResponse("call_1", "get_weather", "{}"),
+                    MockLlmMessageSender.blankResponse(),
+                    MockLlmMessageSender.textResponse("Recovered answer"),
+                )
+            )
+
+            val toolLoop = DefaultToolLoop(
+                llmMessageSender = mockCaller,
+                objectMapper = objectMapper,
+                emptyResponsePolicy = RetryWithFeedbackPolicy(maxRetries = 1),
+            )
+
+            val result = toolLoop.execute(
+                initialMessages = listOf(UserMessage("what is the weather?")),
+                initialTools = listOf(mockTool),
+                outputParser = { it },
+            )
+
+            assertEquals("Recovered answer", result.result)
+            assertEquals(3, mockCaller.historiesSent.size)
+
+            val rePrompt = mockCaller.historiesSent[2]
+            val nudgeIndex = rePrompt.indexOfFirst {
+                it is UserMessage && it.content.contains("no response", ignoreCase = true)
+            }
+            assertTrue(nudgeIndex > 0, "the nudge is what the re-prompt is for: $rePrompt")
+            val beforeNudge = rePrompt[nudgeIndex - 1]
+            assertTrue(
+                beforeNudge !is ToolResultMessage,
+                "the nudge must not follow the tool result: $rePrompt",
+            )
+            assertTrue(
+                beforeNudge is AssistantContent && beforeNudge.content.isNotBlank(),
+                "the nudge must follow a sendable assistant turn: $rePrompt",
+            )
+        }
+
+        /**
+         * Only the re-prompting path replaces the turn, because only it sends the history again.
+         * When the loop exits instead, the blank turn is the answer and the caller still sees it.
+         */
+        @Test
+        fun `exiting on empty leaves the blank turn in the history`() {
+            val mockCaller = MockLlmMessageSender(
+                responses = listOf(MockLlmMessageSender.blankResponse())
+            )
+
+            val toolLoop = DefaultToolLoop(
+                llmMessageSender = mockCaller,
+                objectMapper = objectMapper,
+            )
+
+            val result = toolLoop.execute(
+                initialMessages = listOf(UserMessage("question")),
+                initialTools = emptyList(),
+                outputParser = { it },
+            )
+
+            assertEquals("", result.result)
+            assertTrue(
+                result.conversationHistory.any { it is AssistantContent && it.content.isBlank() },
+                "unchanged on the exit path: ${result.conversationHistory}",
+            )
         }
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/BlankTurnRePromptIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/anthropic/BlankTurnRePromptIT.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.anthropic
+
+import com.embabel.agent.api.models.AnthropicModels
+import com.embabel.agent.autoconfigure.models.anthropic.AgentAnthropicAutoConfiguration
+import com.embabel.agent.test.loop.BlankTurnRePromptTestSupport
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.ApplicationContext
+
+/**
+ * [BlankTurnRePromptTestSupport] against the real Anthropic API. Anthropic takes a blank assistant
+ * turn, so this guards the history the loop sends after the fix rather than the fix itself.
+ */
+@EnabledIfEnvironmentVariable(
+    named = "ANTHROPIC_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires ANTHROPIC_API_KEY and makes a real call to api.anthropic.com",
+)
+class BlankTurnRePromptIT : BlankTurnRePromptTestSupport(AnthropicModels.CLAUDE_HAIKU_4_5) {
+
+    override fun withContext(check: (ApplicationContext) -> Unit) {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AgentAnthropicAutoConfiguration::class.java))
+            .withPropertyValues(
+                // One attempt, so a rejected re-prompt fails fast instead of sitting out the backoff.
+                "embabel.agent.platform.models.anthropic.max-attempts=1",
+            )
+            .run { context -> check(context) }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/BlankTurnRePromptIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-google-genai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/googlegenai/BlankTurnRePromptIT.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.googlegenai
+
+import com.embabel.agent.api.models.GoogleGenAiModels
+import com.embabel.agent.autoconfigure.models.googlegenai.AgentGoogleGenAiAutoConfiguration
+import com.embabel.agent.test.loop.BlankTurnRePromptTestSupport
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.ApplicationContext
+
+/**
+ * [BlankTurnRePromptTestSupport] against the real Google API, in Vertex mode: only Vertex rejects a
+ * blank assistant turn, the API-key endpoint (`generativelanguage.googleapis.com`) accepts it. So
+ * this fails if the fix is reverted.
+ *
+ * Vertex also needs application default credentials, and no environment variable reports whether
+ * those are valid — `gcloud auth application-default login` writes them to a file. `GOOGLE_PROJECT_ID`
+ * alone would let the bulk run start the test on a machine whose credentials have expired, and it
+ * would fail rather than skip. So the run is opt-in, the way `OnnxEmbeddingServiceIT` is.
+ */
+@EnabledIfEnvironmentVariable(
+    named = "EMBABEL_RUN_VERTEX_INTEGRATION_TESTS",
+    matches = ".+",
+    disabledReason = "Integration test needs valid Vertex AI application default credentials",
+)
+@EnabledIfEnvironmentVariable(
+    named = "GOOGLE_PROJECT_ID",
+    matches = ".+",
+    disabledReason = "Integration test requires GOOGLE_PROJECT_ID",
+)
+class BlankTurnRePromptIT : BlankTurnRePromptTestSupport(GoogleGenAiModels.GEMINI_2_5_FLASH) {
+
+    override fun withContext(check: (ApplicationContext) -> Unit) {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AgentGoogleGenAiAutoConfiguration::class.java))
+            .withPropertyValues(
+                // Vertex mode: this is where a blank assistant turn is rejected.
+                "embabel.agent.platform.models.googlegenai.project-id=\${GOOGLE_PROJECT_ID}",
+                "embabel.agent.platform.models.googlegenai.location=us-central1",
+                // One attempt, so a rejected re-prompt fails fast instead of sitting out the backoff.
+                "embabel.agent.platform.models.googlegenai.max-attempts=1",
+            )
+            .run { context -> check(context) }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/mistralai/BlankTurnRePromptIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/mistralai/BlankTurnRePromptIT.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.mistralai
+
+import com.embabel.agent.api.models.MistralAiModels
+import com.embabel.agent.autoconfigure.models.mistralai.AgentMistralAiAutoConfiguration
+import com.embabel.agent.test.loop.BlankTurnRePromptTestSupport
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.ApplicationContext
+
+/**
+ * [BlankTurnRePromptTestSupport] against the real Mistral API. Mistral rejects a blank assistant
+ * turn, so this fails if the fix is reverted.
+ */
+@EnabledIfEnvironmentVariable(
+    named = "MISTRAL_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires MISTRAL_API_KEY and makes a real call to api.mistral.ai",
+)
+class BlankTurnRePromptIT : BlankTurnRePromptTestSupport(MistralAiModels.MINISTRAL_8B) {
+
+    override fun withContext(check: (ApplicationContext) -> Unit) {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AgentMistralAiAutoConfiguration::class.java))
+            .withPropertyValues(
+                // One attempt, so a rejected re-prompt fails fast instead of sitting out the backoff.
+                "embabel.agent.platform.models.mistralai.max-attempts=1",
+            )
+            .run { context -> check(context) }
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/BlankTurnRePromptIT.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/BlankTurnRePromptIT.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.openai
+
+import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.autoconfigure.models.openai.AgentOpenAiAutoConfiguration
+import com.embabel.agent.test.loop.BlankTurnRePromptTestSupport
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.ApplicationContext
+
+/**
+ * [BlankTurnRePromptTestSupport] against the real OpenAI API. OpenAI takes a blank assistant turn,
+ * so this guards the history the loop sends after the fix rather than the fix itself.
+ */
+@EnabledIfEnvironmentVariable(
+    named = "OPENAI_API_KEY",
+    matches = ".+",
+    disabledReason = "Integration test requires OPENAI_API_KEY and makes a real call to api.openai.com",
+)
+class BlankTurnRePromptIT : BlankTurnRePromptTestSupport(OpenAiModels.GPT_41_MINI) {
+
+    override fun withContext(check: (ApplicationContext) -> Unit) {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(AgentOpenAiAutoConfiguration::class.java))
+            .withPropertyValues(
+                // One attempt, so a rejected re-prompt fails fast instead of sitting out the backoff.
+                "embabel.agent.platform.models.openai.max-attempts=1",
+            )
+            .run { context -> check(context) }
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/testing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/testing/page.adoc
@@ -842,6 +842,8 @@ Configure only the integrations you want to exercise:
 - `ZAI_API_KEY`
 - `OLLAMA_BASE_URL` for tests using a local Ollama service
 - `EMBABEL_RUN_ONNX_INTEGRATION_TESTS` to opt into the slow Hugging Face model download
+- `GOOGLE_PROJECT_ID` plus `EMBABEL_RUN_VERTEX_INTEGRATION_TESTS` to opt into the Vertex AI tests, which
+  also need application default credentials (`gcloud auth application-default login`)
 
 Self-contained integration tests still run when none of these variables are set.
 Use Maven's `-pl` option to limit the run to a module:

--- a/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/test/loop/BlankTurnRePromptTestSupport.kt
+++ b/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/test/loop/BlankTurnRePromptTestSupport.kt
@@ -79,9 +79,9 @@ abstract class BlankTurnRePromptTestSupport(
                 outputParser = { it },
             )
 
-            assertEquals(2, sender.calls, "the policy re-prompts once after the blank turn")
+            assertEquals(EXPECTED_CALLS, sender.calls, "the policy re-prompts once after the blank turn")
             assertTrue(
-                result.result.contains("4"),
+                result.result.contains(EXPECTED_ANSWER),
                 "the model answered the re-prompt: ${result.result}",
             )
         }
@@ -96,7 +96,7 @@ abstract class BlankTurnRePromptTestSupport(
             llmMessageSender = sender,
             objectMapper = jacksonObjectMapper(),
             injectionStrategy = ToolInjectionStrategy.NONE,
-            maxIterations = 4,
+            maxIterations = MAX_ITERATIONS,
             toolDecorator = null,
             toolLoopInspectors = emptyList(),
             toolLoopTransformers = emptyList(),
@@ -129,5 +129,14 @@ abstract class BlankTurnRePromptTestSupport(
 
     private companion object {
         const val QUESTION = "What is 2 + 2? Reply with the number only."
+
+        /** The answer to [QUESTION], which only a model that saw the nudge can give. */
+        const val EXPECTED_ANSWER = "4"
+
+        /** The forced blank turn, plus the single re-prompt `maxRetries = 1` allows. */
+        const val EXPECTED_CALLS = 2
+
+        /** Room for the re-prompt without letting a misbehaving model loop for long. */
+        const val MAX_ITERATIONS = 4
     }
 }

--- a/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/test/loop/BlankTurnRePromptTestSupport.kt
+++ b/embabel-agent-test-support/embabel-agent-test-internal/src/main/kotlin/com/embabel/agent/test/loop/BlankTurnRePromptTestSupport.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.test.loop
+
+import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.api.tool.ToolCallContext
+import com.embabel.agent.api.tool.config.ToolLoopConfiguration
+import com.embabel.agent.spi.loop.AutoCorrectionPolicy
+import com.embabel.agent.spi.loop.LlmMessageResponse
+import com.embabel.agent.spi.loop.LlmMessageSender
+import com.embabel.agent.spi.loop.RetryWithFeedbackPolicy
+import com.embabel.agent.spi.loop.ToolInjectionStrategy
+import com.embabel.agent.spi.loop.ToolLoopFactory
+import com.embabel.agent.spi.support.ExecutorAsyncer
+import com.embabel.agent.spi.support.springai.SpringAiLlmService
+import com.embabel.chat.AssistantMessageWithToolCalls
+import com.embabel.chat.Message
+import com.embabel.chat.UserMessage
+import com.embabel.common.ai.model.LlmOptions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationContext
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import java.util.concurrent.Executor
+
+/**
+ * Live check that the re-prompt after a blank turn reaches the model, run against a real provider.
+ *
+ * The blank turn — no text, no tool call — is in the history before the loop knows it is blank.
+ * [RetryWithFeedbackPolicy] then adds a nudge and sends the whole history again. Before the fix
+ * the blank turn went with it, and the providers that reject it answered 400:
+ *
+ * ```
+ * Vertex:  Unable to submit request because it must include at least one parts field,
+ *          which describes the prompt input.
+ * Mistral: Assistant message must have either content or tool_calls, but not none.
+ * ```
+ *
+ * OpenAI and Anthropic take the same history, which is why the loop cannot leave this to the
+ * provider. Their subclasses do not fail before the fix; they tell us if those providers ever
+ * stop taking it.
+ *
+ * Each provider module subclasses this and supplies its own autoconfiguration through
+ * [withContext]. The first turn is forced blank, the second call is real.
+ */
+abstract class BlankTurnRePromptTestSupport(
+    private val modelName: String,
+) {
+
+    /** Applies the module's autoconfiguration and hands [check] the resulting context. */
+    protected abstract fun withContext(check: (ApplicationContext) -> Unit)
+
+    @Test
+    fun `the re-prompt after a blank turn reaches the model`() {
+        withContext { context ->
+            val llm = context.getBeansOfType(SpringAiLlmService::class.java).values
+                .firstOrNull { it.name == modelName }
+            assertNotNull(llm, "no LLM service registered for $modelName")
+
+            val sender = BlankFirstTurn(llm!!.createMessageSender(LlmOptions(modelName)))
+            val result = toolLoop(sender).execute(
+                initialMessages = listOf(UserMessage(QUESTION)),
+                initialTools = emptyList(),
+                outputParser = { it },
+            )
+
+            assertEquals(2, sender.calls, "the policy re-prompts once after the blank turn")
+            assertTrue(
+                result.result.contains("4"),
+                "the model answered the re-prompt: ${result.result}",
+            )
+        }
+    }
+
+    private fun toolLoop(sender: LlmMessageSender) =
+        ToolLoopFactory.create(
+            config = ToolLoopConfiguration(),
+            asyncer = ExecutorAsyncer(Executor { it.run() }),
+            defaultToolNotFoundPolicy = AutoCorrectionPolicy(),
+        ).create(
+            llmMessageSender = sender,
+            objectMapper = jacksonObjectMapper(),
+            injectionStrategy = ToolInjectionStrategy.NONE,
+            maxIterations = 4,
+            toolDecorator = null,
+            toolLoopInspectors = emptyList(),
+            toolLoopTransformers = emptyList(),
+            toolCallInspectors = emptyList(),
+            toolCallContext = ToolCallContext.EMPTY,
+            emptyResponsePolicy = RetryWithFeedbackPolicy(maxRetries = 1),
+        )
+
+    /**
+     * The real sender with its first turn forced blank. Later calls are real and carry whatever
+     * history the loop kept.
+     */
+    private class BlankFirstTurn(private val delegate: LlmMessageSender) : LlmMessageSender {
+
+        var calls = 0
+            private set
+
+        override fun call(messages: List<Message>, tools: List<Tool>): LlmMessageResponse {
+            calls++
+            return if (calls == 1) {
+                LlmMessageResponse(
+                    message = AssistantMessageWithToolCalls(content = "", toolCalls = emptyList()),
+                    textContent = "",
+                )
+            } else {
+                delegate.call(messages, tools)
+            }
+        }
+    }
+
+    private companion object {
+        const val QUESTION = "What is 2 + 2? Reply with the number only."
+    }
+}


### PR DESCRIPTION
## What is wrong

When an LLM returns an empty turn - no text and no tool call - the tool loop asks it again. It adds a short message telling the model it returned nothing, then sends the whole conversation back.

The problem is that the empty turn is already in that conversation. Vertex and Mistral refuse a conversation that contains one:

```
Vertex:  400 Unable to submit request because it must include at least one parts field,
         which describes the prompt input.
Mistral: 400 Assistant message must have either content or tool_calls, but not none.
```

So the call fails and the model never sees the message asking it to try again. OpenAI and Anthropic accept the same conversation, which is why the loop cannot leave this to the provider.

## The fix

Before asking again, the loop replaces the empty turn with a placeholder assistant message: `(no response)`.

It replaces it rather than removing it. Removing it would put the new message straight after the user's question, and the conversation would have two user turns in a row.

Only the retry path does this. If the loop stops instead of retrying, the empty turn is the answer, and the caller still sees it.

## Tests

Unit tests in `ToolLoopTest` cover the conversation the loop sends: after a plain empty turn, after an empty turn that follows a tool call, and the case where the loop stops instead of retrying.

There is also a live test per provider, `BlankTurnRePromptIT`, for OpenAI, Anthropic, Mistral and Google. They share a base class, `BlankTurnRePromptTestSupport`, so each one only supplies its own configuration. The Mistral and Google tests fail if the fix is reverted. The OpenAI and Anthropic ones pass either way; they are there to tell us if those providers ever change their mind.

All four pass against the real APIs.

## Note on the Google test

It runs against Vertex, because the API-key endpoint accepts an empty turn and Vertex does not.

Vertex needs application default credentials, and no environment variable says whether they are valid. `GOOGLE_PROJECT_ID` alone would let `mvn -Pintegration-tests test` start the test on a machine whose credentials have expired, and it would fail instead of being skipped.

So the test is opt-in, behind `EMBABEL_RUN_VERTEX_INTEGRATION_TESTS`, the same way `OnnxEmbeddingServiceIT` is. Both variables are documented in `README.md` and in the testing reference page.
