### PR TITLE
Reject parent change in CacheBackedAgentProcessSnapshotStore

### DIFF
--- a/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStore.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/main/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStore.kt
@@ -75,6 +75,19 @@ class CacheBackedAgentProcessSnapshotStore(
         snapshot: SerializedAgentProcessSnapshot,
         expectedVersion: Long?,
     ): StoredSnapshotMetadata {
+        // AgentProcess.parentId is immutable, so a change here means caller error
+        // or a reused process id. Accepting it would leave the previous index entry
+        // in place and report the child under both parents. Costs one extra read;
+        // avoidable if AgentCacheRegion.replace ever returns the previous value.
+        val stored = region.get(snapshot.processId)
+        if (stored != null && stored.metadata[PARENT_ID] != snapshot.parentId) {
+            throw AgentProcessPersistenceException(
+                "Parent of process [${snapshot.processId}] changed from " +
+                        "[${stored.metadata[PARENT_ID]}] to [${snapshot.parentId}]. " +
+                        "Process parentage is immutable; this is a caller error or a reused process id."
+            )
+        }
+
         val applied = region.replace(
             key = snapshot.processId,
             expectedVersion = expectedVersion,

--- a/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStoreTest.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/CacheBackedAgentProcessSnapshotStoreTest.kt
@@ -171,6 +171,49 @@ class CacheBackedAgentProcessSnapshotStoreTest {
         }
 
         @Test
+        fun `repeated checkpoints keep a single index entry`() {
+            val store = store("repeat")
+            store.save(snapshot(processId = "c1", parentId = "parent", version = 1), expectedVersion = null)
+            store.save(snapshot(processId = "c1", parentId = "parent", version = 2), expectedVersion = 1)
+            store.save(snapshot(processId = "c1", parentId = "parent", version = 3), expectedVersion = 2)
+
+            assertEquals(listOf("c1"), store.findByParentId("parent").map { it.processId })
+        }
+
+        @Test
+        fun `rejects a parent change for an existing process`() {
+            // AgentProcess.parentId is a val, so a change means caller error or a
+            // reused process id. Accepting it would strand the old index entry and
+            // findByParentId would report the child under both parents.
+            val store = store("reparent")
+            store.save(snapshot(processId = "c1", parentId = "old-parent", version = 1), expectedVersion = null)
+
+            val thrown = assertThrows(AgentProcessPersistenceException::class.java) {
+                store.save(snapshot(processId = "c1", parentId = "new-parent", version = 2), expectedVersion = 1)
+            }
+            assertTrue(
+                thrown.message!!.contains("c1"),
+                "message should name the process: ${thrown.message}",
+            )
+            assertEquals(
+                listOf("c1"),
+                store.findByParentId("old-parent").map { it.processId },
+                "the original index entry must be intact",
+            )
+            assertEquals(emptyList<String>(), store.findByParentId("new-parent").map { it.processId })
+        }
+
+        @Test
+        fun `rejects dropping a parent from an existing process`() {
+            val store = store("deparent")
+            store.save(snapshot(processId = "c1", parentId = "parent", version = 1), expectedVersion = null)
+
+            assertThrows(AgentProcessPersistenceException::class.java) {
+                store.save(snapshot(processId = "c1", parentId = null, version = 2), expectedVersion = 1)
+            }
+        }
+
+        @Test
         fun `delete is idempotent`() {
             val store = store("idempotent-delete")
             store.delete("never-existed")


### PR DESCRIPTION
\`save()\` added the new parent index entry without removing a stale one, so a changed \`parentId\` would leave the child indexed under both parents.