### PR TITLE
Boot 4.1.1

### DIFF
--- a/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralSharedClientBuilderTest.java
+++ b/embabel-agent-autoconfigure/models/embabel-agent-mistral-ai-autoconfigure/src/test/java/com/embabel/agent/autoconfigure/models/mistralai/MistralSharedClientBuilderTest.java
@@ -67,10 +67,21 @@ class MistralSharedClientBuilderTest {
                                 .findFirst()
                                 .orElseThrow(() -> new AssertionError("mistral-small-2603 model not registered"));
 
+                        Runnable callAndExpectAbort = () ->
+                                assertThatThrownBy(() -> model.getChatModel().call("hello"))
+                                        .as("the shared builder's 300ms timeout must abort the 3s reply")
+                                        .hasStackTraceContaining("ReadTimeout");
+
+                        // The first HTTP call in the JVM starts the reactor-netty event loop and DNS
+                        // resolver, and warms Jackson and the observation stack. That is one-off work
+                        // unrelated to the timeout, but it lands inside the window measured below: in a
+                        // full reactor build this read 2.679s and then passed on surefire's immediate
+                        // rerun in the same, now-warm JVM. Spend it on a throwaway call so the timed
+                        // one measures the abort rather than the startup.
+                        callAndExpectAbort.run();
+
                         var start = System.nanoTime();
-                        assertThatThrownBy(() -> model.getChatModel().call("hello"))
-                                .as("the shared builder's 300ms timeout must abort the 3s reply")
-                                .hasStackTraceContaining("ReadTimeout");
+                        callAndExpectAbort.run();
                         var elapsed = Duration.ofNanos(System.nanoTime() - start);
 
                         assertThat(elapsed)

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/pom.xml
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/pom.xml
@@ -37,10 +37,10 @@
         </dependency>
 
         <!--
-          openai-java is not declared here: it arrives at compile scope via
-          embabel-agent-openai, which pins it in step with spring-ai-openai. Declaring
-          it locally would override that version and put a second SDK release on the
-          test classpath.
+          The openai-java SDK is not declared here: openai-java-core arrives at compile
+          scope via spring-ai-openai and openai-java-client-okhttp via embabel-agent-openai,
+          which aligns them. Declaring either locally would override that version for this
+          module only and put a second SDK release on the test classpath.
         -->
 
         <dependency>

--- a/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
+++ b/embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/src/test/kotlin/com/embabel/agent/config/models/openai/OpenAiResponsesChatModelTest.kt
@@ -749,7 +749,7 @@ class OpenAiResponsesChatModelTest {
     private fun usage(inputTokens: Long, outputTokens: Long): ResponseUsage =
         ResponseUsage.builder()
             .inputTokens(inputTokens)
-            .inputTokensDetails(ResponseUsage.InputTokensDetails.builder().cachedTokens(0).build())
+            .inputTokensDetails(ResponseUsage.InputTokensDetails.builder().cachedTokens(0).cacheWriteTokens(0).build())
             .outputTokens(outputTokens)
             .outputTokensDetails(ResponseUsage.OutputTokensDetails.builder().reasoningTokens(0).build())
             .totalTokens(inputTokens + outputTokens)

--- a/embabel-agent-openai/pom.xml
+++ b/embabel-agent-openai/pom.xml
@@ -37,14 +37,23 @@
 
         <!--
           Spring AI 2.0 swapped its hand-rolled OpenAiApi for the openai-java SDK.
-          The factory references OpenAIClient / OpenAIOkHttpClient directly, so we
-          need both on the compile classpath. Versions come from the root pom, which
-          aligns them with the openai-java-core that spring-ai-openai pulls in.
+          The factory references OpenAIClient (openai-java-core) and OpenAIOkHttpClient
+          (openai-java-client-okhttp) directly.
+
+          openai-java-core is deliberately NOT declared here. Nothing in the dependency
+          chain manages it, so it resolves to whatever spring-ai-openai declares — which
+          is the version Spring AI itself compiles against, and therefore the only one
+          guaranteed to satisfy Spring AI's own calls into the SDK. Pinning it would
+          silently roll it back on the next Spring AI upgrade.
+
+          openai-java-client-okhttp has no such source: spring-ai-openai depends on
+          openai-java-core and raw okhttp, never the OpenAI okhttp client. Its version
+          comes from the root pom and has to be bumped in step with spring-ai-openai.
+          The enforcer rule below is what catches it when that is forgotten.
+
+          The openai-java aggregate is not declared either — it carries no classes of its
+          own, only dependencies on the two artifacts above.
         -->
-        <dependency>
-            <groupId>com.openai</groupId>
-            <artifactId>openai-java</artifactId>
-        </dependency>
         <dependency>
             <groupId>com.openai</groupId>
             <artifactId>openai-java-client-okhttp</artifactId>
@@ -78,6 +87,45 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <!--
+              The OpenAI SDK splits across three artifacts that must share a version:
+              spring-ai-openai drags openai-java-core forward on every upgrade, while
+              openai-java-client-okhttp only moves when the root pom's openai-java.version
+              is bumped by hand. When those diverge the mismatch surfaces far from here —
+              spring-ai-openai 2.0.1 moved core 4.39.1 -> 4.49.0, which added a required
+              field to ResponseUsage.InputTokensDetails and broke a test four modules
+              downstream with no mention of a version anywhere in the stack trace.
+
+              Scoped to com.openai so it gates the SDK alone. This reuses the parent's
+              enforce-versions execution id rather than adding a second execution: binding
+              the plugin here would otherwise also activate the parent's managed execution,
+              whose repo-wide DependencyConvergence reports forty lines of pre-existing,
+              non-failing warnings on every build of this module. combine.self=override
+              keeps those plugin-level rules out, so fail=true applies to this rule alone.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <fail>true</fail>
+                            <rules combine.self="override">
+                                <dependencyConvergence>
+                                    <includes>
+                                        <include>com.openai:*</include>
+                                    </includes>
+                                </dependencyConvergence>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.embabel.build</groupId>
         <artifactId>embabel-build-parent</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2-SNAPSHOT</version>
     </parent>
     <groupId>com.embabel.agent</groupId>
     <artifactId>embabel-agent-parent</artifactId>
@@ -16,11 +16,11 @@
 
     <properties>
         <argLine />
-        <embabel-common.version>2.0.2</embabel-common.version>
+        <embabel-common.version>2.0.3-SNAPSHOT</embabel-common.version>
         <netty.version>4.2.16.Final</netty.version>
-        <!-- Matches the openai-java-core that spring-ai-openai 2.0.0 depends on. Bump in
+        <!-- Matches the openai-java-core that spring-ai-openai 2.0.1 depends on. Bump in
              step with spring-ai-openai; drop once embabel-build-dependencies catches up. -->
-        <openai-java.version>4.39.1</openai-java.version>
+        <openai-java.version>4.49.0</openai-java.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <sb-contrib.version>7.7.4</sb-contrib.version>
     </properties>
@@ -59,12 +59,20 @@
               OpenAI SDK, aligned repo-wide.
 
               embabel-build-dependencies manages these at 4.36.0, the version
-              spring-ai-openai 2.0.0-M8 compiled against. The 2.0.0 GA release moved its
-              own openai-java-core to 4.39.1, so the managed version now puts two releases
-              of the same SDK on the classpath. Managing them here overrides the parent BOM
+              spring-ai-openai 2.0.0-M8 compiled against. Each spring-ai-openai release
+              since has moved its own openai-java-core forward (2.0.0 GA to 4.39.1,
+              2.0.1 to 4.49.0), so the managed version puts two releases of the same SDK
+              on the classpath. Managing them here overrides the parent BOM
               for direct and transitive uses alike — a version set in a module's
               <dependencies> only governs that module, and reverts to the managed value
               wherever it is inherited downstream.
+
+              openai-java-core is intentionally absent: unmanaged, it resolves to the
+              version spring-ai-openai declares, which is the one Spring AI's own code is
+              compiled against. Keep it that way and bump the property below to match on
+              every Spring AI upgrade — embabel-agent-openai enforces that they converge.
+              The openai-java aggregate is no longer depended on directly; it stays managed
+              so a transitive path cannot reintroduce it at the parent BOM's 4.36.0.
             -->
             <dependency>
                 <groupId>com.openai</groupId>


### PR DESCRIPTION
This pull request primarily updates OpenAI SDK dependencies to ensure version alignment with Spring AI and improve dependency management and test reliability. It also enhances documentation to clarify the reasoning behind these changes and introduces a Maven enforcer rule to catch version mismatches early. Additionally, a minor test fix adapts to a new required field in the SDK.

Dependency management and version alignment:

* Updated the root `pom.xml` to bump `openai-java.version` to `4.49.0` (matching `spring-ai-openai` 2.0.1), and clarified that `openai-java-core` should not be explicitly declared to avoid version mismatches. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L19-R23) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L62-R75)
* Improved comments in both `embabel-agent-openai/pom.xml` and `embabel-agent-autoconfigure/models/embabel-agent-openai-autoconfigure/pom.xml` to explain the rationale for not directly declaring certain OpenAI SDK dependencies and the importance of version alignment. [[1]](diffhunk://#diff-b7bd2c9978d600b78d93c10d295d7b06e5702538f6efe0dd06c49314167bd3f3L40-L47) [[2]](diffhunk://#diff-0a04691825454663deb93069bcd154ce7fbc17cf534364631dd8a503f9bc2379L40-R43)

Build safety and enforcement:

* Added a Maven Enforcer plugin rule in `embabel-agent-openai/pom.xml` to ensure all OpenAI SDK artifacts use the same version, preventing silent breakage due to version drift.

Test and code fixes:

* Updated a test in `OpenAiResponsesChatModelTest.kt` to set the new required `cacheWriteTokens` field in `ResponseUsage.InputTokensDetails`, reflecting changes in the OpenAI SDK.
* Improved a test in `MistralSharedClientBuilderTest.java` to warm up the JVM and avoid measuring unrelated startup costs in timeout tests, increasing test accuracy.

Other:

* Bumped project and dependency versions to next snapshot releases. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L19-R23)