### PR TITLE
Fix validation responsibility boundaries

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -314,7 +314,6 @@ class AgentMetadataReader(
         if (plannerType == PlannerType.GOAP && agenticInfo.isAgent()) {
             val validationResult = agentValidationManager.validate(agent)
             if (!validationResult.isValid) {
-                logger.warn("Agent validation failed:\n${validationResult.errors.joinToString("\n")}")
                 if (skipAgentDeploymentOnError) {
                     logSkipAgentDeploymentOnError( "Agent ${targetType.name} is rejected as it has validation errors as reported above.")
                     return null

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/annotation/support/AgentMetadataReader.kt
@@ -315,7 +315,7 @@ class AgentMetadataReader(
             val validationResult = agentValidationManager.validate(agent)
             if (!validationResult.isValid) {
                 if (skipAgentDeploymentOnError) {
-                    logSkipAgentDeploymentOnError( "Agent ${targetType.name} is rejected as it has validation errors as reported above.")
+                    logSkipAgentDeploymentOnError( "Agent ${targetType.name} is rejected due to validation errors as reported above.")
                     return null
                 }
             }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/validation/DefaultAgentStructureValidator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/validation/DefaultAgentStructureValidator.kt
@@ -71,7 +71,7 @@ class DefaultAgentStructureValidator(
                         component = clazz.name
                     )
                 )
-                loggerFor<DefaultAgentStructureValidator>().warn(error.toString())
+                loggerFor<DefaultAgentStructureValidator>().debug(error.toString())
             }
         }
     }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/validation/GoapPathToCompletionValidator.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/validation/GoapPathToCompletionValidator.kt
@@ -193,7 +193,13 @@ class GoapPathToCompletionValidator : PathToCompletionAgentValidator {
             val goalAction = agentScope.actions.find { it.name == goal.name }
 
             if (goalAction == null) {
-                logger.error("Goal action '${goal.name}' not found in agent actions. Skipping this goal.")
+                errors.add(
+                    error(
+                        ValidationErrorCodes.GOAL_ACTION_NOT_FOUND,
+                        "Goal action '${goal.name}' not found in agent actions.",
+                        agentScope
+                    )
+                )
                 continue
             }
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/core/validation/ValidationErrorCodes.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/core/validation/ValidationErrorCodes.kt
@@ -38,6 +38,9 @@ class ValidationErrorCodes {
         /** Agent has goals but no actions, so no plan can ever reach them. */
         const val NO_ACTIONS_TO_GOALS = "NO_ACTIONS_TO_GOALS"
 
+        /** Goal has no matching action, so it cannot be planned. */
+        const val GOAL_ACTION_NOT_FOUND = "GOAL_ACTION_NOT_FOUND"
+
         /** Action annotation is missing on the method. */
         const val MISSING_ACTION_ANNOTATION = "MISSING_ACTION_ANNOTATION"
     }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/common/core/validation/ValidationErrorCodes.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/common/core/validation/ValidationErrorCodes.kt
@@ -35,13 +35,13 @@ class ValidationErrorCodes {
         /** A condition method takes more than one parameter. */
         const val INVALID_CONDITION_SIGNATURE = "INVALID_CONDITION_SIGNATURE"
 
-        /** Agent has goals but no actions, so no plan can ever reach them. */
+        /** Agent has goals but no actions at all, so no plan can ever reach them. */
         const val NO_ACTIONS_TO_GOALS = "NO_ACTIONS_TO_GOALS"
 
-        /** Goal has no matching action, so it cannot be planned. */
+        /** An assembled agent scope has a goal with no corresponding action. */
         const val GOAL_ACTION_NOT_FOUND = "GOAL_ACTION_NOT_FOUND"
 
-        /** Action annotation is missing on the method. */
+        /** A method annotated with @AchievesGoal is missing its required @Action annotation. */
         const val MISSING_ACTION_ANNOTATION = "MISSING_ACTION_ANNOTATION"
     }
 }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/AchievableGoalValidatorTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/AchievableGoalValidatorTest.kt
@@ -19,6 +19,7 @@ import com.embabel.agent.api.annotation.support.AgentMetadataReader
 import com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation
 import com.embabel.agent.api.annotation.support.AgentWithValidAchievesGoalMethod
 import com.embabel.agent.api.annotation.support.AgenticComponentWithNoActionNoConditionNoGoalAnnotation
+import com.embabel.agent.core.AgentScope
 import com.embabel.agent.spi.validation.GoapPathToCompletionValidator
 import com.embabel.agent.spi.validation.PathToCompletionAgentValidator
 import com.embabel.common.core.validation.ValidationErrorCodes
@@ -40,7 +41,9 @@ class AchievableGoalValidatorTest {
     @Test
     fun `goal without matching action returns validation error`() {
         val reader = AgentMetadataReader(
-            pathToCompletionValidator = PathToCompletionAgentValidator { ValidationResult.VALID }
+            pathToCompletionValidator = object : PathToCompletionAgentValidator {
+                override fun validate(agentScope: AgentScope): ValidationResult = ValidationResult.VALID
+            }
         )
         val agentScope = reader.createAgentMetadata(AgentWithAchievesGoalNoActionAnnotation())
         assertNotNull(agentScope)

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/AchievableGoalValidatorTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/AchievableGoalValidatorTest.kt
@@ -19,12 +19,17 @@ import com.embabel.agent.api.annotation.support.AgentMetadataReader
 import com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation
 import com.embabel.agent.api.annotation.support.AgentWithValidAchievesGoalMethod
 import com.embabel.agent.api.annotation.support.AgenticComponentWithNoActionNoConditionNoGoalAnnotation
+import com.embabel.agent.spi.validation.GoapPathToCompletionValidator
+import com.embabel.agent.spi.validation.PathToCompletionAgentValidator
+import com.embabel.common.core.validation.ValidationErrorCodes
+import com.embabel.common.core.validation.ValidationResult
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.boot.test.system.CapturedOutput
 import org.springframework.boot.test.system.OutputCaptureExtension
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -33,11 +38,30 @@ class AchievableGoalValidatorTest {
     val noActionErrorMessage = """@Action annotation is missing on the method 'com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation.goal' annotated with @AchievesGoal."""
 
     @Test
+    fun `goal without matching action returns validation error`() {
+        val reader = AgentMetadataReader(
+            pathToCompletionValidator = PathToCompletionAgentValidator { ValidationResult.VALID }
+        )
+        val agentScope = reader.createAgentMetadata(AgentWithAchievesGoalNoActionAnnotation())
+        assertNotNull(agentScope)
+
+        val result = GoapPathToCompletionValidator().validate(agentScope)
+
+        assertFalse(result.isValid)
+        assertTrue(result.errors.any { it.code == ValidationErrorCodes.GOAL_ACTION_NOT_FOUND })
+    }
+
+    @Test
     fun `no Action annotation on AchievesGoal method and skip-agent-on-error is false`(output: CapturedOutput) {
         val reader = AgentMetadataReader()
         val agentScope = reader.createAgentMetadata(AgentWithAchievesGoalNoActionAnnotation())
         assertNotNull(agentScope, "Validation error is unexpectedly not ignored.")
         assertTrue(output.out.contains(noActionErrorMessage), "Error message about missing @Action is absent.")
+        assertEquals(
+            1,
+            output.out.lines().count { it.contains("- GOAL_ACTION_NOT_FOUND:") },
+            "Missing goal action should be logged once by the validation manager."
+        )
     }
 
     @Test
@@ -46,6 +70,7 @@ class AchievableGoalValidatorTest {
         val agentScope = reader.createAgentMetadata(AgentWithAchievesGoalNoActionAnnotation())
         assertNull(agentScope, "Validation error is unexpectedly ignored.")
         assertTrue(output.out.contains(noActionErrorMessage), "Error message about missing @Action is absent.")
+        assertTrue(output.out.contains("- GOAL_ACTION_NOT_FOUND:"), "Error message about missing goal action is absent.")
         val className = "com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation"
         assertTrue(output.out.contains("Agent $className is rejected as it has validation errors as reported above."), "Error message mentioning agent is missing.")
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/AchievableGoalValidatorTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/AchievableGoalValidatorTest.kt
@@ -19,11 +19,7 @@ import com.embabel.agent.api.annotation.support.AgentMetadataReader
 import com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation
 import com.embabel.agent.api.annotation.support.AgentWithValidAchievesGoalMethod
 import com.embabel.agent.api.annotation.support.AgenticComponentWithNoActionNoConditionNoGoalAnnotation
-import com.embabel.agent.core.AgentScope
-import com.embabel.agent.spi.validation.GoapPathToCompletionValidator
-import com.embabel.agent.spi.validation.PathToCompletionAgentValidator
 import com.embabel.common.core.validation.ValidationErrorCodes
-import com.embabel.common.core.validation.ValidationResult
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
@@ -39,22 +35,6 @@ class AchievableGoalValidatorTest {
     val noActionErrorMessage = """@Action annotation is missing on the method 'com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation.goal' annotated with @AchievesGoal."""
 
     @Test
-    fun `goal without matching action returns validation error`() {
-        val reader = AgentMetadataReader(
-            pathToCompletionValidator = object : PathToCompletionAgentValidator {
-                override fun validate(agentScope: AgentScope): ValidationResult = ValidationResult.VALID
-            }
-        )
-        val agentScope = reader.createAgentMetadata(AgentWithAchievesGoalNoActionAnnotation())
-        assertNotNull(agentScope)
-
-        val result = GoapPathToCompletionValidator().validate(agentScope)
-
-        assertFalse(result.isValid)
-        assertTrue(result.errors.any { it.code == ValidationErrorCodes.GOAL_ACTION_NOT_FOUND })
-    }
-
-    @Test
     fun `no Action annotation on AchievesGoal method and skip-agent-on-error is false`(output: CapturedOutput) {
         val reader = AgentMetadataReader()
         val agentScope = reader.createAgentMetadata(AgentWithAchievesGoalNoActionAnnotation())
@@ -62,8 +42,8 @@ class AchievableGoalValidatorTest {
         assertTrue(output.out.contains(noActionErrorMessage), "Error message about missing @Action is absent.")
         assertEquals(
             1,
-            output.out.lines().count { it.contains("- GOAL_ACTION_NOT_FOUND:") },
-            "Missing goal action should be logged once by the validation manager."
+            output.out.lines().count { it.contains(ValidationErrorCodes.MISSING_ACTION_ANNOTATION) },
+            "Validation error should be logged once by the validation manager."
         )
     }
 
@@ -73,9 +53,8 @@ class AchievableGoalValidatorTest {
         val agentScope = reader.createAgentMetadata(AgentWithAchievesGoalNoActionAnnotation())
         assertNull(agentScope, "Validation error is unexpectedly ignored.")
         assertTrue(output.out.contains(noActionErrorMessage), "Error message about missing @Action is absent.")
-        assertTrue(output.out.contains("- GOAL_ACTION_NOT_FOUND:"), "Error message about missing goal action is absent.")
         val className = "com.embabel.agent.api.annotation.support.AgentWithAchievesGoalNoActionAnnotation"
-        assertTrue(output.out.contains("Agent $className is rejected as it has validation errors as reported above."), "Error message mentioning agent is missing.")
+        assertTrue(output.out.contains("Agent $className is rejected due to validation errors as reported above."), "Error message mentioning agent is missing.")
     }
 
     @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/DefaultAgentValidationManagerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/validation/DefaultAgentValidationManagerTest.kt
@@ -19,14 +19,16 @@ import com.embabel.agent.api.dsl.evenMoreEvilWizard
 import com.embabel.agent.spi.validation.DefaultAgentStructureValidator
 import com.embabel.agent.spi.validation.DefaultAgentValidationManager
 import com.embabel.agent.spi.validation.GoapPathToCompletionValidator
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.embabel.common.core.validation.ValidationErrorCodes
 import org.junit.jupiter.api.Test
 import org.springframework.context.support.GenericApplicationContext
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DefaultAgentValidationManagerTest {
 
     @Test
-    fun `evil wizard`() {
+    fun `goal without matching action is invalid`() {
         val ac = GenericApplicationContext()
         ac.refresh()
         val manager = DefaultAgentValidationManager(
@@ -35,10 +37,10 @@ class DefaultAgentValidationManagerTest {
                 GoapPathToCompletionValidator(),
             )
         )
-        val r = manager.validateWithDetails(evenMoreEvilWizard())
+        val r = manager.validate(evenMoreEvilWizard())
+        assertFalse(r.isValid)
         assertTrue(
-            r.isValid,
-            "Evil wizards are valid"
+            r.errors.any { it.code == ValidationErrorCodes.GOAL_ACTION_NOT_FOUND }
         )
     }
 

--- a/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/configuration/page.adoc
@@ -197,7 +197,7 @@ Controls how the GOAP planner processes annotated agents during startup.
 |`embabel.agent.api.validation.manager.skip-agent-deployment-on-error`
 |Boolean
 |`false`
-|When `false` (default), validation manager only logs structural errors of `@Agent`s. When `true`, any invalid `@Agent` reported by validation manager is rejected at startup.
+|When `false` (default), the validation manager only logs errors for `@Agent`s. When `true`, any invalid `@Agent` reported by the validation manager is rejected at startup.
 
 |===
 


### PR DESCRIPTION
## Summary

Fixes #1991 by separating validation, logging, and deployment-policy responsibilities.

- Return `GOAL_ACTION_NOT_FOUND` when a goal has no matching action.
- Keep validation error logging within `DefaultAgentValidationManager`.
- Remove duplicate validation error logging from `AgentMetadataReader`.
- Preserve permissive deployment by default.
- Ensure `skip-agent-deployment-on-error=true` rejects agents with missing goal actions.
- Clarify the validation-manager configuration documentation.
- Add regression coverage for structured errors, strict rejection, and single logging.

## Testing

```shell
./mvnw -pl embabel-agent-api -Dtest=AchievableGoalValidatorTest test
```

## Validation flow

1. `AgentMetadataReader` creates the `AgentScope`.
2. Validators return structured validation errors.
3. `DefaultAgentValidationManager` aggregates and logs the errors.
4. `AgentMetadataReader` applies `skip-agent-deployment-on-error`.

`DefaultAgentStructureValidator` retains its lifecycle check at `DEBUG` level, while `DefaultAgentValidationManager` is the final validation-error reporter.

## Scenario verification

The validation flow was exercised using real annotated agent instances and the in-memory `AgentPlatform`.

- Valid agents deploy under permissive and strict policies.
- Invalid annotated agents remain deployable under the default permissive policy.
- Invalid annotated agents are rejected when `skip-agent-deployment-on-error=true`.
- `MISSING_ACTION_ANNOTATION` is logged exactly once.
- An assembled goal without a corresponding action returns and logs `GOAL_ACTION_NOT_FOUND` exactly once.
- The `DefaultAgentStructureValidator` lifecycle check remains operational.

```text
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Command:

```powershell
mvn -pl embabel-agent-api "-Dtest=AgentValidationDeploymentScenarioTest,AchievableGoalValidatorTest,DefaultAgentStructureValidatorTest,DefaultAgentValidationManagerTest" test
```
