### PR TITLE
Fix eager search metadata filtering

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
@@ -561,7 +561,7 @@ context.ai()
 ----
 ====
 
-The preloaded results are included in the prompt as hints. The LLM still has access to all the usual search tools and can perform additional searches as needed.
+The preloaded results are included in the prompt as hints. Any metadata and entity filters configured on the `ToolishRag` are applied to eager search as well as subsequent tool searches. The LLM still has access to all the usual search tools and can perform additional searches as needed.
 
 For more control over the search parameters, pass a `TextSimilaritySearchRequest` directly:
 
@@ -1632,4 +1632,3 @@ See the https://github.com/embabel/rag-demo[rag-demo] project for a complete wor
 - Chatbot with RAG-powered responses
 - Jinja prompt templates for system prompts
 - Spring Shell commands for interactive testing
-

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -78,6 +78,29 @@ internal fun List<SimilarityResult<out Retrievable>>.withNeighbours(
     return this + extra
 }
 
+@Suppress("UNCHECKED_CAST")
+internal fun <T : Retrievable> VectorSearch.searchWithFilter(
+    request: TextSimilaritySearchRequest,
+    clazz: Class<T>,
+    metadataFilter: PropertyFilter?,
+    entityFilter: EntityFilter?,
+): List<SimilarityResult<T>> {
+    if (metadataFilter == null && entityFilter == null) {
+        return vectorSearch(request, clazz)
+    }
+    if (this is FilteringVectorSearch) {
+        return vectorSearchWithFilter(request, clazz, metadataFilter, entityFilter)
+    }
+    return PostFilteringSearch.search(
+        request,
+        metadataFilter,
+        entityFilter,
+        TopKInflationStrategy.DEFAULT,
+    ) { inflatedRequest ->
+        vectorSearch(inflatedRequest, clazz)
+    } as List<SimilarityResult<T>>
+}
+
 internal class VectorSearchTools @JvmOverloads constructor(
     private val vectorSearch: VectorSearch,
     private val searchFor: List<Class<out Retrievable>> = listOf(Chunk::class.java),
@@ -107,47 +130,26 @@ internal class VectorSearchTools @JvmOverloads constructor(
             query, topK, threshold, searchFor.map { it.simpleName }, metadataFilter, entityFilter
         )
         val request = TextSimilaritySearchRequest(query, threshold, topK)
+        val results = search(request)
+        return SimpleRetrievableResultsFormatter.formatResults(SimilarityResults.fromList<Retrievable>(results))
+    }
+
+    internal fun search(request: TextSimilaritySearchRequest): List<SimilarityResult<out Retrievable>> {
         val (hits, ms) = time {
             searchForAllTypes(request)
         }
         // Expanded BEFORE the listener fires: an observer must see what the model sees, or
         // reported provenance and the answer's actual evidence drift apart.
         val results = hits.withNeighbours(resultExpander, searchDefaults.expandNeighbours)
-        resultsListener?.onResultsEvent(ResultsEvent(this, query, results, Duration.ofMillis(ms)))
-        return SimpleRetrievableResultsFormatter.formatResults(SimilarityResults.fromList<Retrievable>(results))
+        resultsListener?.onResultsEvent(ResultsEvent(this, request.query, results, Duration.ofMillis(ms)))
+        return results
     }
 
     private fun searchForAllTypes(request: TextSimilaritySearchRequest): List<SimilarityResult<out Retrievable>> {
         val allResults = searchFor.flatMap { clazz ->
-            searchWithFilter(request, clazz)
+            vectorSearch.searchWithFilter(request, clazz, metadataFilter, entityFilter)
         }
         return deduplicateByIdKeepingHighestScore(allResults)
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun <T : Retrievable> searchWithFilter(
-        request: TextSimilaritySearchRequest,
-        clazz: Class<T>,
-    ): List<SimilarityResult<T>> {
-        if (metadataFilter == null && entityFilter == null) {
-            return vectorSearch.vectorSearch(request, clazz)
-        }
-
-        // If backend supports native filtering, use it
-        if (vectorSearch is FilteringVectorSearch) {
-            return vectorSearch.vectorSearchWithFilter(request, clazz, metadataFilter, entityFilter)
-        }
-
-        // Fallback: inflate topK, search, post-filter, take topK
-        // Note: PostFilteringSearch requires Datum constraint, so we cast
-        return PostFilteringSearch.search(
-            request,
-            metadataFilter,
-            entityFilter,
-            TopKInflationStrategy.DEFAULT
-        ) { inflatedRequest ->
-            vectorSearch.vectorSearch(inflatedRequest, clazz)
-        } as List<SimilarityResult<T>>
     }
 }
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -154,12 +154,7 @@ data class ToolishRag @JvmOverloads constructor(
             }
             if (searchOperations is VectorSearch) {
                 logger.debug("Adding VectorSearchTools to ToolishRag '{}'", name)
-                add(
-                    VectorSearchTools(
-                        searchOperations, vectorSearchFor, metadataFilter, entityFilter, listener, searchDefaults,
-                        searchOperations as? ResultExpander,
-                    )
-                )
+                add(vectorSearchTools(searchOperations))
             } else {
                 if (hints.any { it is TryHyDE }) {
                     logger.warn(
@@ -196,6 +191,16 @@ data class ToolishRag @JvmOverloads constructor(
 
     private val toolObjects: List<Any> get() = initState.toolObjects
     private val validHints: List<PromptContributor> get() = initState.validHints
+
+    private fun vectorSearchTools(vectorSearch: VectorSearch) = VectorSearchTools(
+        vectorSearch,
+        vectorSearchFor,
+        metadataFilter,
+        entityFilter,
+        listener,
+        searchDefaults,
+        searchOperations as? ResultExpander,
+    )
 
     /**
      * Set the types to search for with vector and text search
@@ -276,11 +281,8 @@ data class ToolishRag @JvmOverloads constructor(
             ?: throw UnsupportedOperationException(
                 "Eager search requires VectorSearch but searchOperations is ${searchOperations::class.simpleName}"
             )
-        val results = vectorSearchFor.flatMap { clazz ->
-            vs.vectorSearch(request, clazz)
-        }
-        val deduplicated = deduplicateByIdKeepingHighestScore(results)
-        val formatted = formatter.formatResults(SimilarityResults.fromList(deduplicated))
+        val results = vectorSearchTools(vs).search(request)
+        val formatted = formatter.formatResults(SimilarityResults.fromList(results))
         return copy(
             hints = hints + PromptContributor.fixed("Preloaded search results for '${request.query}':\n$formatted"),
         )

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagEagerSearchTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagEagerSearchTest.kt
@@ -15,8 +15,12 @@
  */
 package com.embabel.agent.rag.tools
 
+import com.embabel.agent.filter.PropertyFilter
+import com.embabel.agent.rag.filter.EntityFilter
 import com.embabel.agent.rag.model.Chunk
 import com.embabel.agent.rag.model.Retrievable
+import com.embabel.agent.rag.service.FilteringVectorSearch
+import com.embabel.agent.rag.service.ResultExpander
 import com.embabel.agent.rag.service.SearchOperations
 import com.embabel.agent.rag.service.VectorSearch
 import com.embabel.common.core.types.SimpleSimilaritySearchResult
@@ -30,6 +34,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 class ToolishRagEagerSearchTest {
+
+    private interface ExpandableVectorSearch : VectorSearch, ResultExpander
 
     private fun createChunk(id: String, text: String): Chunk =
         Chunk(id = id, text = text, parentId = "parent", metadata = emptyMap())
@@ -148,6 +154,103 @@ class ToolishRagEagerSearchTest {
                 )
             }
             assertTrue(eagerRag.hints.isNotEmpty())
+        }
+
+        @Test
+        fun `eager search applies filters natively when supported`() {
+            val vectorSearch = mockk<FilteringVectorSearch>()
+            val metadataFilter = PropertyFilter.eq("ownerId", "alice")
+            val entityFilter = EntityFilter.hasAnyLabel("Person")
+            val chunk = createChunk("chunk1", "Alice's content")
+            every {
+                vectorSearch.vectorSearchWithFilter(
+                    any<TextSimilaritySearchRequest>(),
+                    Chunk::class.java,
+                    metadataFilter,
+                    entityFilter,
+                )
+            } returns listOf(SimpleSimilaritySearchResult(match = chunk, score = 0.9))
+            val rag = ToolishRag(
+                name = "test-rag",
+                description = "Test RAG",
+                searchOperations = vectorSearch,
+                metadataFilter = metadataFilter,
+                entityFilter = entityFilter,
+            )
+
+            val eagerRag = rag.withEagerSearchAbout("test query", 5)
+
+            verify(exactly = 1) {
+                vectorSearch.vectorSearchWithFilter(
+                    any<TextSimilaritySearchRequest>(),
+                    Chunk::class.java,
+                    metadataFilter,
+                    entityFilter,
+                )
+            }
+            assertTrue(eagerRag.notes().contains("Alice's content"))
+        }
+
+        @Test
+        fun `eager search expands results before notifying listener`() {
+            val vectorSearch = mockk<ExpandableVectorSearch>()
+            val hit = createChunk("hit", "Matching content")
+            val neighbour = createChunk("neighbour", "Neighbouring content")
+            every {
+                vectorSearch.vectorSearch(any<TextSimilaritySearchRequest>(), Chunk::class.java)
+            } returns listOf(SimpleSimilaritySearchResult(match = hit, score = 0.9))
+            every {
+                vectorSearch.expandResult("hit", ResultExpander.Method.SEQUENCE, 1)
+            } returns listOf(neighbour)
+            var event: ResultsEvent? = null
+            val rag = ToolishRag(
+                name = "test-rag",
+                description = "Test RAG",
+                searchOperations = vectorSearch,
+                listener = ResultsListener { event = it },
+                searchDefaults = SearchDefaults(expandNeighbours = 1),
+            )
+
+            val eagerRag = rag.withEagerSearchAbout("test query", 5)
+
+            assertTrue(eagerRag.notes().contains("Matching content"))
+            assertTrue(eagerRag.notes().contains("Neighbouring content"))
+            assertEquals(listOf("hit", "neighbour"), event?.results?.map { it.match.id })
+            assertEquals("test query", event?.query)
+        }
+
+        @Test
+        fun `eager search post-filters metadata when native filtering is unavailable`() {
+            val vectorSearch = mockk<VectorSearch>()
+            val included = Chunk(
+                id = "included",
+                text = "Alice's content",
+                parentId = "parent",
+                metadata = mapOf("ownerId" to "alice"),
+            )
+            val excluded = Chunk(
+                id = "excluded",
+                text = "Bob's content",
+                parentId = "parent",
+                metadata = mapOf("ownerId" to "bob"),
+            )
+            every {
+                vectorSearch.vectorSearch(any<TextSimilaritySearchRequest>(), Chunk::class.java)
+            } returns listOf(
+                SimpleSimilaritySearchResult(match = included, score = 0.9),
+                SimpleSimilaritySearchResult(match = excluded, score = 0.8),
+            )
+            val rag = ToolishRag(
+                name = "test-rag",
+                description = "Test RAG",
+                searchOperations = vectorSearch,
+                metadataFilter = PropertyFilter.eq("ownerId", "alice"),
+            )
+
+            val notes = rag.withEagerSearchAbout("test query", 5).notes()
+
+            assertTrue(notes.contains("Alice's content"))
+            assertFalse(notes.contains("Bob's content"))
         }
 
         @Test


### PR DESCRIPTION
## Summary

Fixes `ToolishRag.withEagerSearchAbout()` ignoring configured metadata and entity filters.

Eager search now uses the same filtering flow as regular vector-search tools:

- Uses native filtering when the store implements `FilteringVectorSearch`
- Falls back to inflated retrieval followed by in-memory filtering
- Preserves existing behavior when no filters are configured
- Documents that configured filters also apply to eager search

## Testing

```text
Tests run: 15, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Command:

```bash
mvn -f embabel-agent-rag/embabel-agent-rag-core/pom.xml \
  -Dtest=ToolishRagEagerSearchTest test
```

Fixes #1953.