### PR TITLE
Agent state that outlives a node needs a backend.

### DIFF
--- a/embabel-agent-cache/README.md
+++ b/embabel-agent-cache/README.md
@@ -1,0 +1,108 @@
+# Embabel Agent Cache
+
+Pluggable third-party cache and key-value backends for agent state.
+
+A backend is integrated **once**, through `AgentCacheProvider`, and then serves
+every consumer that needs durable or shared state — process snapshots today,
+contexts and shared runtime process state next. Without this, each consumer
+would grow its own Redis integration, with its own connection management, key
+naming, TTL handling and health checks.
+
+This module depends on `embabel-agent-api`, never the reverse. The API module
+declares the consumer interfaces (`AgentProcessSnapshotStore`,
+`ContextRepository`); this module adapts them onto a cache. `embabel-agent-api`
+gains no new dependencies and needs no changes.
+
+## Layering
+
+```mermaid
+classDiagram
+    direction LR
+
+    class AgentProcessSnapshotStore {
+        <<interface>>
+        embabel-agent-api
+    }
+
+    class AgentCacheProvider {
+        <<interface>>
+        +name
+        +getRegion(config)
+        +close()
+    }
+
+    class AgentCacheRegion {
+        <<interface>>
+        +capabilities
+        +get(key)
+        +put(key, value)
+        +replace(key, expectedVersion, value)
+        +remove(key)
+        +clear()
+        +index(name)
+    }
+
+    class AgentCacheIndex {
+        <<interface>>
+        +add(indexKey, memberKey)
+        +remove(indexKey, memberKey)
+        +members(indexKey)
+    }
+
+    class CacheBackedAgentProcessSnapshotStore
+    class SpringCacheAgentCacheProvider
+    class RedisAgentCacheProvider
+    class HazelcastAgentCacheProvider
+
+    CacheBackedAgentProcessSnapshotStore ..|> AgentProcessSnapshotStore
+    CacheBackedAgentProcessSnapshotStore --> AgentCacheRegion
+    AgentCacheProvider --> AgentCacheRegion
+    AgentCacheRegion --> AgentCacheIndex
+    SpringCacheAgentCacheProvider ..|> AgentCacheProvider
+    RedisAgentCacheProvider ..|> AgentCacheProvider
+    HazelcastAgentCacheProvider ..|> AgentCacheProvider
+```
+
+## Regions
+
+Regions exist because the data has genuinely different retention needs.
+
+| Region | Holds | Policy |
+|---|---|---|
+| `agent-process-snapshots` | durable HITL checkpoints | compare-and-set required; no TTL |
+| `agent-contexts` | long-lived cross-process state | TTL |
+| `agent-processes-runtime` | runtime process state shared between nodes | short TTL |
+
+## Capabilities, not lowest common denominator
+
+Backends differ in what they can guarantee, and the SPI says so out loud rather
+than pretending otherwise. A region declares its `capabilities`; a consumer that
+cannot function without one asks for it via
+`CacheRegionConfig.requiredCapabilities`, and a provider that cannot meet the
+request throws `CacheCapabilityException` at setup.
+
+This follows Hibernate's handling of `AccessType.TRANSACTIONAL`, which throws
+rather than silently degrading. A lost checkpoint under concurrent HITL resume
+is exactly the failure this design refuses to hide.
+
+| Capability | `spring-cache` | `redis` | `hazelcast` |
+|---|---|---|---|
+| `ATOMIC_COMPARE_AND_SET` | no — read-modify-write | yes — Lua / `SET ... IF` | yes — `IMap.replace(k, old, new)` |
+| `SECONDARY_INDEX` | emulated via companion entries | yes — Redis sets | yes — `IMap` predicates |
+| `TIME_TO_LIVE` | backend config only | yes | yes |
+
+## Writing a provider
+
+Implement `AgentCacheProvider` and `AgentCacheRegion`. Everything else —
+snapshot headers, versioning, index maintenance, restore — is in
+`com.embabel.agent.cache.support` and is written once.
+
+`SpringCacheAgentCacheProvider` is the reference implementation and the shortest
+path for most backends: any Spring `CacheManager` works with no new code, at the
+cost of the guarantees noted above.
+
+## Modules
+
+- `embabel-agent-cache-core` — SPI and backend-neutral support
+- `embabel-agent-cache-redis` — native Redis provider *(planned)*
+- `embabel-agent-cache-hazelcast` — native Hazelcast provider *(planned)*

--- a/embabel-agent-cache/embabel-agent-cache-core/pom.xml
+++ b/embabel-agent-cache/embabel-agent-cache-core/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-cache</artifactId>
+        <version>1.5.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-cache-core</artifactId>
+    <packaging>jar</packaging>
+    <name>Embabel Agent Cache Framework</name>
+    <description>Embabel Agent Cache SPI and backend-neutral support</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+
+        <!-- Optional: the generic CacheManager adapter. Users who supply a native
+             provider (Redis, Hazelcast) do not need spring-context-support. -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <configuration>
+                    <myIncremental>false</myIncremental>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <myIncremental>false</myIncremental>
+                            <sourceDirs>
+                                <source>src/main/java</source>
+                                <source>src/main/kotlin</source>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/AgentCache.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/AgentCache.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.cache
+
+import java.time.Duration
+
+/**
+ * Optional behaviour an [AgentCacheRegion] may support.
+ *
+ * Backends differ in what they can guarantee. A region declares what it actually
+ * provides through [AgentCacheRegion.capabilities], and consumers that require a
+ * guarantee ask for it through [CacheRegionConfig.requiredCapabilities] rather
+ * than discovering the shortfall at runtime.
+ */
+enum class CacheCapability {
+
+    /**
+     * [AgentCacheRegion.replace] is atomic with respect to concurrent writers.
+     *
+     * Backends without this can still implement [AgentCacheRegion.replace] as a
+     * read-modify-write, which is adequate for a single writer but permits a lost
+     * update when two nodes checkpoint the same process concurrently.
+     */
+    ATOMIC_COMPARE_AND_SET,
+
+    /**
+     * [AgentCacheRegion.index] returns a usable index rather than null.
+     */
+    SECONDARY_INDEX,
+
+    /**
+     * [CacheRegionConfig.timeToLive] is honoured by the backend.
+     */
+    TIME_TO_LIVE,
+}
+
+/**
+ * Raised when a provider cannot supply a region meeting the requested capabilities.
+ */
+class CacheCapabilityException(
+    message: String,
+) : RuntimeException(message)
+
+/**
+ * Requested characteristics of a cache region.
+ *
+ * @param name unqualified region name; providers may qualify it with a prefix
+ * @param timeToLive entry lifetime, or null to retain entries indefinitely
+ * @param requiredCapabilities capabilities the consumer cannot function without.
+ * A provider unable to meet them must throw [CacheCapabilityException] rather
+ * than returning a region that silently degrades.
+ */
+data class CacheRegionConfig(
+    val name: String,
+    val timeToLive: Duration? = null,
+    val requiredCapabilities: Set<CacheCapability> = emptySet(),
+)
+
+/**
+ * Contract for integrating a third-party cache or key-value store.
+ *
+ * This is the single integration point for a backend such as Redis, Hazelcast,
+ * or any Spring CacheManager. Implementations are responsible only for storing
+ * and retrieving opaque payloads; all agent semantics live in the support layer
+ * of this module, so a backend is integrated once and serves every consumer.
+ *
+ * Implementations must be threadsafe.
+ */
+interface AgentCacheProvider {
+
+    /**
+     * Short name used in logging and in the
+     * `embabel.agent.platform.cache.provider` property, for example `redis`.
+     */
+    val name: String
+
+    /**
+     * Obtain the region for the given configuration, creating it if required.
+     *
+     * Repeated calls with the same [CacheRegionConfig.name] must return a region
+     * over the same underlying storage.
+     *
+     * @throws CacheCapabilityException if [CacheRegionConfig.requiredCapabilities]
+     * cannot be met by this backend.
+     */
+    fun getRegion(config: CacheRegionConfig): AgentCacheRegion
+
+    /**
+     * Release provider-level resources. Called on context shutdown.
+     */
+    fun close() {}
+}
+
+/**
+ * A named area of storage within a provider, holding opaque versioned payloads.
+ *
+ * Regions exist so that data with different retention needs can be configured
+ * independently: process snapshots are durable, contexts expire, runtime process
+ * state is short-lived. See [CacheRegions] for the regions the framework uses.
+ */
+interface AgentCacheRegion {
+
+    val name: String
+
+    /**
+     * What this region actually guarantees. Consumers should branch on this
+     * rather than assuming a backend's behaviour.
+     */
+    val capabilities: Set<CacheCapability>
+
+    fun get(key: String): CachedValue?
+
+    /**
+     * Unconditional write. Prefer [replace] where concurrent writers are possible.
+     */
+    fun put(key: String, value: CachedValue)
+
+    /**
+     * Write [value] only if the currently stored version matches [expectedVersion].
+     *
+     * @param expectedVersion the version the caller believes is stored, or null
+     * when the caller believes no entry exists
+     * @return true if the write was applied, false if the stored version differed
+     */
+    fun replace(key: String, expectedVersion: Long?, value: CachedValue): Boolean
+
+    fun remove(key: String)
+
+    fun clear()
+
+    /**
+     * A secondary index over the keys in this region, or null when this region
+     * does not declare [CacheCapability.SECONDARY_INDEX].
+     *
+     * Indexes let a consumer answer "which keys relate to X" without scanning,
+     * for example finding the child processes of a parent.
+     */
+    fun index(name: String): AgentCacheIndex? = null
+}
+
+/**
+ * A set-valued secondary index over the keys of a region.
+ *
+ * Implementations must tolerate duplicate [add] calls and [remove] of absent
+ * members, since callers may retry after a partial failure.
+ */
+interface AgentCacheIndex {
+
+    val name: String
+
+    fun add(indexKey: String, memberKey: String)
+
+    fun remove(indexKey: String, memberKey: String)
+
+    fun members(indexKey: String): Set<String>
+}
+
+/**
+ * An opaque, versioned payload stored in a region.
+ *
+ * The cache layer never interprets [payload]. Callers that need to filter or
+ * index without deserializing should promote the relevant fields into
+ * [metadata], which backends with native query support may index.
+ *
+ * @param payload serialized bytes
+ * @param version monotonic version used for optimistic concurrency by
+ * [AgentCacheRegion.replace]
+ * @param contentType media type of [payload], for example `application/json`
+ * @param metadata small string-valued attributes describing the payload
+ */
+data class CachedValue(
+    val payload: ByteArray,
+    val version: Long,
+    val contentType: String,
+    val metadata: Map<String, String> = emptyMap(),
+) {
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+                other is CachedValue &&
+                version == other.version &&
+                contentType == other.contentType &&
+                payload.contentEquals(other.payload) &&
+                metadata == other.metadata
+
+    override fun hashCode(): Int {
+        var result = payload.contentHashCode()
+        result = 31 * result + version.hashCode()
+        result = 31 * result + contentType.hashCode()
+        result = 31 * result + metadata.hashCode()
+        return result
+    }
+}
+
+/**
+ * Region names used by the framework.
+ *
+ * These are part of the configuration surface: users name them when setting
+ * per-region TTL or when pre-declaring caches in a backend's own configuration,
+ * so they must not change.
+ */
+object CacheRegions {
+
+    /**
+     * Durable agent process checkpoints. Requires compare-and-set; normally no TTL.
+     */
+    const val AGENT_PROCESS_SNAPSHOTS = "agent-process-snapshots"
+
+    /**
+     * Long-lived context state shared across processes.
+     */
+    const val AGENT_CONTEXTS = "agent-contexts"
+
+    /**
+     * Runtime agent process state shared between nodes. Short TTL.
+     */
+    const val AGENT_PROCESSES_RUNTIME = "agent-processes-runtime"
+}

--- a/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStore.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStore.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.cache.support
+
+import com.embabel.agent.cache.AgentCacheRegion
+import com.embabel.agent.cache.CacheCapability
+import com.embabel.agent.cache.CacheCapabilityException
+import com.embabel.agent.cache.CachedValue
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.persistence.AgentProcessPersistenceException
+import com.embabel.agent.spi.persistence.AgentProcessSnapshotStore
+import com.embabel.agent.spi.persistence.SerializedAgentProcessSnapshot
+import com.embabel.agent.spi.persistence.StoredSnapshotMetadata
+import org.slf4j.LoggerFactory
+import org.springframework.http.MediaType
+import java.time.Instant
+
+/**
+ * [AgentProcessSnapshotStore] backed by any [AgentCacheRegion].
+ *
+ * This is written once and works over every provider, so integrating a backend
+ * means implementing the cache SPI rather than reimplementing snapshot storage.
+ * The region never sees agent types: the process payload is stored opaquely and
+ * the snapshot header travels in [CachedValue.metadata], which backends with
+ * native query support may index.
+ *
+ * @param region region to store snapshots in, normally
+ * [com.embabel.agent.cache.CacheRegions.AGENT_PROCESS_SNAPSHOTS]
+ */
+class CacheBackedAgentProcessSnapshotStore(
+    private val region: AgentCacheRegion,
+) : AgentProcessSnapshotStore {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    /**
+     * Index of parent process id to child process ids, backing [findByParentId].
+     */
+    private val parentIndex = region.index(PARENT_INDEX)
+        ?: throw CacheCapabilityException(
+            "Region [${region.name}] does not support ${CacheCapability.SECONDARY_INDEX}, " +
+                    "which is required to resolve child processes. Use a provider that " +
+                    "declares it, or request it via CacheRegionConfig.requiredCapabilities."
+        )
+
+    init {
+        if (CacheCapability.ATOMIC_COMPARE_AND_SET !in region.capabilities) {
+            logger.warn(
+                """
+                Region [{}] does not support {}.
+                Snapshot writes fall back to read-modify-write, so two nodes checkpointing
+                the same process concurrently can lose an update. Acceptable for a single
+                writer per process; use a provider with atomic compare-and-set otherwise.
+                """.trimIndent(),
+                region.name,
+                CacheCapability.ATOMIC_COMPARE_AND_SET,
+            )
+        }
+    }
+
+    override fun save(
+        snapshot: SerializedAgentProcessSnapshot,
+        expectedVersion: Long?,
+    ): StoredSnapshotMetadata {
+        val applied = region.replace(
+            key = snapshot.processId,
+            expectedVersion = expectedVersion,
+            value = snapshot.toCachedValue(),
+        )
+        if (!applied) {
+            throw AgentProcessPersistenceException(
+                "Stale snapshot for process [${snapshot.processId}]: expected version " +
+                        "$expectedVersion but the stored version differs. The process was " +
+                        "checkpointed concurrently."
+            )
+        }
+        snapshot.parentId?.let { parentIndex.add(it, snapshot.processId) }
+        return StoredSnapshotMetadata(
+            processId = snapshot.processId,
+            version = snapshot.version,
+            updatedAt = snapshot.updatedAt,
+        )
+    }
+
+    override fun findByProcessId(processId: String): SerializedAgentProcessSnapshot? =
+        region.get(processId)?.toSnapshot()
+
+    override fun findByParentId(parentId: String): List<SerializedAgentProcessSnapshot> =
+        parentIndex.members(parentId)
+            .mapNotNull { findByProcessId(it) }
+
+    override fun delete(processId: String) {
+        // Read first so the parent index can be cleaned up. A missing entry is not
+        // an error: delete is idempotent.
+        region.get(processId)
+            ?.metadata
+            ?.get(PARENT_ID)
+            ?.let { parentIndex.remove(it, processId) }
+        region.remove(processId)
+    }
+
+    private fun SerializedAgentProcessSnapshot.toCachedValue(): CachedValue =
+        CachedValue(
+            payload = payload,
+            version = version,
+            contentType = contentType.toString(),
+            metadata = buildMap {
+                put(PROCESS_ID, processId)
+                parentId?.let { put(PARENT_ID, it) }
+                put(AGENT_NAME, agentName)
+                put(STATUS, status.name)
+                put(CREATED_AT, createdAt.toString())
+                put(UPDATED_AT, updatedAt.toString())
+                // Namespace caller metadata so it cannot collide with header keys.
+                metadata.forEach { (key, value) -> put("$USER_PREFIX$key", value) }
+            },
+        )
+
+    private fun CachedValue.toSnapshot(): SerializedAgentProcessSnapshot =
+        SerializedAgentProcessSnapshot(
+            processId = require(PROCESS_ID),
+            parentId = metadata[PARENT_ID],
+            agentName = require(AGENT_NAME),
+            status = AgentProcessStatusCode.valueOf(require(STATUS)),
+            version = version,
+            contentType = MediaType.parseMediaType(contentType),
+            payload = payload,
+            createdAt = Instant.parse(require(CREATED_AT)),
+            updatedAt = Instant.parse(require(UPDATED_AT)),
+            metadata = metadata
+                .filterKeys { it.startsWith(USER_PREFIX) }
+                .mapKeys { (key, _) -> key.removePrefix(USER_PREFIX) },
+        )
+
+    private fun CachedValue.require(key: String): String =
+        metadata[key]
+            ?: throw AgentProcessPersistenceException(
+                "Snapshot in region [${region.name}] is missing required metadata [$key]. " +
+                        "The stored entry was not written by this store, or the payload format changed."
+            )
+
+    companion object {
+
+        /**
+         * Index name for parent-to-child process resolution.
+         */
+        const val PARENT_INDEX = "by-parent-id"
+
+        private const val PROCESS_ID = "embabel.snapshot.processId"
+        private const val PARENT_ID = "embabel.snapshot.parentId"
+        private const val AGENT_NAME = "embabel.snapshot.agentName"
+        private const val STATUS = "embabel.snapshot.status"
+        private const val CREATED_AT = "embabel.snapshot.createdAt"
+        private const val UPDATED_AT = "embabel.snapshot.updatedAt"
+        private const val USER_PREFIX = "embabel.user."
+    }
+}

--- a/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/SpringCacheAgentCacheProvider.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/SpringCacheAgentCacheProvider.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.cache.support
+
+import com.embabel.agent.cache.AgentCacheIndex
+import com.embabel.agent.cache.AgentCacheProvider
+import com.embabel.agent.cache.AgentCacheRegion
+import com.embabel.agent.cache.CacheCapability
+import com.embabel.agent.cache.CacheCapabilityException
+import com.embabel.agent.cache.CacheRegionConfig
+import com.embabel.agent.cache.CachedValue
+import org.springframework.cache.Cache
+import org.springframework.cache.CacheManager
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Generic [AgentCacheProvider] over any Spring [CacheManager].
+ *
+ * This adapter exists so that every JSR-107 and Spring-supported backend works
+ * without a dedicated module: Caffeine, Ehcache 3, Infinispan, Hazelcast via
+ * JCache, and Redis via `RedisCacheManager`. Users configure the backend through
+ * the standard `spring.cache.*` properties they already know.
+ *
+ * ## Guarantees
+ *
+ * Spring's [Cache] is a cache abstraction, not a store abstraction, so this
+ * adapter cannot offer everything the SPI defines:
+ *
+ * - **No atomic compare-and-set.** [Cache] has `putIfAbsent` but no versioned
+ *   CAS, so [AgentCacheRegion.replace] is a read-modify-write guarded by an
+ *   in-JVM lock. That is correct for a single node and permits a lost update
+ *   across nodes. Use a native provider where that matters.
+ * - **Indexes are emulated** as companion entries under a reserved key prefix,
+ *   and index updates are not atomic with the data write they accompany.
+ * - **TTL is not settable here.** Configure it in the backend's own
+ *   configuration, keyed by the region names in
+ *   [com.embabel.agent.cache.CacheRegions].
+ *
+ * Values are stored as [CachedValue] instances, so the configured cache manager
+ * must be able to serialize them. That is automatic for in-memory backends; for
+ * Redis, configure a JSON serializer.
+ */
+class SpringCacheAgentCacheProvider(
+    private val cacheManager: CacheManager,
+) : AgentCacheProvider {
+
+    override val name: String = NAME
+
+    private val regions = ConcurrentHashMap<String, AgentCacheRegion>()
+
+    override fun getRegion(config: CacheRegionConfig): AgentCacheRegion {
+        val unsupported = config.requiredCapabilities - SUPPORTED
+        if (unsupported.isNotEmpty()) {
+            throw CacheCapabilityException(
+                "Provider [$NAME] cannot supply region [${config.name}] with required " +
+                        "capabilities $unsupported. Supported: $SUPPORTED. Use a native " +
+                        "provider such as Redis or Hazelcast."
+            )
+        }
+        return regions.computeIfAbsent(config.name) {
+            val cache = cacheManager.getCache(config.name)
+                ?: throw CacheCapabilityException(
+                    "Cache manager [${cacheManager.javaClass.simpleName}] has no cache named " +
+                            "[${config.name}]. Declare it in the backend configuration, or use a " +
+                            "cache manager that creates caches on demand."
+                )
+            SpringCacheAgentCacheRegion(cache)
+        }
+    }
+
+    companion object {
+
+        const val NAME = "spring-cache"
+
+        private val SUPPORTED = setOf(CacheCapability.SECONDARY_INDEX)
+    }
+}
+
+/**
+ * [AgentCacheRegion] over a single Spring [Cache].
+ *
+ * Index entries share the underlying cache with data entries and are namespaced
+ * by [INDEX_KEY_PREFIX], which is therefore reserved.
+ */
+internal class SpringCacheAgentCacheRegion(
+    private val cache: Cache,
+) : AgentCacheRegion {
+
+    override val name: String get() = cache.name
+
+    override val capabilities: Set<CacheCapability> = setOf(CacheCapability.SECONDARY_INDEX)
+
+    /**
+     * Per-key locks making read-modify-write correct within this JVM. Cross-node
+     * races remain possible; see the provider documentation.
+     */
+    private val locks = ConcurrentHashMap<String, Any>()
+
+    override fun get(key: String): CachedValue? =
+        cache.get(key, CachedValue::class.java)
+
+    override fun put(key: String, value: CachedValue) {
+        cache.put(key, value)
+    }
+
+    override fun replace(
+        key: String,
+        expectedVersion: Long?,
+        value: CachedValue,
+    ): Boolean =
+        synchronized(locks.computeIfAbsent(key) { Any() }) {
+            if (get(key)?.version != expectedVersion) {
+                false
+            } else {
+                put(key, value)
+                true
+            }
+        }
+
+    override fun remove(key: String) {
+        cache.evict(key)
+        locks.remove(key)
+    }
+
+    override fun clear() {
+        cache.clear()
+        locks.clear()
+    }
+
+    override fun index(name: String): AgentCacheIndex = SpringCacheAgentCacheIndex(name)
+
+    /**
+     * Set-valued index emulated as one companion entry per index key.
+     */
+    private inner class SpringCacheAgentCacheIndex(
+        override val name: String,
+    ) : AgentCacheIndex {
+
+        override fun add(indexKey: String, memberKey: String) {
+            mutate(indexKey) { it + memberKey }
+        }
+
+        override fun remove(indexKey: String, memberKey: String) {
+            mutate(indexKey) { it - memberKey }
+        }
+
+        override fun members(indexKey: String): Set<String> =
+            cache.get(entryKey(indexKey), IndexEntry::class.java)?.members ?: emptySet()
+
+        private fun mutate(
+            indexKey: String,
+            change: (Set<String>) -> Set<String>,
+        ) {
+            val key = entryKey(indexKey)
+            synchronized(locks.computeIfAbsent(key) { Any() }) {
+                val updated = change(members(indexKey))
+                if (updated.isEmpty()) {
+                    cache.evict(key)
+                } else {
+                    cache.put(key, IndexEntry(updated))
+                }
+            }
+        }
+
+        private fun entryKey(indexKey: String): String = "$INDEX_KEY_PREFIX$name:$indexKey"
+    }
+
+    internal data class IndexEntry(
+        val members: Set<String>,
+    )
+
+    companion object {
+
+        /**
+         * Reserved key prefix for emulated index entries. Data keys must not use it.
+         */
+        const val INDEX_KEY_PREFIX = "embabel.idx:"
+    }
+}

--- a/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStoreTest.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStoreTest.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.cache.support
+
+import com.embabel.agent.cache.AgentCacheIndex
+import com.embabel.agent.cache.AgentCacheRegion
+import com.embabel.agent.cache.CacheCapability
+import com.embabel.agent.cache.CacheCapabilityException
+import com.embabel.agent.cache.CacheRegionConfig
+import com.embabel.agent.cache.CachedValue
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.persistence.AgentProcessPersistenceException
+import com.embabel.agent.spi.persistence.SerializedAgentProcessSnapshot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.http.MediaType
+import java.time.Instant
+
+class CacheBackedAgentProcessSnapshotStoreTest {
+
+    private val provider = SpringCacheAgentCacheProvider(ConcurrentMapCacheManager())
+
+    private fun store(regionName: String = "snapshots") =
+        CacheBackedAgentProcessSnapshotStore(provider.getRegion(CacheRegionConfig(regionName)))
+
+    private fun snapshot(
+        processId: String = "p1",
+        parentId: String? = null,
+        version: Long = 1,
+        status: AgentProcessStatusCode = AgentProcessStatusCode.WAITING,
+        metadata: Map<String, String> = emptyMap(),
+    ) = SerializedAgentProcessSnapshot(
+        processId = processId,
+        parentId = parentId,
+        agentName = "test-agent",
+        status = status,
+        version = version,
+        contentType = MediaType.APPLICATION_JSON,
+        payload = """{"blackboard":"$processId"}""".toByteArray(),
+        createdAt = Instant.parse("2026-01-01T00:00:00Z"),
+        updatedAt = Instant.parse("2026-01-02T03:04:05Z"),
+        metadata = metadata,
+    )
+
+    @Test
+    fun `round trips every header field`() {
+        val store = store()
+        val original = snapshot(parentId = "parent-1", metadata = mapOf("tenant" to "acme"))
+
+        store.save(original, expectedVersion = null)
+
+        assertEquals(original, store.findByProcessId("p1"))
+    }
+
+    @Test
+    fun `returns null for an unknown process`() {
+        assertNull(store().findByProcessId("missing"))
+    }
+
+    @Test
+    fun `returns stored metadata describing the write`() {
+        val stored = store().save(snapshot(version = 7), expectedVersion = null)
+
+        assertEquals("p1", stored.processId)
+        assertEquals(7L, stored.version)
+        assertEquals(Instant.parse("2026-01-02T03:04:05Z"), stored.updatedAt)
+    }
+
+    @Test
+    fun `user metadata does not collide with header keys`() {
+        val store = store()
+        // A caller key that shadows a header name must survive untouched.
+        val original = snapshot(metadata = mapOf("processId" to "not-the-real-one"))
+
+        store.save(original, expectedVersion = null)
+        val restored = store.findByProcessId("p1")!!
+
+        assertEquals("p1", restored.processId)
+        assertEquals(mapOf("processId" to "not-the-real-one"), restored.metadata)
+    }
+
+    @Nested
+    inner class OptimisticConcurrency {
+
+        @Test
+        fun `accepts a sequential update`() {
+            val store = store("seq")
+            store.save(snapshot(version = 1), expectedVersion = null)
+
+            store.save(snapshot(version = 2), expectedVersion = 1)
+
+            assertEquals(2L, store.findByProcessId("p1")?.version)
+        }
+
+        @Test
+        fun `rejects a stale update`() {
+            val store = store("stale")
+            store.save(snapshot(version = 1), expectedVersion = null)
+            store.save(snapshot(version = 2), expectedVersion = 1)
+
+            val thrown = assertThrows(AgentProcessPersistenceException::class.java) {
+                store.save(snapshot(version = 2), expectedVersion = 1)
+            }
+            assertTrue(
+                thrown.message!!.contains("p1"),
+                "message should name the process: ${thrown.message}",
+            )
+            assertEquals(2L, store.findByProcessId("p1")?.version, "stored value must be untouched")
+        }
+
+        @Test
+        fun `rejects a create when the process already exists`() {
+            val store = store("dup")
+            store.save(snapshot(version = 1), expectedVersion = null)
+
+            assertThrows(AgentProcessPersistenceException::class.java) {
+                store.save(snapshot(version = 1), expectedVersion = null)
+            }
+        }
+    }
+
+    @Nested
+    inner class ParentIndex {
+
+        @Test
+        fun `finds children of a parent`() {
+            val store = store("children")
+            store.save(snapshot(processId = "c1", parentId = "parent"), expectedVersion = null)
+            store.save(snapshot(processId = "c2", parentId = "parent"), expectedVersion = null)
+            store.save(snapshot(processId = "unrelated"), expectedVersion = null)
+
+            assertEquals(
+                setOf("c1", "c2"),
+                store.findByParentId("parent").map { it.processId }.toSet(),
+            )
+        }
+
+        @Test
+        fun `is empty for a parent with no children`() {
+            assertEquals(emptyList<SerializedAgentProcessSnapshot>(), store().findByParentId("lonely"))
+        }
+
+        @Test
+        fun `drops a deleted child from the parent index`() {
+            val store = store("delete-child")
+            store.save(snapshot(processId = "c1", parentId = "parent"), expectedVersion = null)
+            store.save(snapshot(processId = "c2", parentId = "parent"), expectedVersion = null)
+
+            store.delete("c1")
+
+            assertNull(store.findByProcessId("c1"))
+            assertEquals(listOf("c2"), store.findByParentId("parent").map { it.processId })
+        }
+
+        @Test
+        fun `delete is idempotent`() {
+            val store = store("idempotent-delete")
+            store.delete("never-existed")
+            store.save(snapshot(), expectedVersion = null)
+            store.delete("p1")
+            store.delete("p1")
+
+            assertNull(store.findByProcessId("p1"))
+        }
+    }
+
+    @Test
+    fun `refuses a region that cannot index`() {
+        val thrown = assertThrows(CacheCapabilityException::class.java) {
+            CacheBackedAgentProcessSnapshotStore(IndexlessRegion)
+        }
+        assertTrue(
+            thrown.message!!.contains(CacheCapability.SECONDARY_INDEX.name),
+            "message should name the missing capability: ${thrown.message}",
+        )
+    }
+
+    /**
+     * Region declaring no index support, to prove the store fails at construction
+     * rather than at the first [CacheBackedAgentProcessSnapshotStore.findByParentId].
+     */
+    private object IndexlessRegion : AgentCacheRegion {
+        override val name = "indexless"
+        override val capabilities = emptySet<CacheCapability>()
+        override fun get(key: String): CachedValue? = null
+        override fun put(key: String, value: CachedValue) = Unit
+        override fun replace(key: String, expectedVersion: Long?, value: CachedValue) = false
+        override fun remove(key: String) = Unit
+        override fun clear() = Unit
+        override fun index(name: String): AgentCacheIndex? = null
+    }
+}

--- a/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/SpringCacheAgentCacheProviderTest.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/SpringCacheAgentCacheProviderTest.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.cache.support
+
+import com.embabel.agent.cache.CacheCapability
+import com.embabel.agent.cache.CacheCapabilityException
+import com.embabel.agent.cache.CacheRegionConfig
+import com.embabel.agent.cache.CachedValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+
+class SpringCacheAgentCacheProviderTest {
+
+    private val provider = SpringCacheAgentCacheProvider(ConcurrentMapCacheManager())
+
+    private fun region(name: String = "test-region") =
+        provider.getRegion(CacheRegionConfig(name))
+
+    private fun value(
+        body: String,
+        version: Long = 1,
+    ) = CachedValue(
+        payload = body.toByteArray(),
+        version = version,
+        contentType = "application/json",
+    )
+
+    @Test
+    fun `stores and retrieves a value`() {
+        val region = region()
+        region.put("k", value("hello"))
+
+        assertEquals(value("hello"), region.get("k"))
+    }
+
+    @Test
+    fun `returns null for an absent key`() {
+        assertNull(region().get("nope"))
+    }
+
+    @Test
+    fun `returns the same region for repeated calls`() {
+        assertTrue(region("same") === region("same"))
+    }
+
+    @Test
+    fun `removes and clears`() {
+        val region = region()
+        region.put("k", value("v"))
+        region.remove("k")
+        assertNull(region.get("k"))
+
+        region.put("k2", value("v"))
+        region.clear()
+        assertNull(region.get("k2"))
+    }
+
+    @Nested
+    inner class Replace {
+
+        @Test
+        fun `applies when the stored version matches`() {
+            val region = region("replace-match")
+            region.put("k", value("first", version = 1))
+
+            assertTrue(region.replace("k", expectedVersion = 1, value = value("second", version = 2)))
+            assertEquals(2L, region.get("k")?.version)
+        }
+
+        @Test
+        fun `refuses when the stored version differs`() {
+            val region = region("replace-stale")
+            region.put("k", value("first", version = 5))
+
+            assertFalse(region.replace("k", expectedVersion = 1, value = value("second", version = 2)))
+            assertEquals(5L, region.get("k")?.version, "stored value must be untouched")
+        }
+
+        @Test
+        fun `applies a first write when no entry is expected`() {
+            val region = region("replace-create")
+
+            assertTrue(region.replace("k", expectedVersion = null, value = value("first", version = 1)))
+            assertNotNull(region.get("k"))
+        }
+
+        @Test
+        fun `refuses a first write when an entry already exists`() {
+            val region = region("replace-conflict")
+            region.put("k", value("existing", version = 1))
+
+            assertFalse(region.replace("k", expectedVersion = null, value = value("other", version = 1)))
+        }
+    }
+
+    @Nested
+    inner class Index {
+
+        @Test
+        fun `adds and lists members`() {
+            val index = region("index-add").index("by-parent")!!
+            index.add("parent-1", "child-a")
+            index.add("parent-1", "child-b")
+
+            assertEquals(setOf("child-a", "child-b"), index.members("parent-1"))
+        }
+
+        @Test
+        fun `isolates index keys`() {
+            val index = region("index-isolate").index("by-parent")!!
+            index.add("parent-1", "child-a")
+            index.add("parent-2", "child-b")
+
+            assertEquals(setOf("child-a"), index.members("parent-1"))
+            assertEquals(setOf("child-b"), index.members("parent-2"))
+        }
+
+        @Test
+        fun `is empty for an unknown key`() {
+            assertEquals(emptySet<String>(), region("index-empty").index("by-parent")!!.members("nobody"))
+        }
+
+        @Test
+        fun `tolerates duplicate adds and absent removes`() {
+            val index = region("index-idempotent").index("by-parent")!!
+            index.add("p", "c")
+            index.add("p", "c")
+            index.remove("p", "never-added")
+
+            assertEquals(setOf("c"), index.members("p"))
+        }
+
+        @Test
+        fun `removes members`() {
+            val index = region("index-remove").index("by-parent")!!
+            index.add("p", "c1")
+            index.add("p", "c2")
+            index.remove("p", "c1")
+
+            assertEquals(setOf("c2"), index.members("p"))
+        }
+
+        @Test
+        fun `index entries do not appear as data entries`() {
+            val region = region("index-namespace")
+            region.index("by-parent")!!.add("p", "c")
+
+            assertNull(region.get("p"), "index entry must not collide with the data keyspace")
+        }
+    }
+
+    @Nested
+    inner class Capabilities {
+
+        @Test
+        fun `declares secondary index support only`() {
+            assertEquals(setOf(CacheCapability.SECONDARY_INDEX), region("caps").capabilities)
+        }
+
+        @Test
+        fun `refuses a region requiring atomic compare and set`() {
+            val thrown = assertThrows(CacheCapabilityException::class.java) {
+                provider.getRegion(
+                    CacheRegionConfig(
+                        name = "needs-cas",
+                        requiredCapabilities = setOf(CacheCapability.ATOMIC_COMPARE_AND_SET),
+                    )
+                )
+            }
+            assertTrue(
+                thrown.message!!.contains(CacheCapability.ATOMIC_COMPARE_AND_SET.name),
+                "message should name the missing capability: ${thrown.message}",
+            )
+        }
+
+        @Test
+        fun `supplies a region requiring only secondary index`() {
+            assertNotNull(
+                provider.getRegion(
+                    CacheRegionConfig(
+                        name = "needs-index",
+                        requiredCapabilities = setOf(CacheCapability.SECONDARY_INDEX),
+                    )
+                )
+            )
+        }
+    }
+}

--- a/embabel-agent-cache/pom.xml
+++ b/embabel-agent-cache/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.embabel.agent</groupId>
+        <artifactId>embabel-agent-parent</artifactId>
+        <version>1.5.2-SNAPSHOT</version>
+    </parent>
+    <artifactId>embabel-agent-cache</artifactId>
+    <packaging>pom</packaging>
+    <name>Embabel Agent Cache</name>
+    <description>Embabel Agent Cache</description>
+    <url>https://github.com/embabel/embabel-agent</url>
+
+    <scm>
+        <url>https://github.com/embabel/embabel-agent</url>
+        <connection>scm:git:https://github.com/embabel/embabel-agent.git</connection>
+        <developerConnection>scm:git:https://github.com/embabel/embabel-agent.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+
+    <modules>
+        <module>embabel-agent-cache-core</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.embabel.agent</groupId>
+            <artifactId>embabel-agent-test-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/embabel-agent-dependencies/pom.xml
+++ b/embabel-agent-dependencies/pom.xml
@@ -284,6 +284,12 @@
 
             <dependency>
                 <groupId>com.embabel.agent</groupId>
+                <artifactId>embabel-agent-cache-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.embabel.agent</groupId>
                 <artifactId>embabel-agent-skills</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/embabel-agent-docs/src/main/asciidoc/reference/cache/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/cache/page.adoc
@@ -1,0 +1,97 @@
+[[reference.cache]]
+=== Cache Providers
+
+Agent state that must outlive a single node — process snapshots today, contexts
+and shared runtime state next — needs a backend. `embabel-agent-cache` is the
+integration point for one.
+
+A backend is integrated once, through `AgentCacheProvider`, and then serves every
+consumer. Without this, each consumer would grow its own Redis or Hazelcast
+integration, each with its own connection management, key naming, expiry handling
+and health checks.
+
+The module depends on `embabel-agent-api`, never the reverse. The API module
+declares the consumer contracts; this module adapts them onto a cache.
+
+==== Providers And Regions
+
+`AgentCacheProvider` vends `AgentCacheRegion` instances by name. A region holds
+opaque versioned payloads and supports `get`, `put`, `replace`, `remove`, `clear`
+and an optional secondary `index`.
+
+Regions exist because the data has genuinely different retention needs. The names
+in `CacheRegions` are part of the configuration surface, since users reference
+them when declaring caches or expiry in a backend's own configuration:
+
+[cols="1,2,1"]
+|===
+|Region |Holds |Retention
+
+|`agent-process-snapshots`
+|Durable process checkpoints
+|Compare-and-set required, normally no expiry
+
+|`agent-contexts`
+|Long-lived state shared across processes
+|Time to live
+
+|`agent-processes-runtime`
+|Runtime process state shared between nodes
+|Short time to live
+|===
+
+==== Capabilities
+
+Backends differ in what they can guarantee, and the SPI states this rather than
+settling for a lowest common denominator. A region declares its `capabilities`. A
+consumer that cannot function without one requests it through
+`CacheRegionConfig.requiredCapabilities`, and a provider unable to meet the
+request throws `CacheCapabilityException` when the region is created, rather than
+returning something that quietly degrades.
+
+`ATOMIC_COMPARE_AND_SET` is the one that matters most. Snapshot writes use
+`replace` with an expected version; without atomicity that becomes a
+read-modify-write, which is correct for a single writer but permits a lost update
+when two nodes checkpoint the same process concurrently.
+
+==== Spring Cache Provider
+
+`SpringCacheAgentCacheProvider` adapts any Spring `CacheManager`, so JSR-107 and
+Spring-supported backends work with no additional code, configured through the
+standard `spring.cache` properties.
+
+Its limitations are deliberate and documented rather than hidden:
+
+* No atomic compare-and-set. `replace` is a read-modify-write guarded by an
+  in-JVM lock, so it is correct on a single node only.
+* Secondary indexes are emulated as companion entries under a reserved key
+  prefix, and index updates are not atomic with the data write they accompany.
+* Expiry is not settable through the SPI. Configure it in the backend, keyed by
+  the region names above.
+* Values are stored as `CachedValue` instances, so the cache manager must be able
+  to serialize them. That is automatic for in-memory backends; Redis needs a JSON
+  serializer configured.
+
+Applications needing real compare-and-set or native indexing should use a
+provider written against the backend directly.
+
+==== Process Snapshot Storage
+
+`CacheBackedAgentProcessSnapshotStore` implements the
+`AgentProcessSnapshotStore` described in <<reference.persistence>> over any
+region, so a cache backend gives durable agent processes without further code.
+
+The region never sees agent types. The process payload is stored opaquely and the
+snapshot header travels in `CachedValue.metadata`, which backends with native
+query support may index. Parent-to-child lookup uses a secondary index, so the
+store fails at construction on a region that cannot index, rather than at the
+first `findByParentId`.
+
+==== Writing A Provider
+
+Implement `AgentCacheProvider` and `AgentCacheRegion`, and `AgentCacheIndex` if
+the backend can index. Snapshot headers, versioning, index maintenance and
+restore are already written and shared.
+
+`SpringCacheAgentCacheProvider` is the reference implementation and the shortest
+path for most backends.

--- a/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/reference.adoc
@@ -18,6 +18,7 @@ include::chatbots/page.adoc[]
 
 include::agent-process/page.adoc[]
 include::persistence/page.adoc[]
+include::cache/page.adoc[]
 include::agent-platform/page.adoc[]
 
 include::invoking/page.adoc[]

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
 
     <modules>
         <module>embabel-agent-api</module>
+        <module>embabel-agent-cache</module>
         <module>embabel-agent-a2a</module>
         <module>embabel-agent-autoconfigure</module>
         <module>embabel-agent-code</module>


### PR DESCRIPTION
This pull request introduces the new `embabel-agent-cache` module, which provides a unified, pluggable cache and key-value backend framework for agent state. The main goal is to centralize and standardize how durable and shared agent state is stored, avoiding redundant integrations with third-party caches like Redis or Hazelcast across different consumers. The changes include the core SPI, a detailed README, and a reference implementation for process snapshot storage.

Key changes:

**Core SPI and Interfaces:**

* Added the `AgentCacheProvider`, `AgentCacheRegion`, and `AgentCacheIndex` interfaces, along with the `CacheCapability` enum, `CacheRegionConfig` data class, and `CachedValue` data class in `AgentCache.kt`. These abstractions define the contract for integrating third-party cache or key-value stores and allow consumers to request specific capabilities such as atomic compare-and-set or secondary indexes. (`embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/AgentCache.kt`)

**Reference Implementation:**

* Implemented `CacheBackedAgentProcessSnapshotStore`, which provides a reusable, cache-backed implementation of `AgentProcessSnapshotStore`. This class stores agent process snapshots opaquely in the cache and uses metadata for indexing and querying, demonstrating how to use the new SPI. (`embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStore.kt`)

**Documentation:**

* Added a comprehensive `README.md` describing the motivation, architecture, layering, region and capability concepts, and extension points for the new cache module. The documentation includes diagrams and tables to clarify how the SPI should be used and extended. (`embabel-agent-cache/README.md`)

**Build and Dependency Setup:**

* Introduced a new Maven module with its own `pom.xml`, declaring dependencies, plugin configuration, and project metadata for `embabel-agent-cache-core`. (`embabel-agent-cache/embabel-agent-cache-core/pom.xml`)