### PR TITLE
fix: avoid search filter extension shadowing

### DIFF
--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -78,12 +78,11 @@ internal fun List<SimilarityResult<out Retrievable>>.withNeighbours(
     return this + extra
 }
 
-@Suppress("UNCHECKED_CAST")
-internal fun <T : Retrievable> VectorSearch.vectorSearchWithFilter(
+internal fun <T : Retrievable> VectorSearch.vectorSearchWithFilterDispatch(
     request: TextSimilaritySearchRequest,
     clazz: Class<T>,
-    metadataFilter: PropertyFilter?,
-    entityFilter: EntityFilter?,
+    metadataFilter: PropertyFilter? = null,
+    entityFilter: EntityFilter? = null,
 ): List<SimilarityResult<T>> = when {
     metadataFilter == null && entityFilter == null -> vectorSearch(request, clazz)
     this is FilteringVectorSearch -> vectorSearchWithFilter(request, clazz, metadataFilter, entityFilter)
@@ -94,7 +93,7 @@ internal fun <T : Retrievable> VectorSearch.vectorSearchWithFilter(
         TopKInflationStrategy.DEFAULT,
     ) { inflatedRequest ->
         vectorSearch(inflatedRequest, clazz)
-    } as List<SimilarityResult<T>>
+    }
 }
 
 internal class VectorSearchTools @JvmOverloads constructor(
@@ -143,7 +142,7 @@ internal class VectorSearchTools @JvmOverloads constructor(
 
     private fun searchForAllTypes(request: TextSimilaritySearchRequest): List<SimilarityResult<out Retrievable>> {
         val allResults = searchFor.flatMap { clazz ->
-            vectorSearch.vectorSearchWithFilter(request, clazz, metadataFilter, entityFilter)
+            vectorSearch.vectorSearchWithFilterDispatch(request, clazz, metadataFilter, entityFilter)
         }
         return deduplicateByIdKeepingHighestScore(allResults)
     }
@@ -376,12 +375,11 @@ internal class SectionReadingTools @JvmOverloads constructor(
     }
 }
 
-@Suppress("UNCHECKED_CAST")
-internal fun <T : Retrievable> TextSearch.textSearchWithFilter(
+internal fun <T : Retrievable> TextSearch.textSearchWithFilterDispatch(
     request: TextSimilaritySearchRequest,
     clazz: Class<T>,
-    metadataFilter: PropertyFilter?,
-    entityFilter: EntityFilter?,
+    metadataFilter: PropertyFilter? = null,
+    entityFilter: EntityFilter? = null,
 ): List<SimilarityResult<T>> = when {
     metadataFilter == null && entityFilter == null -> textSearch(request, clazz)
     this is FilteringTextSearch -> textSearchWithFilter(request, clazz, metadataFilter, entityFilter)
@@ -392,7 +390,7 @@ internal fun <T : Retrievable> TextSearch.textSearchWithFilter(
         TopKInflationStrategy.DEFAULT,
     ) { inflatedRequest ->
         textSearch(inflatedRequest, clazz)
-    } as List<SimilarityResult<T>>
+    }
 }
 
 /**
@@ -495,7 +493,7 @@ internal class TextSearchTools @JvmOverloads constructor(
 
     private fun searchForAllTypes(request: TextSimilaritySearchRequest): List<SimilarityResult<out Retrievable>> {
         val allResults = searchFor.flatMap { clazz ->
-            textSearch.textSearchWithFilter(request, clazz, metadataFilter, entityFilter)
+            textSearch.textSearchWithFilterDispatch(request, clazz, metadataFilter, entityFilter)
         }
         return deduplicateByIdKeepingHighestScore(allResults)
     }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
@@ -464,10 +464,10 @@ class ToolishRagTest {
     }
 
     @Nested
-    inner class SearchWithFilterExtensionsTests {
+    inner class FilterDispatchExtensionsTests {
 
         @Test
-        fun `filter helpers should be callable on CoreSearchOperations`() {
+        fun `filter dispatch extensions should default filters to null`() {
             val searchOperations = mockk<CoreSearchOperations>()
             val request = TextSimilaritySearchRequest("test query", 0.5, 5)
             every {
@@ -477,8 +477,8 @@ class ToolishRagTest {
                 searchOperations.textSearch(request, Chunk::class.java)
             } returns emptyList()
 
-            val vectorResults = searchOperations.vectorSearchWithFilter(request, Chunk::class.java, null, null)
-            val textResults = searchOperations.textSearchWithFilter(request, Chunk::class.java, null, null)
+            val vectorResults = searchOperations.vectorSearchWithFilterDispatch(request, Chunk::class.java)
+            val textResults = searchOperations.textSearchWithFilterDispatch(request, Chunk::class.java)
 
             assertTrue(vectorResults.isEmpty())
             assertTrue(textResults.isEmpty())


### PR DESCRIPTION
## Summary

Fixes #1970.

Renames the internal search filter extensions so they no longer shadow the similarly named members of `FilteringVectorSearch` and `FilteringTextSearch`.

This prevents a future interface signature change from silently rebinding an extension call to itself and causing unbounded recursion at runtime.

## Changes

- Rename the internal helpers to:
  - `vectorSearchWithFilterDispatch`
  - `textSearchWithFilterDispatch`
- Add `null` defaults for `metadataFilter` and `entityFilter`.
- Update existing call sites.
- Update the regression test to verify two-argument calls work through `CoreSearchOperations`.

## Documentation

No documentation changes are required because the renamed functions are internal and the public filtering API remains unchanged.

## Testing

```bash
mvn -pl embabel-agent-rag/embabel-agent-rag-core -am \
  -Dtest=ToolishRagTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```