### PR TITLE
refactor: remove no-op entity filtering

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/spring/SpringVectorStoreVectorSearch.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/service/spring/SpringVectorStoreVectorSearch.kt
@@ -18,7 +18,6 @@ package com.embabel.agent.rag.service.spring
 import com.embabel.agent.filter.ObjectFilter
 import com.embabel.agent.filter.PropertyFilter
 import com.embabel.agent.rag.filter.EntityFilter
-import com.embabel.agent.rag.filter.InMemoryPropertyFilter
 import com.embabel.agent.rag.model.Chunk
 import com.embabel.agent.rag.model.Retrievable
 import com.embabel.agent.rag.service.FilteringVectorSearch
@@ -52,16 +51,7 @@ class SpringVectorStoreVectorSearch(
         clazz: Class<T>,
         metadataFilter: PropertyFilter?,
         entityFilter: EntityFilter?,
-    ): List<SimilarityResult<T>> {
-        // Apply metadata filter natively via Spring AI
-        val results = executeSearch<T>(request, metadataFilter?.toSpringAiExpression())
-        // Apply property filter in-memory if specified
-        return if (entityFilter != null) {
-            InMemoryPropertyFilter.filterByProperties(results, entityFilter)
-        } else {
-            results
-        }
-    }
+    ): List<SimilarityResult<T>> = executeSearch(request, metadataFilter?.toSpringAiExpression())
 
     @Suppress("UNCHECKED_CAST")
     private fun <T : Retrievable> executeSearch(


### PR DESCRIPTION
## Summary

Remove the no-op entity-filtering branch from `SpringVectorStoreVectorSearch`.

`SpringVectorStoreVectorSearch` only returns `Chunk` results. Since entity filters leave non-entity results unchanged, applying `InMemoryPropertyFilter` at this call site could not alter the result list and misleadingly suggested otherwise.

## Changes

- Return vector-search results directly after applying the native metadata filter.
- Remove the unused `InMemoryPropertyFilter` import.
- Preserve existing behavior.

## Testing

- `mvn test -pl embabel-agent-rag/embabel-agent-rag-core "-Dtest=InMemoryPropertyFilterTest"`
- 15 tests passed with no failures, errors, or skipped tests.

Closes #1969.