### PR TITLE
Persistence activates when the context contains an AgentProcessSnapshotStore Bean

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -24,13 +24,17 @@ import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.api.event.observation.AgentInstrumentation
 import com.embabel.agent.api.event.observation.InternalObservabilityApi
 import com.embabel.agent.api.event.observation.NoOpAgentInstrumentation
+import com.embabel.agent.core.AgentPlatform
 import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.core.ToolGroup
 import com.embabel.agent.core.internal.LlmOperations
+import com.embabel.agent.core.persistence.BlackboardEntrySerializer
 import com.embabel.agent.spi.*
 import com.embabel.agent.spi.logging.ColorPalette
 import com.embabel.agent.spi.logging.DefaultColorPalette
 import com.embabel.agent.spi.logging.LoggingAgenticEventListener
+import com.embabel.agent.spi.persistence.AgentProcessPersistence
+import com.embabel.agent.spi.persistence.AgentProcessSnapshotStore
 import com.embabel.agent.spi.support.*
 import com.embabel.common.util.EmbabelObjectMapperHolder
 import com.embabel.common.ai.autoconfig.ProviderInitialization
@@ -64,6 +68,7 @@ import org.springframework.context.annotation.Primary
     ConfigurableModelProviderProperties::class,
     AgentPlatformProperties::class,
     ProcessRepositoryProperties::class,
+    AgentProcessPersistenceProperties::class,
 )
 class AgentPlatformConfiguration(
 ) {
@@ -140,10 +145,48 @@ class AgentPlatformConfiguration(
         rankingProperties = rankingProperties,
     )
 
+    /**
+     * Runtime repository, decorated for durability when the application supplies an
+     * [AgentProcessSnapshotStore]. Without a store this is the in-memory repository
+     * exactly as before, so behaviour is unchanged for applications that add nothing.
+     *
+     * [agentPlatform] is an [ObjectProvider] because the platform depends on this
+     * repository: it is resolved lazily, only while restoring a process.
+     */
     @Bean
     fun agentProcessRepository(
         processRepositoryProperties: ProcessRepositoryProperties,
-    ): AgentProcessRepository = InMemoryAgentProcessRepository(processRepositoryProperties)
+        persistenceProperties: AgentProcessPersistenceProperties,
+        snapshotStore: ObjectProvider<AgentProcessSnapshotStore>,
+        blackboardEntrySerializers: ObjectProvider<BlackboardEntrySerializer>,
+        embabelObjectMapperHolder: EmbabelObjectMapperHolder,
+        agentPlatform: ObjectProvider<AgentPlatform>,
+    ): AgentProcessRepository {
+        val runtimeRepository = InMemoryAgentProcessRepository(processRepositoryProperties)
+        val store = snapshotStore.getIfAvailable()
+        if (store == null || !persistenceProperties.enabled) {
+            loggerFor<AgentPlatformConfiguration>().info(
+                "Agent processes are not durable: {}",
+                if (store == null) "no AgentProcessSnapshotStore bean is defined"
+                else "embabel.agent.platform.persistence.enabled is false",
+            )
+            return runtimeRepository
+        }
+        loggerFor<AgentPlatformConfiguration>().info(
+            "Agent processes are durable: snapshot store [{}], checkpoint policy [{}]",
+            store.javaClass.name,
+            persistenceProperties.checkpointPolicy,
+        )
+        return AgentProcessPersistence.persistentRepository(
+            runtimeRepository = runtimeRepository,
+            snapshotStore = store,
+            objectMapper = embabelObjectMapperHolder.get(),
+            agents = { agentPlatform.getObject().agents() },
+            platformServices = { agentPlatform.getObject().platformServices },
+            checkpointPolicy = persistenceProperties.resolveCheckpointPolicy(),
+            blackboardEntrySerializers = blackboardEntrySerializers.orderedStream().toList(),
+        )
+    }
 
     @Bean
     fun contextRepository(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentProcessPersistenceProperties.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentProcessPersistenceProperties.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.config.spring
+
+import com.embabel.agent.spi.persistence.AgentProcessCheckpointPolicy
+import com.embabel.agent.spi.support.persistence.LifecycleCheckpointPolicy
+import com.embabel.agent.spi.support.persistence.WaitForCheckpointPolicy
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration properties for durable agent process persistence.
+ *
+ * Persistence activates only when the application also supplies an
+ * [com.embabel.agent.spi.persistence.AgentProcessSnapshotStore] bean, so adding a
+ * store module is enough to turn it on. [enabled] exists to switch it back off
+ * without removing the store.
+ */
+@ConfigurationProperties("embabel.agent.platform.persistence")
+class AgentProcessPersistenceProperties {
+
+    /**
+     * Whether to checkpoint agent processes when a snapshot store is available.
+     * Set to false to keep processes in memory despite a store being present.
+     */
+    var enabled: Boolean = true
+
+    /**
+     * When a process is written to the snapshot store.
+     */
+    var checkpointPolicy: CheckpointPolicy = CheckpointPolicy.LIFECYCLE
+
+    /**
+     * Resolve the configured policy to its implementation.
+     */
+    fun resolveCheckpointPolicy(): AgentProcessCheckpointPolicy =
+        when (checkpointPolicy) {
+            CheckpointPolicy.WAITING -> WaitForCheckpointPolicy
+            CheckpointPolicy.LIFECYCLE -> LifecycleCheckpointPolicy
+        }
+
+    /**
+     * Supported checkpoint boundaries.
+     */
+    enum class CheckpointPolicy {
+
+        /**
+         * Checkpoint only processes parked in `WAITING`. Cheapest, and enough to
+         * recover a human-in-the-loop process whose owning node is lost.
+         */
+        WAITING,
+
+        /**
+         * Checkpoint processes that are `WAITING` or finished, so durable state
+         * also advances once resumed work completes. The default.
+         */
+        LIFECYCLE,
+    }
+
+    companion object {
+        operator fun invoke(
+            enabled: Boolean = true,
+            checkpointPolicy: CheckpointPolicy = CheckpointPolicy.LIFECYCLE,
+        ): AgentProcessPersistenceProperties =
+            AgentProcessPersistenceProperties().apply {
+                this.enabled = enabled
+                this.checkpointPolicy = checkpointPolicy
+            }
+    }
+}

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AgentProcessPersistenceWiringTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AgentProcessPersistenceWiringTest.kt
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.config.spring
+
+import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.persistence.BlackboardEntryDeserializationContext
+import com.embabel.agent.core.persistence.BlackboardEntrySerializationContext
+import com.embabel.agent.core.persistence.BlackboardEntrySerializer
+import com.embabel.agent.core.persistence.SerializedBlackboardValue
+import com.embabel.agent.core.support.DslWaitingAgent
+import com.embabel.agent.core.support.InMemoryBlackboard
+import com.embabel.agent.core.support.SimpleAgentProcess
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.spi.persistence.AgentProcessSnapshotStore
+import com.embabel.agent.spi.support.DefaultPlannerFactory
+import com.embabel.agent.spi.support.persistence.InMemoryAgentProcessSnapshotStore
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.common.util.EmbabelObjectMapperHolder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import org.springframework.http.MediaType
+
+/**
+ * Wiring behaviour of the `agentProcessRepository` bean.
+ *
+ * Calls the `@Bean` method directly rather than booting a context, because the
+ * decision under test is which repository gets built. Assertions are behavioural
+ * (did a snapshot land in the store) rather than type checks, since the
+ * persistent decorator is deliberately internal.
+ */
+class AgentProcessPersistenceWiringTest {
+
+    private val configuration = AgentPlatformConfiguration()
+    private val objectMapperHolder = EmbabelObjectMapperHolder.createDefault()
+
+    @Test
+    fun `plain in memory repository when no snapshot store is available`() {
+        val repository = configuration.agentProcessRepository(
+            processRepositoryProperties = ProcessRepositoryProperties(),
+            persistenceProperties = AgentProcessPersistenceProperties(),
+            snapshotStore = emptyProvider(),
+            blackboardEntrySerializers = emptyProvider(),
+            embabelObjectMapperHolder = objectMapperHolder,
+            agentPlatform = explodingProvider(),
+        )
+
+        // Nothing to assert against a store, so assert the process simply round
+        // trips through the runtime repository.
+        val process = waitingProcess("p1")
+        repository.save(process)
+        assertNotNull(repository.findById("p1"))
+    }
+
+    @Test
+    fun `persists when a snapshot store is available`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = repository(store)
+
+        repository.save(waitingProcess("p1"))
+
+        val snapshot = store.findByProcessId("p1")
+        assertNotNull(snapshot)
+        assertEquals(AgentProcessStatusCode.WAITING, snapshot?.status)
+    }
+
+    @Test
+    fun `does not persist when disabled despite an available store`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = repository(
+            store,
+            persistenceProperties = AgentProcessPersistenceProperties(enabled = false),
+        )
+
+        repository.save(waitingProcess("p1"))
+
+        assertNull(store.findByProcessId("p1"))
+        assertNotNull(repository.findById("p1"), "the runtime repository must still work")
+    }
+
+    @Test
+    fun `honours the waiting checkpoint policy`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = repository(
+            store,
+            persistenceProperties = AgentProcessPersistenceProperties(
+                checkpointPolicy = AgentProcessPersistenceProperties.CheckpointPolicy.WAITING,
+            ),
+        )
+
+        // NOT_STARTED is neither WAITING nor finished, so the wait policy skips it.
+        repository.save(newProcess("p1"))
+
+        assertNull(store.findByProcessId("p1"))
+    }
+
+    @Test
+    fun `applies registered blackboard entry serializer beans`() {
+        val serializer = RecordingSerializer()
+        val repository = repository(
+            InMemoryAgentProcessSnapshotStore(),
+            serializers = providerOf(BlackboardEntrySerializer::class.java, serializer),
+        )
+
+        repository.save(waitingProcess("p1"))
+
+        assertTrue(serializer.used, "serializer beans should reach the persistence layer")
+    }
+
+    @Test
+    fun `does not resolve the agent platform eagerly`() {
+        // The platform depends on this repository, so resolving it while building
+        // the bean would be a circular dependency. Saving must not touch it.
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = configuration.agentProcessRepository(
+            processRepositoryProperties = ProcessRepositoryProperties(),
+            persistenceProperties = AgentProcessPersistenceProperties(),
+            snapshotStore = providerOf(AgentProcessSnapshotStore::class.java, store),
+            blackboardEntrySerializers = emptyProvider(),
+            embabelObjectMapperHolder = objectMapperHolder,
+            agentPlatform = explodingProvider(),
+        )
+
+        repository.save(waitingProcess("p1"))
+
+        assertNotNull(store.findByProcessId("p1"))
+    }
+
+    private fun repository(
+        store: AgentProcessSnapshotStore,
+        persistenceProperties: AgentProcessPersistenceProperties = AgentProcessPersistenceProperties(),
+        serializers: ObjectProvider<BlackboardEntrySerializer> = emptyProvider(),
+    ) = configuration.agentProcessRepository(
+        processRepositoryProperties = ProcessRepositoryProperties(),
+        persistenceProperties = persistenceProperties,
+        snapshotStore = providerOf(AgentProcessSnapshotStore::class.java, store),
+        blackboardEntrySerializers = serializers,
+        embabelObjectMapperHolder = objectMapperHolder,
+        agentPlatform = explodingProvider(),
+    )
+
+    /**
+     * Real [ObjectProvider] over the given singletons, so the test exercises
+     * Spring's own resolution rather than a hand-rolled stub.
+     */
+    private fun <T : Any> providerOf(
+        type: Class<T>,
+        vararg beans: T,
+    ): ObjectProvider<T> {
+        val beanFactory = DefaultListableBeanFactory()
+        beans.forEachIndexed { index, bean -> beanFactory.registerSingleton("bean$index", bean) }
+        return beanFactory.getBeanProvider(type)
+    }
+
+    private inline fun <reified T : Any> emptyProvider(): ObjectProvider<T> =
+        DefaultListableBeanFactory().getBeanProvider(T::class.java)
+
+    /**
+     * Provider that fails if resolved, proving the agent platform is only touched
+     * lazily during restore.
+     */
+    private fun explodingProvider(): ObjectProvider<AgentPlatform> =
+        object : ObjectProvider<AgentPlatform> {
+            override fun getObject(): AgentPlatform =
+                throw AssertionError("agent platform must not be resolved here")
+
+            override fun getObject(vararg args: Any?): AgentPlatform = getObject()
+
+            override fun getIfAvailable(): AgentPlatform = getObject()
+
+            override fun getIfUnique(): AgentPlatform = getObject()
+        }
+
+    private fun waitingProcess(id: String) =
+        newProcess(id).also {
+            assertEquals(AgentProcessStatusCode.WAITING, it.run().status)
+        }
+
+    private fun newProcess(id: String): SimpleAgentProcess {
+        val blackboard = InMemoryBlackboard()
+        blackboard += UserInput("Rod")
+        return SimpleAgentProcess(
+            id = id,
+            parentId = null,
+            agent = DslWaitingAgent,
+            processOptions = ProcessOptions(),
+            blackboard = blackboard,
+            platformServices = dummyPlatformServices(),
+            plannerFactory = DefaultPlannerFactory,
+        )
+    }
+
+    private class RecordingSerializer : BlackboardEntrySerializer {
+
+        var used: Boolean = false
+
+        override fun supportsSerialization(value: Any): Boolean = value is UserInput
+
+        override fun serialize(
+            value: Any,
+            context: BlackboardEntrySerializationContext,
+        ): SerializedBlackboardValue {
+            used = true
+            return SerializedBlackboardValue(
+                typeName = value.javaClass.name,
+                contentType = MediaType.TEXT_PLAIN_VALUE,
+                payload = value.toString().toByteArray(),
+            )
+        }
+
+        override fun deserialize(
+            value: SerializedBlackboardValue,
+            context: BlackboardEntryDeserializationContext,
+        ): Any = value.payload.toString(Charsets.UTF_8)
+    }
+}

--- a/embabel-agent-docs/src/main/asciidoc/reference/persistence/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/persistence/page.adoc
@@ -37,6 +37,44 @@ the agent API. Those backends should live in applications, starters, or tests.
 The API test suite includes an H2/JDBC fixture to prove the end-to-end recovery
 pattern without making JDBC part of the framework.
 
+==== Configuration
+
+Persistence activates when the application context contains an
+`AgentProcessSnapshotStore` bean. Adding a store is enough; no other
+configuration is required. Without one, the platform uses
+`InMemoryAgentProcessRepository` exactly as before.
+
+[source,properties]
+----
+# Turn persistence off without removing the snapshot store. Default true.
+embabel.agent.platform.persistence.enabled=true
+
+# WAITING or LIFECYCLE. Default LIFECYCLE.
+embabel.agent.platform.persistence.checkpoint-policy=LIFECYCLE
+----
+
+`BlackboardEntrySerializer` beans are discovered automatically and consulted in
+Spring `@Order` before the JSON fallback.
+
+Applications that assemble the platform themselves, rather than through Spring
+configuration, can build the same repository directly:
+
+[source,kotlin]
+----
+val repository = AgentProcessPersistence.persistentRepository(
+    runtimeRepository = InMemoryAgentProcessRepository(),
+    snapshotStore = mySnapshotStore,
+    objectMapper = objectMapper,
+    agents = agentPlatform::agents,
+    platformServices = { agentPlatform.platformServices },
+)
+----
+
+The snapshot, serialization and restore machinery stays internal, so the
+snapshot format remains free to change. The contracts an integrator implements,
+`AgentProcessSnapshotStore`, `AgentProcessCheckpointPolicy` and
+`BlackboardEntrySerializer`, are the stable surface.
+
 ==== Blackboard Values
 
 Blackboard state is persisted through `BlackboardEntrySerializer`.


### PR DESCRIPTION
This pull request introduces configurable and extensible support for durable agent process persistence in the agent platform, making it easy to enable or disable process checkpointing and recovery using Spring configuration and beans. The changes are organized into new configuration properties, enhancements to the Spring wiring, comprehensive tests, and updated documentation.

**Configuration and Wiring Enhancements:**

* Added `AgentProcessPersistenceProperties` to provide Spring Boot configuration for process persistence, including options to enable/disable persistence and select a checkpoint policy (`WAITING` or `LIFECYCLE`).
* Updated `AgentPlatformConfiguration` to conditionally decorate the runtime `AgentProcessRepository` with durability, based on the presence of an `AgentProcessSnapshotStore` bean and the configuration properties. This ensures persistence is opt-in and non-intrusive.
* Registered `AgentProcessPersistenceProperties` as a configuration class, enabling property-based customization.
* Extended imports in `AgentPlatformConfiguration` to support the new persistence wiring and serialization hooks.

**Testing and Documentation:**

* Added `AgentProcessPersistenceWiringTest` to verify the correct repository is wired under different conditions, including persistence enablement, checkpoint policies, and integration with custom serializers.
* Updated documentation to explain the new persistence configuration, how to activate it, and how to customize its behavior via properties and beans.