### PR TITLE
Fix known snapdhot persistence issues

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/persistence/BlackboardPersistence.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/persistence/BlackboardPersistence.kt
@@ -53,6 +53,12 @@ interface BlackboardEntrySerializer {
      *
      * Implementations usually inspect [SerializedBlackboardValue.typeName],
      * [SerializedBlackboardValue.contentType], or metadata written during serialization.
+     *
+     * **The default returns `false`.** A serializer that overrides only
+     * [supportsSerialization] and [serialize] will write values but never restore
+     * them — the fallback serializer handles deserialization instead, which will
+     * likely produce wrong results or fail. Override both [supportsDeserialization]
+     * and [deserialize] for a complete serialization round-trip.
      */
     fun supportsDeserialization(value: SerializedBlackboardValue): Boolean = false
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/persistence/AgentProcessSnapshots.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/persistence/AgentProcessSnapshots.kt
@@ -63,7 +63,7 @@ interface AgentProcessSnapshotStore {
     /**
      * Return the latest serialized snapshot for the process, if one exists.
      */
-    fun findByProcessId(processId: String): SerializedAgentProcessSnapshot?
+    fun findLatestByProcessId(processId: String): SerializedAgentProcessSnapshot?
 
     /**
      * Return latest serialized snapshots for direct child processes.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/AgentProcessSnapshotRestorer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/AgentProcessSnapshotRestorer.kt
@@ -127,7 +127,7 @@ internal class SimpleAgentProcessRestorerFactory : AgentProcessRestorerFactory {
 }
 
 internal class ConcurrentAgentProcessRestorerFactory(
-    // TODO: Production/autoconfiguration wiring should supply the same
+    // Current limitation: production wiring should supply the same
     // AgentProcessCallback providers used by newly created processes.
     private val callbacks: () -> List<AgentProcessCallback> = { emptyList() },
 ) : AgentProcessRestorerFactory {

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/BlackboardEntrySerializerResolver.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/BlackboardEntrySerializerResolver.kt
@@ -27,6 +27,15 @@ import org.springframework.core.annotation.AnnotationAwareOrderComparator
  * Spring supplies custom serializers as an ordered list of beans. This resolver
  * applies that ordering, tries custom serializers first, and delegates to the
  * fallback serializer when no custom serializer supports the value.
+ *
+ * Serialization and deserialization use different dispatch paths: serialization
+ * matches on the live object via [BlackboardEntrySerializer.supportsSerialization],
+ * deserialization matches on the stored payload via
+ * [BlackboardEntrySerializer.supportsDeserialization]. A serializer must write a
+ * unique [com.embabel.agent.core.persistence.SerializedBlackboardValue.typeName]
+ * and match on it in [BlackboardEntrySerializer.supportsDeserialization]; otherwise
+ * the fallback serializer handles restore, which will likely fail or produce
+ * wrong results. Mismatches only surface at restore time, not at write time.
  */
 internal class BlackboardEntrySerializerResolver(
     serializers: List<BlackboardEntrySerializer>,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/InMemoryAgentProcessSnapshotStore.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/InMemoryAgentProcessSnapshotStore.kt
@@ -62,7 +62,7 @@ class InMemoryAgentProcessSnapshotStore : AgentProcessSnapshotStore {
         )
     }
 
-    override fun findByProcessId(processId: String): SerializedAgentProcessSnapshot? =
+    override fun findLatestByProcessId(processId: String): SerializedAgentProcessSnapshot? =
         snapshots[processId]
 
     override fun findByParentId(parentId: String): List<SerializedAgentProcessSnapshot> =

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/InMemoryBlackboardSnapshotter.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/InMemoryBlackboardSnapshotter.kt
@@ -138,6 +138,10 @@ internal class InMemoryBlackboardSnapshotter(
         val snapshot: BlackboardEntrySnapshot,
     )
 
+    // Uses reference equality (===) for most types, structural equality (==) for
+    // java.time.* values. Two equal-but-distinct objects (e.g. separately constructed
+    // data class instances with identical fields) are treated as different blackboard
+    // values and serialized separately.
     private fun sameBlackboardValue(
         left: Any,
         right: Any,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/JacksonAgentProcessStateSerializer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/JacksonAgentProcessStateSerializer.kt
@@ -55,6 +55,12 @@ internal class JacksonAgentProcessStateSerializer(
                 "Unsupported agent process snapshot content type [${snapshot.contentType}]"
             )
         }
-        return objectMapper.readValue(snapshot.payload, AgentProcessSnapshot::class.java)
+        return try {
+            objectMapper.readValue(snapshot.payload, AgentProcessSnapshot::class.java)
+        } catch (e: Exception) {
+            throw AgentProcessPersistenceException(
+                "Cannot deserialize agent process snapshot [${snapshot.processId}]", e
+            )
+        }
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/JacksonBlackboardEntrySerializer.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/JacksonBlackboardEntrySerializer.kt
@@ -15,12 +15,14 @@
  */
 package com.embabel.agent.spi.support.persistence
 
+import com.embabel.agent.core.persistence.AgentProcessPersistenceException
 import com.embabel.agent.core.persistence.BlackboardEntryDeserializationContext
 import com.embabel.agent.core.persistence.BlackboardEntrySerializationContext
 import com.embabel.agent.core.persistence.BlackboardEntrySerializer
 import com.embabel.agent.core.persistence.SerializedBlackboardValue
 import tools.jackson.databind.ObjectMapper
 import org.springframework.http.MediaType
+import org.springframework.util.ClassUtils
 
 /**
  * Default JSON serializer for blackboard entries.
@@ -30,6 +32,11 @@ import org.springframework.http.MediaType
  * value type and restores through that class, which is appropriate for simple
  * DTOs, Kotlin data classes, records, primitives, and collections that Jackson
  * can handle.
+ *
+ * **Generic type erasure:** parameterised collections such as `List<MyDto>` are
+ * stored and restored as their raw type. Jackson deserializes elements as
+ * `LinkedHashMap` rather than `MyDto`. Use a custom [BlackboardEntrySerializer]
+ * for any blackboard value that requires type parameters at restore time.
  *
  * Applications needing different semantics, such as storing JPA entities as
  * references instead of materialized object graphs, should provide a more
@@ -55,9 +62,25 @@ class JacksonBlackboardEntrySerializer(
         value: SerializedBlackboardValue,
         context: BlackboardEntryDeserializationContext,
     ): Any {
-        require(MediaType.parseMediaType(value.contentType).isCompatibleWith(MediaType.APPLICATION_JSON)) {
-            "Unsupported blackboard value content type [${value.contentType}]"
+        if (!MediaType.parseMediaType(value.contentType).isCompatibleWith(MediaType.APPLICATION_JSON)) {
+            throw AgentProcessPersistenceException(
+                "Unsupported blackboard value content type [${value.contentType}]"
+            )
         }
-        return objectMapper.readValue(value.payload, Class.forName(value.typeName))
+        val type = try {
+            ClassUtils.forName(value.typeName, ClassUtils.getDefaultClassLoader())
+        } catch (e: ClassNotFoundException) {
+            throw AgentProcessPersistenceException(
+                "Cannot restore blackboard value: class [${value.typeName}] not found. " +
+                        "The class may have been renamed or removed.", e
+            )
+        }
+        return try {
+            objectMapper.readValue(value.payload, type)
+        } catch (e: Exception) {
+            throw AgentProcessPersistenceException(
+                "Cannot deserialize blackboard value of type [${value.typeName}]", e
+            )
+        }
     }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/PersistentAgentProcessRepository.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/PersistentAgentProcessRepository.kt
@@ -31,12 +31,10 @@ import com.embabel.agent.spi.persistence.AgentProcessSnapshotStore
  * processes. The snapshot store is consulted when the runtime repository
  * misses, allowing another runtime to rebuild a process from durable state.
  *
- * This foundation keeps runtime save and snapshot save as separate operations.
- * The snapshot store's expected-version check prevents stale writes, but a
- * concurrent writer can still win between lookup and save, causing the store to
- * reject this checkpoint. Transactional multi-runtime semantics require a
- * persistent runtime repository and snapshot store that participate in the same
- * transaction boundary.
+ * The snapshot store is always written before the runtime repository. If the
+ * snapshot save fails, the runtime repository is not updated and the exception
+ * propagates to the caller. Concurrent checkpoint conflicts are caught by the
+ * store's expected-version check. These two writes are not atomic.
  */
 internal class PersistentAgentProcessRepository(
     private val runtimeRepository: AgentProcessRepository,
@@ -50,7 +48,7 @@ internal class PersistentAgentProcessRepository(
 ) : AbstractAgentProcessRepository() {
 
     override fun findById(id: String): AgentProcess? =
-        runtimeRepository.findById(id) ?: restore(snapshotStore.findByProcessId(id))
+        runtimeRepository.findById(id) ?: restore(snapshotStore.findLatestByProcessId(id))
 
     override fun findByParentId(parentId: String): List<AgentProcess> {
         val runtimeChildren = runtimeRepository.findByParentId(parentId)
@@ -62,14 +60,13 @@ internal class PersistentAgentProcessRepository(
     }
 
     override fun doSave(agentProcess: AgentProcess): AgentProcess {
-        val saved = runtimeRepository.save(agentProcess)
-        checkpointIfNeeded(saved)
-        return saved
+        checkpointIfNeeded(agentProcess)
+        return runtimeRepository.save(agentProcess)
     }
 
     override fun doUpdate(agentProcess: AgentProcess) {
-        runtimeRepository.update(agentProcess)
         checkpointIfNeeded(agentProcess)
+        runtimeRepository.update(agentProcess)
     }
 
     override fun delete(agentProcess: AgentProcess) {
@@ -81,7 +78,7 @@ internal class PersistentAgentProcessRepository(
         if (!checkpointPolicy.shouldStoreSnapshot(agentProcess)) {
             return
         }
-        val existing = snapshotStore.findByProcessId(agentProcess.id)
+        val existing = snapshotStore.findLatestByProcessId(agentProcess.id)
         val nextVersion = (existing?.version ?: 0) + 1
         val snapshot = snapshotFactory.snapshot(
             agentProcess = agentProcess,
@@ -93,6 +90,10 @@ internal class PersistentAgentProcessRepository(
         )
     }
 
+    // After the first restore the process is cached in the runtime repository, so
+    // subsequent findById calls will not reach here. Two concurrent misses can both
+    // restore and save the same snapshot; the redundant save is harmless because the
+    // runtime repository stores by process id and the restored state is identical.
     private fun restore(serialized: com.embabel.agent.spi.persistence.SerializedAgentProcessSnapshot?): AgentProcess? =
         serialized?.let {
             val restored = snapshotRestorer.restore(

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/README.md
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/README.md
@@ -54,7 +54,7 @@ classDiagram
     class AgentProcessSnapshotStore {
         <<interface>>
         +save(snapshot, expectedVersion)
-        +findByProcessId(processId)
+        +findLatestByProcessId(processId)
         +findByParentId(parentId)
         +delete(processId)
     }
@@ -121,25 +121,91 @@ classDiagram
 delegate is the runtime repository holding active in-process objects; the
 snapshot store is only consulted when the runtime repository misses.
 
-## MUST TODO
+## TODO
 
-- Add a JDBC `AgentProcessRepository` implementation for production cases that
-  need runtime state and snapshots to participate in the same database
-  transaction. The current tests use `InMemoryAgentProcessRepository` as the
-  pluggable runtime repository.
-- Add a configurable `BlackboardSnapshotter` SPI so persistence is not tied to
-  `InMemoryBlackboard`.
-- Add explicit action-boundary checkpoint support if durable state must advance
-  after intermediate actions, not only at `WAITING` and terminal boundaries.
-- Review direct `AgentProcessSnapshotStore` versioning ergonomics. The
-  persistent repository computes expected versions, but direct store callers must
-  still supply the correct compare-and-set version.
-- Define retry or outbox semantics for rejected checkpoints in multi-runtime
-  deployments.
-- Decide whether repeated `InMemoryBlackboard.bind` calls for the same key
-  should keep historical entry values or replace the earlier entry. Snapshot
-  restore preserves the current behavior, which can make overwritten values
-  visible as unnamed entries.
+### Cache integration
+
+- **Spring Boot autoconfiguration**: when an `AgentCacheProvider` bean is
+  present, automatically create a `CacheBackedAgentProcessSnapshotStore` using
+  `CacheRegions.AGENT_PROCESS_SNAPSHOTS` and register it as the
+  `AgentProcessSnapshotStore` bean. Users should need no manual wiring beyond
+  declaring their cache backend.
+- **Boot-context E2E test**: prove that a `CacheManager` or `AgentCacheProvider`
+  bean alone activates platform persistence — snapshot saved, pod-loss simulated,
+  process restored on a fresh repository.
+- **Distributed CAS E2E with Testcontainers Redis**: `SpringCacheAgentCacheProvider`
+  uses in-JVM locking only and cannot guarantee `ATOMIC_COMPARE_AND_SET` across
+  pods. A Testcontainers-backed Redis test is needed to prove concurrent
+  checkpoint conflicts are correctly rejected in a real distributed scenario.
+- **Native Redis provider** (`embabel-agent-cache-redis`): implement
+  `AgentCacheProvider` over Lettuce or Redisson with atomic `SET ... IF` for
+  production-safe `ATOMIC_COMPARE_AND_SET`.
+- **Parent index cleanup in `CacheBackedAgentProcessSnapshotStore`**: `save()`
+  adds the new parent index entry but does not remove the old one if `parentId`
+  changes. Confirm `parentId` is immutable and assert it, or add cleanup on
+  update.
+- **Callback wiring for restored `ConcurrentAgentProcess`**: production
+  autoconfiguration must supply the same `AgentProcessCallback` providers used
+  by newly created processes.
+
+### Action-boundary checkpoint
+
+- **`PostActionCheckpointPolicy`**: checkpoint after each action completes so a
+  long-running agent can resume from its last completed action rather than
+  restart entirely on pod loss. This is the main gap for non-HITL agents that
+  are too expensive to restart.
+- **Factory support for `RUNNING` state**: `AgentProcessSnapshotFactory`
+  currently requires `WAITING` or finished. Supporting action-boundary snapshots
+  requires snapshots of a `RUNNING` process with partial action history.
+- **Planner resume from partial history**: on restore from an action-boundary
+  snapshot, the planner must skip already-completed actions and continue from
+  where execution left off.
+- **Pre-LLM call checkpoint** *(follow-on)*: checkpoint before expensive
+  non-deterministic LLM calls so a pod failure after the call does not force a
+  re-run. Requires wiring into the operation scheduler or LLM client layer.
+- **Explicit/programmatic checkpoint** *(follow-on)*: allow agent or action code
+  to call `checkpoint()` at semantically meaningful points, giving developers
+  control without the cost of checkpointing every action boundary.
+
+### Other
+
+- **`BlackboardSnapshotter` SPI**: replace the direct `InMemoryBlackboard` cast
+  in `AgentProcessSnapshotFactory` so persistence is not tied to one blackboard
+  implementation.
+- **Versioning ergonomics**: the persistent repository computes expected
+  versions internally; direct `AgentProcessSnapshotStore` callers must still
+  supply the correct compare-and-set version manually.
+- **Retry / outbox semantics**: define behavior for rejected checkpoints in
+  multi-runtime deployments — fail fast, retry with back-off, or outbox pattern.
+- **`InMemoryBlackboard.bind` overwrite behavior**: repeated bind calls for the
+  same key append old values as unnamed entries. Decide whether to preserve or
+  replace; snapshot restore preserves current behavior.
+
+### Blackboard audit events
+
+- **`BlackboardListener` SPI on `Blackboard`**: fire before/after each `bind()`
+  and remove, supplying old value and new value. Without this hook, audit can
+  only diff consecutive snapshots and misses intra-action intermediate changes.
+- **`BlackboardAuditEvent`**: `processId`, `actionName`, `key`,
+  `changeType` (ADDED / UPDATED / REMOVED), `oldValue: SerializedBlackboardValue?`,
+  `newValue: SerializedBlackboardValue?`, `timestamp`. Reuses
+  `SerializedBlackboardValue` and `BlackboardEntrySerializer` for both sides.
+- **`BlackboardAuditPublisher` SPI**: append-only backend decoupled from
+  `AgentProcessSnapshotStore`. Audit events are immutable; snapshots are
+  mutable overwrites — they must not share the same store.
+- **Action context threading**: the blackboard mutation point sits inside an
+  action executor. The listener needs the current action name threaded through
+  so each audit event records its cause.
+- **`BlackboardEntrySerializationContext` extension**: add `actionName` and
+  `changeType` fields so serializers can include audit metadata in the payload
+  without breaking the existing snapshot serialization path.
+
+## Nice to Have
+
+- **JDBC `AgentProcessRepository`**: for cases where runtime state and snapshots
+  must participate in the same database transaction. The current
+  `InMemoryAgentProcessRepository` is sufficient for Kubernetes HITL recovery
+  via snapshot restore-on-miss.
 
 ## Scope
 

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/WaitForCheckpointPolicy.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/WaitForCheckpointPolicy.kt
@@ -26,6 +26,9 @@ import com.embabel.agent.spi.persistence.AgentProcessCheckpointPolicy
  * [issue #1965](https://github.com/embabel/embabel-agent/issues/1965): persist
  * when a process intentionally waits for external input, so another pod can
  * restore and resume it later.
+ *
+ * Kept as a named object rather than a lambda so it can be referenced by name
+ * in configuration and documentation.
  */
 object WaitForCheckpointPolicy : AgentProcessCheckpointPolicy {
 
@@ -39,6 +42,9 @@ object WaitForCheckpointPolicy : AgentProcessCheckpointPolicy {
  * Waiting snapshots allow another runtime to resume work after local process
  * loss. Finished snapshots then advance the durable state after the resumed
  * process completes, fails, or is externally terminated.
+ *
+ * Kept as a named object rather than a lambda so it can be referenced by name
+ * in configuration and documentation.
  */
 object LifecycleCheckpointPolicy : AgentProcessCheckpointPolicy {
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/hitl/WaitForPersistentRepositoryJdbcMvcIntegrationTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/api/hitl/WaitForPersistentRepositoryJdbcMvcIntegrationTest.kt
@@ -291,7 +291,7 @@ class WaitForPersistentRepositoryJdbcMvcIntegrationTest {
 
         assertThat(runtimeRepository.findById(awaitableResponse.processId)?.status)
             .isEqualTo(AgentProcessStatusCode.WAITING)
-        assertThat(snapshotStore.findByProcessId(awaitableResponse.processId)).isNotNull
+        assertThat(snapshotStore.findLatestByProcessId(awaitableResponse.processId)).isNotNull
         persistentMvcTestLogger.info(
             "Test step 1 complete: durable snapshots={}",
             (snapshotStore as JdbcAgentProcessSnapshotStoreForTest).describeRows(),
@@ -327,7 +327,7 @@ class WaitForPersistentRepositoryJdbcMvcIntegrationTest {
         assertThat(completedProcess?.status).isEqualTo(AgentProcessStatusCode.COMPLETED)
         assertThat(completedProcess?.blackboard?.last(AdventureResult::class.java)?.outcome)
             .isEqualTo("You chose: Castle")
-        val completedSnapshot = snapshotStore.findByProcessId(awaitableResponse.processId)
+        val completedSnapshot = snapshotStore.findLatestByProcessId(awaitableResponse.processId)
         assertThat(completedSnapshot?.status).isEqualTo(AgentProcessStatusCode.COMPLETED)
         assertThat(completedSnapshot?.version).isEqualTo(2)
         persistentMvcTestLogger.info(
@@ -459,7 +459,7 @@ private class JdbcAgentProcessSnapshotStoreForTest(
             update(snapshot, expectedVersion)
         }
         if (updated != 1) {
-            val found = findByProcessId(snapshot.processId)?.version
+            val found = findLatestByProcessId(snapshot.processId)?.version
             throw AgentProcessPersistenceException(
                 "Cannot save snapshot for process [${snapshot.processId}]: expected version " +
                 "[$expectedVersion] but found [$found]"
@@ -480,7 +480,7 @@ private class JdbcAgentProcessSnapshotStoreForTest(
         )
     }
 
-    override fun findByProcessId(processId: String): SerializedAgentProcessSnapshot? {
+    override fun findLatestByProcessId(processId: String): SerializedAgentProcessSnapshot? {
         val snapshot = jdbcTemplate.query(
             """
             select process_id, parent_id, agent_name, status, version, content_type, payload, created_at, updated_at

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AgentProcessPersistenceWiringTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AgentProcessPersistenceWiringTest.kt
@@ -78,7 +78,7 @@ class AgentProcessPersistenceWiringTest {
 
         repository.save(waitingProcess("p1"))
 
-        val snapshot = store.findByProcessId("p1")
+        val snapshot = store.findLatestByProcessId("p1")
         assertNotNull(snapshot)
         assertEquals(AgentProcessStatusCode.WAITING, snapshot?.status)
     }
@@ -93,7 +93,7 @@ class AgentProcessPersistenceWiringTest {
 
         repository.save(waitingProcess("p1"))
 
-        assertNull(store.findByProcessId("p1"))
+        assertNull(store.findLatestByProcessId("p1"))
         assertNotNull(repository.findById("p1"), "the runtime repository must still work")
     }
 
@@ -110,7 +110,7 @@ class AgentProcessPersistenceWiringTest {
         // NOT_STARTED is neither WAITING nor finished, so the wait policy skips it.
         repository.save(newProcess("p1"))
 
-        assertNull(store.findByProcessId("p1"))
+        assertNull(store.findLatestByProcessId("p1"))
     }
 
     @Test
@@ -142,7 +142,7 @@ class AgentProcessPersistenceWiringTest {
 
         repository.save(waitingProcess("p1"))
 
-        assertNotNull(store.findByProcessId("p1"))
+        assertNotNull(store.findLatestByProcessId("p1"))
     }
 
     private fun repository(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistenceTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistenceTest.kt
@@ -61,7 +61,7 @@ class AgentProcessPersistenceTest {
 
         repository.save(waitingProcess("p1"))
 
-        val snapshot = store.findByProcessId("p1")
+        val snapshot = store.findLatestByProcessId("p1")
         assertNotNull(snapshot)
         assertEquals(AgentProcessStatusCode.WAITING, snapshot?.status)
         assertEquals(1L, snapshot?.version)
@@ -107,7 +107,7 @@ class AgentProcessPersistenceTest {
         repository.save(process)
         repository.update(process)
 
-        assertEquals(2L, store.findByProcessId("p1")?.version, "update should advance the version")
+        assertEquals(2L, store.findLatestByProcessId("p1")?.version, "update should advance the version")
     }
 
     @Test
@@ -120,7 +120,7 @@ class AgentProcessPersistenceTest {
 
         repository.save(newProcess("p1"))
 
-        assertNull(store.findByProcessId("p1"), "a NOT_STARTED process is not a wait checkpoint")
+        assertNull(store.findLatestByProcessId("p1"), "a NOT_STARTED process is not a wait checkpoint")
     }
 
     @Test
@@ -143,7 +143,7 @@ class AgentProcessPersistenceTest {
 
         repository.delete(process)
 
-        assertNull(store.findByProcessId("p1"))
+        assertNull(store.findLatestByProcessId("p1"))
         assertNull(runtime.findById("p1"))
     }
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/InMemoryAgentProcessSnapshotStoreTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/InMemoryAgentProcessSnapshotStoreTest.kt
@@ -41,7 +41,7 @@ class InMemoryAgentProcessSnapshotStoreTest {
         assertEquals(1, stored.version)
         assertEquals(now, stored.updatedAt)
 
-        val loaded = store.findByProcessId("p1")
+        val loaded = store.findLatestByProcessId("p1")
         assertSnapshotFields(snapshot, loaded)
         assertArrayEquals(snapshot.payload, loaded?.payload)
     }
@@ -65,7 +65,7 @@ class InMemoryAgentProcessSnapshotStoreTest {
         val stored = store.save(updated, expectedVersion = 1)
 
         assertEquals(2, stored.version)
-        val loaded = store.findByProcessId("p1")
+        val loaded = store.findLatestByProcessId("p1")
         assertSnapshotFields(updated, loaded)
         assertArrayEquals(updated.payload, loaded?.payload)
     }
@@ -88,7 +88,7 @@ class InMemoryAgentProcessSnapshotStoreTest {
 
         store.delete("p1")
 
-        assertNull(store.findByProcessId("p1"))
+        assertNull(store.findLatestByProcessId("p1"))
     }
 
     @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/JacksonAgentProcessStateSerializerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/JacksonAgentProcessStateSerializerTest.kt
@@ -87,6 +87,25 @@ class JacksonAgentProcessStateSerializerTest {
         }
     }
 
+    @Test
+    fun `corrupt payload throws AgentProcessPersistenceException`() {
+        val serialized = SerializedAgentProcessSnapshot(
+            processId = "p1",
+            parentId = null,
+            agentName = "test-agent",
+            status = AgentProcessStatusCode.WAITING,
+            version = 1,
+            contentType = MediaType.APPLICATION_JSON,
+            payload = "not valid json".toByteArray(),
+            createdAt = createdAt,
+            updatedAt = updatedAt,
+        )
+
+        assertThrows(AgentProcessPersistenceException::class.java) {
+            serializer.deserialize(serialized)
+        }
+    }
+
     @Nested
     inner class Performance {
 

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/JacksonBlackboardEntrySerializerTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/JacksonBlackboardEntrySerializerTest.kt
@@ -15,6 +15,7 @@
  */
 package com.embabel.agent.spi.support.persistence
 
+import com.embabel.agent.core.persistence.AgentProcessPersistenceException
 import com.embabel.agent.core.persistence.SerializedBlackboardValue
 import com.embabel.common.util.EmbabelObjectMapperHolder
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -48,7 +49,33 @@ class JacksonBlackboardEntrySerializerTest {
             payload = "<value />".toByteArray(),
         )
 
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(AgentProcessPersistenceException::class.java) {
+            serializer.deserialize(serialized)
+        }
+    }
+
+    @Test
+    fun `unknown class name throws AgentProcessPersistenceException`() {
+        val serialized = SerializedBlackboardValue(
+            typeName = "com.example.NonExistentClass",
+            contentType = MediaType.APPLICATION_JSON_VALUE,
+            payload = "{}".toByteArray(),
+        )
+
+        assertThrows(AgentProcessPersistenceException::class.java) {
+            serializer.deserialize(serialized)
+        }
+    }
+
+    @Test
+    fun `corrupt payload throws AgentProcessPersistenceException`() {
+        val serialized = SerializedBlackboardValue(
+            typeName = SampleValue::class.java.name,
+            contentType = MediaType.APPLICATION_JSON_VALUE,
+            payload = "not valid json".toByteArray(),
+        )
+
+        assertThrows(AgentProcessPersistenceException::class.java) {
             serializer.deserialize(serialized)
         }
     }

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/PersistentAgentProcessRepositoryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/PersistentAgentProcessRepositoryTest.kt
@@ -18,12 +18,16 @@ package com.embabel.agent.spi.support.persistence
 import com.embabel.agent.core.AgentProcessStatusCode
 import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.persistence.AgentProcessPersistenceException
 import com.embabel.agent.core.support.DslWaitingAgent
 import com.embabel.agent.core.support.InMemoryBlackboard
 import com.embabel.agent.core.support.InternalAgentStateApi
 import com.embabel.agent.core.support.SimpleAgentProcess
 import com.embabel.agent.domain.io.UserInput
 import com.embabel.agent.spi.persistence.AgentProcessCheckpointPolicy
+import com.embabel.agent.spi.persistence.SerializedAgentProcessSnapshot
+import com.embabel.agent.spi.persistence.StoredSnapshotMetadata
+import com.embabel.agent.spi.persistence.AgentProcessSnapshotStore
 import com.embabel.agent.spi.support.DefaultPlannerFactory
 import com.embabel.agent.spi.support.InMemoryAgentProcessRepository
 import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
@@ -32,6 +36,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @OptIn(InternalAgentStateApi::class)
 class PersistentAgentProcessRepositoryTest {
@@ -55,7 +60,7 @@ class PersistentAgentProcessRepositoryTest {
 
         repository.save(process)
 
-        val snapshot = snapshotStore.findByProcessId("p1")
+        val snapshot = snapshotStore.findLatestByProcessId("p1")
         assertNotNull(snapshot)
         assertEquals(1, snapshot?.version)
         assertEquals(AgentProcessStatusCode.WAITING, snapshot?.status)
@@ -72,7 +77,7 @@ class PersistentAgentProcessRepositoryTest {
 
         repository.save(process)
 
-        assertNull(snapshotStore.findByProcessId("p1"))
+        assertNull(snapshotStore.findLatestByProcessId("p1"))
     }
 
     @Test
@@ -87,7 +92,7 @@ class PersistentAgentProcessRepositoryTest {
 
         repository.save(process)
 
-        val snapshot = snapshotStore.findByProcessId("p1")
+        val snapshot = snapshotStore.findLatestByProcessId("p1")
         assertNotNull(snapshot)
         assertEquals(1, snapshot?.version)
         assertEquals(AgentProcessStatusCode.COMPLETED, snapshot?.status)
@@ -102,7 +107,26 @@ class PersistentAgentProcessRepositoryTest {
         repository.save(process)
         repository.update(process)
 
-        assertEquals(2, snapshotStore.findByProcessId("p1")?.version)
+        assertEquals(2, snapshotStore.findLatestByProcessId("p1")?.version)
+    }
+
+    @Test
+    fun `snapshot save failure on initial save does not register process in runtime repository`() {
+        val runtimeRepository = InMemoryAgentProcessRepository()
+        val repository = PersistentAgentProcessRepository(
+            runtimeRepository = runtimeRepository,
+            snapshotStore = FailingAgentProcessSnapshotStore(),
+            checkpointPolicy = LifecycleCheckpointPolicy,
+            snapshotFactory = snapshotFactory,
+            snapshotSerializer = snapshotSerializer,
+            snapshotRestorer = snapshotRestorer,
+            agents = { listOf(DslWaitingAgent) },
+            platformServices = { dummyPlatformServices() },
+        )
+
+        assertThrows<AgentProcessPersistenceException> { repository.save(waitingProcess("p1")) }
+
+        assertNull(runtimeRepository.findById("p1"), "process must not be registered when checkpoint fails")
     }
 
     @Test
@@ -143,6 +167,14 @@ class PersistentAgentProcessRepositoryTest {
             agents = { listOf(DslWaitingAgent) },
             platformServices = { dummyPlatformServices() },
         )
+
+    private class FailingAgentProcessSnapshotStore : AgentProcessSnapshotStore {
+        override fun save(snapshot: SerializedAgentProcessSnapshot, expectedVersion: Long?): StoredSnapshotMetadata =
+            throw AgentProcessPersistenceException("store unavailable")
+        override fun findLatestByProcessId(processId: String): SerializedAgentProcessSnapshot? = null
+        override fun findByParentId(parentId: String): List<SerializedAgentProcessSnapshot> = emptyList()
+        override fun delete(processId: String) {}
+    }
 
     private fun waitingProcess(id: String): SimpleAgentProcess =
         newProcess(id).also {

--- a/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStore.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStore.kt
@@ -95,12 +95,12 @@ class CacheBackedAgentProcessSnapshotStore(
         )
     }
 
-    override fun findByProcessId(processId: String): SerializedAgentProcessSnapshot? =
+    override fun findLatestByProcessId(processId: String): SerializedAgentProcessSnapshot? =
         region.get(processId)?.toSnapshot()
 
     override fun findByParentId(parentId: String): List<SerializedAgentProcessSnapshot> =
         parentIndex.members(parentId)
-            .mapNotNull { findByProcessId(it) }
+            .mapNotNull { findLatestByProcessId(it) }
 
     override fun delete(processId: String) {
         // Read first so the parent index can be cleaned up. A missing entry is not

--- a/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStoreTest.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStoreTest.kt
@@ -67,12 +67,12 @@ class CacheBackedAgentProcessSnapshotStoreTest {
 
         store.save(original, expectedVersion = null)
 
-        assertEquals(original, store.findByProcessId("p1"))
+        assertEquals(original, store.findLatestByProcessId("p1"))
     }
 
     @Test
     fun `returns null for an unknown process`() {
-        assertNull(store().findByProcessId("missing"))
+        assertNull(store().findLatestByProcessId("missing"))
     }
 
     @Test
@@ -91,7 +91,7 @@ class CacheBackedAgentProcessSnapshotStoreTest {
         val original = snapshot(metadata = mapOf("processId" to "not-the-real-one"))
 
         store.save(original, expectedVersion = null)
-        val restored = store.findByProcessId("p1")!!
+        val restored = store.findLatestByProcessId("p1")!!
 
         assertEquals("p1", restored.processId)
         assertEquals(mapOf("processId" to "not-the-real-one"), restored.metadata)
@@ -107,7 +107,7 @@ class CacheBackedAgentProcessSnapshotStoreTest {
 
             store.save(snapshot(version = 2), expectedVersion = 1)
 
-            assertEquals(2L, store.findByProcessId("p1")?.version)
+            assertEquals(2L, store.findLatestByProcessId("p1")?.version)
         }
 
         @Test
@@ -123,7 +123,7 @@ class CacheBackedAgentProcessSnapshotStoreTest {
                 thrown.message!!.contains("p1"),
                 "message should name the process: ${thrown.message}",
             )
-            assertEquals(2L, store.findByProcessId("p1")?.version, "stored value must be untouched")
+            assertEquals(2L, store.findLatestByProcessId("p1")?.version, "stored value must be untouched")
         }
 
         @Test
@@ -166,7 +166,7 @@ class CacheBackedAgentProcessSnapshotStoreTest {
 
             store.delete("c1")
 
-            assertNull(store.findByProcessId("c1"))
+            assertNull(store.findLatestByProcessId("c1"))
             assertEquals(listOf("c2"), store.findByParentId("parent").map { it.processId })
         }
 
@@ -178,7 +178,7 @@ class CacheBackedAgentProcessSnapshotStoreTest {
             store.delete("p1")
             store.delete("p1")
 
-            assertNull(store.findByProcessId("p1"))
+            assertNull(store.findLatestByProcessId("p1"))
         }
     }
 


### PR DESCRIPTION
# Overview

- fix(persistence): checkpoint snapshot store before runtime repository
- fix(persistence): rename findLatestByProcessId, wrap deserialization errors
- docs(persistence): document contracts, limitations, and roadmap

References: #1988 #1989 

## Summary

  - Fixes a production correctness bug: snapshot store is now always written
    before the runtime repository. A failed checkpoint leaves the process
    unregistered rather than silently stranded in memory without a durable
    recovery point.
  - Renames `findByProcessId` → `findLatestByProcessId` on the
    `AgentProcessSnapshotStore` SPI for clarity.
  - Wraps all deserialization errors as `AgentProcessPersistenceException`
    and switches to `ClassUtils.forName` for correct classloader behaviour
    in Spring Boot deployments.
  - Adds documentation for known limitations: generic type erasure in the
    fallback serializer, asymmetric serializer dispatch, identity equality
    in blackboard change detection, and the `supportsDeserialization` default.
  - Expands the persistence README roadmap to cover cache autoconfiguration,
    distributed testing, action-boundary checkpointing, and blackboard
    audit events.
