### PR TITLE
Add durable asset storage contracts

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/AssetStore.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/AssetStore.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat
+
+import com.embabel.agent.api.reference.LlmReference
+import com.embabel.common.ai.media.MimeTypes
+import java.io.InputStream
+import java.time.Instant
+
+/**
+ * An [Asset] whose content can be copied to durable storage.
+ *
+ * Implementations own the returned stream and callers must close it.
+ */
+interface MaterializableAsset : Asset {
+
+    val name: String
+
+    /**
+     * MIME type of the content, preferably one of the values defined by [MimeTypes].
+     * Null when the producer cannot determine it.
+     */
+    val mimeType: String?
+
+    fun openStream(): InputStream
+}
+
+/**
+ * Durable metadata for a materialized asset.
+ *
+ * [storageUri] is opaque to consumers. It is interpreted only by the [AssetStore]
+ * that created this reference.
+ */
+data class DurableAsset(
+    override val id: String,
+    val name: String,
+    val mimeType: String?,
+    val sizeBytes: Long,
+    val contentHash: String,
+    val storageUri: String,
+    override val timestamp: Instant = Instant.now(),
+) : Asset {
+
+    override fun persistent(): Boolean = true
+
+    override fun reference(): LlmReference = LlmReference.of(
+        name = name,
+        description = "Durably stored asset $name",
+        tools = emptyList(),
+        notes = "MIME type: ${mimeType ?: "unknown"}; size: $sizeBytes bytes",
+    )
+}
+
+/**
+ * Application-supplied SPI for storing and resolving durable asset content.
+ *
+ * Implementations may use a filesystem, object storage, database, or another blob store.
+ * Conversation stores should persist [DurableAsset] metadata, not the content bytes.
+ * Unlike [AssetTracker], which tracks assets in a live conversation, an [AssetStore]
+ * owns content beyond the lifetime of the process that created it.
+ */
+interface AssetStore {
+
+    /**
+     * Copy [asset] content to durable storage before its original location expires.
+     * The implementation derives [DurableAsset.sizeBytes] and
+     * [DurableAsset.contentHash] while copying the stream.
+     */
+    fun store(asset: MaterializableAsset): DurableAsset
+
+    /**
+     * Open the content represented by [asset]. The caller must close the returned stream.
+     */
+    fun open(asset: DurableAsset): InputStream
+
+    /**
+     * Delete content represented by [asset]. Retention policy is implementation-specific.
+     */
+    fun delete(asset: DurableAsset)
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/AssetTracker.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/AssetTracker.kt
@@ -60,6 +60,19 @@ interface AssetTracker : AssetView {
     }
 
     /**
+     * Wrap a tool so any returned [MaterializableAsset] instances are copied to
+     * [assetStore] and the resulting [DurableAsset] instances are tracked.
+     */
+    fun addDurablyReturnedAssets(tool: Tool, assetStore: AssetStore): Tool {
+        return AssetAddingTool(
+            delegate = tool,
+            assetTracker = this,
+            converter = assetStore::store,
+            clazz = MaterializableAsset::class.java,
+        )
+    }
+
+    /**
      * Make these tools track any assets produced.
      */
     fun addAnyReturnedAssets(tools: List<Tool>): List<Tool> {
@@ -74,6 +87,13 @@ interface AssetTracker : AssetView {
      */
     fun addAnyReturnedAssets(tools: List<Tool>, filter: Predicate<Asset>): List<Tool> {
         return tools.map { addReturnedAssets(it, filter) }
+    }
+
+    /**
+     * Make these tools materialize and track any returned [MaterializableAsset] instances.
+     */
+    fun addAnyDurablyReturnedAssets(tools: List<Tool>, assetStore: AssetStore): List<Tool> {
+        return tools.map { addDurablyReturnedAssets(it, assetStore) }
     }
 
     companion object {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/FileSystemAssetStore.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/chat/support/FileSystemAssetStore.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat.support
+
+import com.embabel.chat.AssetStore
+import com.embabel.chat.DurableAsset
+import com.embabel.chat.MaterializableAsset
+import java.io.InputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.DigestInputStream
+import java.security.MessageDigest
+import java.util.HexFormat
+import java.util.UUID
+
+/**
+ * Durable [AssetStore] that keeps asset content below [root].
+ *
+ * The storage URI is intentionally opaque and relative to this store's root, allowing
+ * the root directory to move without invalidating persisted [DurableAsset] metadata.
+ */
+class FileSystemAssetStore(root: Path) : AssetStore {
+
+    private val root = root.toAbsolutePath().normalize()
+
+    init {
+        Files.createDirectories(this.root)
+    }
+
+    override fun store(asset: MaterializableAsset): DurableAsset {
+        val storageUri = UUID.randomUUID().toString()
+        val target = pathFor(storageUri)
+        val digest = MessageDigest.getInstance(HASH_ALGORITHM)
+
+        try {
+            asset.openStream().use { source ->
+                DigestInputStream(source, digest).use { content ->
+                    Files.copy(content, target)
+                }
+            }
+        } catch (ex: Exception) {
+            Files.deleteIfExists(target)
+            throw ex
+        }
+
+        return DurableAsset(
+            id = asset.id,
+            name = asset.name,
+            mimeType = asset.mimeType,
+            sizeBytes = Files.size(target),
+            contentHash = HexFormat.of().formatHex(digest.digest()),
+            storageUri = storageUri,
+            timestamp = asset.timestamp,
+        )
+    }
+
+    override fun open(asset: DurableAsset): InputStream = Files.newInputStream(pathFor(asset.storageUri))
+
+    override fun delete(asset: DurableAsset) {
+        Files.deleteIfExists(pathFor(asset.storageUri))
+    }
+
+    private fun pathFor(storageUri: String): Path {
+        val path = root.resolve(storageUri).normalize()
+        require(path.parent == root) { "Invalid asset storage URI" }
+        return path
+    }
+
+    private companion object {
+        const val HASH_ALGORITHM = "SHA-256"
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/chat/AssetStoreTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/chat/AssetStoreTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.chat
+
+import com.embabel.agent.api.reference.LlmReference
+import com.embabel.agent.api.tool.Tool
+import com.embabel.chat.support.FileSystemAssetStore
+import com.embabel.common.ai.media.MimeTypes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.nio.file.Path
+import java.time.Instant
+
+class AssetStoreTest {
+
+    @Test
+    fun `durable asset is persistent and exposes metadata as a reference`() {
+        val timestamp = Instant.parse("2026-08-20T00:00:00Z")
+        val asset = DurableAsset(
+            id = "asset-1",
+            name = "report.pdf",
+            mimeType = MimeTypes.PDF,
+            sizeBytes = 42,
+            contentHash = "abc123",
+            storageUri = "asset://reports/asset-1",
+            timestamp = timestamp,
+        )
+
+        assertThat(asset.persistent()).isTrue()
+        assertThat(asset.timestamp).isEqualTo(timestamp)
+        assertThat(asset.reference().name).isEqualTo("report.pdf")
+        assertThat(asset.reference().notes()).contains("application/pdf", "42 bytes")
+    }
+
+    @Test
+    fun `filesystem store derives metadata and restores content`(@TempDir directory: Path) {
+        val source = TestMaterializableAsset()
+        val store = FileSystemAssetStore(directory)
+
+        val durable = store.store(source)
+
+        assertThat(durable.id).isEqualTo(source.id)
+        assertThat(durable.sizeBytes).isEqualTo(6)
+        assertThat(durable.contentHash)
+            .isEqualTo("845e91831319e89c4d656bdb80c278ac09a7230d61e5dfd2e1b1fbb436ac8917")
+        assertThat(store.open(durable).bufferedReader().use { it.readText() }).isEqualTo("report")
+
+        store.delete(durable)
+
+        assertThat(directory.resolve(durable.storageUri)).doesNotExist()
+    }
+
+    @Test
+    fun `durably returned assets are stored before being tracked`() {
+        val source = TestMaterializableAsset()
+        val store = RecordingAssetStore()
+        val tracker = AssetTracker.inMemory()
+        val tool = Tool.of("report", "Create a report") { _ ->
+            Tool.Result.withArtifact("created", source)
+        }
+
+        tracker.addDurablyReturnedAssets(tool, store).call("{}")
+
+        assertThat(store.stored).containsExactly(source)
+        assertThat(tracker.assets).containsExactly(store.durableAsset)
+        assertThat(tracker.assets.single().persistent()).isTrue()
+    }
+
+    private class TestMaterializableAsset : MaterializableAsset {
+        override val id: String = "source-1"
+        override val name: String = "report.txt"
+        override val mimeType: String = "text/plain"
+        override val timestamp: Instant = Instant.parse("2026-08-20T00:00:00Z")
+
+        override fun persistent(): Boolean = false
+
+        override fun openStream(): InputStream = ByteArrayInputStream("report".toByteArray())
+
+        override fun reference(): LlmReference = LlmReference.of(name, "Test asset", emptyList())
+    }
+
+    private class RecordingAssetStore : AssetStore {
+        val stored = mutableListOf<MaterializableAsset>()
+        val durableAsset = DurableAsset(
+            id = "durable-1",
+            name = "report.txt",
+            mimeType = "text/plain",
+            sizeBytes = 6,
+            contentHash = "hash",
+            storageUri = "asset://durable-1",
+        )
+
+        override fun store(asset: MaterializableAsset): DurableAsset {
+            stored += asset
+            return durableAsset
+        }
+
+        override fun open(asset: DurableAsset): InputStream = ByteArrayInputStream("report".toByteArray())
+
+        override fun delete(asset: DurableAsset) = Unit
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/chatbots/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/chatbots/page.adoc
@@ -263,8 +263,54 @@ val trackedAssets = conversation.assetTracker.assets
 Use conversation-level tracking when:
 
 - Assets are created by tools or external processes
-- Assets should persist across multiple messages
+- Assets should remain available across multiple messages in a live conversation
 - You want explicit control over what's tracked
+
+Tracking an asset does not by itself make its content durable.
+An asset whose content is held in a temporary file or sandbox must be materialized before that location is removed.
+
+===== Durable Asset Content
+
+`MaterializableAsset` identifies an asset whose content can be copied to durable storage.
+An `AssetStore` performs that copy, calculates the content size and SHA-256 hash, and returns a `DurableAsset` containing portable metadata and an opaque storage URI.
+The built-in `FileSystemAssetStore` provides durable local storage; applications can implement `AssetStore` for object storage, databases, or other backends:
+
+[tabs]
+====
+Java::
++
+[source,java]
+----
+Tool durableTool = conversation.getAssetTracker()
+    .addDurablyReturnedAssets(
+        generatingTool,
+        new FileSystemAssetStore(Path.of("/var/lib/my-application/assets"))
+    );
+----
+
+Kotlin::
++
+[source,kotlin]
+----
+val durableTool = conversation.assetTracker
+    .addDurablyReturnedAssets(
+        generatingTool,
+        FileSystemAssetStore(Path.of("/var/lib/my-application/assets"))
+    )
+----
+====
+
+The three responsibilities are separate:
+
+- `AssetTracker` keeps assets available to a live conversation.
+- `AssetStore` owns the content after the process or temporary source that created it is gone.
+- Conversation persistence stores `DurableAsset` metadata with messages so those references survive a reload.
+
+When the wrapped tool returns a `MaterializableAsset`, the store completes the copy before the durable result is added to the tracker.
+`storageUri` is interpreted only by the `AssetStore` that created it, allowing implementations to use a filesystem, object storage, or another blob store.
+Conversation persistence should store the `DurableAsset` metadata and use the configured store to resolve its content after reloading.
+
+NOTE: Applications remain responsible for selecting the storage root or providing another `AssetStore`, and for deciding when durable content can be deleted.
 
 ===== Message-Level Assets
 

--- a/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ScriptExecutionResult.kt
+++ b/embabel-agent-skills/src/main/kotlin/com/embabel/agent/skills/script/ScriptExecutionResult.kt
@@ -15,7 +15,12 @@
  */
 package com.embabel.agent.skills.script
 
+import com.embabel.agent.api.reference.LlmReference
+import com.embabel.chat.MaterializableAsset
+import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
+import java.util.UUID
 import kotlin.time.Duration
 
 /**
@@ -31,11 +36,27 @@ import kotlin.time.Duration
  * @param sizeBytes the size of the file in bytes
  */
 data class ScriptArtifact(
-    val name: String,
+    override val name: String,
     val path: Path,
-    val mimeType: String? = null,
+    override val mimeType: String? = null,
     val sizeBytes: Long,
-) {
+) : MaterializableAsset {
+
+    override val id: String = UUID.randomUUID().toString()
+
+    override val timestamp: Instant = Instant.now()
+
+    override fun persistent(): Boolean = false
+
+    override fun openStream() = Files.newInputStream(path)
+
+    override fun reference(): LlmReference = LlmReference.of(
+        name = name,
+        description = "Artifact produced by a skill script",
+        tools = emptyList(),
+        notes = "MIME type: ${mimeType ?: "unknown"}; size: $sizeBytes bytes; path: $path",
+    )
+
     companion object {
         /**
          * Common MIME types by file extension.

--- a/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/ScriptArtifactTest.kt
+++ b/embabel-agent-skills/src/test/kotlin/com/embabel/agent/skills/script/ScriptArtifactTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.skills.script
+
+import com.embabel.chat.MaterializableAsset
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ScriptArtifactTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `script artifact exposes content for durable storage`() {
+        val path = tempDir.resolve("report.txt")
+        Files.writeString(path, "report content")
+        val artifact = ScriptArtifact(
+            name = "report.txt",
+            path = path,
+            mimeType = "text/plain",
+            sizeBytes = Files.size(path),
+        )
+
+        assertThat(artifact).isInstanceOf(MaterializableAsset::class.java)
+        assertThat(artifact.persistent()).isFalse()
+        artifact.openStream().bufferedReader().use { reader ->
+            assertThat(reader.readText()).isEqualTo("report content")
+        }
+    }
+
+    @Test
+    fun `script artifact can be tracked as an asset`() {
+        val path = tempDir.resolve("report.pdf")
+        Files.write(path, byteArrayOf(1, 2, 3))
+        val artifact = ScriptArtifact(
+            name = "report.pdf",
+            path = path,
+            mimeType = "application/pdf",
+            sizeBytes = Files.size(path),
+        )
+
+        assertThat(artifact.id).isNotBlank()
+        assertThat(artifact.reference().name).isEqualTo("report.pdf")
+        assertThat(artifact.reference().notes()).contains("application/pdf", path.toString())
+    }
+}


### PR DESCRIPTION
## Summary

Adds the repository-side foundation for durable conversation assets.

- Introduces `MaterializableAsset` for assets whose content can be copied before their original location expires.
- Introduces `DurableAsset` as portable metadata containing an opaque storage URI and content hash.
- Introduces the `AssetStore` SPI for storing, opening, and deleting durable asset content.
- Adds `AssetTracker` helpers that materialize tool-returned assets before tracking them.
- Makes `ScriptArtifact` a materializable, ephemeral asset so sandbox-produced files can participate in the standard asset flow.
- Documents the distinction between in-memory tracking and durable storage, including retention responsibilities.

The implementation reuses `AssetAddingTool` for tool-result conversion and tracking.

## Motivation

`AssistantMessage` and `Conversation` can track assets, but tracking alone does not preserve temporary files or restore their metadata after a process restart.

Script artifacts are especially affected because their paths refer to temporary execution directories. Applications currently need custom plumbing to copy those files before cleanup.

This change establishes the core contracts and capture flow required for durable storage. Conversation-store persistence and rehydration will be handled separately in `embabel-chat-store`.

## Example

```kotlin
val durableTool = conversation.assetTracker
    .addDurablyReturnedAssets(generatingTool, assetStore)
```

When the wrapped tool returns a `MaterializableAsset`, its content is stored first and the resulting `DurableAsset` is added to the tracker.

## Verification

- `AssetStoreTest`: 2 tests passed
- `ScriptArtifactTest`: 2 tests passed

## Follow-up

Update `embabel-chat-store` to persist `DurableAsset` metadata with assistant messages and restore those assets when conversations are loaded.

Closes #1821