### PR TITLE
fix: retain chunks when applying entity filters

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
@@ -1096,6 +1096,7 @@ return InMemoryPropertyFilter.filterResults(results, metadataFilter, entityFilte
 ====
 
 For `EntityFilter.HasAnyLabel`, the in-memory filter checks if the entity has any of the specified labels via `NamedEntityData.labels()`.
+Non-entity results such as chunks pass through unchanged, so an entity filter can be used with searches that return both chunks and entities.
 
 This ensures filtering works across all backends, with native optimization for metadata filters where available.
 
@@ -1632,4 +1633,3 @@ See the https://github.com/embabel/rag-demo[rag-demo] project for a complete wor
 - Chatbot with RAG-powered responses
 - Jinja prompt templates for system prompts
 - Spring Shell commands for interactive testing
-

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/filter/InMemoryPropertyFilter.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/filter/InMemoryPropertyFilter.kt
@@ -56,7 +56,8 @@ object InMemoryPropertyFilter {
 
     /**
      * Test if an object matches a [PropertyFilter] using reflection.
-     * Supports both [PropertyFilter] leaf types and [EntityFilter].
+     * Supports both [PropertyFilter] leaf types and [EntityFilter]. Entity filters leave
+     * non-[NamedEntityData] targets unchanged because they are outside the filter's scope.
      */
     fun matchesObject(filter: PropertyFilter, target: Any): Boolean {
         if (target is NamedEntityData) {
@@ -65,7 +66,7 @@ object InMemoryPropertyFilter {
 
         // For other objects, use reflection to build a properties map
         return when (filter) {
-            is EntityFilter -> false // Entity filters only apply to NamedEntityData
+            is EntityFilter -> true // Non-entity targets are outside the filter's scope
             else -> GenericPropertyFilter.matches(filter, extractProperties(target))
         }
     }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/filter/README.md
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/filter/README.md
@@ -125,6 +125,9 @@ val filtered = InMemoryPropertyFilter.filterResults(
 )
 ```
 
+Entity filters apply only to `NamedEntityData`. Non-entity results such as chunks pass through unchanged, which allows
+the same filter to be used for searches that return both chunks and entities.
+
 ## Native Filter Translation
 
 Some backends support native filter translation:

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/filter/InMemoryPropertyFilterTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/filter/InMemoryPropertyFilterTest.kt
@@ -17,8 +17,10 @@ package com.embabel.agent.rag.filter
 
 import com.embabel.agent.filter.PropertyFilter
 import com.embabel.agent.rag.model.Chunk
+import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.model.SimpleNamedEntityData
 import com.embabel.common.core.types.SimpleSimilaritySearchResult
+import com.embabel.common.core.types.SimilarityResult
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -108,8 +110,8 @@ class InMemoryPropertyFilterTest {
         }
 
         @Test
-        fun `an entity filter never matches a non-entity object`() {
-            assertFalse(
+        fun `an entity filter does not exclude a non-entity object`() {
+            assertTrue(
                 InMemoryPropertyFilter.matchesObject(EntityFilter.hasAnyLabel("Person"), PlainDocument("alice", "active"))
             )
         }
@@ -197,6 +199,24 @@ class InMemoryPropertyFilterTest {
 
             assertEquals(1, filtered.size)
             assertEquals("1", filtered.single().match.id)
+        }
+
+        @Test
+        fun `an entity filter retains chunks while filtering entities`() {
+            val results: List<SimilarityResult<Retrievable>> = listOf(
+                SimpleSimilaritySearchResult(match = chunk("1"), score = 0.9),
+                SimpleSimilaritySearchResult(match = entity("person", labels = setOf("Person")), score = 0.8),
+                SimpleSimilaritySearchResult(match = entity("company", labels = setOf("Company")), score = 0.7),
+                SimpleSimilaritySearchResult(match = chunk("2"), score = 0.6),
+            )
+
+            val filtered = InMemoryPropertyFilter.filterResults(
+                results,
+                metadataFilter = null,
+                entityFilter = EntityFilter.hasAnyLabel("Person"),
+            )
+
+            assertEquals(listOf("1", "person", "2"), filtered.map { it.match.id })
         }
 
         @Test


### PR DESCRIPTION
## Summary

Fixes #1959.

When in-memory post-filtering is used, entity filters now leave non-entity results such as `Chunk` unchanged instead of removing them.

Entity results continue to be filtered using their labels. This also fixes mixed searches containing both chunks and entities.

## Changes

- Pass non-`NamedEntityData` results through entity-only filters
- Add regression coverage for chunk and mixed-result searches
- Document the in-memory filtering behavior

## Testing

```bash
./mvnw -pl embabel-agent-rag/embabel-agent-rag-core -Dtest=InMemoryPropertyFilterTest test
```