### PR TITLE
Add public entry point for assembling a persistent AgentProcessRepository

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistence.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistence.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.persistence
+
+import com.embabel.agent.api.common.PlatformServices
+import com.embabel.agent.core.Agent
+import com.embabel.agent.core.AgentProcessRepository
+import com.embabel.agent.core.persistence.BlackboardEntrySerializer
+import com.embabel.agent.spi.support.persistence.AgentProcessSnapshotFactory
+import com.embabel.agent.spi.support.persistence.AgentProcessSnapshotRestorer
+import com.embabel.agent.spi.support.persistence.BlackboardEntrySerializerResolver
+import com.embabel.agent.spi.support.persistence.InMemoryBlackboardSnapshotter
+import com.embabel.agent.spi.support.persistence.JacksonAgentProcessStateSerializer
+import com.embabel.agent.spi.support.persistence.JacksonBlackboardEntrySerializer
+import com.embabel.agent.spi.support.persistence.LifecycleCheckpointPolicy
+import com.embabel.agent.spi.support.persistence.PersistentAgentProcessRepository
+import tools.jackson.databind.ObjectMapper
+import java.time.Clock
+
+/**
+ * Entry point for assembling a durable [AgentProcessRepository].
+ *
+ * An application supplies an [AgentProcessSnapshotStore] for its own backend, and
+ * this builds the snapshot, serialization and restore machinery around it. That
+ * machinery stays internal deliberately: the snapshot model is an implementation
+ * detail that must be free to change, whereas the pieces an integrator supplies
+ * ([AgentProcessSnapshotStore], [AgentProcessCheckpointPolicy] and
+ * [BlackboardEntrySerializer]) are stable contracts.
+ *
+ * ```
+ * val repository = AgentProcessPersistence.persistentRepository(
+ *     runtimeRepository = InMemoryAgentProcessRepository(),
+ *     snapshotStore = myRedisSnapshotStore,
+ *     objectMapper = objectMapper,
+ *     agents = agentPlatform::agents,
+ *     platformServices = { agentPlatform.platformServices },
+ * )
+ * ```
+ */
+object AgentProcessPersistence {
+
+    /**
+     * Decorate [runtimeRepository] so that processes are checkpointed to
+     * [snapshotStore] and restored from it when runtime state has been lost.
+     *
+     * The returned repository reads through: [AgentProcessRepository.findById]
+     * falls back to the snapshot store on a miss and warms the runtime
+     * repository with what it restores.
+     *
+     * @param runtimeRepository fast, usually in-memory, repository holding live processes
+     * @param snapshotStore durable backend supplied by the application
+     * @param objectMapper mapper used for the snapshot payload and for blackboard
+     * values not claimed by a supplied serializer
+     * @param agents supplier of currently registered agents. Snapshots store the
+     * agent name, so restore binds a process to the live definition; this is a
+     * supplier because the platform is constructed after the repository
+     * @param platformServices supplier of platform services for restored processes,
+     * a supplier for the same reason
+     * @param checkpointPolicy when a process is written to the snapshot store.
+     * Defaults to [LifecycleCheckpointPolicy], which checkpoints processes that
+     * are `WAITING` or finished
+     * @param blackboardEntrySerializers application serializers for blackboard
+     * values needing special handling, consulted in Spring `@Order` before the
+     * Jackson fallback
+     * @param clock clock used to stamp snapshots
+     */
+    fun persistentRepository(
+        runtimeRepository: AgentProcessRepository,
+        snapshotStore: AgentProcessSnapshotStore,
+        objectMapper: ObjectMapper,
+        agents: () -> Collection<Agent>,
+        platformServices: () -> PlatformServices,
+        checkpointPolicy: AgentProcessCheckpointPolicy = LifecycleCheckpointPolicy,
+        blackboardEntrySerializers: List<BlackboardEntrySerializer> = emptyList(),
+        clock: Clock = Clock.systemUTC(),
+    ): AgentProcessRepository {
+        val blackboardSnapshotter = InMemoryBlackboardSnapshotter(
+            BlackboardEntrySerializerResolver(
+                serializers = blackboardEntrySerializers,
+                fallback = JacksonBlackboardEntrySerializer(objectMapper),
+            )
+        )
+        return PersistentAgentProcessRepository(
+            runtimeRepository = runtimeRepository,
+            snapshotStore = snapshotStore,
+            checkpointPolicy = checkpointPolicy,
+            snapshotFactory = AgentProcessSnapshotFactory(blackboardSnapshotter),
+            snapshotSerializer = JacksonAgentProcessStateSerializer(objectMapper, clock),
+            snapshotRestorer = AgentProcessSnapshotRestorer(blackboardSnapshotter),
+            agents = agents,
+            platformServices = platformServices,
+        )
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistenceTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistenceTest.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.persistence
+
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.AgentProcessRepository
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.persistence.BlackboardEntryDeserializationContext
+import com.embabel.agent.core.persistence.BlackboardEntrySerializationContext
+import com.embabel.agent.core.persistence.BlackboardEntrySerializer
+import com.embabel.agent.core.persistence.SerializedBlackboardValue
+import com.embabel.agent.core.support.DslWaitingAgent
+import com.embabel.agent.core.support.InMemoryBlackboard
+import com.embabel.agent.core.support.SimpleAgentProcess
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.spi.support.DefaultPlannerFactory
+import com.embabel.agent.spi.support.InMemoryAgentProcessRepository
+import com.embabel.agent.spi.support.persistence.InMemoryAgentProcessSnapshotStore
+import com.embabel.agent.spi.support.persistence.WaitForCheckpointPolicy
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.common.util.EmbabelObjectMapperHolder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+
+/**
+ * Proves that a persistent repository can be assembled and used through public
+ * API only.
+ *
+ * Deliberately references no `internal` type and takes no
+ * [com.embabel.agent.core.support.InternalAgentStateApi] opt-in, so it exercises
+ * exactly what an application or a third-party snapshot store module can reach.
+ * Kotlin `internal` is module-wide, so the compiler would permit more here; the
+ * restriction is the point of the test.
+ */
+class AgentProcessPersistenceTest {
+
+    private val objectMapper = EmbabelObjectMapperHolder.createDefault().get()
+
+    @Test
+    fun `checkpoints a waiting process`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = persistentRepository(snapshotStore = store)
+
+        repository.save(waitingProcess("p1"))
+
+        val snapshot = store.findByProcessId("p1")
+        assertNotNull(snapshot)
+        assertEquals(AgentProcessStatusCode.WAITING, snapshot?.status)
+        assertEquals(1L, snapshot?.version)
+    }
+
+    @Test
+    fun `restores a process after the runtime repository is lost`() {
+        // The Kubernetes autoscaling case: the pod holding the process is gone,
+        // and a different node must resume it from durable state alone.
+        val store = InMemoryAgentProcessSnapshotStore()
+        val original = waitingProcess("p1")
+        persistentRepository(snapshotStore = store).save(original)
+
+        val onAnotherNode = persistentRepository(
+            runtimeRepository = InMemoryAgentProcessRepository(),
+            snapshotStore = store,
+        )
+        val restored = onAnotherNode.findById("p1")
+
+        assertNotNull(restored)
+        assertEquals("p1", restored?.id)
+        assertEquals(AgentProcessStatusCode.WAITING, restored?.status)
+        assertEquals(original.history, restored?.history)
+    }
+
+    @Test
+    fun `repopulates the runtime repository on restore`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        persistentRepository(snapshotStore = store).save(waitingProcess("p1"))
+
+        val runtime = InMemoryAgentProcessRepository()
+        persistentRepository(runtimeRepository = runtime, snapshotStore = store).findById("p1")
+
+        assertNotNull(runtime.findById("p1"), "restore should warm the runtime repository")
+    }
+
+    @Test
+    fun `defaults to checkpointing finished processes as well as waiting ones`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = persistentRepository(snapshotStore = store)
+        val process = waitingProcess("p1")
+
+        repository.save(process)
+        repository.update(process)
+
+        assertEquals(2L, store.findByProcessId("p1")?.version, "update should advance the version")
+    }
+
+    @Test
+    fun `honours a supplied checkpoint policy`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = persistentRepository(
+            snapshotStore = store,
+            checkpointPolicy = WaitForCheckpointPolicy,
+        )
+
+        repository.save(newProcess("p1"))
+
+        assertNull(store.findByProcessId("p1"), "a NOT_STARTED process is not a wait checkpoint")
+    }
+
+    @Test
+    fun `applies a custom blackboard entry serializer`() {
+        val serializer = RecordingSerializer()
+        val repository = persistentRepository(blackboardEntrySerializers = listOf(serializer))
+
+        repository.save(waitingProcess("p1"))
+
+        assertTrue(serializer.used, "a registered serializer should take precedence over the Jackson fallback")
+    }
+
+    @Test
+    fun `deletes from both the runtime repository and the snapshot store`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val runtime = InMemoryAgentProcessRepository()
+        val repository = persistentRepository(runtimeRepository = runtime, snapshotStore = store)
+        val process = waitingProcess("p1")
+        repository.save(process)
+
+        repository.delete(process)
+
+        assertNull(store.findByProcessId("p1"))
+        assertNull(runtime.findById("p1"))
+    }
+
+    private fun persistentRepository(
+        runtimeRepository: AgentProcessRepository = InMemoryAgentProcessRepository(),
+        snapshotStore: AgentProcessSnapshotStore = InMemoryAgentProcessSnapshotStore(),
+        checkpointPolicy: AgentProcessCheckpointPolicy? = null,
+        blackboardEntrySerializers: List<BlackboardEntrySerializer> = emptyList(),
+    ): AgentProcessRepository =
+        if (checkpointPolicy == null) {
+            AgentProcessPersistence.persistentRepository(
+                runtimeRepository = runtimeRepository,
+                snapshotStore = snapshotStore,
+                objectMapper = objectMapper,
+                agents = { listOf(DslWaitingAgent) },
+                platformServices = { dummyPlatformServices() },
+                blackboardEntrySerializers = blackboardEntrySerializers,
+            )
+        } else {
+            AgentProcessPersistence.persistentRepository(
+                runtimeRepository = runtimeRepository,
+                snapshotStore = snapshotStore,
+                objectMapper = objectMapper,
+                agents = { listOf(DslWaitingAgent) },
+                platformServices = { dummyPlatformServices() },
+                checkpointPolicy = checkpointPolicy,
+                blackboardEntrySerializers = blackboardEntrySerializers,
+            )
+        }
+
+    private fun waitingProcess(id: String): AgentProcess =
+        newProcess(id).also {
+            assertEquals(AgentProcessStatusCode.WAITING, it.run().status)
+        }
+
+    private fun newProcess(id: String): SimpleAgentProcess {
+        val blackboard = InMemoryBlackboard()
+        blackboard += UserInput("Rod")
+        return SimpleAgentProcess(
+            id = id,
+            parentId = null,
+            agent = DslWaitingAgent,
+            processOptions = ProcessOptions(),
+            blackboard = blackboard,
+            platformServices = dummyPlatformServices(),
+            plannerFactory = DefaultPlannerFactory,
+        )
+    }
+
+    private class RecordingSerializer : BlackboardEntrySerializer {
+
+        var used: Boolean = false
+
+        override fun supportsSerialization(value: Any): Boolean = value is UserInput
+
+        override fun serialize(
+            value: Any,
+            context: BlackboardEntrySerializationContext,
+        ): SerializedBlackboardValue {
+            used = true
+            return SerializedBlackboardValue(
+                typeName = value.javaClass.name,
+                contentType = MediaType.TEXT_PLAIN_VALUE,
+                payload = value.toString().toByteArray(),
+            )
+        }
+
+        override fun deserialize(
+            value: SerializedBlackboardValue,
+            context: BlackboardEntryDeserializationContext,
+        ): Any = value.payload.toString(Charsets.UTF_8)
+    }
+}


### PR DESCRIPTION
This pull request introduces the new `AgentProcessPersistence` API for assembling a durable `AgentProcessRepository`, along with a comprehensive public test suite. The new API allows applications to easily create persistent agent process repositories by supplying their own snapshot store and optional customizations, while keeping implementation details encapsulated. The accompanying test ensures the public API is sufficient and works as intended.

New API for persistent agent process repositories:

* Added the `AgentProcessPersistence` object, which provides the `persistentRepository` method to assemble a persistent `AgentProcessRepository` from user-supplied components, supporting checkpointing and restoration of agent processes.

Public API test coverage:

* Introduced `AgentProcessPersistenceTest`, a public-facing test that verifies the persistent repository can be assembled and used without accessing internals, covering checkpointing, restoration, custom serializers, checkpoint policies, and deletion behavior.