### PR TITLE
Feat: add OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ Optional:
 - `ANTHROPIC_API_KEY`: For the Anthropic API. Necessary for the coding agent.
 - `MINIMAX_API_KEY`: For the [MiniMax](https://www.minimax.io) API. Supports MiniMax-M3, MiniMax-M2.7 and MiniMax-M2.7-highspeed models.
 - `ZAI_API_KEY`: For the [Z.ai](https://z.ai) (Zhipu AI) API. Supports GLM-5.2, GLM-4.7, GLM-4.6, GLM-4.5-Air and GLM-4.7-Flash models.
+- `ORCAROUTER_API_KEY`: For the [OrcaRouter](https://www.orcarouter.ai) API. Supports orcarouter/auto, orcarouter/fusion, orcarouter/fusion-flash and orcarouter/fusion-mini models.
 - OCI Generative AI uses OCI SDK authentication providers. Add `embabel-agent-starter-oci-genai` and set
   `embabel.agent.platform.models.ocigenai.compartment-id`; OCI config file, instance principal, resource principal,
   workload identity, session token and simple key authentication are supported.
@@ -988,6 +989,7 @@ need to configure the integrations you want to exercise:
 - `GOOGLE_GENAI_API_KEY`
 - `DASHSCOPE_API_KEY`
 - `ZAI_API_KEY`
+- `ORCAROUTER_API_KEY`
 - `OLLAMA_BASE_URL` for tests using a local Ollama service
 - `EMBABEL_RUN_ONNX_INTEGRATION_TESTS` to opt into the slow Hugging Face model download
 - `GOOGLE_PROJECT_ID` plus `EMBABEL_RUN_VERTEX_INTEGRATION_TESTS` to opt into the Vertex AI tests, which

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/OrcaRouterModels.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/models/OrcaRouterModels.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.models
+
+/**
+ * Provides constants for OrcaRouter model identifiers.
+ * OrcaRouter exposes models from multiple vendors through an OpenAI-compatible API.
+ *
+ * @see <a href="https://www.orcarouter.ai">OrcaRouter</a>
+ */
+class OrcaRouterModels {
+
+    companion object {
+
+        const val AUTO = "orcarouter/auto"
+        const val FUSION = "orcarouter/fusion"
+        const val FUSION_FLASH = "orcarouter/fusion-flash"
+        const val FUSION_MINI = "orcarouter/fusion-mini"
+
+        const val PROVIDER = "OrcaRouter"
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/CredentialEndpointConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/byok/CredentialEndpointConfig.kt
@@ -40,9 +40,9 @@ import org.springframework.context.annotation.Configuration
  * returning a value, with nothing from `com.embabel.agent.spi` in it, because a gateway speaking
  * the OpenAI protocol needs no client this module does not already have.
  *
- * That is one bean per provider *module*, not per provider: `embabel-agent-openai` speaks to five
- * providers over one wire protocol, so the coverage is Anthropic, OpenAI, DeepSeek, Mistral, Gemini
- * and Atlas Cloud - the whole BYOK surface. A deployment using any of them writes nothing at all.
+ * That is one bean per provider *module*, not per provider: `embabel-agent-openai` speaks to six
+ * providers over one wire protocol, so the coverage is Anthropic, OpenAI, DeepSeek, Mistral, Gemini,
+ * Atlas Cloud and OrcaRouter - the whole BYOK surface. A deployment using any of them writes nothing at all.
  *
  * Without these, a [com.embabel.common.ai.model.RoleResolution.Credential] fails with
  * `NoSuitableModelException` until the application registers a factory of its own - and that
@@ -160,10 +160,10 @@ class CredentialEndpointConfig {
      * Every OpenAI-compatible provider, on the same terms.
      *
      * One lookup rather than one per provider, because `embabel-agent-openai` carries OpenAI,
-     * DeepSeek, Mistral, Gemini and Atlas Cloud behind a single wire protocol, and the only thing
-     * that differs is the base URL - which [OpenAiCompatibleModelFactory.endpointFor] already
-     * knows. Reading it there rather than restating it keeps this from drifting when an endpoint
-     * moves.
+     * DeepSeek, Mistral, Gemini, Atlas Cloud and OrcaRouter behind a single wire protocol, and the
+     * only thing that differs is the base URL - which [OpenAiCompatibleModelFactory.endpointFor]
+     * already knows. Reading it there rather than restating it keeps this from drifting when an
+     * endpoint moves.
      */
     private fun openAiCompatibleEndpointFor(credential: ProviderCredential): CredentialEndpoint? =
         OpenAiCompatibleModelFactory.endpointFor(credential.provider)?.let {

--- a/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/CredentialEndpointConfigTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-byok-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/byok/CredentialEndpointConfigTest.kt
@@ -22,6 +22,7 @@ import com.embabel.agent.api.models.DeepSeekModels
 import com.embabel.agent.api.models.GoogleGenAiModels
 import com.embabel.agent.api.models.MistralAiModels
 import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.api.models.OrcaRouterModels
 import com.embabel.agent.autoconfigure.models.byok.AgentByokAutoConfiguration
 import com.embabel.agent.openai.OpenAiCompatibleModelFactory
 import com.embabel.agent.spi.LlmService
@@ -163,6 +164,7 @@ class CredentialEndpointConfigTest {
             MistralAiModels.PROVIDER to MistralAiModels.MINISTRAL_8B,
             GoogleGenAiModels.PROVIDER to GoogleGenAiModels.GEMINI_2_5_FLASH,
             AtlasCloudModels.PROVIDER to AtlasCloudModels.QWEN3_5_FLASH,
+            OrcaRouterModels.PROVIDER to OrcaRouterModels.AUTO,
         )
         contextRunner.run { context ->
             val factories = factoriesIn(context)

--- a/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-autoconfigure</artifactId>
+        <version>1.5.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>embabel-agent-orcarouter-autoconfigure</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Autoconfiguration Models OrcaRouter</name>
+    <description>OrcaRouter Models Auto-Configuration for Embabel Agent API</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-openai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-openai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/orcarouter/AgentOrcaRouterAutoConfiguration.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/main/java/com/embabel/agent/autoconfigure/models/orcarouter/AgentOrcaRouterAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.orcarouter;
+
+import com.embabel.agent.config.models.orcarouter.OrcaRouterModelsConfig;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Autoconfiguration for OrcaRouter models in the Embabel Agent system.
+ * <p>
+ * This class serves as a Spring Boot autoconfiguration entry point that:
+ * - Imports the {@link OrcaRouterModelsConfig} configuration to register OrcaRouter model beans
+ * <p>
+ * The configuration is automatically activated when the OrcaRouter
+ * dependencies are present on the classpath and the ORCAROUTER_API_KEY
+ * environment variable is set.
+ */
+@AutoConfiguration
+@AutoConfigureBefore(name = {"com.embabel.agent.autoconfigure.platform.AgentPlatformAutoConfiguration"})
+@Import(OrcaRouterModelsConfig.class)
+public class AgentOrcaRouterAutoConfiguration {
+    private static final Logger logger = LoggerFactory.getLogger(AgentOrcaRouterAutoConfiguration.class);
+
+    @PostConstruct
+    public void logEvent() {
+        logger.info("AgentOrcaRouterAutoConfiguration about to proceed...");
+    }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/orcarouter/OrcaRouterModelsConfig.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/main/kotlin/com/embabel/agent/config/models/orcarouter/OrcaRouterModelsConfig.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.orcarouter
+
+import com.embabel.agent.api.models.OrcaRouterModels
+import com.embabel.agent.config.models.orcarouter.OrcaRouterProperties.Companion.PREFIX
+import com.embabel.agent.openai.OpenAiCompatibleModelFactory
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.common.RetryProperties
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.OptionsConverter
+import com.embabel.common.ai.model.PricingModel
+import com.embabel.common.util.ExcludeFromJacocoGeneratedReport
+import com.embabel.common.util.loggerFor
+import io.micrometer.observation.ObservationRegistry
+import org.springframework.ai.chat.prompt.ChatOptions
+import org.springframework.ai.openai.OpenAiChatOptions
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestClient
+import org.springframework.web.reactive.function.client.WebClient
+import java.time.LocalDate
+
+/**
+ * Configuration properties for OrcaRouter models.
+ * These properties are bound from the Spring configuration with the prefix
+ * "embabel.agent.platform.models.orcarouter" and control retry behavior
+ * when calling OrcaRouter APIs.
+ */
+@ConfigurationProperties(prefix = PREFIX)
+class OrcaRouterProperties : RetryProperties {
+    /**
+     * Base URL for OrcaRouter API requests.
+     */
+    var baseUrl: String = "https://api.orcarouter.ai/v1"
+
+    /**
+     * API key for authenticating with OrcaRouter services.
+     */
+    var apiKey: String? = null
+
+    /**
+     *  Maximum number of attempts.
+     */
+    override var maxAttempts: Int = 4
+
+    /**
+     * Initial backoff interval (in milliseconds).
+     */
+    override var backoffMillis: Long = 1500L
+
+    /**
+     * Backoff interval multiplier.
+     */
+    override var backoffMultiplier: Double = 2.0
+
+    /**
+     * Maximum backoff interval (in milliseconds).
+     */
+    override var backoffMaxInterval: Long = 60000L
+
+    override val propertyPrefix: String = PREFIX
+    companion object {
+        const val PREFIX  = "embabel.agent.platform.models.orcarouter"
+    }
+}
+
+/**
+ * Configuration class for OrcaRouter models.
+ * This class provides beans for OrcaRouter models (auto, fusion, fusion-flash, fusion-mini)
+ * via the OpenAI-compatible API provided by OrcaRouter.
+ *
+ * To use, set the following environment variables:
+ * ```
+ * ORCAROUTER_API_KEY=your-api-key
+ * ```
+ *
+ * @see <a href="https://www.orcarouter.ai">OrcaRouter</a>
+ */
+@Configuration(proxyBeanMethods = false)
+@EnableConfigurationProperties(OrcaRouterProperties::class)
+@ExcludeFromJacocoGeneratedReport(reason = "OrcaRouter configuration can't be unit tested")
+class OrcaRouterModelsConfig(
+    @param:Value("\${ORCAROUTER_BASE_URL:#{null}}")
+    private val envBaseUrl: String?,
+    @param:Value("\${ORCAROUTER_API_KEY:#{null}}")
+    private val envApiKey: String?,
+    observationRegistry: ObjectProvider<ObservationRegistry>,
+    private val properties: OrcaRouterProperties,
+    @Qualifier("aiModelRestClientBuilder")
+    restClientBuilder: ObjectProvider<RestClient.Builder>,
+    @Qualifier("aiModelWebClientBuilder")
+    webClientBuilder: ObjectProvider<WebClient.Builder>,
+) : OpenAiCompatibleModelFactory(
+    baseUrl = envBaseUrl?.trim()?.takeIf { it.isNotEmpty() } ?: properties.baseUrl,
+    apiKey = envApiKey?.trim()?.takeIf { it.isNotEmpty() }
+        ?: properties.apiKey?.trim()?.takeIf { it.isNotEmpty() }
+        ?: error("OrcaRouter API key required: set ORCAROUTER_API_KEY env var or embabel.agent.platform.models.orcarouter.api-key"),
+    completionsPath = null,
+    embeddingsPath = null,
+    observationRegistry = observationRegistry.getIfUnique { ObservationRegistry.NOOP },
+    restClientBuilder = restClientBuilder,
+    webClientBuilder = webClientBuilder,
+) {
+
+    init {
+        logger.info("OrcaRouter models are available: {}", properties)
+    }
+
+    @Bean
+    fun orcaRouterAuto(): LlmService<*> {
+        return openAiCompatibleLlm(
+            model = OrcaRouterModels.AUTO,
+            provider = OrcaRouterModels.PROVIDER,
+            knowledgeCutoffDate = null,
+            optionsConverter = OrcaRouterOptionsConverter,
+            pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+            retryTemplate = properties.retryTemplate(OrcaRouterModels.AUTO),
+        )
+    }
+
+    @Bean
+    fun orcaRouterFusion(): LlmService<*> {
+        return openAiCompatibleLlm(
+            model = OrcaRouterModels.FUSION,
+            provider = OrcaRouterModels.PROVIDER,
+            knowledgeCutoffDate = null,
+            optionsConverter = OrcaRouterOptionsConverter,
+            pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+            retryTemplate = properties.retryTemplate(OrcaRouterModels.FUSION),
+        )
+    }
+
+    @Bean
+    fun orcaRouterFusionFlash(): LlmService<*> {
+        return openAiCompatibleLlm(
+            model = OrcaRouterModels.FUSION_FLASH,
+            provider = OrcaRouterModels.PROVIDER,
+            knowledgeCutoffDate = null,
+            optionsConverter = OrcaRouterOptionsConverter,
+            pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+            retryTemplate = properties.retryTemplate(OrcaRouterModels.FUSION_FLASH),
+        )
+    }
+
+    @Bean
+    fun orcaRouterFusionMini(): LlmService<*> {
+        return openAiCompatibleLlm(
+            model = OrcaRouterModels.FUSION_MINI,
+            provider = OrcaRouterModels.PROVIDER,
+            knowledgeCutoffDate = null,
+            optionsConverter = OrcaRouterOptionsConverter,
+            pricingModel = PricingModel.ALL_YOU_CAN_EAT,
+            retryTemplate = properties.retryTemplate(OrcaRouterModels.FUSION_MINI),
+        )
+    }
+}
+
+/**
+ * Options converter for OrcaRouter models.
+ * OrcaRouter accepts OpenAI-compatible chat options unchanged.
+ */
+object OrcaRouterOptionsConverter : OptionsConverter {
+    override fun convertOptions(options: LlmOptions, model: String): ChatOptions =
+        OpenAiChatOptions.builder()
+            .model(model)
+            .temperature(options.temperature)
+            .topP(options.topP)
+            .maxTokens(options.maxTokens)
+            .presencePenalty(options.presencePenalty)
+            .frequencyPenalty(options.frequencyPenalty)
+            .build()
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,16 @@
+#
+# Copyright 2025-2025 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.embabel.agent.autoconfigure.models.orcarouter.AgentOrcaRouterAutoConfiguration

--- a/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/orcarouter/AgentOrcaRouterAutoConfigurationTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/orcarouter/AgentOrcaRouterAutoConfigurationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.autoconfigure.models.orcarouter;
+
+import com.embabel.agent.spi.LlmService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the OrcaRouter entrypoint auto-configuration imports the provider config and exposes all configured OrcaRouter model beans when credentials are present.
+ */
+class AgentOrcaRouterAutoConfigurationTest {
+
+   /**
+    * Context runner configured with a test API key so the provider configuration can instantiate its model beans without depending on real environment variables.
+    */
+   private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+           .withConfiguration(AutoConfigurations.of(AgentOrcaRouterAutoConfiguration.class))
+           .withPropertyValues("embabel.agent.platform.models.orcarouter.api-key=test-key");
+
+   /**
+    * Confirms that all OrcaRouter model beans are registered and backed by the generic LLM service abstraction exposed to the rest of the platform.
+    */
+   @Test
+   void registersOrcaRouterModelBeans() {
+      // Act
+      contextRunner.run(context -> {
+         // Assert
+         assertThat(context).hasBean("orcaRouterAuto");
+         assertThat(context).hasBean("orcaRouterFusion");
+         assertThat(context).hasBean("orcaRouterFusionFlash");
+         assertThat(context).hasBean("orcaRouterFusionMini");
+         assertThat(context.getBean("orcaRouterAuto")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("orcaRouterFusion")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("orcaRouterFusionFlash")).isInstanceOf(LlmService.class);
+         assertThat(context.getBean("orcaRouterFusionMini")).isInstanceOf(LlmService.class);
+      });
+   }
+}

--- a/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/orcarouter/OrcaRouterOptionsConverterTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-orcarouter-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/orcarouter/OrcaRouterOptionsConverterTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.config.models.orcarouter
+
+import com.embabel.agent.test.models.OptionsConverterTestSupport
+import com.embabel.common.ai.model.LlmOptions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class OrcaRouterOptionsConverterTest : OptionsConverterTestSupport(
+    optionsConverter = OrcaRouterOptionsConverter
+) {
+    @Test
+    fun `should set override maxTokens default`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withMaxTokens(200), "test-model")
+        assertEquals(200, options.maxTokens)
+    }
+
+    @Test
+    fun `should preserve temperature`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTemperature(0.7), "test-model")
+        assertEquals(0.7, options.temperature)
+    }
+
+    @Test
+    fun `should preserve topP`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withTopP(0.9), "test-model")
+        assertEquals(0.9, options.topP)
+    }
+
+    @Test
+    fun `should preserve presencePenalty`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withPresencePenalty(0.5), "test-model")
+        assertEquals(0.5, options.presencePenalty)
+    }
+
+    @Test
+    fun `should preserve frequencyPenalty`() {
+        val options = optionsConverter.convertOptions(LlmOptions().withFrequencyPenalty(0.3), "test-model")
+        assertEquals(0.3, options.frequencyPenalty)
+    }
+
+    @Test
+    fun `should handle null temperature`() {
+        val options = optionsConverter.convertOptions(LlmOptions(), "test-model")
+        // Spring AI 2.0's OpenAiChatOptions package is @NullMarked, so Kotlin treats
+        // getTemperature() as non-null Double — direct property access NPEs on a null
+        // runtime value. Read into a Double? local to bypass. (Migration doc §5.11.)
+        val temperature: Double? = options.temperature
+        assertEquals(null, temperature)
+    }
+
+    @Test
+    fun `should preserve model id`() {
+        val options = optionsConverter.convertOptions(LlmOptions(), "orcarouter/auto")
+        assertTrue(options.model.contains("orcarouter/auto"))
+    }
+}

--- a/embabel-agent-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/pom.xml
@@ -40,6 +40,7 @@
         <module>models/embabel-agent-google-genai-autoconfigure</module>
         <module>models/embabel-agent-oci-genai-autoconfigure</module>
         <module>models/embabel-agent-minimax-autoconfigure</module>
+        <module>models/embabel-agent-orcarouter-autoconfigure</module>
         <module>models/embabel-agent-zai-autoconfigure</module>
         <module>models/embabel-agent-dashscope-autoconfigure</module>
         <module>models/embabel-agent-mistral-ai-autoconfigure</module>

--- a/embabel-agent-common/embabel-agent-byok/src/main/kotlin/com/embabel/common/byok/ProviderDetection.kt
+++ b/embabel-agent-common/embabel-agent-byok/src/main/kotlin/com/embabel/common/byok/ProviderDetection.kt
@@ -32,6 +32,7 @@ import java.util.concurrent.Executors
  *     OpenAiCompatibleModelFactory.mistral(userKey),
  *     OpenAiCompatibleModelFactory.gemini(userKey),
  *     OpenAiCompatibleModelFactory.atlasCloud(userKey),
+ *     OpenAiCompatibleModelFactory.orcaRouter(userKey),
  * )
  * val detectedProvider = service.provider
  * ```

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -199,6 +199,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-orcarouter-autoconfigure</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-zai-autoconfigure</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -356,6 +362,12 @@
             <dependency>
                 <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-starter-minimax</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-starter-orcarouter</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/getting-started/installing/page.adoc
@@ -506,6 +506,62 @@ dependencies {
 ----
 ====
 
+===== OrcaRouter
+
+Uses the OpenAI-compatible gateway endpoint for OrcaRouter models.
+
+* Required:
+- `ORCAROUTER_API_KEY`: API key for OrcaRouter services
+* Optional:
+- `ORCAROUTER_BASE_URL`: base URL for OrcaRouter API (default: `https://api.orcarouter.ai/v1`)
+
+Alternatively, configure via `application.yml`:
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        orcarouter:
+          api-key: ${ORCAROUTER_API_KEY:sk-orca-dev-key}
+          base-url: ${ORCAROUTER_BASE_URL:}
+----
+
+You also need to add the `embabel-agent-starter-orcarouter` starter.
+
+Add this to your build system as follows:
+[tabs]
+====
+Maven (pom.xml)::
++
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-orcarouter</artifactId>
+    <version>${embabel-agent.version}</version>
+</dependency>
+----
+Gradle Kotlin DSL (build.gradle.kts)::
++
+[source,kotlin]
+----
+dependencies {
+    implementation("com.embabel.agent:embabel-agent-starter-orcarouter:${embabel-agent.version}")
+}
+----
+
+Gradle Groovy DSL (build.gradle)::
++
+[source,groovy]
+----
+dependencies {
+    implementation 'com.embabel.agent:embabel-agent-starter-orcarouter:${embabel-agent.version}'
+}
+----
+====
+
 ===== Google Gemini (OpenAI Compatible)
 
 Uses the OpenAI-compatible endpoint for Gemini models.

--- a/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/modules/page.adoc
@@ -260,6 +260,12 @@ The following are modules intended for direct use (versus supporting infrastruct
 | Quick start with Mistral
 | Stable
 
+| `embabel-agent-starter-orcarouter`
+| This repo
+| OrcaRouter starter
+| Quick start with OrcaRouter gateway models
+| Stable
+
 | `embabel-agent-starter-zai`
 | This repo
 | Z.ai (Zhipu GLM) starter

--- a/embabel-agent-docs/src/main/asciidoc/reference/orcarouter/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/orcarouter/page.adoc
@@ -1,0 +1,179 @@
+[[reference.orcarouter]]
+=== OrcaRouter Integration
+
+https://www.orcarouter.ai[OrcaRouter] is a model gateway that routes to models from multiple vendors through one OpenAI-compatible API.
+Embabel integrates OrcaRouter as a first-class provider using the same `OpenAiCompatibleModelFactory` pattern as other OpenAI-compatible providers (MiniMax, Atlas Cloud).
+
+It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+==== Add the Dependency
+
+[tabs]
+====
+Maven::
++
+[source,xml]
+----
+<dependency>
+    <groupId>com.embabel.agent</groupId>
+    <artifactId>embabel-agent-starter-orcarouter</artifactId>
+</dependency>
+----
+
+Gradle (Kotlin)::
++
+[source,kotlin]
+----
+implementation("com.embabel.agent:embabel-agent-starter-orcarouter")
+----
+
+Gradle (Groovy)::
++
+[source,groovy]
+----
+implementation 'com.embabel.agent:embabel-agent-starter-orcarouter'
+----
+====
+
+==== API Key Configuration
+
+Set your OrcaRouter API key via environment variable (recommended) or Spring property:
+
+[source,bash]
+----
+export ORCAROUTER_API_KEY=your-api-key
+----
+
+Or in `application.yml`:
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        orcarouter:
+          api-key: your-api-key
+----
+
+TIP: The environment variable `ORCAROUTER_API_KEY` takes precedence over the property value.
+Use the property for local development and the environment variable in production deployments.
+
+==== Available Models
+
+[cols="2,3,1,1",options="header"]
+|===
+|Model Name |Model ID |Context Window |Route
+
+|`OrcaRouter Auto`
+|`orcarouter/auto`
+|Smart
+|Automatic per-request model selection
+
+|`OrcaRouter Fusion`
+|`orcarouter/fusion`
+|1M tokens
+|Flagship long-context
+
+|`OrcaRouter Fusion Flash`
+|`orcarouter/fusion-flash`
+|200K tokens
+|Fast, cost-effective
+
+|`OrcaRouter Fusion Mini`
+|`orcarouter/fusion-mini`
+|1M tokens
+|Cheapest tier
+
+|===
+
+`orcarouter/auto` is the smart-routing default: the gateway picks the best available model for each request.
+`orcarouter/fusion` is the flagship long-context model, `orcarouter/fusion-flash` trades some quality for lower latency and cost, and `orcarouter/fusion-mini` is the cheapest tier for high-volume extraction and classification steps.
+
+==== Using OrcaRouter Models
+
+Reference models by name in `@LlmCall` or programmatically via `ai.withLlm()`:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+// Declarative
+@LlmCall(llm = "orcarouter/auto")
+fun summarize(article: Article): Summary
+
+// Programmatic
+ai.withLlm("orcarouter/fusion-flash")
+    .create<Classification>("Classify this input")
+----
+
+Java::
++
+[source,java]
+----
+// Declarative
+@LlmCall(llm = "orcarouter/auto")
+Summary summarize(Article article);
+
+// Programmatic
+ai.withLlm("orcarouter/fusion-flash")
+    .create("Classify this input", Classification.class);
+----
+====
+
+Or map OrcaRouter models to roles in your configuration:
+
+[source,yaml]
+----
+embabel:
+  models:
+    llms:
+      cheapest: orcarouter/fusion-mini
+      best: orcarouter/fusion
+----
+
+Then reference by role with the `#` prefix:
+
+[tabs]
+====
+Kotlin::
++
+[source,kotlin]
+----
+@LlmCall(llm = "#cheapest")
+fun extractEntities(text: String): EntityList
+----
+
+Java::
++
+[source,java]
+----
+@LlmCall(llm = "#cheapest")
+EntityList extractEntities(String text);
+----
+====
+
+==== Configuration Reference
+
+[source,yaml]
+----
+embabel:
+  agent:
+    platform:
+      models:
+        orcarouter:
+          api-key: your-api-key                   # Alternative to ORCAROUTER_API_KEY env var
+          base-url: https://api.orcarouter.ai/v1  # Default
+          max-attempts: 4                          # Retry attempts (default: 4)
+          backoff-millis: 1500                     # Initial backoff ms (default: 1500)
+          backoff-multiplier: 2.0                  # Backoff multiplier (default: 2.0)
+          backoff-max-interval: 60000              # Max backoff ms (default: 60000)
+----
+
+==== See Also
+
+* <<reference.llms,Working with LLMs>>
+* <<reference.configuration,Configuration Reference>>
+* https://www.orcarouter.ai[OrcaRouter]

--- a/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
@@ -35,6 +35,8 @@ include::bedrock/page.adoc[]
 
 include::minimax/page.adoc[]
 
+include::orcarouter/page.adoc[]
+
 include::zai/page.adoc[]
 
 include::dashscope/page.adoc[]

--- a/embabel-agent-docs/src/main/asciidoc/reference/testing/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/testing/page.adoc
@@ -840,6 +840,7 @@ Configure only the integrations you want to exercise:
 - `GOOGLE_GENAI_API_KEY`
 - `DASHSCOPE_API_KEY`
 - `ZAI_API_KEY`
+- `ORCAROUTER_API_KEY`
 - `OLLAMA_BASE_URL` for tests using a local Ollama service
 - `EMBABEL_RUN_ONNX_INTEGRATION_TESTS` to opt into the slow Hugging Face model download
 - `GOOGLE_PROJECT_ID` plus `EMBABEL_RUN_VERTEX_INTEGRATION_TESTS` to opt into the Vertex AI tests, which

--- a/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
+++ b/embabel-agent-openai/src/main/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactory.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.api.models.DeepSeekModels
 import com.embabel.agent.api.models.GoogleGenAiModels
 import com.embabel.agent.api.models.MistralAiModels
 import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.api.models.OrcaRouterModels
 import com.embabel.agent.spi.LlmService
 import com.embabel.agent.spi.support.springai.SpringAiLlmService
 import com.embabel.chat.UserMessage
@@ -98,9 +99,10 @@ open class OpenAiCompatibleModelFactory(
             "https://generativelanguage.googleapis.com/v1beta/openai",
         )
         private val ATLAS_CLOUD = ProviderEndpoint(AtlasCloudModels.PROVIDER, "https://api.atlascloud.ai/v1")
+        private val ORCA_ROUTER = ProviderEndpoint(OrcaRouterModels.PROVIDER, "https://api.orcarouter.ai/v1")
 
         private val ENDPOINTS_BY_PROVIDER: Map<String, ProviderEndpoint> =
-            listOf(OPEN_AI, DEEP_SEEK, MISTRAL, GEMINI, ATLAS_CLOUD)
+            listOf(OPEN_AI, DEEP_SEEK, MISTRAL, GEMINI, ATLAS_CLOUD, ORCA_ROUTER)
                 .associateBy { it.provider.lowercase() }
 
         /**
@@ -155,6 +157,13 @@ open class OpenAiCompatibleModelFactory(
          */
         fun atlasCloud(apiKey: String): ByokSpec =
             ByokSpec(ATLAS_CLOUD.baseUrl, apiKey, AtlasCloudModels.QWEN3_5_FLASH, ATLAS_CLOUD.provider)
+
+        /**
+         * Returns a [ByokSpec] for OrcaRouter (OpenAI-compatible gateway endpoint).
+         * Validates against [OrcaRouterModels.AUTO] by default.
+         */
+        fun orcaRouter(apiKey: String): ByokSpec =
+            ByokSpec(ORCA_ROUTER.baseUrl, apiKey, OrcaRouterModels.AUTO, ORCA_ROUTER.provider)
 
         /**
          * Returns a [ByokSpec] for a custom OpenAI-compatible provider.

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryBuildValidatedTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryBuildValidatedTest.kt
@@ -158,6 +158,7 @@ class OpenAiCompatibleModelFactoryBuildValidatedTest {
             OpenAiCompatibleModelFactory.mistral("\t"),
             OpenAiCompatibleModelFactory.gemini(" "),
             OpenAiCompatibleModelFactory.atlasCloud("\n"),
+            OpenAiCompatibleModelFactory.orcaRouter(" \t "),
         ).forEach { spec ->
             val e = assertThrows<InvalidApiKeyException> { spec.buildValidated() }
             assertEquals(BLANK_API_KEY_MESSAGE, e.message)

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokIT.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokIT.kt
@@ -70,6 +70,15 @@ class OpenAiCompatibleModelFactoryByokIT {
     }
 
     @Test
+    @EnabledIfEnvironmentVariable(named = "ORCAROUTER_API_KEY", matches = ".+")
+    fun `orcaRouter buildValidated succeeds with valid key`() {
+        val service = OpenAiCompatibleModelFactory.orcaRouter(System.getenv("ORCAROUTER_API_KEY"))
+            .buildValidated()
+        assertNotNull(service)
+        assertEquals("OrcaRouter", service.provider)
+    }
+
+    @Test
     @EnabledIfEnvironmentVariable(named = "OPENAI_API_KEY", matches = ".+")
     fun `openAiEmbedding buildValidated succeeds with valid key`() {
         val service = OpenAiCompatibleModelFactory

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryByokSpecTest.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.api.models.DeepSeekModels
 import com.embabel.agent.api.models.GoogleGenAiModels
 import com.embabel.agent.api.models.MistralAiModels
 import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.api.models.OrcaRouterModels
 import com.embabel.common.byok.ByokFactory
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Test
@@ -52,6 +53,11 @@ class OpenAiCompatibleModelFactoryByokSpecTest {
     }
 
     @Test
+    fun `orcaRouter returns ByokFactory`() {
+        assertInstanceOf(ByokFactory::class.java, OpenAiCompatibleModelFactory.orcaRouter("key"))
+    }
+
+    @Test
     fun `byok with explicit params returns ByokFactory`() {
         assertInstanceOf(
             ByokFactory::class.java,
@@ -81,6 +87,7 @@ class OpenAiCompatibleModelFactoryByokSpecTest {
         val mistralSpec = OpenAiCompatibleModelFactory.mistral("key")
         val geminiSpec = OpenAiCompatibleModelFactory.gemini("key")
         val atlasCloudSpec = OpenAiCompatibleModelFactory.atlasCloud("key")
+        val orcaRouterSpec = OpenAiCompatibleModelFactory.orcaRouter("key")
 
         // Each spec should construct without error (no network call at this stage)
         assertInstanceOf(ByokFactory::class.java, openAiSpec)
@@ -88,8 +95,11 @@ class OpenAiCompatibleModelFactoryByokSpecTest {
         assertInstanceOf(ByokFactory::class.java, mistralSpec)
         assertInstanceOf(ByokFactory::class.java, geminiSpec)
         assertInstanceOf(ByokFactory::class.java, atlasCloudSpec)
+        assertInstanceOf(ByokFactory::class.java, orcaRouterSpec)
 
         val overridden = atlasCloudSpec.validating(AtlasCloudModels.QWEN3_8_MAX, AtlasCloudModels.PROVIDER)
         assertInstanceOf(ByokFactory::class.java, overridden)
+        val overriddenOrca = orcaRouterSpec.validating(OrcaRouterModels.AUTO, OrcaRouterModels.PROVIDER)
+        assertInstanceOf(ByokFactory::class.java, overriddenOrca)
     }
 }

--- a/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryEndpointTest.kt
+++ b/embabel-agent-openai/src/test/kotlin/com/embabel/agent/openai/OpenAiCompatibleModelFactoryEndpointTest.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.api.models.DeepSeekModels
 import com.embabel.agent.api.models.GoogleGenAiModels
 import com.embabel.agent.api.models.MistralAiModels
 import com.embabel.agent.api.models.OpenAiModels
+import com.embabel.agent.api.models.OrcaRouterModels
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Nested
@@ -44,6 +45,7 @@ class OpenAiCompatibleModelFactoryEndpointTest {
                 MistralAiModels.PROVIDER to "https://api.mistral.ai/v1",
                 GoogleGenAiModels.PROVIDER to "https://generativelanguage.googleapis.com/v1beta/openai",
                 AtlasCloudModels.PROVIDER to "https://api.atlascloud.ai/v1",
+                OrcaRouterModels.PROVIDER to "https://api.orcarouter.ai/v1",
             )
             expected.forEach { (provider, baseUrl) ->
                 assertEquals(baseUrl, OpenAiCompatibleModelFactory.endpointFor(provider)?.baseUrl, provider)

--- a/embabel-agent-starters/embabel-agent-starter-orcarouter/pom.xml
+++ b/embabel-agent-starters/embabel-agent-starter-orcarouter/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-starters</artifactId>
+        <version>1.5.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>embabel-agent-starter-orcarouter</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent OrcaRouter Starter</name>
+    <description>Embabel Agent OrcaRouter Starter</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-platform-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-orcarouter-autoconfigure</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/embabel-agent-starters/pom.xml
+++ b/embabel-agent-starters/pom.xml
@@ -39,6 +39,7 @@
         <module>embabel-agent-starter-google-genai</module>
         <module>embabel-agent-starter-oci-genai</module>
         <module>embabel-agent-starter-minimax</module>
+        <module>embabel-agent-starter-orcarouter</module>
         <module>embabel-agent-starter-zai</module>
         <module>embabel-agent-starter-dashscope</module>
         <module>embabel-agent-starter-mistral-ai</module>


### PR DESCRIPTION
### Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a named, first-class OpenAI-compatible provider, mirroring the existing MiniMax wiring.

OrcaRouter is a model gateway that routes to models from multiple vendors through one OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This makes OrcaRouter selectable the same way MiniMax / Z.ai / Atlas Cloud are today: add the starter, set `ORCAROUTER_API_KEY`, and the four gateway models (`orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini`) appear as `LlmService` beans.

### Changes

- **New module** `embabel-agent-orcarouter-autoconfigure` — `OrcaRouterModelsConfig` registers four `LlmService` beans via `OpenAiCompatibleModelFactory` (base URL `https://api.orcarouter.ai/v1`, env vars `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL`), plus `OrcaRouterOptionsConverter` and unit tests.
- **New starter** `embabel-agent-starter-orcarouter`.
- **API constants** — `OrcaRouterModels` (`orcarouter/auto`, `fusion`, `fusion-flash`, `fusion-mini`).
- **BYOK** — `OpenAiCompatibleModelFactory.orcaRouter(apiKey)` factory and `endpointFor("OrcaRouter")` support; `CredentialEndpointConfig` and `ProviderDetection` docs updated.
- **POM wiring** — modules added to `embabel-agent-autoconfigure`, `embabel-agent-starters`, `embabel-agent-dependencies`.
- **Docs** — README env var list, `getting-started/installing`, `reference/orcarouter`, modules starter table, testing env list.

### Validation

- `mvn test` on `embabel-agent-openai`, `embabel-agent-orcarouter-autoconfigure`, and `embabel-agent-byok-autoconfigure` — all green (new `OrcaRouterOptionsConverterTest` 8/8, `AgentOrcaRouterAutoConfigurationTest` 1/1).
- **Live check**: `OpenAiCompatibleModelFactory.orcaRouter(key).buildValidated()` against `https://api.orcarouter.ai/v1` with a real key returns a working `LlmService` (HTTP 200, provider `OrcaRouter`).

Disclosure: I'm an engineer on the OrcaRouter team.
