### PR TITLE
Feature: Add tag selection control to Thinking via included / excluded Tags

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
@@ -521,14 +521,21 @@ internal data class OperationContextDelegate(
         val thinkingEnabledLlm = llm.withThinking(
             (llm.thinking ?: Thinking.withExtraction()).applyExtraction()
         )
+        val thinking = thinkingEnabledLlm.thinking
+        // Inject a system prompt hint so the model knows which tag to use for reasoning.
+        // Placed after the agent identity prompt but before contextual contributors.
+        val tagHintContributor = thinking?.includedTags
+            ?.takeIf { thinking.injectSystemPrompt }
+            ?.first()
+            ?.let { tag -> PromptContributor.fixed("When reasoning, wrap your thoughts in <$tag></$tag> tags.") }
         val toolConfig = resolveToolConfig()
         return LlmInteraction(
             llm = thinkingEnabledLlm,
             toolGroups = toolGroups,
             tools = toolConfig.tools,
-            promptContributors = promptContributors + contextualPromptContributors.map {
-                it.toPromptContributor(context)
-            },
+            promptContributors = promptContributors +
+                listOfNotNull(tagHintContributor) +
+                contextualPromptContributors.map { it.toPromptContributor(context) },
             id = interactionId ?: InteractionId("${context.operation.name}-thinking"),
             generateExamples = generateExamples,
             fieldFilter = fieldFilter,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/common/support/OperationContextDelegate.kt
@@ -527,7 +527,7 @@ internal data class OperationContextDelegate(
         val tagHintContributor = thinking?.includedTags
             ?.takeIf { thinking.injectSystemPrompt }
             ?.first()
-            ?.let { tag -> PromptContributor.fixed("When reasoning, wrap your thoughts in <$tag></$tag> tags.") }
+            ?.let { tag -> PromptContributor.fixed("You must provide your reasoning wrapped in <$tag></$tag> tags.") }
         val toolConfig = resolveToolConfig()
         return LlmInteraction(
             llm = thinkingEnabledLlm,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ToolLoopLlmOperations.kt
@@ -384,7 +384,11 @@ open class ToolLoopLlmOperations(
         // For String output: return raw text (with thinking tags preserved)
         // For other types: converter chain handles thinking suppression for JSON parsing
         val outputParser: (String) -> ThinkingResponse<O> = { text ->
-            val thinkingBlocks = extractAllThinkingBlocks(text)
+            val thinkingBlocks = extractAllThinkingBlocks(
+                text,
+                includedTags = interaction.llm.thinking?.includedTags,
+                excludedTags = interaction.llm.thinking?.excludedTags,
+            )
             val result = if (outputClass == String::class.java) {
                 @Suppress("UNCHECKED_CAST")
                 text as O  // Raw text, not sanitized - thinking blocks preserved in response
@@ -449,7 +453,13 @@ open class ToolLoopLlmOperations(
         // Filter by role to catch both AssistantMessage and AssistantMessageWithToolCalls
         val allThinkingBlocks = result.conversationHistory
             .filter { it.role == com.embabel.chat.Role.ASSISTANT }
-            .flatMap { extractAllThinkingBlocks(it.content) }
+            .flatMap {
+                extractAllThinkingBlocks(
+                    it.content,
+                    includedTags = interaction.llm.thinking?.includedTags,
+                    excludedTags = interaction.llm.thinking?.excludedTags,
+                )
+            }
 
         // Merge accumulated thinking blocks with the final result
         val thinkingResponse = ThinkingResponse(
@@ -490,7 +500,11 @@ open class ToolLoopLlmOperations(
 
             // Output parser: extract thinking blocks FIRST, then parse MaybeReturn
             val outputParser: (String) -> Result<ThinkingResponse<O>> = { text ->
-                val thinkingBlocks = extractAllThinkingBlocks(text)
+                val thinkingBlocks = extractAllThinkingBlocks(
+                    text,
+                    includedTags = interaction.llm.thinking?.includedTags,
+                    excludedTags = interaction.llm.thinking?.excludedTags,
+                )
                 try {
                     val maybeResult = if (text.isNotBlank()) {
                         converter.convert(text)!!
@@ -584,7 +598,11 @@ open class ToolLoopLlmOperations(
 
             // Accumulate thinking blocks from ALL assistant messages across all iterations
             // Filter by role to catch both AssistantMessage and AssistantMessageWithToolCalls
-            val allThinkingBlocks = accumulateThinkingBlocks(result.conversationHistory)
+            val allThinkingBlocks = accumulateThinkingBlocks(
+                result.conversationHistory,
+                includedTags = interaction.llm.thinking?.includedTags,
+                excludedTags = interaction.llm.thinking?.excludedTags,
+            )
 
             // Merge accumulated thinking blocks with the final result (success or failure path)
             val thinkingResult = mergeThinkingBlocksWithResult(finalIterationResult, allThinkingBlocks)
@@ -976,10 +994,20 @@ open class ToolLoopLlmOperations(
      * Filters by ASSISTANT role to catch both AssistantMessage and AssistantMessageWithToolCalls.
      */
     @OptIn(InternalThinkingApi::class)
-    private fun accumulateThinkingBlocks(conversationHistory: List<Message>): List<ThinkingBlock> {
+    private fun accumulateThinkingBlocks(
+        conversationHistory: List<Message>,
+        includedTags: Set<String>? = null,
+        excludedTags: Set<String>? = null,
+    ): List<ThinkingBlock> {
         return conversationHistory
             .filter { it.role == com.embabel.chat.Role.ASSISTANT }
-            .flatMap { extractAllThinkingBlocks(it.content) }
+            .flatMap {
+                extractAllThinkingBlocks(
+                    it.content,
+                    includedTags = includedTags,
+                    excludedTags = excludedTags,
+                )
+            }
     }
 
     /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/springai/ChatClientLlmOperations.kt
@@ -403,7 +403,11 @@ internal class ChatClientLlmOperations(
                     recordUsage(llm, chatResponse, llmRequestEvent)
                     val rawText = chatResponse.result!!.output.text as String
 
-                    val thinkingBlocks = extractAllThinkingBlocks(rawText)
+                    val thinkingBlocks = extractAllThinkingBlocks(
+                        rawText,
+                        includedTags = interaction.llm.thinking?.includedTags,
+                        excludedTags = interaction.llm.thinking?.excludedTags,
+                    )
                     logger.debug("Extracted {} thinking blocks for String response", thinkingBlocks.size)
 
                     val thinkingResponse = ThinkingResponse(
@@ -421,7 +425,11 @@ internal class ChatClientLlmOperations(
                     recordUsage(llm, chatResponse, llmRequestEvent)
                     val rawText = chatResponse.result!!.output.text ?: ""
 
-                    val thinkingBlocks = extractAllThinkingBlocks(rawText)
+                    val thinkingBlocks = extractAllThinkingBlocks(
+                        rawText,
+                        includedTags = interaction.llm.thinking?.includedTags,
+                        excludedTags = interaction.llm.thinking?.excludedTags,
+                    )
                     logger.debug(
                         "Extracted {} thinking blocks for {} response",
                         thinkingBlocks.size,
@@ -558,7 +566,11 @@ internal class ChatClientLlmOperations(
                     val chatResponse = requireChatResponse(callResponse, interaction)
                     recordUsage(llm, chatResponse, llmRequestEvent)
                     val rawText = chatResponse.result!!.output.text ?: ""
-                    val thinkingBlocks = extractAllThinkingBlocks(rawText)
+                    val thinkingBlocks = extractAllThinkingBlocks(
+                        rawText,
+                        includedTags = interaction.llm.thinking?.includedTags,
+                        excludedTags = interaction.llm.thinking?.excludedTags,
+                    )
 
                     // Execute converter chain manually instead of using responseEntity
                     try {

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/OperationContextDelegateTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/common/support/OperationContextDelegateTest.kt
@@ -463,6 +463,64 @@ class OperationContextDelegateTest {
                 assertTrue(thinking!!.extractThinking, "extractThinking must be true even without explicit thinking config")
                 assertNull(thinking.tokenBudget, "tokenBudget should remain null when not configured")
             }
+
+            @Nested
+            inner class TagHintInjectionTest {
+
+                private fun captureInteractionWith(thinking: com.embabel.common.ai.model.Thinking): LlmInteraction {
+                    val (mockContext, _, _) = createMockedContext()
+                    val mockProcessContext = mockk<ProcessContext>(relaxed = true)
+                    every { mockContext.processContext } returns mockProcessContext
+                    val capturedInteraction = slot<LlmInteraction>()
+                    every {
+                        mockProcessContext.createObjectWithThinking<TestResult>(
+                            any(), capture(capturedInteraction), any(), any(), any()
+                        )
+                    } returns ThinkingResponse(result = TestResult("test"), thinkingBlocks = emptyList())
+                    OperationContextDelegate(
+                        context = mockContext,
+                        llm = LlmOptions().withThinking(thinking),
+                        toolGroups = emptySet(),
+                        toolObjects = emptyList(),
+                        promptContributors = emptyList(),
+                    ).createObjectWithThinking(listOf(UserMessage("test")), TestResult::class.java)
+                    return capturedInteraction.captured
+                }
+
+                @Test
+                fun `injects tag hint when includedTags set and injectSystemPrompt true`() {
+                    val interaction = captureInteractionWith(
+                        Thinking.withIncludedTags("analysis", "plan")
+                    )
+                    val contributions = interaction.promptContributors.map { it.contribution() }
+                    assertTrue(
+                        contributions.any { it.contains("<analysis>") },
+                        "Expected tag hint with first includedTag in prompt contributors"
+                    )
+                }
+
+                @Test
+                fun `does not inject tag hint when injectSystemPrompt false`() {
+                    val interaction = captureInteractionWith(
+                        Thinking.withIncludedTags("analysis").withInjectSystemPrompt(false)
+                    )
+                    val contributions = interaction.promptContributors.map { it.contribution() }
+                    assertFalse(
+                        contributions.any { it.contains("<analysis>") },
+                        "Expected no tag hint when injectSystemPrompt=false"
+                    )
+                }
+
+                @Test
+                fun `does not inject tag hint when includedTags is null`() {
+                    val interaction = captureInteractionWith(Thinking.withExtraction())
+                    val contributions = interaction.promptContributors.map { it.contribution() }
+                    assertFalse(
+                        contributions.any { it.contains("<") && it.contains(">") },
+                        "Expected no tag hint when includedTags is null"
+                    )
+                }
+            }
         }
 
         @Test

--- a/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LLMAnthropicThinkingIT.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-anthropic-autoconfigure/src/test/java/com/embabel/agent/config/models/anthropic/LLMAnthropicThinkingIT.java
@@ -24,7 +24,10 @@ import com.embabel.agent.api.validation.guardrails.UserInputGuardRail;
 import com.embabel.agent.autoconfigure.models.anthropic.AgentAnthropicAutoConfiguration;
 import com.embabel.agent.core.Blackboard;
 import com.embabel.agent.spi.LlmService;
+import com.embabel.common.ai.model.LlmOptions;
+import com.embabel.common.ai.model.Thinking;
 import com.embabel.common.core.thinking.ThinkingBlock;
+import com.embabel.common.core.thinking.ThinkingTagType;
 import com.embabel.common.core.thinking.ThinkingResponse;
 import com.embabel.common.core.validation.ValidationError;
 import com.embabel.common.core.validation.ValidationResult;
@@ -459,6 +462,42 @@ class LLMAnthropicThinkingIT {
         logger.info("Thinking testThinkingCreateObjectIfPossibleWithCriticalGuardRailSeverity test completed successfully");
     }
 
+
+    @Test
+    void testThinkingWithIncludedTags() {
+        logger.info("Starting thinking includedTags integration test");
+
+        PromptRunner runner = ai.withLlm(
+                LlmOptions.withModel("claude-sonnet-4-5")
+                        .withThinking(Thinking.withIncludedTags("analysis"))
+        );
+        assertTrue(runner.supportsThinking(), "Expected Anthropic prompt runner to support thinking");
+
+        String prompt = "What is the hottest month in Florida and its average high temperature?";
+
+        ThinkingResponse<MonthItem> response = runner
+                .thinking()
+                .createObject(prompt, MonthItem.class);
+
+        assertNotNull(response, "Response should not be null");
+
+        MonthItem result = response.getResult();
+        assertNotNull(result, "Result object should not be null");
+        assertNotNull(result.getName(), "Month name should not be null");
+        logger.info("Created object: {}", result);
+
+        List<ThinkingBlock> thinkingBlocks = response.getThinkingBlocks();
+        assertNotNull(thinkingBlocks, "Thinking blocks should not be null");
+        assertFalse(thinkingBlocks.isEmpty(), "Should have thinking content");
+
+        // Only TAG blocks with tagValue "analysis" should be present; no other TAG blocks
+        thinkingBlocks.stream()
+                .filter(b -> b.getTagType() == ThinkingTagType.TAG)
+                .forEach(b -> assertEquals("analysis", b.getTagValue(),
+                        "Expected only 'analysis' TAG blocks, got: " + b.getTagValue()));
+
+        logger.info("includedTags test completed with {} thinking blocks", thinkingBlocks.size());
+    }
 
     @Test
     void testThinkingWithComplexPrompt() {

--- a/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/LlmOptions.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/main/kotlin/com/embabel/common/ai/model/LlmOptions.kt
@@ -29,11 +29,21 @@ import java.time.Duration
 /**
  * Thinking config. Set on Anthropic models
  * and some Ollama models.
+ *
+ * @property includedTags when set, only [ThinkingBlock][com.embabel.common.core.thinking.ThinkingBlock]s
+ *   whose tag name is in this set are returned. PREFIX and NO_PREFIX blocks are suppressed.
+ * @property excludedTags when set, [ThinkingBlock][com.embabel.common.core.thinking.ThinkingBlock]s
+ *   whose tag name is in this set are dropped. PREFIX and NO_PREFIX blocks pass through.
+ * @property injectSystemPrompt when true and [includedTags] is set, a system prompt hint is injected
+ *   instructing the model to wrap reasoning in the first included tag.
  */
 class Thinking private constructor(
     val enabled: Boolean = false,
     val tokenBudget: Int? = null,
     val extractThinking: Boolean = false,
+    val includedTags: Set<String>? = null,
+    val excludedTags: Set<String>? = null,
+    val injectSystemPrompt: Boolean = true,
 ) {
 
     companion object {
@@ -49,6 +59,18 @@ class Thinking private constructor(
             extractThinking = true,
         )
 
+        @JvmStatic
+        fun withIncludedTags(vararg tags: String): Thinking = Thinking(
+            extractThinking = true,
+            includedTags = tags.toSet(),
+        )
+
+        @JvmStatic
+        fun withExcludedTags(vararg tags: String): Thinking = Thinking(
+            extractThinking = true,
+            excludedTags = tags.toSet(),
+        )
+
         val NONE: Thinking = Thinking(
             enabled = false,
         )
@@ -61,6 +83,9 @@ class Thinking private constructor(
         enabled = this.enabled,
         tokenBudget = this.tokenBudget,
         extractThinking = true,
+        includedTags = this.includedTags,
+        excludedTags = this.excludedTags,
+        injectSystemPrompt = this.injectSystemPrompt,
     )
 
     /**
@@ -70,6 +95,21 @@ class Thinking private constructor(
         enabled = true,
         tokenBudget = tokenBudget,
         extractThinking = this.extractThinking,
+        includedTags = this.includedTags,
+        excludedTags = this.excludedTags,
+        injectSystemPrompt = this.injectSystemPrompt,
+    )
+
+    /**
+     * Control whether a system prompt hint is injected when [includedTags] is set.
+     */
+    fun withInjectSystemPrompt(inject: Boolean): Thinking = Thinking(
+        enabled = this.enabled,
+        tokenBudget = this.tokenBudget,
+        extractThinking = this.extractThinking,
+        includedTags = this.includedTags,
+        excludedTags = this.excludedTags,
+        injectSystemPrompt = inject,
     )
 }
 

--- a/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/model/ThinkingTest.kt
+++ b/embabel-agent-common/embabel-agent-ai/src/test/kotlin/com/embabel/common/ai/model/ThinkingTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.common.ai.model
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ThinkingTest {
+
+    @Nested
+    inner class FactoryMethods {
+
+        @Test
+        fun `withIncludedTags sets includedTags and enables extraction`() {
+            val thinking = Thinking.withIncludedTags("analysis", "plan")
+            assertEquals(setOf("analysis", "plan"), thinking.includedTags)
+            assertNull(thinking.excludedTags)
+            assertTrue(thinking.extractThinking)
+            assertTrue(thinking.injectSystemPrompt)
+        }
+
+        @Test
+        fun `withExcludedTags sets excludedTags and enables extraction`() {
+            val thinking = Thinking.withExcludedTags("think")
+            assertEquals(setOf("think"), thinking.excludedTags)
+            assertNull(thinking.includedTags)
+            assertTrue(thinking.extractThinking)
+            assertTrue(thinking.injectSystemPrompt)
+        }
+    }
+
+    @Nested
+    inner class Propagation {
+
+        @Test
+        fun `applyExtraction preserves includedTags and excludedTags`() {
+            val withIncluded = Thinking.withIncludedTags("analysis").applyExtraction()
+            assertNotNull(withIncluded.includedTags)
+            assertTrue(withIncluded.extractThinking)
+
+            val withExcluded = Thinking.withExcludedTags("think").applyExtraction()
+            assertNotNull(withExcluded.excludedTags)
+            assertTrue(withExcluded.extractThinking)
+        }
+
+        @Test
+        fun `applyTokenBudget preserves includedTags and excludedTags and injectSystemPrompt`() {
+            val thinking = Thinking.withIncludedTags("analysis").applyTokenBudget(4000)
+            assertEquals(setOf("analysis"), thinking.includedTags)
+            assertEquals(4000, thinking.tokenBudget)
+            assertTrue(thinking.injectSystemPrompt)
+        }
+
+        @Test
+        fun `applyExtraction preserves injectSystemPrompt false`() {
+            val thinking = Thinking.withIncludedTags("analysis")
+                .withInjectSystemPrompt(false)
+                .applyExtraction()
+            assertFalse(thinking.injectSystemPrompt)
+            assertTrue(thinking.extractThinking)
+        }
+    }
+
+    @Nested
+    inner class InjectSystemPrompt {
+
+        @Test
+        fun `withInjectSystemPrompt false disables injection`() {
+            val thinking = Thinking.withIncludedTags("plan").withInjectSystemPrompt(false)
+            assertFalse(thinking.injectSystemPrompt)
+            assertEquals(setOf("plan"), thinking.includedTags)
+        }
+
+        @Test
+        fun `default injectSystemPrompt is true`() {
+            assertTrue(Thinking.withIncludedTags("plan").injectSystemPrompt)
+            assertTrue(Thinking.withExtraction().injectSystemPrompt)
+        }
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/thinking/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/thinking/page.adoc
@@ -138,6 +138,48 @@ if (result != null) {
 ----
 ====
 
+==== Thinking Tag Control
+
+Without changing your prompt, you can control which XML-tagged reasoning blocks the model produces and returns.
+
+Use `includedTags` to keep only blocks wrapped in the named tags — the model is automatically instructed (via a system prompt hint) to use those tags for its reasoning.
+Use `excludedTags` to drop blocks with specific tag names while keeping all others.
+
+NOTE: `includedTags` and `excludedTags` apply only to named TAG blocks. Untagged reasoning (PREFIX and NO_PREFIX style blocks) always passes through.
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+// Only return the "analysis" reasoning block; model is guided to use that tag
+ThinkingResponse<MonthItem> response = runner
+        .thinking(Thinking.withIncludedTags("analysis"))
+        .createObject(prompt, MonthItem.class);
+
+// Drop "scratchpad" blocks, keep all others
+ThinkingResponse<MonthItem> response2 = runner
+        .thinking(Thinking.withExcludedTags("scratchpad"))
+        .createObject(prompt, MonthItem.class);
+----
+
+Kotlin::
++
+[source,kotlin]
+----
+// Only return the "analysis" reasoning block; model is guided to use that tag
+val response = runner
+        .thinking(Thinking.withIncludedTags("analysis"))
+        .createObject(prompt, MonthItem::class.java)
+
+// Drop "scratchpad" blocks, keep all others
+val response2 = runner
+        .thinking(Thinking.withExcludedTags("scratchpad"))
+        .createObject(prompt, MonthItem::class.java)
+----
+====
+
 ==== Provider Notes
 
 Embabel exposes thinking through a provider-neutral API:


### PR DESCRIPTION
## Overview
Feature: Add tag selection control to Thinking via includedTags/excludedTags and with system prompt hint injection

See #1790 


 ## Summary

  - Adds `includedTags`, `excludedTags`, and `injectSystemPrompt` fields to `Thinking` class with factory methods `withIncludedTags`, `withExcludedTags`, `withInjectSystemPrompt`
  - All `extractAllThinkingBlocks` call sites in `ChatClientLlmOperations` and `ToolLoopLlmOperations` pass the new filters through from `LlmInteraction`
  - `OperationContextDelegate.thinkingInteraction()` injects a system prompt hint when `includedTags` is set and `injectSystemPrompt` is true, guiding the model to wrap reasoning in the
  first included tag
  - Documentation: new "Thinking Tag Control" section in `reference/thinking/page.adoc`
  - Integration test: `testThinkingWithIncludedTags` in `LLMAnthropicThinkingIT`

  ## Depends on

  _embabel-common_ PR 133 (adds `includedTags`/`excludedTags` params to `extractAllThinkingBlocks`)


## Example

```
 PromptRunner runner = ai.withLlm(
                LlmOptions.withModel("claude-sonnet-4-5")
                        .withThinking(Thinking.withIncludedTags("analysis"))
        );
        assertTrue(runner.supportsThinking(), "Expected Anthropic prompt runner to support thinking");

        String prompt = "What is the hottest month in Florida and its average high temperature?";

        ThinkingResponse<MonthItem> response = runner
                .thinking()
                .createObject(prompt, MonthItem.class);
```

OUTPUT

```
3:10:43.714 [main] DEBUG ChatClientLlmOperations - LLM thinking response=ThinkingResponse(result=MonthItem{name='July', temperature=91}, thinkingBlocks=[ThinkingBlock(content=The user is asking about the hottest month in Florida and its average high temperature. Based on my knowledge, Florida's hottest month is typically July or August, with July being slightly hotter on average. The average high temperature in July across Florida is approximately 90-92°F (32-33°C), though this can vary by location within the state. I'll use 91°F as a representative average high temperature for July in Florida., tagType=TAG, tagValue=analysis)], exception=null)
22:20:54.764 [main] INFO  Embabel - [strange_dubinsky] (InfrastructureInjectionConfigurationKt-thinking) received LLM response of type ThinkingResponse from ByNameModelSelectionCriteria(name=claude-sonnet-4-5) in 3 seconds
22:20:54.764 [main] INFO  LLMAnthropicThinkingIT - Created object: MonthItem{name='July', temperature=92}
22:20:54.766 [main] INFO  LLMAnthropicThinkingIT - includedTags test completed with 1 thinking blocks
22:
```