### PR TITLE
Feature: Agent and Action Delay Policy

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/annotations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/annotations.kt
@@ -88,7 +88,7 @@ annotation class Agent(
     val opaque: Boolean = false,
     val actionRetryPolicy: ActionRetryPolicy = ActionRetryPolicy.DEFAULT,
     val actionRetryPolicyExpression: String = "",
-    val delay: Delay = Delay.NONE,
+    val delay: Delay = Delay.UNSET,
 )
 
 /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/annotations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/annotations.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.api.annotation
 import com.embabel.agent.api.common.PlannerType
 import com.embabel.agent.core.IoBinding
 import com.embabel.agent.core.ActionRetryPolicy
+import com.embabel.agent.core.Delay
 import com.embabel.common.core.types.Semver.Companion.DEFAULT_VERSION
 import com.embabel.common.core.types.ZeroToOne
 import org.springframework.core.annotation.AliasFor
@@ -87,6 +88,7 @@ annotation class Agent(
     val opaque: Boolean = false,
     val actionRetryPolicy: ActionRetryPolicy = ActionRetryPolicy.DEFAULT,
     val actionRetryPolicyExpression: String = "",
+    val delay: Delay = Delay.NONE,
 )
 
 /**
@@ -210,6 +212,7 @@ annotation class Action(
     val trigger: KClass<*> = Unit::class,
     val actionRetryPolicy: ActionRetryPolicy = ActionRetryPolicy.DEFAULT,
     val actionRetryPolicyExpression: String = "",
+    val delayMs: Long = -1L,
 )
 
 /**

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
@@ -64,14 +64,15 @@ class DefaultActionQosProvider(
             }
         }
 
-        // delayMs = -1L is the sentinel meaning "not set"; non-negative values (including 0) are explicit.
-        // 0 is treated as None (no delay), consistent with DelayPolicy.of(Long).
-        val actionDelay = method.getAnnotation(Action::class.java)?.let {
+        // -1L is the sentinel meaning "not set at action level"; null propagates agent-level delay.
+        // 0 is explicit "no delay" and overrides the agent default, so use null (not DelayPolicy.None)
+        // as the "not set" signal — otherwise delayMs=0 and delayMs=-1 are indistinguishable.
+        val actionDelay: DelayPolicy? = method.getAnnotation(Action::class.java)?.let {
             val ms = it.delayMs
-            if (ms >= 0) DelayPolicy.of(ms) else DelayPolicy.None
-        } ?: DelayPolicy.None
+            if (ms >= 0L) DelayPolicy.of(ms) else null
+        }
 
-        val delayPolicy = actionDelay.takeIf { it != DelayPolicy.None } ?: agentDelay
+        val delayPolicy = actionDelay ?: agentDelay
 
         return props.toActionQos().copy(delayPolicy = delayPolicy)
     }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
@@ -42,7 +42,7 @@ class DefaultActionQosProvider(
 
         var defaultActionQos = actionQosProperties.default
 
-        var agentDelay: DelayPolicy = DelayPolicy.SameAsAgent
+        var agentDelay: DelayPolicy = DelayPolicy.Inherit
         var props = instance.javaClass.getAnnotation(Agent::class.java)?.let {
             if (hasRetryExpression(it.actionRetryPolicyExpression)) {
                 defaultActionQos = defaultActionQos
@@ -66,9 +66,9 @@ class DefaultActionQosProvider(
 
         val actionDelay = method.getAnnotation(Action::class.java)
             ?.let { DelayPolicy.of(it.delayMs) }
-            ?: DelayPolicy.SameAsAgent
+            ?: DelayPolicy.Inherit
 
-        val delayPolicy = actionDelay.takeIf { it != DelayPolicy.SameAsAgent } ?: agentDelay
+        val delayPolicy = actionDelay.takeIf { it != DelayPolicy.Inherit } ?: agentDelay
 
         return props.toActionQos().copy(delayPolicy = delayPolicy)
     }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
@@ -64,15 +64,11 @@ class DefaultActionQosProvider(
             }
         }
 
-        // -1L is the sentinel meaning "not set at action level"; null propagates agent-level delay.
-        // 0 is explicit "no delay" and overrides the agent default, so use null (not DelayPolicy.SameAsAgent)
-        // as the "not set" signal — otherwise delayMs=0 and delayMs=-1 are indistinguishable.
-        val actionDelay: DelayPolicy? = method.getAnnotation(Action::class.java)?.let {
-            val ms = it.delayMs
-            if (ms >= 0L) DelayPolicy.of(ms) else null
-        }
+        val actionDelay = method.getAnnotation(Action::class.java)
+            ?.let { DelayPolicy.of(it.delayMs) }
+            ?: DelayPolicy.SameAsAgent
 
-        val delayPolicy = actionDelay ?: agentDelay
+        val delayPolicy = actionDelay.takeIf { it != DelayPolicy.SameAsAgent } ?: agentDelay
 
         return props.toActionQos().copy(delayPolicy = delayPolicy)
     }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.api.annotation.Action
 import com.embabel.agent.api.annotation.Agent
 import com.embabel.agent.core.ActionQos
 import com.embabel.agent.core.ActionRetryPolicy
+import com.embabel.agent.core.DelayPolicy
 import com.embabel.agent.spi.config.spring.AgentPlatformProperties
 import org.springframework.stereotype.Component
 import java.lang.reflect.Method
@@ -41,18 +42,17 @@ class DefaultActionQosProvider(
 
         var defaultActionQos = actionQosProperties.default
 
+        var agentDelay: DelayPolicy = DelayPolicy.None
         var props = instance.javaClass.getAnnotation(Agent::class.java)?.let {
             if (hasRetryExpression(it.actionRetryPolicyExpression)) {
                 defaultActionQos = defaultActionQos
                     .overridingNotNull(getBound(it.actionRetryPolicyExpression))
             }
-
             if (it.actionRetryPolicy == ActionRetryPolicy.FIRE_ONCE) {
                 defaultActionQos = defaultActionQos.copy(maxAttempts = 1)
             }
-
+            agentDelay = DelayPolicy.of(it.delay)
             defaultActionQos
-
         } ?: defaultActionQos
 
         method.getAnnotation(Action::class.java)?.let {
@@ -64,8 +64,16 @@ class DefaultActionQosProvider(
             }
         }
 
+        // delayMs = -1L is the sentinel meaning "not set"; non-negative values (including 0) are explicit.
+        // 0 is treated as None (no delay), consistent with DelayPolicy.of(Long).
+        val actionDelay = method.getAnnotation(Action::class.java)?.let {
+            val ms = it.delayMs
+            if (ms >= 0) DelayPolicy.of(ms) else DelayPolicy.None
+        } ?: DelayPolicy.None
 
-        return props.toActionQos()
+        val delayPolicy = actionDelay.takeIf { it != DelayPolicy.None } ?: agentDelay
+
+        return props.toActionQos().copy(delayPolicy = delayPolicy)
     }
 
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/DefaultActionQosProvider.kt
@@ -42,7 +42,7 @@ class DefaultActionQosProvider(
 
         var defaultActionQos = actionQosProperties.default
 
-        var agentDelay: DelayPolicy = DelayPolicy.None
+        var agentDelay: DelayPolicy = DelayPolicy.SameAsAgent
         var props = instance.javaClass.getAnnotation(Agent::class.java)?.let {
             if (hasRetryExpression(it.actionRetryPolicyExpression)) {
                 defaultActionQos = defaultActionQos
@@ -65,7 +65,7 @@ class DefaultActionQosProvider(
         }
 
         // -1L is the sentinel meaning "not set at action level"; null propagates agent-level delay.
-        // 0 is explicit "no delay" and overrides the agent default, so use null (not DelayPolicy.None)
+        // 0 is explicit "no delay" and overrides the agent default, so use null (not DelayPolicy.SameAsAgent)
         // as the "not set" signal — otherwise delayMs=0 and delayMs=-1 are indistinguishable.
         val actionDelay: DelayPolicy? = method.getAnnotation(Action::class.java)?.let {
             val ms = it.delayMs

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionQos.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionQos.kt
@@ -26,5 +26,5 @@ data class ActionQos(
     override val backoffMaxInterval: Long = 60000,
     override val propertyPrefix: String = "",
     val idempotent: Boolean = false,
-    val delayPolicy: DelayPolicy = DelayPolicy.None,
+    val delayPolicy: DelayPolicy = DelayPolicy.SameAsAgent,
 ) : RetryProperties

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionQos.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionQos.kt
@@ -26,5 +26,5 @@ data class ActionQos(
     override val backoffMaxInterval: Long = 60000,
     override val propertyPrefix: String = "",
     val idempotent: Boolean = false,
-    val delayPolicy: DelayPolicy = DelayPolicy.SameAsAgent,
+    val delayPolicy: DelayPolicy = DelayPolicy.Inherit,
 ) : RetryProperties

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionQos.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ActionQos.kt
@@ -26,4 +26,5 @@ data class ActionQos(
     override val backoffMaxInterval: Long = 60000,
     override val propertyPrefix: String = "",
     val idempotent: Boolean = false,
+    val delayPolicy: DelayPolicy = DelayPolicy.None,
 ) : RetryProperties

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
@@ -41,10 +41,12 @@ sealed interface DelayPolicy {
 
     /**
      * Sentinel meaning "not set / inherit from the enclosing agent scope".
-     * Use [of] with an explicit `0L` when no delay is intentional.
+     *
+     * Serialized as `-1` so it round-trips correctly: `of(-1L)` returns [SameAsAgent],
+     * while `of(0L)` returns `Fixed(0)` — explicit zero delay.
      */
     object SameAsAgent : DelayPolicy {
-        override val millis: Long = 0L
+        override val millis: Long = -1L
     }
 
     /**
@@ -56,10 +58,11 @@ sealed interface DelayPolicy {
 
         /**
          * Construct a [DelayPolicy] from a coarse-grained [Delay] level.
+         * Delegates to [of(Long)]: [Delay.UNSET] (millis = -1) maps to [SameAsAgent];
+         * all non-negative values produce [Fixed].
          */
         @JvmStatic
-        fun of(delay: Delay): DelayPolicy =
-            if (delay.millis <= 0) SameAsAgent else Fixed(delay.millis)
+        fun of(delay: Delay): DelayPolicy = of(delay.millis)
 
         /**
          * Constructs a [DelayPolicy] from an explicit millisecond value.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
@@ -62,15 +62,13 @@ sealed interface DelayPolicy {
             if (delay.millis <= 0) SameAsAgent else Fixed(delay.millis)
 
         /**
-         * Constructs a [Fixed] policy from an explicit millisecond value.
-         * Negative values are clamped to zero.
-         *
-         * Always returns [Fixed], never [SameAsAgent] — so callers that distinguish
-         * "explicitly zero" from "not set" can use identity equality against [SameAsAgent].
-         * Use [SameAsAgent] directly when the intent is "unset, inherit from the enclosing agent scope".
+         * Constructs a [DelayPolicy] from an explicit millisecond value.
+         * Negative values (including the [@Action][com.embabel.agent.api.annotation.Action]
+         * default of `-1`) map to [SameAsAgent] — "not set, inherit from the enclosing scope".
+         * Non-negative values produce [Fixed].
          */
         @JsonCreator
         @JvmStatic
-        fun of(millis: Long): DelayPolicy = Fixed(maxOf(0L, millis))
+        fun of(millis: Long): DelayPolicy = if (millis < 0) SameAsAgent else Fixed(millis)
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
@@ -29,7 +29,7 @@ import java.time.Duration
  * Serialized as a plain millisecond Long value via [millis].
  * A [Duration] view is available via [duration] for callers that require it.
  *
- * Use [DelayPolicy.None] when no delay is required.
+ * Use [DelayPolicy.SameAsAgent] when the action should inherit the enclosing agent's delay.
  * Use [DelayPolicy.of] factory methods to construct from a [Delay] level or raw milliseconds.
  */
 sealed interface DelayPolicy {
@@ -40,10 +40,10 @@ sealed interface DelayPolicy {
     val duration: Duration get() = Duration.ofMillis(millis)
 
     /**
-     * Sentinel meaning "not set / inherit from the enclosing scope".
+     * Sentinel meaning "not set / inherit from the enclosing agent scope".
      * Use [of] with an explicit `0L` when no delay is intentional.
      */
-    object None : DelayPolicy {
+    object SameAsAgent : DelayPolicy {
         override val millis: Long = 0L
     }
 
@@ -59,15 +59,15 @@ sealed interface DelayPolicy {
          */
         @JvmStatic
         fun of(delay: Delay): DelayPolicy =
-            if (delay.millis <= 0) None else Fixed(delay.millis)
+            if (delay.millis <= 0) SameAsAgent else Fixed(delay.millis)
 
         /**
          * Constructs a [Fixed] policy from an explicit millisecond value.
          * Negative values are clamped to zero.
          *
-         * Always returns [Fixed], never [None] — so callers that distinguish
-         * "explicitly zero" from "not set" can use identity equality against [None].
-         * Use [None] directly when the intent is "unset, inherit from the enclosing scope".
+         * Always returns [Fixed], never [SameAsAgent] — so callers that distinguish
+         * "explicitly zero" from "not set" can use identity equality against [SameAsAgent].
+         * Use [SameAsAgent] directly when the intent is "unset, inherit from the enclosing agent scope".
          */
         @JsonCreator
         @JvmStatic

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
@@ -29,7 +29,7 @@ import java.time.Duration
  * Serialized as a plain millisecond Long value via [millis].
  * A [Duration] view is available via [duration] for callers that require it.
  *
- * Use [DelayPolicy.SameAsAgent] when the action should inherit the enclosing agent's delay.
+ * Use [DelayPolicy.Inherit] when the action should inherit the enclosing agent's delay.
  * Use [DelayPolicy.of] factory methods to construct from a [Delay] level or raw milliseconds.
  */
 sealed interface DelayPolicy {
@@ -42,10 +42,10 @@ sealed interface DelayPolicy {
     /**
      * Sentinel meaning "not set / inherit from the enclosing agent scope".
      *
-     * Serialized as `-1` so it round-trips correctly: `of(-1L)` returns [SameAsAgent],
+     * Serialized as `-1` so it round-trips correctly: `of(-1L)` returns [Inherit],
      * while `of(0L)` returns `Fixed(0)` — explicit zero delay.
      */
-    object SameAsAgent : DelayPolicy {
+    object Inherit : DelayPolicy {
         override val millis: Long = -1L
     }
 
@@ -58,7 +58,7 @@ sealed interface DelayPolicy {
 
         /**
          * Construct a [DelayPolicy] from a coarse-grained [Delay] level.
-         * Delegates to [of(Long)]: [Delay.UNSET] (millis = -1) maps to [SameAsAgent];
+         * Delegates to [of(Long)]: [Delay.UNSET] (millis = -1) maps to [Inherit];
          * all non-negative values produce [Fixed].
          */
         @JvmStatic
@@ -67,11 +67,11 @@ sealed interface DelayPolicy {
         /**
          * Constructs a [DelayPolicy] from an explicit millisecond value.
          * Negative values (including the [@Action][com.embabel.agent.api.annotation.Action]
-         * default of `-1`) map to [SameAsAgent] — "not set, inherit from the enclosing scope".
+         * default of `-1`) map to [Inherit] — "not set, inherit from the enclosing scope".
          * Non-negative values produce [Fixed].
          */
         @JsonCreator
         @JvmStatic
-        fun of(millis: Long): DelayPolicy = if (millis < 0) SameAsAgent else Fixed(millis)
+        fun of(millis: Long): DelayPolicy = if (millis < 0) Inherit else Fixed(millis)
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
@@ -40,7 +40,8 @@ sealed interface DelayPolicy {
     val duration: Duration get() = Duration.ofMillis(millis)
 
     /**
-     * No delay.
+     * Sentinel meaning "not set / inherit from the enclosing scope".
+     * Use [of] with an explicit `0L` when no delay is intentional.
      */
     object None : DelayPolicy {
         override val millis: Long = 0L
@@ -61,11 +62,15 @@ sealed interface DelayPolicy {
             if (delay.millis <= 0) None else Fixed(delay.millis)
 
         /**
-         * Construct a [DelayPolicy] from an explicit millisecond value.
+         * Constructs a [Fixed] policy from an explicit millisecond value.
+         * Negative values are clamped to zero.
+         *
+         * Always returns [Fixed], never [None] — so callers that distinguish
+         * "explicitly zero" from "not set" can use identity equality against [None].
+         * Use [None] directly when the intent is "unset, inherit from the enclosing scope".
          */
         @JsonCreator
         @JvmStatic
-        fun of(millis: Long): DelayPolicy =
-            if (millis <= 0) None else Fixed(millis)
+        fun of(millis: Long): DelayPolicy = Fixed(maxOf(0L, millis))
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/DelayPolicy.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+import java.time.Duration
+
+/**
+ * Encapsulates a delay duration for agent operations.
+ *
+ * Normalizes coarse-grained [Delay] enum values and raw millisecond values
+ * into a plain millisecond [Long], so consumers never need to perform their own
+ * enum-to-milliseconds lookups.
+ *
+ * Serialized as a plain millisecond Long value via [millis].
+ * A [Duration] view is available via [duration] for callers that require it.
+ *
+ * Use [DelayPolicy.None] when no delay is required.
+ * Use [DelayPolicy.of] factory methods to construct from a [Delay] level or raw milliseconds.
+ */
+sealed interface DelayPolicy {
+
+    @get:JsonValue
+    val millis: Long
+
+    val duration: Duration get() = Duration.ofMillis(millis)
+
+    /**
+     * No delay.
+     */
+    object None : DelayPolicy {
+        override val millis: Long = 0L
+    }
+
+    /**
+     * A fixed delay of [millis] milliseconds.
+     */
+    data class Fixed(override val millis: Long) : DelayPolicy
+
+    companion object {
+
+        /**
+         * Construct a [DelayPolicy] from a coarse-grained [Delay] level.
+         */
+        @JvmStatic
+        fun of(delay: Delay): DelayPolicy =
+            if (delay.millis <= 0) None else Fixed(delay.millis)
+
+        /**
+         * Construct a [DelayPolicy] from an explicit millisecond value.
+         */
+        @JsonCreator
+        @JvmStatic
+        fun of(millis: Long): DelayPolicy =
+            if (millis <= 0) None else Fixed(millis)
+    }
+}

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
@@ -78,15 +78,19 @@ data class Verbosity @JvmOverloads constructor(
 
 }
 
+private const val DELAY_NONE_MS   = 0L
+private const val DELAY_MEDIUM_MS = 400L
+private const val DELAY_LONG_MS   = 2000L
+
 enum class Delay(val millis: Long) {
-    NONE(0),
-    MEDIUM(400),
-    LONG(2000);
+    NONE(DELAY_NONE_MS),
+    MEDIUM(DELAY_MEDIUM_MS),
+    LONG(DELAY_LONG_MS);
 
     companion object {
-        const val NONE_MS   = 0L
-        const val MEDIUM_MS = 400L
-        const val LONG_MS   = 2000L
+        const val NONE_MS   = DELAY_NONE_MS
+        const val MEDIUM_MS = DELAY_MEDIUM_MS
+        const val LONG_MS   = DELAY_LONG_MS
     }
 }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
@@ -78,8 +78,16 @@ data class Verbosity @JvmOverloads constructor(
 
 }
 
-enum class Delay {
-    NONE, MEDIUM, LONG
+enum class Delay(val millis: Long) {
+    NONE(0),
+    MEDIUM(400),
+    LONG(2000);
+
+    companion object {
+        const val NONE_MS   = 0L
+        const val MEDIUM_MS = 400L
+        const val LONG_MS   = 2000L
+    }
 }
 
 /**
@@ -91,6 +99,9 @@ data class ProcessControl @JvmOverloads constructor(
     val operationDelay: Delay = Delay.NONE,
     val earlyTerminationPolicy: EarlyTerminationPolicy = EarlyTerminationPolicy.maxActions(100),
 ) {
+
+    val toolDelayPolicy: DelayPolicy get() = DelayPolicy.of(toolDelay)
+    val operationDelayPolicy: DelayPolicy get() = DelayPolicy.of(operationDelay)
 
     fun withToolDelay(toolDelay: Delay): ProcessControl =
         this.copy(toolDelay = toolDelay)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/ProcessOptions.kt
@@ -78,16 +78,20 @@ data class Verbosity @JvmOverloads constructor(
 
 }
 
+private const val DELAY_UNSET_MS  = -1L
 private const val DELAY_NONE_MS   = 0L
 private const val DELAY_MEDIUM_MS = 400L
 private const val DELAY_LONG_MS   = 2000L
 
 enum class Delay(val millis: Long) {
+    /** Sentinel: inherit delay from the enclosing agent or process scope. */
+    UNSET(DELAY_UNSET_MS),
     NONE(DELAY_NONE_MS),
     MEDIUM(DELAY_MEDIUM_MS),
     LONG(DELAY_LONG_MS);
 
     companion object {
+        const val UNSET_MS  = DELAY_UNSET_MS
         const val NONE_MS   = DELAY_NONE_MS
         const val MEDIUM_MS = DELAY_MEDIUM_MS
         const val LONG_MS   = DELAY_LONG_MS

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ProcessOptionsOperationScheduler.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ProcessOptionsOperationScheduler.kt
@@ -18,21 +18,25 @@ package com.embabel.agent.spi.support
 import com.embabel.agent.api.event.ActionExecutionStartEvent
 import com.embabel.agent.api.event.ToolCallRequestEvent
 import com.embabel.agent.core.Delay
+import com.embabel.agent.core.DelayPolicy
 import com.embabel.agent.spi.ActionExecutionSchedule
 import com.embabel.agent.spi.DelayedActionExecutionSchedule
 import com.embabel.agent.spi.OperationScheduler
 import com.embabel.agent.spi.ToolCallSchedule
-import java.time.Duration
+import org.slf4j.LoggerFactory
 
 /**
- * Operation scheduler driven from process options
+ * Operation scheduler driven from process options.
+ * Action-level [DelayPolicy] takes precedence over the process-level fallback.
  */
 class ProcessOptionsOperationScheduler(
+    @Deprecated("Unused: delay is read directly from DelayPolicy.duration")
     val operationDelays: Map<Delay, Long> = mapOf(
         Delay.NONE to 0L,
         Delay.MEDIUM to 400L,
         Delay.LONG to 2000L,
     ),
+    @Deprecated("Unused: delay is read directly from DelayPolicy.duration")
     val toolDelays: Map<Delay, Long> = mapOf(
         Delay.NONE to 0L,
         Delay.MEDIUM to 400L,
@@ -40,23 +44,36 @@ class ProcessOptionsOperationScheduler(
     ),
 ) : OperationScheduler {
 
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Resolves the delay for an action using a two-level priority chain:
+     * 1. Action QoS delay — resolved by [com.embabel.agent.api.annotation.support.DefaultActionQosProvider] from
+     *    [@Action][com.embabel.agent.api.annotation.Action] or [@Agent][com.embabel.agent.api.annotation.Agent]
+     *    annotations (action-level wins over agent-level).
+     * 2. Process-level fallback from [com.embabel.agent.core.ProcessControl.operationDelayPolicy].
+     *
+     * A [DelayPolicy.None] QoS delay is treated as "not set" and falls through to the process fallback.
+     */
     override fun scheduleAction(actionExecutionStartEvent: ActionExecutionStartEvent): ActionExecutionSchedule {
-        return DelayedActionExecutionSchedule(
-            Duration.ofMillis(
-                operationDelays[actionExecutionStartEvent.agentProcess.processContext.processOptions.processControl.operationDelay]
-                    ?: 0L,
+        val processControl = actionExecutionStartEvent.agentProcess.processContext.processOptions.processControl
+        val actionQosDelay = actionExecutionStartEvent.action.qos.delayPolicy.takeIf { it != DelayPolicy.None }
+        val delay = actionQosDelay ?: processControl.operationDelayPolicy
+        if (delay != DelayPolicy.None) {
+            val source = if (actionQosDelay != null) "qos" else "process"
+            logger.debug(
+                "Scheduling {}ms delay for action {} (source: {})",
+                delay.millis,
+                actionExecutionStartEvent.action.name,
+                source,
             )
-        )
+        }
+        return DelayedActionExecutionSchedule(delay.duration)
     }
 
     override fun scheduleToolCall(functionCallRequestEvent: ToolCallRequestEvent): ToolCallSchedule {
         return ToolCallSchedule(
-            delay = Duration.ofMillis(
-                toolDelays[functionCallRequestEvent.agentProcess.processContext.processOptions.processControl.operationDelay]
-                    ?: 0L,
-            )
+            delay = functionCallRequestEvent.agentProcess.processContext.processOptions.processControl.toolDelayPolicy.duration,
         )
     }
-
-
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ProcessOptionsOperationScheduler.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ProcessOptionsOperationScheduler.kt
@@ -53,13 +53,13 @@ class ProcessOptionsOperationScheduler(
      *    annotations (action-level wins over agent-level).
      * 2. Process-level fallback from [com.embabel.agent.core.ProcessControl.operationDelayPolicy].
      *
-     * A [DelayPolicy.None] QoS delay is treated as "not set" and falls through to the process fallback.
+     * A [DelayPolicy.SameAsAgent] QoS delay is treated as "not set" and falls through to the process fallback.
      */
     override fun scheduleAction(actionExecutionStartEvent: ActionExecutionStartEvent): ActionExecutionSchedule {
         val processControl = actionExecutionStartEvent.agentProcess.processContext.processOptions.processControl
-        val actionQosDelay = actionExecutionStartEvent.action.qos.delayPolicy.takeIf { it != DelayPolicy.None }
+        val actionQosDelay = actionExecutionStartEvent.action.qos.delayPolicy.takeIf { it != DelayPolicy.SameAsAgent }
         val delay = actionQosDelay ?: processControl.operationDelayPolicy
-        if (delay != DelayPolicy.None) {
+        if (delay != DelayPolicy.SameAsAgent) {
             val source = if (actionQosDelay != null) "qos" else "process"
             logger.debug(
                 "Scheduling {}ms delay for action {} (source: {})",

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ProcessOptionsOperationScheduler.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ProcessOptionsOperationScheduler.kt
@@ -32,15 +32,15 @@ import org.slf4j.LoggerFactory
 class ProcessOptionsOperationScheduler(
     @Deprecated("Unused: delay is read directly from DelayPolicy.duration")
     val operationDelays: Map<Delay, Long> = mapOf(
-        Delay.NONE to 0L,
-        Delay.MEDIUM to 400L,
-        Delay.LONG to 2000L,
+        Delay.NONE to Delay.NONE_MS,
+        Delay.MEDIUM to Delay.MEDIUM_MS,
+        Delay.LONG to Delay.LONG_MS,
     ),
     @Deprecated("Unused: delay is read directly from DelayPolicy.duration")
     val toolDelays: Map<Delay, Long> = mapOf(
-        Delay.NONE to 0L,
-        Delay.MEDIUM to 400L,
-        Delay.LONG to 2000L,
+        Delay.NONE to Delay.NONE_MS,
+        Delay.MEDIUM to Delay.MEDIUM_MS,
+        Delay.LONG to Delay.LONG_MS,
     ),
 ) : OperationScheduler {
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ProcessOptionsOperationScheduler.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/ProcessOptionsOperationScheduler.kt
@@ -53,13 +53,13 @@ class ProcessOptionsOperationScheduler(
      *    annotations (action-level wins over agent-level).
      * 2. Process-level fallback from [com.embabel.agent.core.ProcessControl.operationDelayPolicy].
      *
-     * A [DelayPolicy.SameAsAgent] QoS delay is treated as "not set" and falls through to the process fallback.
+     * A [DelayPolicy.Inherit] QoS delay is treated as "not set" and falls through to the process fallback.
      */
     override fun scheduleAction(actionExecutionStartEvent: ActionExecutionStartEvent): ActionExecutionSchedule {
         val processControl = actionExecutionStartEvent.agentProcess.processContext.processOptions.processControl
-        val actionQosDelay = actionExecutionStartEvent.action.qos.delayPolicy.takeIf { it != DelayPolicy.SameAsAgent }
+        val actionQosDelay = actionExecutionStartEvent.action.qos.delayPolicy.takeIf { it != DelayPolicy.Inherit }
         val delay = actionQosDelay ?: processControl.operationDelayPolicy
-        if (delay != DelayPolicy.SameAsAgent) {
+        if (delay != DelayPolicy.Inherit) {
             val source = if (actionQosDelay != null) "qos" else "process"
             logger.debug(
                 "Scheduling {}ms delay for action {} (source: {})",

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/delay/AgentActionDelayTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/delay/AgentActionDelayTest.kt
@@ -23,6 +23,7 @@ import com.embabel.agent.api.common.ActionContext
 import com.embabel.agent.api.channel.DevNullOutputChannel
 import com.embabel.agent.core.AgentProcessStatusCode
 import com.embabel.agent.core.Delay
+import com.embabel.agent.core.ProcessControl
 import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.core.expression.LogicalExpressionParser
 import com.embabel.agent.core.support.InMemoryBlackboard
@@ -115,6 +116,22 @@ class AgentActionDelayTest {
         }
     }
 
+    @Agent(description = "delayMs=0 suppresses process-level LONG operation delay")
+    class AgentWithZeroDelayOverridingProcessDelay {
+        @Action
+        fun step1(userInput: UserInput, context: ActionContext): DelayStep1 {
+            context["step1End"] = System.currentTimeMillis()
+            return DelayStep1(userInput.content)
+        }
+
+        @Action(delayMs = 0L)
+        @AchievesGoal(description = "final")
+        fun step2(step: DelayStep1, context: ActionContext): DelayStep2 {
+            context["step2Start"] = System.currentTimeMillis()
+            return DelayStep2(step.content)
+        }
+    }
+
     @Agent(description = "delayMs=0 suppresses agent-level LONG delay", delay = Delay.LONG)
     class AgentWithZeroDelayOverridingAgentDelay {
         @Action
@@ -131,7 +148,7 @@ class AgentActionDelayTest {
         }
     }
 
-    private fun blackboardFor(instance: Any): InMemoryBlackboard {
+    private fun blackboardFor(instance: Any, processOptions: ProcessOptions = ProcessOptions()): InMemoryBlackboard {
         val reader = AgentMetadataReader()
         val agent = reader.createAgentMetadata(instance) as CoreAgent
         val blackboard = InMemoryBlackboard()
@@ -152,7 +169,7 @@ class AgentActionDelayTest {
         val process = SimpleAgentProcess(
             id = "test-${instance.javaClass.simpleName}",
             agent = agent,
-            processOptions = ProcessOptions(),
+            processOptions = processOptions,
             blackboard = blackboard,
             platformServices = platformServices,
             plannerFactory = DefaultPlannerFactory,
@@ -184,6 +201,20 @@ class AgentActionDelayTest {
             assertThat(gap(blackboardFor(AgentWithAgentLevelDelay())))
                 .`as`("gap should be at least ${Delay.MEDIUM.millis}ms")
                 .isGreaterThanOrEqualTo(Delay.MEDIUM.millis - TOLERANCE_MS)
+        }
+    }
+
+    @Nested
+    inner class ActionOverridesProcessDelay {
+
+        @Test
+        fun `delayMs=0 suppresses process-level operation delay`() {
+            val processOptions = ProcessOptions().withProcessControl(
+                ProcessControl().withOperationDelay(Delay.LONG)
+            )
+            assertThat(gap(blackboardFor(AgentWithZeroDelayOverridingProcessDelay(), processOptions)))
+                .`as`("explicit delayMs=0 must override process LONG operation delay — gap must be near zero")
+                .isLessThan(TOLERANCE_MS)
         }
     }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/delay/AgentActionDelayTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/delay/AgentActionDelayTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.api.delay
+
+import com.embabel.agent.api.annotation.AchievesGoal
+import com.embabel.agent.api.annotation.Action
+import com.embabel.agent.api.annotation.Agent
+import com.embabel.agent.api.annotation.support.AgentMetadataReader
+import com.embabel.agent.api.common.ActionContext
+import com.embabel.agent.api.channel.DevNullOutputChannel
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.Delay
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.expression.LogicalExpressionParser
+import com.embabel.agent.core.support.InMemoryBlackboard
+import com.embabel.agent.core.support.SimpleAgentProcess
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.spi.support.DefaultPlannerFactory
+import com.embabel.agent.spi.support.ExecutorAsyncer
+import com.embabel.agent.spi.support.InMemoryAgentProcessRepository
+import com.embabel.agent.spi.support.ProcessOptionsOperationScheduler
+import com.embabel.agent.spi.support.SpringContextPlatformServices
+import com.embabel.agent.test.common.EventSavingAgenticEventListener
+import com.embabel.agent.test.integration.DummyObjectCreatingLlmOperations
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyAgentPlatform
+import com.embabel.common.textio.template.JinjavaTemplateRenderer
+import com.embabel.common.util.EmbabelObjectMapperHolder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import com.embabel.agent.core.Agent as CoreAgent
+
+private const val ACTION_DELAY_MS = 200L
+private const val TOLERANCE_MS = 50L
+
+data class DelayStep1(val content: String)
+data class DelayStep2(val content: String)
+
+class AgentActionDelayTest {
+
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+
+    init {
+        (LoggerFactory.getLogger(ProcessOptionsOperationScheduler::class.java)
+                as ch.qos.logback.classic.Logger).level = ch.qos.logback.classic.Level.DEBUG
+    }
+
+    @AfterEach
+    fun tearDown() {
+        executor.shutdown()
+    }
+
+    @Agent(description = "agent with action-level delay")
+    class AgentWithActionDelay {
+        @Action
+        fun step1(userInput: UserInput, context: ActionContext): DelayStep1 {
+            context["step1End"] = System.currentTimeMillis()
+            return DelayStep1(userInput.content)
+        }
+
+        @Action(delayMs = ACTION_DELAY_MS)
+        @AchievesGoal(description = "final")
+        fun step2(step: DelayStep1, context: ActionContext): DelayStep2 {
+            context["step2Start"] = System.currentTimeMillis()
+            return DelayStep2(step.content)
+        }
+    }
+
+    @Agent(description = "agent with agent-level MEDIUM delay", delay = Delay.MEDIUM)
+    class AgentWithAgentLevelDelay {
+        @Action
+        fun step1(userInput: UserInput, context: ActionContext): DelayStep1 {
+            context["step1End"] = System.currentTimeMillis()
+            return DelayStep1(userInput.content)
+        }
+
+        @Action
+        @AchievesGoal(description = "final")
+        fun step2(step: DelayStep1, context: ActionContext): DelayStep2 {
+            context["step2Start"] = System.currentTimeMillis()
+            return DelayStep2(step.content)
+        }
+    }
+
+    @Agent(description = "action-level delay overrides agent-level LONG delay", delay = Delay.LONG)
+    class AgentWithActionOverridingAgentDelay {
+        @Action
+        fun step1(userInput: UserInput, context: ActionContext): DelayStep1 {
+            context["step1End"] = System.currentTimeMillis()
+            return DelayStep1(userInput.content)
+        }
+
+        @Action(delayMs = ACTION_DELAY_MS)
+        @AchievesGoal(description = "final")
+        fun step2(step: DelayStep1, context: ActionContext): DelayStep2 {
+            context["step2Start"] = System.currentTimeMillis()
+            return DelayStep2(step.content)
+        }
+    }
+
+    private fun blackboardFor(instance: Any): InMemoryBlackboard {
+        val reader = AgentMetadataReader()
+        val agent = reader.createAgentMetadata(instance) as CoreAgent
+        val blackboard = InMemoryBlackboard()
+        blackboard += UserInput("test")
+        val platformServices = SpringContextPlatformServices(
+            agentPlatform = dummyAgentPlatform(),
+            llmOperations = DummyObjectCreatingLlmOperations.LoremIpsum,
+            eventListener = EventSavingAgenticEventListener(),
+            operationScheduler = ProcessOptionsOperationScheduler(),
+            asyncer = ExecutorAsyncer(executor),
+            embabelObjectMapperHolder = EmbabelObjectMapperHolder.createDefault(),
+            applicationContext = null,
+            outputChannel = DevNullOutputChannel,
+            templateRenderer = JinjavaTemplateRenderer(),
+            customLogicalExpressionParser = LogicalExpressionParser.EMPTY,
+            agentProcessRepository = InMemoryAgentProcessRepository(),
+        )
+        val process = SimpleAgentProcess(
+            id = "test-${instance.javaClass.simpleName}",
+            agent = agent,
+            processOptions = ProcessOptions(),
+            blackboard = blackboard,
+            platformServices = platformServices,
+            plannerFactory = DefaultPlannerFactory,
+            parentId = null,
+        )
+        assertThat(process.run().status).isEqualTo(AgentProcessStatusCode.COMPLETED)
+        return blackboard
+    }
+
+    private fun gap(blackboard: InMemoryBlackboard): Long =
+        (blackboard["step2Start"] as Long) - (blackboard["step1End"] as Long)
+
+    @Nested
+    inner class ActionLevelDelay {
+
+        @Test
+        fun `action delayMs causes sleep before action body`() {
+            assertThat(gap(blackboardFor(AgentWithActionDelay())))
+                .`as`("gap should be at least ${ACTION_DELAY_MS}ms")
+                .isGreaterThanOrEqualTo(ACTION_DELAY_MS - TOLERANCE_MS)
+        }
+    }
+
+    @Nested
+    inner class AgentLevelDelay {
+
+        @Test
+        fun `agent-level delay propagates to actions`() {
+            assertThat(gap(blackboardFor(AgentWithAgentLevelDelay())))
+                .`as`("gap should be at least ${Delay.MEDIUM.millis}ms")
+                .isGreaterThanOrEqualTo(Delay.MEDIUM.millis - TOLERANCE_MS)
+        }
+    }
+
+    @Nested
+    inner class ActionOverridesAgentDelay {
+
+        @Test
+        fun `action delayMs overrides agent-level delay`() {
+            assertThat(gap(blackboardFor(AgentWithActionOverridingAgentDelay())))
+                .`as`("action delay (${ACTION_DELAY_MS}ms) should apply, not agent-level LONG")
+                .isGreaterThanOrEqualTo(ACTION_DELAY_MS - TOLERANCE_MS)
+                .isLessThan(Delay.LONG.millis / 2)
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/delay/AgentActionDelayTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/delay/AgentActionDelayTest.kt
@@ -115,6 +115,22 @@ class AgentActionDelayTest {
         }
     }
 
+    @Agent(description = "delayMs=0 suppresses agent-level LONG delay", delay = Delay.LONG)
+    class AgentWithZeroDelayOverridingAgentDelay {
+        @Action
+        fun step1(userInput: UserInput, context: ActionContext): DelayStep1 {
+            context["step1End"] = System.currentTimeMillis()
+            return DelayStep1(userInput.content)
+        }
+
+        @Action(delayMs = 0L)
+        @AchievesGoal(description = "final")
+        fun step2(step: DelayStep1, context: ActionContext): DelayStep2 {
+            context["step2Start"] = System.currentTimeMillis()
+            return DelayStep2(step.content)
+        }
+    }
+
     private fun blackboardFor(instance: Any): InMemoryBlackboard {
         val reader = AgentMetadataReader()
         val agent = reader.createAgentMetadata(instance) as CoreAgent
@@ -180,6 +196,13 @@ class AgentActionDelayTest {
                 .`as`("action delay (${ACTION_DELAY_MS}ms) should apply, not agent-level LONG")
                 .isGreaterThanOrEqualTo(ACTION_DELAY_MS - TOLERANCE_MS)
                 .isLessThan(Delay.LONG.millis / 2)
+        }
+
+        @Test
+        fun `delayMs=0 suppresses agent-level delay entirely`() {
+            assertThat(gap(blackboardFor(AgentWithZeroDelayOverridingAgentDelay())))
+                .`as`("explicit delayMs=0 must override agent LONG delay — gap must be near zero")
+                .isLessThan(TOLERANCE_MS)
         }
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
@@ -84,10 +84,8 @@ class DelayPolicyTest {
         }
 
         @Test
-        fun `negative millis is clamped to Fixed(0) not None`() {
-            val policy = DelayPolicy.of(-1L)
-            assertInstanceOf(DelayPolicy.Fixed::class.java, policy)
-            assertEquals(Duration.ZERO, policy.duration)
+        fun `negative millis returns SameAsAgent`() {
+            assertSame(DelayPolicy.SameAsAgent, DelayPolicy.of(-1L))
         }
     }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
@@ -30,13 +30,9 @@ class DelayPolicyTest {
 
         @Test
         fun `has negative millis sentinel`() {
-            assertEquals(-1L, DelayPolicy.SameAsAgent.millis)
+            assertEquals(-1L, DelayPolicy.Inherit.millis)
         }
 
-        @Test
-        fun `is singleton`() {
-            assertSame(DelayPolicy.SameAsAgent, DelayPolicy.SameAsAgent)
-        }
     }
 
     @Nested
@@ -53,8 +49,8 @@ class DelayPolicyTest {
     inner class OfDelay {
 
         @Test
-        fun `UNSET maps to SameAsAgent`() {
-            assertSame(DelayPolicy.SameAsAgent, DelayPolicy.of(Delay.UNSET))
+        fun `UNSET maps to Inherit`() {
+            assertSame(DelayPolicy.Inherit, DelayPolicy.of(Delay.UNSET))
         }
 
         @Test
@@ -91,8 +87,8 @@ class DelayPolicyTest {
         }
 
         @Test
-        fun `negative millis returns SameAsAgent`() {
-            assertSame(DelayPolicy.SameAsAgent, DelayPolicy.of(-1L))
+        fun `negative millis returns Inherit`() {
+            assertSame(DelayPolicy.Inherit, DelayPolicy.of(-1L))
         }
     }
 
@@ -102,8 +98,8 @@ class DelayPolicyTest {
         private val mapper = EmbabelObjectMapperHolder.createDefault().get()
 
         @Test
-        fun `SameAsAgent serializes to -1`() {
-            assertEquals("-1", mapper.writeValueAsString(DelayPolicy.SameAsAgent))
+        fun `Inherit serializes to -1`() {
+            assertEquals("-1", mapper.writeValueAsString(DelayPolicy.Inherit))
         }
 
         @Test
@@ -133,10 +129,10 @@ class DelayPolicyTest {
         }
 
         @Test
-        fun `SameAsAgent round-trips correctly`() {
-            val json = mapper.writeValueAsString(DelayPolicy.SameAsAgent)
+        fun `Inherit round-trips correctly`() {
+            val json = mapper.writeValueAsString(DelayPolicy.Inherit)
             val restored = mapper.readValue(json, DelayPolicy::class.java)
-            assertSame(DelayPolicy.SameAsAgent, restored)
+            assertSame(DelayPolicy.Inherit, restored)
         }
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
@@ -26,16 +26,16 @@ import java.time.Duration
 class DelayPolicyTest {
 
     @Nested
-    inner class None {
+    inner class SameAsAgent {
 
         @Test
         fun `has zero duration`() {
-            assertEquals(Duration.ZERO, DelayPolicy.None.duration)
+            assertEquals(Duration.ZERO, DelayPolicy.SameAsAgent.duration)
         }
 
         @Test
         fun `is singleton`() {
-            assertSame(DelayPolicy.None, DelayPolicy.None)
+            assertSame(DelayPolicy.SameAsAgent, DelayPolicy.SameAsAgent)
         }
     }
 
@@ -53,8 +53,8 @@ class DelayPolicyTest {
     inner class OfDelay {
 
         @Test
-        fun `NONE maps to None`() {
-            assertSame(DelayPolicy.None, DelayPolicy.of(Delay.NONE))
+        fun `NONE maps to SameAsAgent`() {
+            assertSame(DelayPolicy.SameAsAgent, DelayPolicy.of(Delay.NONE))
         }
 
         @Test
@@ -97,8 +97,8 @@ class DelayPolicyTest {
         private val mapper = EmbabelObjectMapperHolder.createDefault().get()
 
         @Test
-        fun `None serializes to 0`() {
-            assertEquals("0", mapper.writeValueAsString(DelayPolicy.None))
+        fun `SameAsAgent serializes to 0`() {
+            assertEquals("0", mapper.writeValueAsString(DelayPolicy.SameAsAgent))
         }
 
         @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.core
+
+import com.embabel.common.util.EmbabelObjectMapperHolder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class DelayPolicyTest {
+
+    @Nested
+    inner class None {
+
+        @Test
+        fun `has zero duration`() {
+            assertEquals(Duration.ZERO, DelayPolicy.None.duration)
+        }
+
+        @Test
+        fun `is singleton`() {
+            assertSame(DelayPolicy.None, DelayPolicy.None)
+        }
+    }
+
+    @Nested
+    inner class Fixed {
+
+        @Test
+        fun `holds given duration`() {
+            val policy = DelayPolicy.Fixed(5000L)
+            assertEquals(Duration.ofSeconds(5), policy.duration)
+        }
+    }
+
+    @Nested
+    inner class OfDelay {
+
+        @Test
+        fun `NONE maps to None`() {
+            assertSame(DelayPolicy.None, DelayPolicy.of(Delay.NONE))
+        }
+
+        @Test
+        fun `MEDIUM maps to 400ms`() {
+            assertEquals(Duration.ofMillis(400), DelayPolicy.of(Delay.MEDIUM).duration)
+        }
+
+        @Test
+        fun `LONG maps to 2 seconds`() {
+            assertEquals(Duration.ofSeconds(2), DelayPolicy.of(Delay.LONG).duration)
+        }
+    }
+
+    @Nested
+    inner class OfMillis {
+
+        @Test
+        fun `positive millis produces Fixed`() {
+            assertEquals(Duration.ofMillis(1500), DelayPolicy.of(1500L).duration)
+        }
+
+        @Test
+        fun `zero millis produces None`() {
+            assertSame(DelayPolicy.None, DelayPolicy.of(0L))
+        }
+
+        @Test
+        fun `negative millis produces None`() {
+            assertSame(DelayPolicy.None, DelayPolicy.of(-1L))
+        }
+    }
+
+    @Nested
+    inner class Serialization {
+
+        private val mapper = EmbabelObjectMapperHolder.createDefault().get()
+
+        @Test
+        fun `None serializes to 0`() {
+            assertEquals("0", mapper.writeValueAsString(DelayPolicy.None))
+        }
+
+        @Test
+        fun `Fixed serializes to millis`() {
+            assertEquals("400", mapper.writeValueAsString(DelayPolicy.Fixed(400L)))
+        }
+
+        @Test
+        fun `0 deserializes to None`() {
+            assertSame(DelayPolicy.None, mapper.readValue("0", DelayPolicy::class.java))
+        }
+
+        @Test
+        fun `positive millis deserializes to Fixed`() {
+            val policy = mapper.readValue("2000", DelayPolicy::class.java)
+            assertEquals(Duration.ofSeconds(2), policy.duration)
+        }
+
+        @Test
+        fun `round-trip Fixed`() {
+            val original = DelayPolicy.Fixed(1500L)
+            val json = mapper.writeValueAsString(original)
+            val restored = mapper.readValue(json, DelayPolicy::class.java)
+            assertEquals(original.duration, restored.duration)
+        }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.core
 
 import com.embabel.common.util.EmbabelObjectMapperHolder
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -76,13 +77,17 @@ class DelayPolicyTest {
         }
 
         @Test
-        fun `zero millis produces None`() {
-            assertSame(DelayPolicy.None, DelayPolicy.of(0L))
+        fun `zero millis produces Fixed(0) not None`() {
+            val policy = DelayPolicy.of(0L)
+            assertInstanceOf(DelayPolicy.Fixed::class.java, policy)
+            assertEquals(Duration.ZERO, policy.duration)
         }
 
         @Test
-        fun `negative millis produces None`() {
-            assertSame(DelayPolicy.None, DelayPolicy.of(-1L))
+        fun `negative millis is clamped to Fixed(0) not None`() {
+            val policy = DelayPolicy.of(-1L)
+            assertInstanceOf(DelayPolicy.Fixed::class.java, policy)
+            assertEquals(Duration.ZERO, policy.duration)
         }
     }
 
@@ -102,8 +107,10 @@ class DelayPolicyTest {
         }
 
         @Test
-        fun `0 deserializes to None`() {
-            assertSame(DelayPolicy.None, mapper.readValue("0", DelayPolicy::class.java))
+        fun `0 deserializes to Fixed with zero duration`() {
+            val policy = mapper.readValue("0", DelayPolicy::class.java)
+            assertInstanceOf(DelayPolicy.Fixed::class.java, policy)
+            assertEquals(Duration.ZERO, policy.duration)
         }
 
         @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/DelayPolicyTest.kt
@@ -29,8 +29,8 @@ class DelayPolicyTest {
     inner class SameAsAgent {
 
         @Test
-        fun `has zero duration`() {
-            assertEquals(Duration.ZERO, DelayPolicy.SameAsAgent.duration)
+        fun `has negative millis sentinel`() {
+            assertEquals(-1L, DelayPolicy.SameAsAgent.millis)
         }
 
         @Test
@@ -53,8 +53,15 @@ class DelayPolicyTest {
     inner class OfDelay {
 
         @Test
-        fun `NONE maps to SameAsAgent`() {
-            assertSame(DelayPolicy.SameAsAgent, DelayPolicy.of(Delay.NONE))
+        fun `UNSET maps to SameAsAgent`() {
+            assertSame(DelayPolicy.SameAsAgent, DelayPolicy.of(Delay.UNSET))
+        }
+
+        @Test
+        fun `NONE maps to Fixed zero`() {
+            val policy = DelayPolicy.of(Delay.NONE)
+            assertInstanceOf(DelayPolicy.Fixed::class.java, policy)
+            assertEquals(Duration.ZERO, policy.duration)
         }
 
         @Test
@@ -95,8 +102,8 @@ class DelayPolicyTest {
         private val mapper = EmbabelObjectMapperHolder.createDefault().get()
 
         @Test
-        fun `SameAsAgent serializes to 0`() {
-            assertEquals("0", mapper.writeValueAsString(DelayPolicy.SameAsAgent))
+        fun `SameAsAgent serializes to -1`() {
+            assertEquals("-1", mapper.writeValueAsString(DelayPolicy.SameAsAgent))
         }
 
         @Test
@@ -123,6 +130,13 @@ class DelayPolicyTest {
             val json = mapper.writeValueAsString(original)
             val restored = mapper.readValue(json, DelayPolicy::class.java)
             assertEquals(original.duration, restored.duration)
+        }
+
+        @Test
+        fun `SameAsAgent round-trips correctly`() {
+            val json = mapper.writeValueAsString(DelayPolicy.SameAsAgent)
+            val restored = mapper.readValue(json, DelayPolicy::class.java)
+            assertSame(DelayPolicy.SameAsAgent, restored)
         }
     }
 }

--- a/embabel-agent-docs/src/main/asciidoc/reference/annotations/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/annotations/page.adoc
@@ -15,7 +15,9 @@ You must provide the `description` parameter, which is a human-readable descript
 This is particularly important as it may be used by the LLM in agent selection.
 
 The optional `delay` parameter sets a default delay tier for all actions within this agent, using the `Delay` enum (`NONE`, `MEDIUM`, `LONG`).
-Individual actions can override this with their own `delayMs` value.
+When omitted, the default is `Delay.UNSET`, which means actions inherit the process-level delay.
+`Delay.NONE` explicitly sets zero delay for all actions in the agent, overriding any process-level delay.
+Individual actions can override the agent-level delay with their own `delayMs` value.
 
 ==== The `@EmbabelComponent` annotation
 
@@ -51,8 +53,8 @@ Defaults to false.
 - `delayMs`: Pause in milliseconds inserted after the planner selects this action but before the action body executes.
 Useful for rate-limited APIs where breathing room is needed between calls.
 Overrides any agent-level `delay` default set on `@Agent`.
-Use `Delay.NONE_MS`, `Delay.MEDIUM_MS`, or `Delay.LONG_MS` for named values, or supply an arbitrary millisecond value (e.g., `1500L`) for precise control.
-A value of `-1` (the default) means inherit from the agent or process level.
+Use `Delay.NONE_MS` (0), `Delay.MEDIUM_MS`, or `Delay.LONG_MS` for named values, or supply an arbitrary millisecond value (e.g., `1500L`) for precise control.
+A value of `-1` (the default, `Delay.UNSET_MS`) means inherit from the agent or process level.
 A value of `0` (or `Delay.NONE_MS`) explicitly suppresses any agent- or process-level delay — it does not inherit.
 
 ===== Clearing the Blackboard

--- a/embabel-agent-docs/src/main/asciidoc/reference/annotations/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/annotations/page.adoc
@@ -53,6 +53,7 @@ Useful for rate-limited APIs where breathing room is needed between calls.
 Overrides any agent-level `delay` default set on `@Agent`.
 Use `Delay.NONE_MS`, `Delay.MEDIUM_MS`, or `Delay.LONG_MS` for named values, or supply an arbitrary millisecond value (e.g., `1500L`) for precise control.
 A value of `-1` (the default) means inherit from the agent or process level.
+A value of `0` (or `Delay.NONE_MS`) explicitly suppresses any agent- or process-level delay — it does not inherit.
 
 ===== Clearing the Blackboard
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/annotations/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/annotations/page.adoc
@@ -14,6 +14,9 @@ It will also be registered with the agent framework, so it can be used in agent 
 You must provide the `description` parameter, which is a human-readable description of the agent.
 This is particularly important as it may be used by the LLM in agent selection.
 
+The optional `delay` parameter sets a default delay tier for all actions within this agent, using the `Delay` enum (`NONE`, `MEDIUM`, `LONG`).
+Individual actions can override this with their own `delayMs` value.
+
 ==== The `@EmbabelComponent` annotation
 
 This annotation is used on a class to indicate that this class exposes actions, goals and conditions that may be used by agents, but is not an agent in itself.
@@ -43,8 +46,13 @@ When true, all objects on the blackboard are removed except the action's output.
 This is useful for resetting context in multi-step workflows.
 It can also make persistence of flows more efficient by dispensing with objects that are no longer needed.
 Defaults to false.
-- `cost`:Relative cost of the action from 0-1. Defaults to 0.0.
+- `cost`: Relative cost of the action from 0-1. Defaults to 0.0.
 - `value`: Relative value of performing the action from 0-1. Defaults to 0.0.
+- `delayMs`: Pause in milliseconds inserted after the planner selects this action but before the action body executes.
+Useful for rate-limited APIs where breathing room is needed between calls.
+Overrides any agent-level `delay` default set on `@Agent`.
+Use `Delay.NONE_MS`, `Delay.MEDIUM_MS`, or `Delay.LONG_MS` for named values, or supply an arbitrary millisecond value (e.g., `1500L`) for precise control.
+A value of `-1` (the default) means inherit from the agent or process level.
 
 ===== Clearing the Blackboard
 


### PR DESCRIPTION
# Overview: Action delay policy

Adds delay policy support for agent actions.  
For example, to control rate limits.
```@Agent(delay = Delay.MEDIUM)``` sets a default delay for all actions; 
```@Action(delayMs = 1500L)``` sets a  millisecond override per action.
 Action-level delay takes precedence over agent-level.

Closes: #195 

