### PR TITLE
Prepare 1.5.1 Release

### DIFF
--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-dependencies-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
         <relativePath />
     </parent>
     <groupId>com.embabel.agent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.1</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,7 +16,7 @@
 
     <properties>
         <argLine />
-        <embabel-common.version>2.0.2-SNAPSHOT</embabel-common.version>
+        <embabel-common.version>2.0.2</embabel-common.version>
         <netty.version>4.2.16.Final</netty.version>
         <!-- Matches the openai-java-core that spring-ai-openai 2.0.0 depends on. Bump in
              step with spring-ai-openai; drop once embabel-build-dependencies catches up. -->


### PR DESCRIPTION
This pull request updates project dependencies to use stable release versions instead of snapshot versions. The most important changes are:

Dependency version updates:

* Updated the parent POM version in `pom.xml` from `2.0.1-SNAPSHOT` to the stable release `2.0.1`.
* Updated the `embabel-common.version` property in `pom.xml` from `2.0.2-SNAPSHOT` to `2.0.2`.
* Updated the parent POM version in `embabel-agent-dependencies/pom.xml` from `2.0.1-SNAPSHOT` to `2.0.1`.