### PR TITLE
Improve shell command message when agent is empty

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -82,7 +82,7 @@ internal data class AgenticInfo(
             errors += "Both @Agentic and @Agent annotations found on ${targetType.name}. Treating class as Agent, but both should not be used"
         }
         if (agentAnnotation != null && agentAnnotation.description.isBlank()) {
-            errors + "No description provided for @${Agent::class.java.simpleName} on ${targetType.name}"
+            errors += "No description provided for @${Agent::class.java.simpleName} on ${targetType.name}"
         }
         return errors
     }
@@ -157,7 +157,7 @@ class AgentMetadataReader(
                 // Don't put this behind skipAgentDeploymentOnError as any bean can be reached here.
                 return null
         }
-
+        val agenticType =  if (agenticInfo.isAgent()) "Agent" else "Agentic component"
         if (agenticInfo.validationErrors().isNotEmpty()) {
             logger.warn(
                 agenticInfo.validationErrors().joinToString("\n"),
@@ -166,7 +166,7 @@ class AgentMetadataReader(
                 targetType.name,
             )
             if (skipAgentDeploymentOnError) {
-                logSkipAgentDeploymentOnError( "Agent ${targetType.name} is rejected as it has validation errors as reported above.")
+                logSkipAgentDeploymentOnError( "$agenticType ${targetType.name} is rejected as it has validation errors as reported above.")
                 return null
             }
         }
@@ -221,13 +221,13 @@ class AgentMetadataReader(
 
         if (actionMethods.isEmpty() && goals.isEmpty() && conditionMethods.isEmpty()) {
             logger.warn(
-                "❓No methods annotated with @{} or @{} and no goals defined on {}",
+                "$agenticType ${targetType.name} is not registered due to no methods annotated with @{} or @{} and no goals defined on {}",
                 Action::class.simpleName,
                 Condition::class.simpleName,
                 targetType.name,
             )
             if (skipAgentDeploymentOnError) {
-                logSkipAgentDeploymentOnError( "Agent ${targetType.name} is rejected as it does not have any action, condition and goals.")
+                logSkipAgentDeploymentOnError( "$agenticType ${targetType.name} is rejected as it does not have any action, condition and goals.")
                 return null
             }
         }
@@ -241,7 +241,7 @@ class AgentMetadataReader(
                         targetType.name,
                     )
                     if (skipAgentDeploymentOnError) {
-                        logSkipAgentDeploymentOnError( "Agent ${targetType.name} is rejected as it does not have any @AchievesGoal action.")
+                        logSkipAgentDeploymentOnError( "$agenticType ${targetType.name} is rejected as it does not have any @AchievesGoal action.")
                         return null
                     }
                 } else if (goalActions.size > 1) {
@@ -251,7 +251,7 @@ class AgentMetadataReader(
                         targetType.name,
                     )
                     if (skipAgentDeploymentOnError) {
-                        logSkipAgentDeploymentOnError( "Agent ${targetType.name} is rejected as it has more than one @AchievesGoal action.")
+                        logSkipAgentDeploymentOnError( "$agenticType ${targetType.name} is rejected as it has more than one @AchievesGoal action.")
                         return null
                     }
                 }
@@ -275,14 +275,14 @@ class AgentMetadataReader(
                     val typeNames = distinctGoalTypes.joinToString { it.simpleName.ifEmpty { it.name } }
                     if (restrictedGoals) {
                         logger.warn(
-                            "Agent {} has @AchievesGoal actions returning distinct types [{}] - rejected. Set embabel.agent.platform.planner.restricted-goals=false to allow",
+                            "$agenticType {} has @AchievesGoal actions returning distinct types [{}] - rejected. Set embabel.agent.platform.planner.restricted-goals=false to allow",
                             targetType.name,
                             typeNames,
                         )
                         return null
                     }
                     logger.debug(
-                        "Agent {} has @AchievesGoal actions returning distinct types [{}] - allowing (restricted-goals=false)",
+                        "$agenticType {} has @AchievesGoal actions returning distinct types [{}] - allowing (restricted-goals=false)",
                         targetType.name,
                         typeNames,
                     )

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
@@ -341,7 +341,7 @@ abstract class AbstractAgentProcess(
      */
     private fun executeTurn(): AgentProcess {
         if (agent.goals.isEmpty() && processOptions.plannerType.needsGoals) {
-            logger.info("🛑 Process {} has no goals: {}", this.id, agent.goals)
+            logger.error("🛑 Process {} has no goals", this.id)
             error("Agent ${agent.name} has no goals: ${agent.infoString(verbose = true)}")
         }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/annotation/support/testTypes.kt
@@ -870,9 +870,19 @@ class AgentWithOperationContextConstructorInjection(
     fun act(input: UserInput): PersonWithReverseTool = PersonWithReverseTool(input.content)
 }
 
-@Agent(description = "goal method is not annotated with Action")
+@Agent(description = "goal method is not annotated with Action on agent")
 class AgentWithAchievesGoalNoActionAnnotation {
     @Action
+    fun makeFrogFromPerson(userInput: UserInput): Frog {
+        return Frog(userInput.content)
+    }
+
+    @AchievesGoal(description = "goal")
+    fun goal(frog: Frog): PersonWithReverseTool = PersonWithReverseTool(frog.name)
+}
+
+@EmbabelComponent()
+class AgenticComponentWithNoActionNoConditionNoGoalAnnotation {
     fun makeFrogFromPerson(userInput: UserInput): Frog {
         return Frog(userInput.content)
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/AchievableGoalValidatorTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/AchievableGoalValidatorTest.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.validation
 import com.embabel.agent.api.annotation.support.AgentMetadataReader
 import com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation
 import com.embabel.agent.api.annotation.support.AgentWithValidAchievesGoalMethod
+import com.embabel.agent.api.annotation.support.AgenticComponentWithNoActionNoConditionNoGoalAnnotation
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
@@ -40,11 +41,23 @@ class AchievableGoalValidatorTest {
     }
 
     @Test
-    fun `no Action annotation on AchievesGoal method but skip-agent-on-error is true`(output: CapturedOutput) {
+    fun `no Action annotation on AchievesGoal method of an Agent but skip-agent-on-error is true`(output: CapturedOutput) {
         val reader = AgentMetadataReader(skipAgentDeploymentOnError = true)
         val agentScope = reader.createAgentMetadata(AgentWithAchievesGoalNoActionAnnotation())
         assertNull(agentScope, "Validation error is unexpectedly ignored.")
         assertTrue(output.out.contains(noActionErrorMessage), "Error message about missing @Action is absent.")
+        val className = "com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation"
+        assertTrue(output.out.contains("Agent $className is rejected as it has validation errors as reported above."), "Error message mentioning agent is missing.")
+    }
+
+    @Test
+    fun `no Action annotation on AchievesGoal method of an Agentic component but skip-agent-on-error is true`(output: CapturedOutput) {
+        val reader = AgentMetadataReader(skipAgentDeploymentOnError = true)
+        val agentScope = reader.createAgentMetadata(AgenticComponentWithNoActionNoConditionNoGoalAnnotation())
+        assertNull(agentScope, "Validation error is unexpectedly ignored.")
+        val className = "com.embabel.agent.api.annotation.support.AgenticComponentWithNoActionNoConditionNoGoalAnnotation"
+        assertTrue(output.out.contains("Agentic component $className is not registered due to no methods annotated with @Action or @Condition and no goals defined on $className"), "Error message about missing @Action is absent.")
+        assertTrue(output.out.contains("Agentic component $className is rejected as it does not have any action, condition and goals."), "Error message mentioning Agentic component is missing.")
     }
 
     @Test

--- a/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt
+++ b/embabel-agent-shell/src/main/kotlin/com/embabel/agent/shell/ShellCommands.kt
@@ -189,13 +189,17 @@ class ShellCommands(
 
     @ShellMethod("List agents")
     fun agents(): String {
+        val agents = agentPlatform.agents()
+        if (agents.isEmpty()) {
+            return "No agents registered"
+        }
         val detail = "${"Agents:".bold()}\n${
-            agentPlatform.agents()
+            agents
                 .joinToString(separator = "\n${"-".repeat(shellProperties.lineLength)}\n") {
                     it.infoString(verbose = true, indent = 1)
                 }
         }"
-        return detail + "\n\nTL;DR\n${agentPlatform.agents().joinToString("\n") { "${it.name}: ${it.description}" }}"
+        return detail + "\n\nSummary\n${agents.joinToString("\n") { "${it.name}: ${it.description}" }}"
     }
 
     @ShellMethod("List actions")
@@ -204,7 +208,7 @@ class ShellCommands(
             agentPlatform.actions
                 .joinToString(separator = "\n") { it.infoString(verbose = true, indent = 1) }
         }"
-        return detail + "\n\nTL;DR\n${agentPlatform.actions.joinToString("\n") { "${it.name}: ${it.description}" }}"
+        return detail + "\n\nSummary\n${agentPlatform.actions.joinToString("\n") { "${it.name}: ${it.description}" }}"
     }
 
     @ShellMethod("List conditions")

--- a/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/ShellCommandsAgentsTest.kt
+++ b/embabel-agent-shell/src/test/kotlin/com/embabel/agent/shell/ShellCommandsAgentsTest.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.shell
+
+import com.embabel.agent.api.common.ToolsStats
+import com.embabel.agent.api.common.autonomy.Autonomy
+import com.embabel.agent.api.common.autonomy.AutonomyProperties
+import com.embabel.agent.core.Agent
+import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.shell.config.ShellProperties
+import com.embabel.agent.spi.logging.ColorPalette
+import com.embabel.agent.spi.logging.DefaultColorPalette
+import com.embabel.agent.spi.logging.LoggingPersonality
+import com.embabel.common.ai.model.ModelProvider
+import com.embabel.common.util.EmbabelObjectMapperHolder
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.ConfigurableEnvironment
+
+/**
+ * Regression tests for the agents shell command (issue #1741):
+ * empty-state messaging and preserved good output when agents exist.
+ */
+class ShellCommandsAgentsTest {
+
+    private val autonomy: Autonomy = mockk(relaxed = true)
+    private val modelProvider: ModelProvider = mockk(relaxed = true)
+    private val terminalServices: TerminalServices = mockk(relaxed = true)
+    private val environment: ConfigurableEnvironment = mockk(relaxed = true)
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+    private val colorPalette: ColorPalette = DefaultColorPalette()
+    private val loggingPersonality: LoggingPersonality = mockk(relaxed = true) {
+        every { logger } returns mockk(relaxed = true)
+        every { colorPalette } returns this@ShellCommandsAgentsTest.colorPalette
+    }
+    private val toolsStats: ToolsStats = mockk(relaxed = true)
+    private val context: ConfigurableApplicationContext = mockk(relaxed = true)
+    private val agentPlatform: AgentPlatform = mockk(relaxed = true)
+    private val autonomyProperties: AutonomyProperties = mockk(relaxed = true)
+    private val shellProperties = ShellProperties()
+
+    private lateinit var shellCommands: ShellCommands
+
+    @BeforeEach
+    fun setUp() {
+        every { autonomy.agentPlatform } returns agentPlatform
+        every { autonomy.properties } returns autonomyProperties
+        shellCommands = ShellCommands(
+            autonomy = autonomy,
+            modelProvider = modelProvider,
+            terminalServices = terminalServices,
+            environment = environment,
+            embabelObjectMapperHolder = EmbabelObjectMapperHolder.createDefault(),
+            colorPalette = colorPalette,
+            loggingPersonality = loggingPersonality,
+            toolsStats = toolsStats,
+            context = context,
+            shellProperties = shellProperties,
+            asyncer =  mockk(relaxed = true)
+        )
+    }
+
+    private fun agent(
+        name: String,
+        description: String,
+        provider: String = "test-provider",
+    ) = Agent(
+        name = name,
+        provider = provider,
+        description = description,
+        actions = emptyList(),
+        goals = emptySet(),
+    )
+
+    /** Strip ANSI escape codes so assertions ignore bold/color styling. */
+    private fun String.stripAnsi(): String =
+        replace(Regex("\u001B\\[[;\\d]*m"), "")
+
+    @Nested
+    inner class EmptyAgents {
+
+        @Test
+        fun `shows no agents registered when platform has no agents`() {
+            every { agentPlatform.agents() } returns emptyList()
+
+            val result = shellCommands.agents()
+
+            assertEquals("No agents registered", result)
+        }
+    }
+
+    @Nested
+    inner class RegisteredAgents {
+
+        @Test
+        fun `single agent has detailed listing and summary`() {
+            val demo = agent(name = "demo-agent", description = "A demo agent")
+            every { agentPlatform.agents() } returns listOf(demo)
+
+            val result = shellCommands.agents().stripAnsi()
+
+            assertTrue(result.contains("Agents:"), "Expected Agents header, got: $result")
+            assertTrue(result.contains("description: A demo agent"), "Expected detailed description, got: $result")
+            assertTrue(result.contains("provider: test-provider"), "Expected provider in detail, got: $result")
+            assertTrue(result.contains("name: demo-agent"), "Expected name in detail, got: $result")
+            assertTrue(result.contains("Summary"), "Expected Summary section, got: $result")
+            assertTrue(
+                result.contains("demo-agent: A demo agent"),
+                "Expected name:description summary line, got: $result",
+            )
+            assertTrue(
+                result.indexOf("Agents:") < result.indexOf("Summary"),
+                "Detail listing should come before Summary, got: $result",
+            )
+            assertTrue(
+                result.indexOf("description: A demo agent") < result.indexOf("Summary"),
+                "Verbose detail should appear before Summary, got: $result",
+            )
+            assertFalse(
+                result.contains("No agents registered"),
+                "Should not claim no agents when agents exist: $result",
+            )
+        }
+
+        @Test
+        fun `multiple agents are separated and all appear in summary`() {
+            val poet = agent(name = "Poet", description = "Write poems")
+            val coder = agent(name = "Coder", description = "Answer coding questions")
+            every { agentPlatform.agents() } returns listOf(poet, coder)
+
+            val result = shellCommands.agents().stripAnsi()
+            val separator = "-".repeat(shellProperties.lineLength)
+
+            assertTrue(result.contains("description: Write poems"), "Expected Poet detail, got: $result")
+            assertTrue(
+                result.contains("description: Answer coding questions"),
+                "Expected Coder detail, got: $result",
+            )
+            assertTrue(
+                result.contains(separator),
+                "Expected separator between agents of length ${shellProperties.lineLength}, got: $result",
+            )
+            assertTrue(
+                result.indexOf("description: Write poems") < result.indexOf(separator) &&
+                        result.indexOf(separator) < result.indexOf("description: Answer coding questions"),
+                "Separator should sit between agent detail blocks, got: $result",
+            )
+
+            val summaryStart = result.indexOf("Summary")
+            assertTrue(summaryStart >= 0, "Expected Summary section, got: $result")
+            val summary = result.substring(summaryStart)
+            assertTrue(summary.contains("Poet: Write poems"), "Expected Poet in summary: $summary")
+            assertTrue(
+                summary.contains("Coder: Answer coding questions"),
+                "Expected Coder in summary: $summary",
+            )
+            assertTrue(
+                summary.indexOf("Poet: Write poems") < summary.indexOf("Coder: Answer coding questions"),
+                "Summary should preserve agent order, got: $summary",
+            )
+        }
+
+        @Test
+        fun `summary is only name and description lines after the Summary header`() {
+            val agent = agent(name = "demo-agent", description = "A demo agent")
+            every { agentPlatform.agents() } returns listOf(agent)
+
+            val result = shellCommands.agents().stripAnsi()
+            val summaryLines = result.substringAfter("Summary").trim().lines()
+
+            assertEquals(
+                listOf("demo-agent: A demo agent"),
+                summaryLines,
+                "Summary should be only concise name:description lines",
+            )
+        }
+    }
+}


### PR DESCRIPTION

Fixes #1741 
Most of the changes are taken from #1786  (Contributed by @simeshev)

Changes:

- Added an explicit empty-state response for the agents shell command and preserve detailed output + a concise summary when agents exist.
- Improved agent registration failure warnings.
- Adjusted logging severity when an agent process runs with no goals (where goals are required).

**Test**
   - Added tests in ShellCommandsAgentsTest
   - Tested on a real agent application  with `embabel.agent.api.validation.manager.skip-agent-deployment-on-error=true` and agent did not have any actions/goal/conditions  and `No agents registered` displayed as expected.
  
 ```
    00:06:01.831 [main] WARN  AgentMetadataReader - No @EmbabelComponent or @Agent annotation found on org.springframework.shell.boot.TerminalUIAutoConfiguration
00:06:01.831 [main] WARN  AgentMetadataReader - No @EmbabelComponent or @Agent annotation found on org.springframework.shell.component.ViewComponentExecutor
00:06:01.831 [main] INFO  DelegatingAgentScanningBeanPostProcessor - All deferred beans were post-processed.
00:06:01.836 [main] INFO  Agent101Application - Started Agent101Application in 1.241 seconds (process running for 1.362)
embabel> 
<===<====No agents registeredTING [29s]
embabel> n
<===========--> 88% EXECUTING [1m 1s]
```
