### PR TITLE
Say which expression syntax a text query mode means

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/SearchOperations.kt
@@ -145,14 +145,14 @@ enum class TextQueryMode {
      * owns precision, and owns escaping: an unbalanced `/` or a bare `:` is a parse failure, not a
      * search for those characters.
      */
-    EXPRESSION,
+    LUCENE_EXPRESSION,
 }
 
 /**
  * Full-text search.
  *
  * How the `query` string is interpreted depends on [queryMode] — see [TextQueryMode]. Every
- * implementation historically behaved as [TextQueryMode.EXPRESSION], which remains the default.
+ * implementation historically behaved as [TextQueryMode.LUCENE_EXPRESSION], which remains the default.
  */
 interface TextSearch : TypeRetrievalOperations {
 
@@ -161,11 +161,11 @@ interface TextSearch : TypeRetrievalOperations {
      *
      * A capability, not a preference. An implementation backed by substring matching cannot honour
      * an expression however it is configured, and one backed by an engine whose syntax differs from
-     * Lucene's should not claim [TextQueryMode.EXPRESSION] merely because it has a parser.
+     * Lucene's should not claim [TextQueryMode.LUCENE_EXPRESSION] merely because it has a parser.
      * Deployments choose among these; they cannot choose outside them.
      */
     val supportedQueryModes: Set<TextQueryMode>
-        get() = setOf(TextQueryMode.EXPRESSION)
+        get() = setOf(TextQueryMode.LUCENE_EXPRESSION)
 
     /**
      * The mode currently in effect. Must be a member of [supportedQueryModes].
@@ -180,13 +180,13 @@ interface TextSearch : TypeRetrievalOperations {
     /**
      * Performs full-text search.
      *
-     * The syntax below applies when [queryMode] is [TextQueryMode.EXPRESSION]. Under
+     * The syntax below applies when [queryMode] is [TextQueryMode.LUCENE_EXPRESSION]. Under
      * [TextQueryMode.LITERAL] the query is escaped and matched as text, so none of these operators
      * has any effect.
      *
      * Not all implementations will support all capabilities (such as fuzzy matching).
      * However, the use of quotes for phrases and + / - for required / excluded terms should be
-     * widely supported among implementations that declare [TextQueryMode.EXPRESSION].
+     * widely supported among implementations that declare [TextQueryMode.LUCENE_EXPRESSION].
      *
      * The "query" field of request supports the following syntax:
      *

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/service/TextQueryModeTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/service/TextQueryModeTest.kt
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test
 class TextQueryModeTest {
 
     private open class Stub(
-        override val supportedQueryModes: Set<TextQueryMode> = setOf(TextQueryMode.EXPRESSION),
+        override val supportedQueryModes: Set<TextQueryMode> = setOf(TextQueryMode.LUCENE_EXPRESSION),
     ) : TextSearch {
         override fun supportsType(type: String) = true
         override fun <T : Retrievable> textSearch(
@@ -41,12 +41,12 @@ class TextQueryModeTest {
 
     @Test
     @DisplayName("an implementation that declares nothing behaves as it always has")
-    fun `default is EXPRESSION`() {
+    fun `default is LUCENE_EXPRESSION`() {
         // Every implementation predating the mode passed the caller's query through untouched.
         // Defaulting anywhere else would silently change what those stores do with an operator.
         val store = object : Stub() {}
-        assertEquals(setOf(TextQueryMode.EXPRESSION), store.supportedQueryModes)
-        assertEquals(TextQueryMode.EXPRESSION, store.queryMode)
+        assertEquals(setOf(TextQueryMode.LUCENE_EXPRESSION), store.supportedQueryModes)
+        assertEquals(TextQueryMode.LUCENE_EXPRESSION, store.queryMode)
     }
 
     @Test
@@ -65,7 +65,7 @@ class TextQueryModeTest {
         val stores = listOf(
             object : Stub() {},
             object : Stub(setOf(TextQueryMode.LITERAL)) {},
-            object : Stub(setOf(TextQueryMode.LITERAL, TextQueryMode.EXPRESSION)) {},
+            object : Stub(setOf(TextQueryMode.LITERAL, TextQueryMode.LUCENE_EXPRESSION)) {},
         )
         stores.forEach { store ->
             assertTrue(
@@ -78,10 +78,10 @@ class TextQueryModeTest {
     @Test
     @DisplayName("supporting both leaves the choice to the deployment")
     fun `an implementation may serve both modes`() {
-        val store = object : Stub(setOf(TextQueryMode.LITERAL, TextQueryMode.EXPRESSION)) {
+        val store = object : Stub(setOf(TextQueryMode.LITERAL, TextQueryMode.LUCENE_EXPRESSION)) {
             override val queryMode = TextQueryMode.LITERAL
         }
         assertEquals(TextQueryMode.LITERAL, store.queryMode)
-        assertTrue(TextQueryMode.EXPRESSION in store.supportedQueryModes, "still available to configure")
+        assertTrue(TextQueryMode.LUCENE_EXPRESSION in store.supportedQueryModes, "still available to configure")
     }
 }


### PR DESCRIPTION
### BLUF

Closes #1919. `TextQueryMode.EXPRESSION` means a *Lucene* expression. Its own KDoc says so, in bold,
on the line beneath it; the name does not. This enum is how a store declares what it can parse, so
the moment a second expression syntax appears, `EXPRESSION` is the constant that cannot be pointed
at either one. Renamed to `LUCENE_EXPRESSION`, which is what it has always meant.

### Before

```kotlin
enum class TextQueryMode {
    LITERAL,

    /**
     * The query is a **Lucene expression** the caller composes, passed through unaltered.
     */
    EXPRESSION,
}
```

### After

```kotlin
enum class TextQueryMode {
    LITERAL,

    /**
     * The query is a **Lucene expression** the caller composes, passed through unaltered.
     */
    LUCENE_EXPRESSION,
}
```

The default `supportedQueryModes` is still this mode, so every existing implementation keeps exactly
its current behaviour.

### Notes

- Nothing but the name changes. The four KDoc references in `TextSearch` and `TextQueryModeTest`
  follow the constant.
- Safe outside this repo: `TextQueryMode` has no references in `embabel-agent-rag-graph`,
  `-rag-neo-ogm`, `-rag-pgvector`, `embabel-agent-experimental`, `embabel-agent-examples` or
  `impromptu`.
- The graph store's `FullTextQueryMode` is a separate type and is untouched. Worth saying because
  *that* one is bound from `embabel.agent.rag.graph.query-mode`, so renaming its constants would
  break deployed `application.yml` files. This one has no such exposure.

### Tests

`TextQueryModeTest`, 4 tests, unchanged in substance and renamed with the constant. Full
`embabel-agent-rag-core` suite: **707 passing, 0 failures.** Full reactor: **7371 passing,
0 failures.**
