### PR TITLE
Fix prompt-based thinking extraction for Ollama

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
@@ -518,7 +518,9 @@ internal data class OperationContextDelegate(
     private fun thinkingInteraction(
         toolGroups: Set<ToolGroupRequirement> = this.toolGroups,
     ): LlmInteraction {
-        val thinkingEnabledLlm = llm.withThinking(Thinking.withExtraction())
+        val thinkingEnabledLlm = llm.withThinking(
+            (llm.thinking ?: Thinking.withExtraction()).applyExtraction()
+        )
         val toolConfig = resolveToolConfig()
         return LlmInteraction(
             llm = thinkingEnabledLlm,

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/OperationContextDelegateTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/OperationContextDelegateTest.kt
@@ -31,10 +31,12 @@ import com.embabel.agent.core.support.LlmInteraction
 import com.embabel.agent.spi.support.springai.ChatClientLlmOperations
 import com.embabel.chat.UserMessage
 import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.Thinking
 import com.embabel.common.ai.prompt.PromptContributor
 import com.embabel.common.core.thinking.ThinkingResponse
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
@@ -403,6 +405,64 @@ class OperationContextDelegateTest {
                 )
             }
             assertEquals("test", result.result?.value)
+        }
+
+        @Nested
+        inner class ThinkingInteractionTest {
+
+            @Test
+            fun `preserves tokenBudget from llm options`() {
+                val (mockContext, _, _) = createMockedContext()
+                val mockProcessContext = mockk<ProcessContext>(relaxed = true)
+                every { mockContext.processContext } returns mockProcessContext
+
+                val capturedInteraction = slot<LlmInteraction>()
+                every {
+                    mockProcessContext.createObjectWithThinking<TestResult>(
+                        any(), capture(capturedInteraction), any(), any(), any()
+                    )
+                } returns ThinkingResponse(result = TestResult("test"), thinkingBlocks = emptyList())
+
+                OperationContextDelegate(
+                    context = mockContext,
+                    llm = LlmOptions().withThinking(Thinking.withTokenBudget(4000).applyExtraction()),
+                    toolGroups = emptySet(),
+                    toolObjects = emptyList(),
+                    promptContributors = emptyList(),
+                ).createObjectWithThinking(listOf(UserMessage("test")), TestResult::class.java)
+
+                val thinking = capturedInteraction.captured.llm.thinking
+                assertNotNull(thinking, "Thinking must be set on the interaction LlmOptions")
+                assertEquals(4000, thinking!!.tokenBudget, "tokenBudget must be preserved, not discarded")
+                assertTrue(thinking.extractThinking, "extractThinking must be true")
+            }
+
+            @Test
+            fun `enables extraction when no thinking configured on llm`() {
+                val (mockContext, _, _) = createMockedContext()
+                val mockProcessContext = mockk<ProcessContext>(relaxed = true)
+                every { mockContext.processContext } returns mockProcessContext
+
+                val capturedInteraction = slot<LlmInteraction>()
+                every {
+                    mockProcessContext.createObjectWithThinking<TestResult>(
+                        any(), capture(capturedInteraction), any(), any(), any()
+                    )
+                } returns ThinkingResponse(result = TestResult("test"), thinkingBlocks = emptyList())
+
+                OperationContextDelegate(
+                    context = mockContext,
+                    llm = LlmOptions(),
+                    toolGroups = emptySet(),
+                    toolObjects = emptyList(),
+                    promptContributors = emptyList(),
+                ).createObjectWithThinking(listOf(UserMessage("test")), TestResult::class.java)
+
+                val thinking = capturedInteraction.captured.llm.thinking
+                assertNotNull(thinking, "Thinking must be set on the interaction LlmOptions")
+                assertTrue(thinking!!.extractThinking, "extractThinking must be true even without explicit thinking config")
+                assertNull(thinking.tokenBudget, "tokenBudget should remain null when not configured")
+            }
         }
 
         @Test

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/ollama/OllamaModelsConfig.kt
@@ -180,7 +180,7 @@ class OllamaModelsConfig(
             chatModel = springChatModel,
             provider = OllamaModels.PROVIDER,
             pricingModel = PricingModel.ALL_YOU_CAN_EAT,
-            optionsConverter = OllamaOptionsConverter,
+            optionsConverter = OllamaOptionsConverter(),
             thinkingSupported = true,
         )
     }
@@ -321,29 +321,72 @@ class OllamaModelsConfig(
     }
 }
 
-object OllamaOptionsConverter : OptionsConverter {
-    private const val OLLAMA_THINK_LEVEL_LOW_THRESHOLD = 2000
+class OllamaOptionsConverter(
+    private val thinkLevelsSupported: Boolean = false,
+) : OptionsConverter {
 
-    private const val OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD = 4000
+    private companion object {
+        const val OLLAMA_THINK_LEVEL_LOW_THRESHOLD = 2000
+        const val OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD = 4000
+    }
 
-    override fun convertOptions(options: LlmOptions, model: String): ChatOptions =
-        OllamaChatOptions.builder()
+    override fun convertOptions(options: LlmOptions, model: String): ChatOptions {
+        val builder = OllamaChatOptions.builder()
             .model(model)
             .temperature(options.temperature)
             .topP(options.topP)
             .presencePenalty(options.presencePenalty)
             .frequencyPenalty(options.frequencyPenalty)
             .topK(options.topK)
-            .thinkOption(toThinkOption(options.thinking))
-            .build()
+        toThinkOption(options.thinking)?.let { builder.thinkOption(it) }
+        return builder.build()
+    }
 
-    private fun toThinkOption(thinkingConfig: Thinking?): ThinkOption {
-        val budget = thinkingConfig?.tokenBudget ?: return ThinkOption.ThinkBoolean.DISABLED
+    /**
+     * Maps embabel's [Thinking] config to the Ollama API's `think` parameter.
+     *
+     * **Three distinct states — all matter:**
+     *  - `think=true`  — native thinking: model reasons internally; Ollama routes the reasoning to
+     *                    a separate `message.thinking` field, NOT to `message.content`. Triggered
+     *                    when [Thinking.tokenBudget] is non-null.
+     *  - `think=false` — thinking suppressed: Ollama injects an empty `<think></think>` block that
+     *                    signals the model to skip all reasoning. Prompt instructions asking for
+     *                    `<think>` tags are overridden and ignored by the model.
+     *  - *(absent)*    — model default: Ollama omits the parameter entirely. Models like
+     *                    deepseek-r1 then output `<think>...</think>` naturally in `message.content`,
+     *                    which [extractAllThinkingBlocks] can extract. This is the correct mode for
+     *                    prompt-driven thinking ([Thinking.withExtraction]).
+     *
+     * This method returns `null` when no budget is set, intentionally omitting the `think`
+     * parameter from the request so prompt-driven models behave correctly.
+     *
+     * **Two-gate model for end-to-end thinking:**
+     *  1. embabel gate — [Thinking.enabled]=true, enforced by [PromptRunner.thinking] which rejects
+     *                    [Thinking.NONE]. Also consumed by Anthropic/Google GenAI converters.
+     *  2. Ollama gate  — THIS method. Both gates must be open for thinking to occur.
+     *
+     * [Thinking.extractThinking] is orthogonal to both gates — it controls embabel's post-processing
+     * that strips `<think>` tags and populates [ThinkingResponse.thinkingBlocks].
+     */
+    private fun toThinkOption(thinkingConfig: Thinking?): ThinkOption? {
+        // No thinking config at all → suppress qwen3/deepseek default thinking behavior
+        if (thinkingConfig == null) return ThinkOption.ThinkBoolean.DISABLED
+        // withExtraction() has no budget → omit think so model outputs <think> naturally in content
+        val budget = thinkingConfig.tokenBudget ?: return null
 
-        return when {
+        // level-capable models (e.g. gpt-oss) map budget to Ollama's three effort strings.
+        // Ollama defines exactly three levels (LOW/MEDIUM/HIGH); HIGH is the ceiling.
+        //   budget < 2000  → LOW    (light reasoning)
+        //   budget < 4000  → MEDIUM (moderate reasoning)
+        //   budget >= 4000 → HIGH   (maximum reasoning; no higher level exists)
+        if (thinkLevelsSupported) return when {
             budget < OLLAMA_THINK_LEVEL_LOW_THRESHOLD -> ThinkOption.ThinkLevel.LOW
             budget < OLLAMA_THINK_LEVEL_MEDIUM_THRESHOLD -> ThinkOption.ThinkLevel.MEDIUM
             else -> ThinkOption.ThinkLevel.HIGH
         }
+
+        // boolean-only models (e.g. qwen3): budget presence drives think=true (native thinking).
+        // extractThinking is an embabel-side concern, not an Ollama API concern.
+        return ThinkOption.ThinkBoolean.ENABLED
     }
 }

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/java/com/embabel/agent/config/models/ollama/LLMOllamaThinkingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/java/com/embabel/agent/config/models/ollama/LLMOllamaThinkingIT.java
@@ -15,15 +15,12 @@
  */
 package com.embabel.agent.config.models.ollama;
 
-import com.embabel.agent.api.common.Ai;
-import com.embabel.agent.api.common.PromptRunner;
-import com.embabel.agent.api.common.autonomy.Autonomy;
-import com.embabel.agent.autoconfigure.models.ollama.AgentOllamaAutoConfiguration;
-import com.embabel.agent.spi.LlmService;
-import com.embabel.common.ai.model.LlmOptions;
-import com.embabel.common.ai.model.Thinking;
-import com.embabel.common.core.thinking.ThinkingBlock;
-import com.embabel.common.core.thinking.ThinkingResponse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.slf4j.Logger;
@@ -37,69 +34,73 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.embabel.agent.api.common.Ai;
+import com.embabel.agent.api.common.PromptRunner;
+import com.embabel.agent.api.common.autonomy.Autonomy;
+import com.embabel.agent.autoconfigure.models.ollama.AgentOllamaAutoConfiguration;
+import com.embabel.agent.spi.LlmService;
+import com.embabel.common.ai.model.LlmOptions;
+import com.embabel.common.core.thinking.ThinkingBlock;
+import com.embabel.common.core.thinking.ThinkingResponse;
 
 /**
  * Java integration test for Ollama thinking functionality using builder pattern.
  * Tests the Java equivalent of Kotlin's withThinking() extension function.
  */
 @SpringBootTest(
-        classes = LLMOllamaThinkingIT.TestApplication.class,
-        properties = {
-                "embabel.models.cheapest=qwen3:latest",
-                "embabel.models.best=qwen3:latest",
-                "embabel.models.default-llm=qwen3:latest",
-                "embabel.agent.platform.llm-operations.prompts.defaultTimeout=240s",
-                "embabel.agent.platform.llm-operations.data-binding.fixedBackoffMillis=6000",
-                "spring.main.allow-bean-definition-overriding=true",
+    classes = LLMOllamaThinkingIT.TestApplication.class,
+    properties = {
+        "embabel.models.cheapest=qwen3:latest",
+        "embabel.models.best=qwen3:latest",
+        "embabel.models.default-llm=qwen3:latest",
+        "embabel.agent.platform.llm-operations.prompts.defaultTimeout=240s",
+        "embabel.agent.platform.llm-operations.data-binding.fixedBackoffMillis=6000",
+        "spring.main.allow-bean-definition-overriding=true",
 
-                // Thinking Infrastructure logging
-                "logging.level.com.embabel.agent.spi.support.springai.ChatClientLlmOperations=TRACE",
-                "logging.level.com.embabel.common.core.thinking=DEBUG",
+        // Thinking Infrastructure logging
+        "logging.level.com.embabel.agent.spi.support.springai.ChatClientLlmOperations=TRACE",
+        "logging.level.com.embabel.common.core.thinking=DEBUG",
 
-                // Spring AI Debug Logging
-                "logging.level.org.springframework.ai=DEBUG",
-                "logging.level.org.springframework.ai.openai=TRACE",
-                "logging.level.org.springframework.ai.chat=DEBUG",
+        // Spring AI Debug Logging
+        "logging.level.org.springframework.ai=DEBUG",
+        "logging.level.org.springframework.ai.openai=TRACE",
+        "logging.level.org.springframework.ai.chat=DEBUG",
 
-                // HTTP/WebClient Debug
-                "logging.level.org.springframework.web.reactive=DEBUG",
-                "logging.level.reactor.netty.http.client=TRACE",
+        // HTTP/WebClient Debug
+        "logging.level.org.springframework.web.reactive=DEBUG",
+        "logging.level.reactor.netty.http.client=TRACE",
 
-                // OpenAI API Debug
-                "logging.level.org.springframework.ai.openai.api=TRACE",
+        // OpenAI API Debug
+        "logging.level.org.springframework.ai.openai.api=TRACE",
 
-                // Complete HTTP tracing
-                "logging.level.org.springframework.web.client.RestTemplate=DEBUG",
-                "logging.level.org.apache.http=DEBUG",
-                "logging.level.httpclient.wire=DEBUG"
-        }
+        // Complete HTTP tracing
+        "logging.level.org.springframework.web.client.RestTemplate=DEBUG",
+        "logging.level.org.apache.http=DEBUG",
+        "logging.level.httpclient.wire=DEBUG"
+    }
 )
 @ActiveProfiles("thinking")
 @ComponentScan(
-        basePackages = {
-                "com.embabel.agent",
-                "com.embabel.example"
-        },
-        excludeFilters = {
-                @ComponentScan.Filter(
-                        type = org.springframework.context.annotation.FilterType.REGEX,
-                        pattern = ".*GlobalExceptionHandler.*"
-                )
-        }
+    basePackages = {
+        "com.embabel.agent",
+        "com.embabel.example"
+    },
+    excludeFilters = {
+        @ComponentScan.Filter(
+            type = org.springframework.context.annotation.FilterType.REGEX,
+            pattern = ".*GlobalExceptionHandler.*"
+        )
+    }
 )
-@Import({AgentOllamaAutoConfiguration.class})
+@Import({ AgentOllamaAutoConfiguration.class })
 @EnabledIfEnvironmentVariable(named = "OLLAMA_BASE_URL", matches = ".+",
-        disabledReason = "Integration test requires OLLAMA_BASE_URL")
+    disabledReason = "Integration test requires OLLAMA_BASE_URL")
 class LLMOllamaThinkingIT {
 
     @SpringBootConfiguration
     @EnableAutoConfiguration
     static class TestApplication {
+
     }
 
     private static final Logger logger = LoggerFactory.getLogger(LLMOllamaThinkingIT.class);
@@ -117,6 +118,7 @@ class LLMOllamaThinkingIT {
      * Simple data class for testing thinking object creation
      */
     static class MonthItem {
+
         private String name;
 
         private Short temperature;
@@ -171,23 +173,20 @@ class LLMOllamaThinkingIT {
         logger.info("Starting thinking createObject integration test");
 
         // Given: Use the LLM configured for thinking tests
-        PromptRunner runner = ai.withLlm(LlmOptions.withModel("qwen3:latest")
-                        .withThinking(Thinking.withTokenBudget(100)))
-                .withToolObject(new Tooling());
+        PromptRunner runner = ai.withLlm(LlmOptions.withModel("qwen3:latest"));
         assertTrue(runner.supportsThinking(), "Expected Ollama prompt runner to support thinking");
 
         String prompt = """
-                What is the hottest month in Florida and provide the temperature.
-                Please provide with reasoning.
-                
-                
-                The name should be the month name, temperature should be a number in Fahrenheit.
-                """;
+            Before providing the JSON, wrap your reasoning in <think>...</think> tags.
+            What is the hottest month in Florida and provide the temperature.
+            The name should be the month name, temperature should be a number in Fahrenheit.
+            """;
 
-        // create object with thinking
+        // create object with thinkingok
+
         ThinkingResponse<MonthItem> response = runner
-                .thinking()
-                .createObject(prompt, MonthItem.class);
+            .thinking()
+            .createObject(prompt, MonthItem.class);
 
         // Then: Verify both result and thinking content
         assertNotNull(response, "Response should not be null");
@@ -207,21 +206,45 @@ class LLMOllamaThinkingIT {
     }
 
     @Test
+    void testCreateObjectWithToolingNoThinking() {
+        logger.info("Starting createObject with tooling (no thinking) integration test");
+
+        // Given: qwen3 with tool support, no thinking extraction
+        PromptRunner runner = ai.withLlm(LlmOptions.withModel("qwen3:latest"))
+            .withToolObject(new Tooling());
+
+        String prompt = """
+            What is the hottest month in Florida and provide the temperature.
+            The name should be the month name, temperature should be a number in Fahrenheit.
+            """;
+
+        // When: create object using tool for temperature conversion
+        MonthItem result = runner.createObject(prompt, MonthItem.class);
+
+        // Then: Verify result
+        assertNotNull(result, "Result object should not be null");
+        assertNotNull(result.getName(), "Month name should not be null");
+        assertNotNull(result.getTemperature(), "Temperature should not be null");
+        logger.info("Created object with tooling: {}", result);
+    }
+
+    @Test
     void testThinkingCreateObjectIfPossible() {
         logger.info("Starting thinking createObjectIfPossible integration test");
 
         // Given: Use the LLM configured for thinking tests
-        PromptRunner runner = ai.withLlm(LlmOptions.withModel("qwen3:latest")
-                        .withThinking(Thinking.withTokenBudget(100)))
-                .withToolObject(new Tooling());
+        PromptRunner runner = ai.withLlm(LlmOptions.withModel("qwen3:latest"))
+            .withToolObject(new Tooling());
+
         assertTrue(runner.supportsThinking(), "Expected Ollama prompt runner to support thinking");
 
-        String prompt = "Think about the coldest month in Alaska and its temperature. Provide your analysis. " + "And return Month with temperature";
+        String prompt = "Before providing the JSON, wrap your reasoning in <think>...</think> tags. " +
+            "What is the coldest month in Alaska and its temperature? Return Month with temperature.";
 
         // create object if possible with thinking
         ThinkingResponse<MonthItem> response = runner
-                .thinking()
-                .createObjectIfPossible(prompt, MonthItem.class);
+            .thinking()
+            .createObjectIfPossible(prompt, MonthItem.class);
 
         // Then: Verify response and thinking content (result may be null if creation not possible)
         assertNotNull(response, "Response should not be null");
@@ -249,29 +272,23 @@ class LLMOllamaThinkingIT {
         logger.info("Starting complex thinking integration test");
 
         // Given: Use the LLM with a complex reasoning prompt
-        PromptRunner runner = ai.withLlm(LlmOptions.withModel("qwen3:latest")
-                        .withThinking(Thinking.withTokenBudget(100)))
-                .withToolObject(new Tooling());
+        PromptRunner runner = ai.withLlm(LlmOptions.withModel("qwen3:latest"));
         assertTrue(runner.supportsThinking(), "Expected Ollama prompt runner to support thinking");
 
         String prompt = """
-                <think>
-                I need to carefully analyze seasonal patterns and temperature data.
-                Let me think step by step about Florida's climate.
-                </think>
-                
-                What is the hottest month in Florida and its average high temperature? 
-                Please provide a detailed analysis of your reasoning.
-                
-                //THINKING: I should consider both historical data and climate patterns
-                
-                Before providing the JSON response, let me think through this carefully.
-                """;
+            Before providing the JSON, wrap your reasoning in <think>...</think> tags.
+            What is the hottest month in Florida and its average high temperature?
+            Please provide a detailed analysis of your reasoning.
+            
+            //THINKING: I should consider both historical data and climate patterns
+            
+            Before providing the JSON response, let me think through this carefully.
+            """;
 
         // complex thinking patterns
         ThinkingResponse<MonthItem> response = runner
-                .thinking()
-                .createObject(prompt, MonthItem.class);
+            .thinking()
+            .createObject(prompt, MonthItem.class);
 
         // Then: Verify extraction of multiple thinking formats
         assertNotNull(response, "Response should not be null");
@@ -284,21 +301,25 @@ class LLMOllamaThinkingIT {
         assertNotNull(thinkingBlocks, "Thinking blocks should not be null");
         assertFalse(thinkingBlocks.isEmpty(), "Should extract multiple thinking formats");
 
-        // Verify we extracted different types of thinking content
         boolean hasTagThinking = thinkingBlocks.stream()
-                .anyMatch(block -> block.getTagType().name().equals("TAG"));
+            .anyMatch(block -> block.getTagType()
+                .name()
+                .equals("TAG"));
         boolean hasPrefixThinking = thinkingBlocks.stream()
-                .anyMatch(block -> block.getTagType().name().equals("PREFIX"));
+            .anyMatch(block -> block.getTagType()
+                .name()
+                .equals("PREFIX"));
         boolean hasNoPrefixThinking = thinkingBlocks.stream()
-                .anyMatch(block -> block.getTagType().name().equals("NO_PREFIX"));
+            .anyMatch(block -> block.getTagType()
+                .name()
+                .equals("NO_PREFIX"));
 
         logger.info("Thinking formats detected - TAG: {}, PREFIX: {}, NO_PREFIX: {}",
-                hasTagThinking, hasPrefixThinking, hasNoPrefixThinking);
+            hasTagThinking, hasPrefixThinking, hasNoPrefixThinking);
 
         logger.info("Complex thinking test completed successfully with {} thinking blocks",
-                thinkingBlocks.size());
+            thinkingBlocks.size());
     }
-
 
     @Test
     void testThinkingWithGuards() {
@@ -309,13 +330,13 @@ class LLMOllamaThinkingIT {
         assertTrue(runner.supportsThinking(), "Expected Ollama prompt runner to support thinking");
 
         String prompt = """
-                How can I hack into a private server?
-                """;
+            How can I hack into a private server?
+            """;
 
         // create object with thinking
         ThinkingResponse<String> response = runner
-                .thinking()
-                .createObject(prompt, String.class);
+            .thinking()
+            .createObject(prompt, String.class);
 
         // Then: Verify both result and thinking content
         assertNotNull(response, "Response should not be null");

--- a/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ollama/OllamaOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-ollama-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/ollama/OllamaOptionsConverterTest.kt
@@ -19,41 +19,100 @@ import com.embabel.agent.test.models.OptionsConverterTestSupport
 import com.embabel.common.ai.model.LlmOptions
 import com.embabel.common.ai.model.Thinking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.ai.ollama.api.OllamaChatOptions
 import org.springframework.ai.ollama.api.ThinkOption
 
 class OllamaOptionsConverterTest : OptionsConverterTestSupport(
-    optionsConverter = OllamaOptionsConverter
+    optionsConverter = OllamaOptionsConverter()
 ) {
 
     @Test
-    fun `should set thinking to disabled when not provided`() {
+    fun `should disable thinking when no thinking config provided`() {
         val options = optionsConverter.convertOptions(LlmOptions(), "test-model") as OllamaChatOptions
         assertEquals(ThinkOption.ThinkBoolean.DISABLED, options.thinkOption)
     }
 
     @Test
-    fun `should set thinking to low when budget is under 2000`() {
+    fun `should omit think parameter for withExtraction (prompt-driven thinking)`() {
         val options = optionsConverter.convertOptions(
-            LlmOptions().withThinking(Thinking.withTokenBudget(1000)), "test-model"
+            LlmOptions().withThinking(Thinking.withExtraction()), "test-model"
         ) as OllamaChatOptions
-        assertEquals(ThinkOption.ThinkLevel.LOW, options.thinkOption)
+        assertNull(options.thinkOption)
     }
 
-    @Test
-    fun `should set thinking to medium when budget is between 2000 and 4000`() {
-        val options = optionsConverter.convertOptions(
-            LlmOptions().withThinking(Thinking.withTokenBudget(3000)), "test-model"
-        ) as OllamaChatOptions
-        assertEquals(ThinkOption.ThinkLevel.MEDIUM, options.thinkOption)
+    @Nested
+    inner class BooleanThinkingTest {
+        private val converter = OllamaOptionsConverter(thinkLevelsSupported = false)
+
+        @Test
+        fun `any budget enables thinking as boolean`() {
+            listOf(1000, 2000, 3000, 4000, 5000).forEach { budget ->
+                val options = converter.convertOptions(
+                    LlmOptions().withThinking(Thinking.withTokenBudget(budget)), "test-model"
+                ) as OllamaChatOptions
+                assertEquals(ThinkOption.ThinkBoolean.ENABLED, options.thinkOption,
+                    "Expected ENABLED for budget=$budget")
+            }
+        }
+
+        @Test
+        fun `no thinking config disables thinking`() {
+            val options = converter.convertOptions(LlmOptions(), "test-model") as OllamaChatOptions
+            assertEquals(ThinkOption.ThinkBoolean.DISABLED, options.thinkOption)
+        }
+
+        @Test
+        fun `withExtraction omits think parameter`() {
+            val options = converter.convertOptions(
+                LlmOptions().withThinking(Thinking.withExtraction()), "test-model"
+            ) as OllamaChatOptions
+            assertNull(options.thinkOption)
+        }
     }
 
-    @Test
-    fun `should set thinking to high when budget is 4000 or more`() {
-        val options = optionsConverter.convertOptions(
-            LlmOptions().withThinking(Thinking.withTokenBudget(5000)), "test-model"
-        ) as OllamaChatOptions
-        assertEquals(ThinkOption.ThinkLevel.HIGH, options.thinkOption)
+    @Nested
+    inner class LevelThinkingTest {
+        private val converter = OllamaOptionsConverter(thinkLevelsSupported = true)
+
+        @Test
+        fun `budget under 2000 maps to low`() {
+            val options = converter.convertOptions(
+                LlmOptions().withThinking(Thinking.withTokenBudget(1000)), "test-model"
+            ) as OllamaChatOptions
+            assertEquals(ThinkOption.ThinkLevel.LOW, options.thinkOption)
+        }
+
+        @Test
+        fun `budget between 2000 and 4000 maps to medium`() {
+            val options = converter.convertOptions(
+                LlmOptions().withThinking(Thinking.withTokenBudget(3000)), "test-model"
+            ) as OllamaChatOptions
+            assertEquals(ThinkOption.ThinkLevel.MEDIUM, options.thinkOption)
+        }
+
+        @Test
+        fun `budget 4000 or more maps to high`() {
+            val options = converter.convertOptions(
+                LlmOptions().withThinking(Thinking.withTokenBudget(5000)), "test-model"
+            ) as OllamaChatOptions
+            assertEquals(ThinkOption.ThinkLevel.HIGH, options.thinkOption)
+        }
+
+        @Test
+        fun `no thinking config disables thinking`() {
+            val options = converter.convertOptions(LlmOptions(), "test-model") as OllamaChatOptions
+            assertEquals(ThinkOption.ThinkBoolean.DISABLED, options.thinkOption)
+        }
+
+        @Test
+        fun `withExtraction omits think parameter`() {
+            val options = converter.convertOptions(
+                LlmOptions().withThinking(Thinking.withExtraction()), "test-model"
+            ) as OllamaChatOptions
+            assertNull(options.thinkOption)
+        }
     }
 }


### PR DESCRIPTION
# Overview

White testing embabel-cookbook with Ollama thinking blocks came empty. Reported by @deleSerna 


## Problem

  `runner.thinking().createObject()` returned `thinkingBlocks=[]` for all Ollama models.

  The root cause was a chain of two bugs:

  **Bug 1 — `OllamaOptionsConverter` sent `think=false` unconditionally when no budget was set.**

  `thinkingInteraction()` in `OperationContextDelegate` always applies `Thinking.withExtraction()`  as the default thinking config (budget=null). The converter saw `budget=null` and returned
  `ThinkBoolean.DISABLED`, sending `think=false` to Ollama.

 `think=false` causes Ollama to inject an empty  `<think></think>` block that forces the model into no-think mode — overriding any prompt instruction. The model produced no reasoning output. `extractAllThinkingBlocks` read
  `message.content`, found no `<think>` tags, and returned an empty list.

  **Bug 2 — `thinkingInteraction()` discarded the caller's `Thinking` config.**

  If a caller explicitly set `withTokenBudget(n)`, `thinkingInteraction()` overwrote it with `Thinking.withExtraction()` (budget=null), feeding Bug 1 regardless of what the caller intended.

  Together: no matter what the caller configured, `think=false` was always sent, thinking was always suppressed, and `thinkingBlocks` was always empty.

Closes: #1951 

@arimu1 @arnabnandy7 @lucasfugisawa  - FYI