### PR TITLE
Upgrade apache httpcomponents core5 due to High Vulnerability

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -18,6 +18,7 @@
     <properties>
         <bouncycastle.version>1.84</bouncycastle.version>
         <oci-sdk.version>3.86.1</oci-sdk.version>
+        <apache-httpcomponents.version>5.4.3</apache-httpcomponents.version>
     </properties>
 
     <scm>
@@ -454,6 +455,18 @@
                 <groupId>io.opentelemetry.semconv</groupId>
                 <artifactId>opentelemetry-semconv</artifactId>
                 <version>1.29.0-alpha</version>
+            </dependency>
+
+            <!-- High Vulnerability Fix: overrides httpcore5 version managed through parent chain -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>${apache-httpcomponents.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>${apache-httpcomponents.version}</version>
             </dependency>
 
             <!--


### PR DESCRIPTION
# Overview

Upgraded 


org.apache.httpcomponents.core5:httpcore5
and
org.apache.httpcomponents.core5:httpcore5-h2

to version 5.4.3 

Due to high vulnerability:

```
git/embabel-agent$ mvn dependency:tree|grep core5
[INFO] |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:runtime
[INFO] |  |     \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:runtime
[INFO] |  |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:runtime (optional)
[INFO] |  |  |     \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:runtime (optional)
[INFO] |  |     +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:compile
[INFO] |  |     \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:compile
[INFO] |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:runtime
[INFO] |  |     \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:runtime
[INFO] |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:test
[INFO] |  +- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:test
[INFO] |  |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:runtime
[INFO] |  |  |     \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:runtime
[INFO] |     |     +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:compile
[INFO] |     |     \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:compile
[INFO] |  |  |  +- org.apache.httpcomponents.core5:httpcore5:jar:5.4.3:runtime
[INFO] |  |  |     \- org.apache.httpcomponents.core5:httpcore5-h2:jar:5.4.3:runtime

```

