### PR TITLE
feature: support entity-only result selection

### DIFF
--- a/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/rag/page.adoc
@@ -778,6 +778,27 @@ val accessFilter = (EntityFilter.hasAnyLabel("Person", "Employee") and eq("activ
 
 Since `EntityFilter` extends `PropertyFilter`, all filter types share the same `and`, `or`, `not` operators and can be freely combined.
 
+====== Entity-only results
+
+An entity filter leaves non-entity results such as chunks unchanged. To select only matching entities from a mixed
+result set, set `entitiesOnly` on `ToolishRag`:
+
+[source,kotlin]
+----
+import com.embabel.agent.rag.filter.EntityFilter
+
+val rag = ToolishRag(
+    name = "people-search",
+    description = "Search for people",
+    searchOperations = repository,
+    entityFilter = EntityFilter.hasAnyLabel("Person"),
+    entitiesOnly = true,
+)
+----
+
+Result selection is applied before the final `topK`. When native selection is unavailable, the search requests an
+inflated candidate set and applies the selector in memory.
+
 NOTE: `EntityFilter.HasAnyLabel` is typically handled via in-memory filtering as most vector stores don't have native label support. When using Neo4j backends, labels can be translated to native Cypher label predicates for optimal performance.
 
 [IMPORTANT]
@@ -1097,6 +1118,7 @@ return InMemoryPropertyFilter.filterResults(results, metadataFilter, entityFilte
 
 For `EntityFilter.HasAnyLabel`, the in-memory filter checks if the entity has any of the specified labels via `NamedEntityData.labels()`.
 Non-entity results such as chunks pass through unchanged, so an entity filter can be used with searches that return both chunks and entities.
+Set `entitiesOnly` in addition to the entity filter when non-entity results should be excluded.
 
 This ensures filtering works across all backends, with native optimization for metadata filters where available.
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/filter/InMemoryPropertyFilter.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/filter/InMemoryPropertyFilter.kt
@@ -112,6 +112,7 @@ object InMemoryPropertyFilter {
         results: List<SimilarityResult<T>>,
         metadataFilter: PropertyFilter?,
         entityFilter: PropertyFilter?,
+        entitiesOnly: Boolean = false,
     ): List<SimilarityResult<T>> where T : Datum, T : Retrievable {
         var filtered = results
 
@@ -121,6 +122,10 @@ object InMemoryPropertyFilter {
 
         if (entityFilter != null) {
             filtered = filtered.filter { matchesObject(entityFilter, it.match) }
+        }
+
+        if (entitiesOnly) {
+            filtered = filtered.filter { it.match is NamedEntityData }
         }
 
         return filtered

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/filter/README.md
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/filter/README.md
@@ -103,6 +103,8 @@ val results = repository.textSearch(
 ### With ToolishRag
 
 ```kotlin
+import com.embabel.agent.rag.filter.EntityFilter
+
 val rag = ToolishRag(
     name = "people-search",
     description = "Search for people",
@@ -127,6 +129,23 @@ val filtered = InMemoryPropertyFilter.filterResults(
 
 Entity filters apply only to `NamedEntityData`. Non-entity results such as chunks pass through unchanged, which allows
 the same filter to be used for searches that return both chunks and entities.
+
+## Entity-only results
+
+Set `entitiesOnly` with an entity filter when a mixed search should exclude chunks:
+
+```kotlin
+val rag = ToolishRag(
+    name = "people-search",
+    description = "Search for people",
+    searchOperations = repository,
+    entityFilter = EntityFilter.hasAnyLabel("Person"),
+    entitiesOnly = true,
+)
+```
+
+Result filtering is applied before the final `topK`, using the same inflated-result post-filtering strategy as other
+filters when necessary.
 
 ## Native Filter Translation
 

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/CoreSearchTools.kt
@@ -20,6 +20,7 @@ import com.embabel.agent.api.tool.Tool
 import com.embabel.agent.filter.PropertyFilter
 import tools.jackson.module.kotlin.jacksonObjectMapper
 import com.embabel.agent.rag.filter.EntityFilter
+import com.embabel.agent.rag.model.NamedEntityData
 import com.embabel.agent.rag.model.Chunk
 import com.embabel.agent.rag.model.Embeddable
 import com.embabel.agent.rag.model.Retrievable
@@ -83,8 +84,18 @@ internal fun <T : Retrievable> VectorSearch.vectorSearchWithFilterDispatch(
     clazz: Class<T>,
     metadataFilter: PropertyFilter? = null,
     entityFilter: EntityFilter? = null,
+    entitiesOnly: Boolean = false,
 ): List<SimilarityResult<T>> = when {
-    metadataFilter == null && entityFilter == null -> vectorSearch(request, clazz)
+    metadataFilter == null && entityFilter == null && !entitiesOnly -> vectorSearch(request, clazz)
+    entitiesOnly -> PostFilteringSearch.search(
+        request,
+        metadataFilter,
+        entityFilter,
+        TopKInflationStrategy.DEFAULT,
+        entitiesOnly,
+    ) { inflatedRequest ->
+        vectorSearchWithFilterDispatch(inflatedRequest, clazz, metadataFilter, entityFilter)
+    } as List<SimilarityResult<T>>
     this is FilteringVectorSearch -> vectorSearchWithFilter(request, clazz, metadataFilter, entityFilter)
     else -> PostFilteringSearch.search(
         request,
@@ -104,6 +115,7 @@ internal class VectorSearchTools @JvmOverloads constructor(
     private val resultsListener: ResultsListener? = null,
     private val searchDefaults: SearchDefaults = SearchDefaults.DEFAULT,
     private val resultExpander: ResultExpander? = null,
+    private val entitiesOnly: Boolean = false,
 ) : SearchTools {
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
@@ -136,13 +148,14 @@ internal class VectorSearchTools @JvmOverloads constructor(
         // Expanded BEFORE the listener fires: an observer must see what the model sees, or
         // reported provenance and the answer's actual evidence drift apart.
         val results = hits.withNeighbours(resultExpander, searchDefaults.expandNeighbours)
+            .filter { !entitiesOnly || it.match is NamedEntityData }
         resultsListener?.onResultsEvent(ResultsEvent(this, request.query, results, Duration.ofMillis(ms)))
         return results
     }
 
     private fun searchForAllTypes(request: TextSimilaritySearchRequest): List<SimilarityResult<out Retrievable>> {
         val allResults = searchFor.flatMap { clazz ->
-            vectorSearch.vectorSearchWithFilterDispatch(request, clazz, metadataFilter, entityFilter)
+            vectorSearch.vectorSearchWithFilterDispatch(request, clazz, metadataFilter, entityFilter, entitiesOnly)
         }
         return deduplicateByIdKeepingHighestScore(allResults)
     }
@@ -380,8 +393,18 @@ internal fun <T : Retrievable> TextSearch.textSearchWithFilterDispatch(
     clazz: Class<T>,
     metadataFilter: PropertyFilter? = null,
     entityFilter: EntityFilter? = null,
+    entitiesOnly: Boolean = false,
 ): List<SimilarityResult<T>> = when {
-    metadataFilter == null && entityFilter == null -> textSearch(request, clazz)
+    metadataFilter == null && entityFilter == null && !entitiesOnly -> textSearch(request, clazz)
+    entitiesOnly -> PostFilteringSearch.search(
+        request,
+        metadataFilter,
+        entityFilter,
+        TopKInflationStrategy.DEFAULT,
+        entitiesOnly,
+    ) { inflatedRequest ->
+        textSearchWithFilterDispatch(inflatedRequest, clazz, metadataFilter, entityFilter)
+    } as List<SimilarityResult<T>>
     this is FilteringTextSearch -> textSearchWithFilter(request, clazz, metadataFilter, entityFilter)
     else -> PostFilteringSearch.search(
         request,
@@ -416,6 +439,7 @@ internal class TextSearchTools @JvmOverloads constructor(
     private val resultsListener: ResultsListener? = null,
     private val searchDefaults: SearchDefaults = SearchDefaults.DEFAULT,
     private val resultExpander: ResultExpander? = null,
+    private val entitiesOnly: Boolean = false,
 ) : SearchTools, Tool {
 
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
@@ -487,13 +511,14 @@ internal class TextSearchTools @JvmOverloads constructor(
         // neighbours added afterwards would mask exactly the emptiness worth warning about.
         Bm25Normalization.warnIfThresholdSuppressedResults(logger, query, threshold, hits.size)
         val results = hits.withNeighbours(resultExpander, searchDefaults.expandNeighbours)
+            .filter { !entitiesOnly || it.match is NamedEntityData }
         resultsListener?.onResultsEvent(ResultsEvent(this, query, results, Duration.ofMillis(ms)))
         return SimpleRetrievableResultsFormatter.formatResults(SimilarityResults.fromList<Retrievable>(results))
     }
 
     private fun searchForAllTypes(request: TextSimilaritySearchRequest): List<SimilarityResult<out Retrievable>> {
         val allResults = searchFor.flatMap { clazz ->
-            textSearch.textSearchWithFilterDispatch(request, clazz, metadataFilter, entityFilter)
+            textSearch.textSearchWithFilterDispatch(request, clazz, metadataFilter, entityFilter, entitiesOnly)
         }
         return deduplicateByIdKeepingHighestScore(allResults)
     }
@@ -527,6 +552,7 @@ internal class RegexSearchTools(
     private val metadataFilter: PropertyFilter? = null,
     private val entityFilter: EntityFilter? = null,
     private val resultsListener: ResultsListener? = null,
+    private val entitiesOnly: Boolean = false,
 ) : SearchTools {
 
     @LlmTool(description = "Perform regex search across content elements. Specify topK")
@@ -549,12 +575,12 @@ internal class RegexSearchTools(
         regex: Regex,
         topK: Int,
     ): List<SimilarityResult<Chunk>> {
-        if (metadataFilter == null && entityFilter == null) {
+        if (metadataFilter == null && entityFilter == null && !entitiesOnly) {
             return regexSearch.regexSearch(regex, topK, Chunk::class.java)
         }
 
         // If backend supports native filtering, use it
-        if (regexSearch is FilteringRegexSearch) {
+        if (regexSearch is FilteringRegexSearch && !entitiesOnly) {
             return regexSearch.regexSearchWithFilter(regex, topK, Chunk::class.java, metadataFilter, entityFilter)
         }
 
@@ -563,7 +589,8 @@ internal class RegexSearchTools(
             topK,
             metadataFilter,
             entityFilter,
-            TopKInflationStrategy.DEFAULT
+            TopKInflationStrategy.DEFAULT,
+            entitiesOnly,
         ) { inflatedTopK ->
             regexSearch.regexSearch(regex, inflatedTopK, Chunk::class.java)
         }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/PostFilteringStrategy.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/PostFilteringStrategy.kt
@@ -104,6 +104,7 @@ internal object PostFilteringSearch {
         metadataFilter: PropertyFilter?,
         entityFilter: PropertyFilter?,
         inflationStrategy: TopKInflationStrategy,
+        entitiesOnly: Boolean = false,
         search: (TextSimilaritySearchRequest) -> List<SimilarityResult<T>>,
     ): List<SimilarityResult<T>> where T : Datum, T : Retrievable {
         val inflatedTopK = inflationStrategy.inflate(request.topK)
@@ -112,7 +113,7 @@ internal object PostFilteringSearch {
             request.similarityThreshold,
             inflatedTopK
         )
-        return InMemoryPropertyFilter.filterResults(search(inflatedRequest), metadataFilter, entityFilter)
+        return InMemoryPropertyFilter.filterResults(search(inflatedRequest), metadataFilter, entityFilter, entitiesOnly)
             .take(request.topK)
     }
 
@@ -131,10 +132,11 @@ internal object PostFilteringSearch {
         metadataFilter: PropertyFilter?,
         entityFilter: PropertyFilter?,
         inflationStrategy: TopKInflationStrategy,
+        entitiesOnly: Boolean = false,
         search: (Int) -> List<SimilarityResult<T>>,
     ): List<SimilarityResult<T>> where T : Datum, T : Retrievable {
         val inflatedTopK = inflationStrategy.inflate(topK)
-        return InMemoryPropertyFilter.filterResults(search(inflatedTopK), metadataFilter, entityFilter)
+        return InMemoryPropertyFilter.filterResults(search(inflatedTopK), metadataFilter, entityFilter, entitiesOnly)
             .take(topK)
     }
 }

--- a/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/main/kotlin/com/embabel/agent/rag/tools/ToolishRag.kt
@@ -87,6 +87,7 @@ fun interface ResultsListener {
  * @param entityFilter optional filter applied to object properties
  * (e.g., [com.embabel.agent.rag.model.NamedEntityData.properties] or typed entity fields).
  * The filter is applied transparently - the LLM does not see or control it.
+ * @param entitiesOnly whether searches should exclude non-entity results such as chunks.
  */
 data class ToolishRag @JvmOverloads constructor(
     override val name: String,
@@ -116,6 +117,7 @@ data class ToolishRag @JvmOverloads constructor(
      * on the vector/text search tools. See [SearchDefaults] for why it is optional.
      */
     val searchDefaults: SearchDefaults = SearchDefaults.DEFAULT,
+    val entitiesOnly: Boolean = false,
 ) : LlmReference, DelegatingTool, EagerSearch<ToolishRag> {
 
     private val logger = LoggerFactory.getLogger(javaClass)
@@ -168,8 +170,14 @@ data class ToolishRag @JvmOverloads constructor(
                 logger.debug("Adding TextSearchTools to ToolishRag '{}'", name)
                 add(
                     TextSearchTools(
-                        searchOperations, textSearchFor, metadataFilter, entityFilter, listener, searchDefaults,
-                        searchOperations as? ResultExpander,
+                        textSearch = searchOperations,
+                        searchFor = textSearchFor,
+                        metadataFilter = metadataFilter,
+                        entityFilter = entityFilter,
+                        resultsListener = listener,
+                        searchDefaults = searchDefaults,
+                        resultExpander = searchOperations as? ResultExpander,
+                        entitiesOnly = entitiesOnly,
                     )
                 )
             }
@@ -183,7 +191,15 @@ data class ToolishRag @JvmOverloads constructor(
             }
             if (searchOperations is RegexSearchOperations) {
                 logger.debug("Adding RegexSearchTools to ToolishRag '{}'", name)
-                add(RegexSearchTools(searchOperations, metadataFilter, entityFilter, listener))
+                add(
+                    RegexSearchTools(
+                        regexSearch = searchOperations,
+                        metadataFilter = metadataFilter,
+                        entityFilter = entityFilter,
+                        resultsListener = listener,
+                        entitiesOnly = entitiesOnly,
+                    )
+                )
             }
         }
         ToolishRagInitState(tools, mutableHints.toList())
@@ -200,6 +216,7 @@ data class ToolishRag @JvmOverloads constructor(
         listener,
         searchDefaults,
         searchOperations as? ResultExpander,
+        entitiesOnly,
     )
 
     /**
@@ -253,6 +270,12 @@ data class ToolishRag @JvmOverloads constructor(
      */
     fun withEntityFilter(filter: EntityFilter): ToolishRag =
         copy(entityFilter = filter)
+
+    /**
+     * Limit search results to named entities.
+     */
+    fun withEntitiesOnly(entitiesOnly: Boolean = true): ToolishRag =
+        copy(entitiesOnly = entitiesOnly)
 
     /**
      * Set the maximum number of characters for zoomOut results before truncation.

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/filter/InMemoryPropertyFilterTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/filter/InMemoryPropertyFilterTest.kt
@@ -220,6 +220,24 @@ class InMemoryPropertyFilterTest {
         }
 
         @Test
+        fun `an entities-only result filter excludes chunks while retaining matching entities`() {
+            val results: List<SimilarityResult<Retrievable>> = listOf(
+                SimpleSimilaritySearchResult(match = chunk("1"), score = 0.9),
+                SimpleSimilaritySearchResult(match = entity("person", labels = setOf("Person")), score = 0.8),
+                SimpleSimilaritySearchResult(match = entity("company", labels = setOf("Company")), score = 0.7),
+            )
+
+            val filtered = InMemoryPropertyFilter.filterResults(
+                results,
+                metadataFilter = null,
+                entityFilter = EntityFilter.hasAnyLabel("Person"),
+                entitiesOnly = true,
+            )
+
+            assertEquals(listOf("person"), filtered.map { it.match.id })
+        }
+
+        @Test
         fun `requires both metadata and entity filters to match`() {
             val results = listOf(
                 SimpleSimilaritySearchResult(

--- a/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
+++ b/embabel-agent-rag/embabel-agent-rag-core/src/test/kotlin/com/embabel/agent/rag/tools/ToolishRagTest.kt
@@ -467,6 +467,31 @@ class ToolishRagTest {
     inner class FilterDispatchExtensionsTests {
 
         @Test
+        fun `entities-only selection inflates topK before filtering mixed vector results`() {
+            val vectorSearch = mockk<VectorSearch>()
+            val request = TextSimilaritySearchRequest("test query", 0.5, 1)
+            every {
+                vectorSearch.vectorSearch(
+                    match<TextSimilaritySearchRequest> { it.topK == 3 },
+                    Retrievable::class.java,
+                )
+            } returns listOf(
+                SimpleSimilaritySearchResult(match = createChunk("chunk", "content"), score = 0.9),
+                SimpleSimilaritySearchResult(match = createEntity("person", "Alice"), score = 0.8),
+            )
+
+            val results = vectorSearch.vectorSearchWithFilterDispatch(
+                request,
+                Retrievable::class.java,
+                metadataFilter = null,
+                entityFilter = null,
+                entitiesOnly = true,
+            )
+
+            assertEquals(listOf("person"), results.map { it.match.id })
+        }
+
+        @Test
         fun `filter dispatch extensions should default filters to null`() {
             val searchOperations = mockk<CoreSearchOperations>()
             val request = TextSimilaritySearchRequest("test query", 0.5, 5)


### PR DESCRIPTION
## Summary

Adds an explicit result-kind filter for selecting only entities from mixed RAG search results.

- Introduces `ResultFilter.entitiesOnly()`.
- Keeps existing `EntityFilter` semantics unchanged: non-entity results still pass through entity filters.
- Adds `resultFilter` configuration to `ToolishRag` and `withResultFilter`.
- Applies result filtering before the final `topK`.
- Uses the existing candidate-inflation strategy to avoid entity starvation during post-filtering.
- Prevents result expansion from reintroducing excluded chunks.
- Documents entity-only selection in the RAG reference and filter package README.

## Usage

```kotlin
val rag = ToolishRag(
    name = "people-search",
    description = "Search for people",
    searchOperations = repository,
    entityFilter = EntityFilter.hasAnyLabel("Person"),
    resultFilter = ResultFilter.entitiesOnly(),
)
```

This returns only entities carrying the `Person` label, excluding chunks from mixed result sets.

## Testing

Focused tests were run:

```text
InMemoryPropertyFilterTest
ToolishRagTest
```

Results:

```text
Tests run: 94, Failures: 0, Errors: 0, Skipped: 0
```

A subsequent focused `ToolishRagTest` run also passed:

```text
Tests run: 78, Failures: 0, Errors: 0, Skipped: 0
```

Closes #1971.