### PR TITLE
Add JCache-backed agent process persistence with JCache reference implementation

### DIFF
--- a/embabel-agent-cache/embabel-agent-cache-core/pom.xml
+++ b/embabel-agent-cache/embabel-agent-cache-core/pom.xml
@@ -38,6 +38,27 @@
             <artifactId>embabel-agent-test-common</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Spring MVC test slice for WaitForPersistentRepositoryJCacheMvcIntegrationTest -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/CacheBackedPersistenceIntegrationTest.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/CacheBackedPersistenceIntegrationTest.kt
@@ -64,7 +64,7 @@ import org.springframework.cache.concurrent.ConcurrentMapCacheManager
  * region and store. Only [AgentPlatform] is mocked, because it is a collaborator
  * of restore rather than anything under test here.
  */
-class CacheBackedPersistenceIT {
+class CacheBackedPersistenceIntegrationTest {
 
     private val objectMapperHolder = EmbabelObjectMapperHolder.createDefault()
 
@@ -83,7 +83,7 @@ class CacheBackedPersistenceIT {
 
     @Test
     fun `checkpoints a waiting process into the cache region`() {
-        val repository = nodeRepository(store())
+        val repository = persistentRepository(store())
 
         repository.save(waitingProcess("p1"))
 
@@ -104,10 +104,10 @@ class CacheBackedPersistenceIT {
         // The Kubernetes case #1965 describes: the pod owning the process is
         // scaled away while a human is still deciding.
         val original = waitingProcess("p1")
-        nodeRepository(store()).save(original)
+        persistentRepository(store()).save(original)
 
         // A fresh repository: its runtime store is empty, as on a different pod.
-        val survivingNode = nodeRepository(store())
+        val survivingNode = persistentRepository(store())
         val restored = survivingNode.findById("p1")
 
         assertNotNull(restored)
@@ -120,19 +120,19 @@ class CacheBackedPersistenceIT {
     fun `a lost process is unrecoverable without the shared cache`() {
         // Control for the test above: proves restore came from the cache and not
         // from anything the repositories share in memory.
-        nodeRepository(store()).save(waitingProcess("p1"))
+        persistentRepository(store()).save(waitingProcess("p1"))
 
         val isolatedProvider = SpringCacheAgentCacheProvider(ConcurrentMapCacheManager())
         val isolatedStore = CacheBackedAgentProcessSnapshotStore(
             isolatedProvider.getRegion(CacheRegionConfig(CacheRegions.AGENT_PROCESS_SNAPSHOTS))
         )
 
-        assertNull(nodeRepository(isolatedStore).findById("p1"))
+        assertNull(persistentRepository(isolatedStore).findById("p1"))
     }
 
     @Test
     fun `nothing is cached when persistence is disabled`() {
-        val repository = nodeRepository(
+        val repository = persistentRepository(
             store(),
             persistenceProperties = AgentProcessPersistenceProperties(enabled = false),
         )
@@ -161,7 +161,7 @@ class CacheBackedPersistenceIT {
 
     @Test
     fun `deleting a process clears it from the cache`() {
-        val repository = nodeRepository(store())
+        val repository = persistentRepository(store())
         val process = waitingProcess("p1")
         repository.save(process)
 
@@ -173,7 +173,7 @@ class CacheBackedPersistenceIT {
     /**
      * Build the repository exactly as the platform does, over the given store.
      */
-    private fun nodeRepository(
+    private fun persistentRepository(
         snapshotStore: AgentProcessSnapshotStore,
         persistenceProperties: AgentProcessPersistenceProperties = AgentProcessPersistenceProperties(),
     ): AgentProcessRepository =

--- a/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/JCacheAgentCacheProvider.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/JCacheAgentCacheProvider.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.cache.support
+
+import com.embabel.agent.cache.AgentCacheIndex
+import com.embabel.agent.cache.AgentCacheProvider
+import com.embabel.agent.cache.AgentCacheRegion
+import com.embabel.agent.cache.CacheCapability
+import com.embabel.agent.cache.CacheRegionConfig
+import com.embabel.agent.cache.CachedValue
+import java.util.concurrent.ConcurrentHashMap
+import javax.cache.Cache
+import javax.cache.CacheManager
+import javax.cache.configuration.MutableConfiguration
+
+/**
+ * Reference [AgentCacheProvider] over a JSR-107 [CacheManager].
+ *
+ * Intended as a test fixture demonstrating true [CacheCapability.ATOMIC_COMPARE_AND_SET]
+ * via [Cache.replace]. Backends such as Ehcache 3, Infinispan, and Hazelcast honour
+ * the JCache CAS contract at the API level.
+ *
+ * Caches are configured with [MutableConfiguration.setStoreByValue] `false` so that
+ * [CachedValue] instances are stored by reference — no [java.io.Serializable] requirement.
+ * For heap-only use in tests this is correct; a production provider targeting an
+ * off-heap or distributed tier would need serialization.
+ */
+internal class JCacheAgentCacheProvider(
+    private val cacheManager: CacheManager,
+) : AgentCacheProvider {
+
+    override val name: String = NAME
+
+    private val regions = ConcurrentHashMap<String, AgentCacheRegion>()
+
+    override fun getRegion(config: CacheRegionConfig): AgentCacheRegion =
+        regions.computeIfAbsent(config.name) {
+            val cache: Cache<String, CachedValue> =
+                cacheManager.getCache(config.name, String::class.java, CachedValue::class.java)
+                    ?: cacheManager.createCache(
+                        config.name,
+                        MutableConfiguration<String, CachedValue>()
+                            .setTypes(String::class.java, CachedValue::class.java)
+                            .setStoreByValue(false),
+                    )
+            JCacheAgentCacheRegion(cache)
+        }
+
+    override fun close() {
+        cacheManager.close()
+    }
+
+    companion object {
+        const val NAME = "jcache"
+    }
+}
+
+/**
+ * [AgentCacheRegion] backed by a JSR-107 [Cache].
+ *
+ * CAS is delegated to [Cache.replace] which is atomic at the JCache API level.
+ * [CachedValue.equals] performs structural comparison (payload bytes, version,
+ * contentType, metadata), which is what JCache uses to match the expected value.
+ *
+ * Secondary index entries are held in an in-process [ConcurrentHashMap] — they
+ * are intentionally not in the distributed cache. This is a known limitation of
+ * the reference implementation: index updates are not atomic with data writes and
+ * are lost on pod restart. A production provider would store index entries in the
+ * same distributed tier as data entries.
+ */
+internal class JCacheAgentCacheRegion(
+    private val cache: Cache<String, CachedValue>,
+) : AgentCacheRegion {
+
+    override val name: String get() = cache.name
+
+    override val capabilities: Set<CacheCapability> = setOf(
+        CacheCapability.ATOMIC_COMPARE_AND_SET,
+        CacheCapability.SECONDARY_INDEX,
+    )
+
+    override fun get(key: String): CachedValue? = cache.get(key)
+
+    override fun put(key: String, value: CachedValue) {
+        cache.put(key, value)
+    }
+
+    override fun replace(key: String, expectedVersion: Long?, value: CachedValue): Boolean {
+        if (expectedVersion == null) {
+            // Atomic insert: succeeds only when the key is absent.
+            // JCache Cache.putIfAbsent returns true when inserted, false when already present.
+            return cache.putIfAbsent(key, value)
+        }
+        val current = cache.get(key) ?: return false
+        if (current.version != expectedVersion) return false
+        // Atomic CAS: JCache compares by equals(), which CachedValue implements structurally.
+        return cache.replace(key, current, value)
+    }
+
+    override fun remove(key: String) {
+        cache.remove(key)
+    }
+
+    override fun clear() {
+        cache.clear()
+    }
+
+    override fun index(name: String): AgentCacheIndex = JCacheAgentCacheIndex(name)
+
+    private val indexData = ConcurrentHashMap<String, MutableSet<String>>()
+
+    private inner class JCacheAgentCacheIndex(
+        override val name: String,
+    ) : AgentCacheIndex {
+
+        override fun add(indexKey: String, memberKey: String) {
+            indexData.computeIfAbsent(entryKey(indexKey)) {
+                ConcurrentHashMap.newKeySet()
+            }.add(memberKey)
+        }
+
+        override fun remove(indexKey: String, memberKey: String) {
+            indexData[entryKey(indexKey)]?.remove(memberKey)
+        }
+
+        override fun members(indexKey: String): Set<String> =
+            indexData[entryKey(indexKey)]?.toSet() ?: emptySet()
+
+        private fun entryKey(indexKey: String): String = "$name:$indexKey"
+    }
+}

--- a/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/JCacheAgentProcessPersistenceTest.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/JCacheAgentProcessPersistenceTest.kt
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.cache.support
+
+import com.embabel.agent.api.dsl.agent
+import com.embabel.agent.cache.CacheRegionConfig
+import com.embabel.agent.cache.CacheRegions
+import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.core.AgentProcessRepository
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.hitl.ConfirmationRequest
+import com.embabel.agent.core.hitl.waitFor
+import com.embabel.agent.core.support.InMemoryBlackboard
+import com.embabel.agent.core.support.SimpleAgentProcess
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.spi.config.spring.AgentPlatformConfiguration
+import com.embabel.agent.spi.config.spring.AgentProcessPersistenceProperties
+import com.embabel.agent.spi.config.spring.ProcessRepositoryProperties
+import com.embabel.agent.spi.persistence.AgentProcessSnapshotStore
+import com.embabel.agent.spi.support.DefaultPlannerFactory
+import com.embabel.agent.test.domain.Frog
+import com.embabel.agent.test.domain.MagicVictim
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.common.util.EmbabelObjectMapperHolder
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import javax.cache.Caching
+
+/**
+ * End-to-end test for the JCache-backed snapshot persistence seam.
+ *
+ * Mirrors [CacheBackedPersistenceIT] substituting [JCacheAgentCacheProvider] backed
+ * by Ehcache 3 (resolved via the JCache [Caching] SPI) for the Spring adapter.
+ *
+ * A single [javax.cache.CacheManager] is shared across all tests via the companion
+ * (Ehcache's default manager requires an absolute URI; per-test unique URIs are
+ * rejected). The snapshot region is cleared in [setUp] before each test; the isolation test
+ * uses a distinct region name to simulate a separate store.
+ *
+ * The additional concurrent-CAS test proves [JCacheAgentCacheRegion] delivers true
+ * [com.embabel.agent.cache.CacheCapability.ATOMIC_COMPARE_AND_SET] — a guarantee
+ * [SpringCacheAgentCacheProvider] cannot make across JVM boundaries.
+ */
+class JCacheAgentProcessPersistenceTest {
+
+    private val objectMapperHolder = EmbabelObjectMapperHolder.createDefault()
+
+    private val provider = JCacheAgentCacheProvider(sharedCacheManager)
+
+    @BeforeEach
+    fun setUp() {
+        // Clear before each test so stale data from a prior run (or failed retry) never
+        // causes a false "expected version null but stored version differs" on first insert.
+        region().clear()
+    }
+
+    private fun region() =
+        provider.getRegion(CacheRegionConfig(CacheRegions.AGENT_PROCESS_SNAPSHOTS))
+
+    private fun store(): AgentProcessSnapshotStore =
+        CacheBackedAgentProcessSnapshotStore(region())
+
+    // --- Tests mirroring CacheBackedPersistenceIT ---
+
+    @Test
+    fun `checkpoints a waiting process into the jcache region`() {
+        val repository = persistentRepository(store())
+
+        repository.save(waitingProcess("p1"))
+
+        val cached = region().get("p1")
+        assertNotNull(cached)
+        assertEquals(1L, cached?.version)
+        assertTrue(cached!!.payload.isNotEmpty())
+        assertEquals(
+            AgentProcessStatusCode.WAITING.name,
+            cached.metadata["embabel.snapshot.status"],
+        )
+    }
+
+    @Test
+    fun `another node resumes a waiting process from the shared jcache`() {
+        val original = waitingProcess("p1")
+        persistentRepository(store()).save(original)
+
+        val survivingNode = persistentRepository(store())
+        val restored = survivingNode.findById("p1")
+
+        assertNotNull(restored)
+        assertEquals("p1", restored?.id)
+        assertEquals(AgentProcessStatusCode.WAITING, restored?.status)
+        assertEquals(original.history, restored?.history)
+    }
+
+    @Test
+    fun `a lost process is unrecoverable without the shared jcache`() {
+        persistentRepository(store()).save(waitingProcess("p1"))
+
+        // A distinct region name acts as a separate store — simulates a node that
+        // shares no cache backend with the one that wrote the snapshot.
+        val isolatedStore = CacheBackedAgentProcessSnapshotStore(
+            provider.getRegion(CacheRegionConfig("isolated-snapshots-${UUID.randomUUID()}"))
+        )
+        assertNull(persistentRepository(isolatedStore).findById("p1"))
+    }
+
+    @Test
+    fun `nothing is cached when persistence is disabled`() {
+        val repository = persistentRepository(
+            store(),
+            persistenceProperties = AgentProcessPersistenceProperties(enabled = false),
+        )
+
+        repository.save(waitingProcess("p1"))
+
+        assertNull(region().get("p1"), "disabled persistence must not write to the cache")
+    }
+
+    @Test
+    fun `runs in memory when no snapshot store is registered`() {
+        val repository = AgentPlatformConfiguration().agentProcessRepository(
+            processRepositoryProperties = ProcessRepositoryProperties(),
+            persistenceProperties = AgentProcessPersistenceProperties(),
+            snapshotStore = emptyProvider(),
+            blackboardEntrySerializers = emptyProvider(),
+            embabelObjectMapperHolder = objectMapperHolder,
+            agentPlatform = agentPlatformProvider(),
+        )
+
+        repository.save(waitingProcess("p1"))
+
+        assertNull(region().get("p1"))
+        assertNotNull(repository.findById("p1"))
+    }
+
+    @Test
+    fun `deleting a process clears it from the jcache region`() {
+        val repository = persistentRepository(store())
+        val process = waitingProcess("p1")
+        repository.save(process)
+
+        repository.delete(process)
+
+        assertNull(region().get("p1"))
+    }
+
+    // --- JCache-specific: proves ATOMIC_COMPARE_AND_SET ---
+
+    @Test
+    fun `concurrent checkpoint conflict is rejected by jcache CAS`() {
+        // Seed an initial snapshot at version 1 so both threads have something to CAS against.
+        persistentRepository(store()).save(waitingProcess("p-cas"))
+
+        val casRegion = region()
+        val v1 = casRegion.get("p-cas") ?: error("Expected seeded snapshot at version 1")
+        assertEquals(1L, v1.version)
+
+        val v2 = v1.copy(version = 2L)
+        val wins = AtomicInteger(0)
+        val losses = AtomicInteger(0)
+        val ready = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+
+        repeat(2) {
+            executor.submit {
+                ready.await()
+                if (casRegion.replace("p-cas", 1L, v2)) wins.incrementAndGet()
+                else losses.incrementAndGet()
+            }
+        }
+
+        ready.countDown()
+        executor.shutdown()
+        executor.awaitTermination(5, TimeUnit.SECONDS)
+
+        assertEquals(1, wins.get(), "exactly one thread must win the CAS")
+        assertEquals(1, losses.get(), "exactly one thread must lose the CAS")
+        assertEquals(2L, casRegion.get("p-cas")?.version, "stored version must be 2")
+        assertFalse(
+            casRegion.replace("p-cas", 1L, v2),
+            "stale version must be rejected after the race",
+        )
+    }
+
+    // --- Helpers ---
+
+    private fun persistentRepository(
+        snapshotStore: AgentProcessSnapshotStore,
+        persistenceProperties: AgentProcessPersistenceProperties = AgentProcessPersistenceProperties(),
+    ): AgentProcessRepository =
+        AgentPlatformConfiguration().agentProcessRepository(
+            processRepositoryProperties = ProcessRepositoryProperties(),
+            persistenceProperties = persistenceProperties,
+            snapshotStore = providerOf(AgentProcessSnapshotStore::class.java, snapshotStore),
+            blackboardEntrySerializers = emptyProvider(),
+            embabelObjectMapperHolder = objectMapperHolder,
+            agentPlatform = agentPlatformProvider(),
+        )
+
+    private fun <T : Any> providerOf(type: Class<T>, vararg beans: T): ObjectProvider<T> {
+        val beanFactory = DefaultListableBeanFactory()
+        beans.forEachIndexed { index, bean -> beanFactory.registerSingleton("bean$index", bean) }
+        return beanFactory.getBeanProvider(type)
+    }
+
+    private inline fun <reified T : Any> emptyProvider(): ObjectProvider<T> =
+        DefaultListableBeanFactory().getBeanProvider(T::class.java)
+
+    private fun agentPlatformProvider(): ObjectProvider<AgentPlatform> {
+        val platform = mockk<AgentPlatform>(relaxed = true)
+        every { platform.agents() } returns listOf(WaitingAgent)
+        every { platform.platformServices } returns dummyPlatformServices()
+        return providerOf(AgentPlatform::class.java, platform)
+    }
+
+    private fun waitingProcess(id: String) =
+        newProcess(id).also {
+            assertEquals(AgentProcessStatusCode.WAITING, it.run().status)
+        }
+
+    private fun newProcess(id: String): SimpleAgentProcess {
+        val blackboard = InMemoryBlackboard()
+        blackboard += UserInput("Rod")
+        return SimpleAgentProcess(
+            id = id,
+            parentId = null,
+            agent = WaitingAgent,
+            processOptions = ProcessOptions(),
+            blackboard = blackboard,
+            platformServices = dummyPlatformServices(),
+            plannerFactory = DefaultPlannerFactory,
+        )
+    }
+
+    companion object {
+
+        // Shared across all test instances: Ehcache's getCacheManager() no-arg
+        // uses the provider's default absolute URI, avoiding the relative-URI
+        // rejection that per-test unique URIs trigger.
+        val sharedCacheManager: javax.cache.CacheManager by lazy {
+            Caching.getCachingProvider().cacheManager
+        }
+
+        private val WaitingAgent =
+            agent("JCacheWaiter", description = "Waits for confirmation") {
+
+                transformation<UserInput, MagicVictim>(name = "await-confirmation") {
+                    waitFor(
+                        ConfirmationRequest(
+                            MagicVictim(name = "Rod"),
+                            "Is this the dude?",
+                        )
+                    )
+                }
+
+                transformation<MagicVictim, Frog>(name = "to-frog") {
+                    Frog(name = it.input.name)
+                }
+
+                goal(name = "done", description = "done", satisfiedBy = Frog::class)
+            }
+    }
+}

--- a/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/WaitForPersistentRepositoryJCacheMvcIntegrationTest.kt
+++ b/embabel-agent-cache/embabel-agent-cache-core/src/test/kotlin/com/embabel/agent/cache/support/WaitForPersistentRepositoryJCacheMvcIntegrationTest.kt
@@ -1,0 +1,497 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.cache.support
+
+import com.embabel.agent.api.annotation.AchievesGoal
+import com.embabel.agent.api.annotation.Action
+import com.embabel.agent.api.annotation.support.AgentMetadataReader
+import com.embabel.agent.api.common.ActionContext
+import com.embabel.agent.cache.AgentCacheProvider
+import com.embabel.agent.cache.CacheRegionConfig
+import com.embabel.agent.cache.CacheRegions
+import com.embabel.agent.core.Agent
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.AgentProcessRepository
+import com.embabel.agent.core.AgentProcessStatusCode
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.hitl.AbstractAwaitable
+import com.embabel.agent.core.hitl.AwaitableResponse
+import com.embabel.agent.core.hitl.ResponseImpact
+import com.embabel.agent.core.hitl.waitFor
+import com.embabel.agent.core.persistence.BlackboardEntryDeserializationContext
+import com.embabel.agent.core.persistence.BlackboardEntrySerializationContext
+import com.embabel.agent.core.persistence.BlackboardEntrySerializer
+import com.embabel.agent.core.persistence.SerializedBlackboardValue
+import com.embabel.agent.core.support.InMemoryBlackboard
+import com.embabel.agent.core.support.SimpleAgentProcess
+import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.spi.persistence.AgentProcessPersistence
+import com.embabel.agent.spi.persistence.AgentProcessSnapshotStore
+import com.embabel.agent.spi.support.DefaultPlannerFactory
+import com.embabel.agent.spi.support.InMemoryAgentProcessRepository
+import com.embabel.agent.test.integration.IntegrationTestUtils.dummyPlatformServices
+import com.embabel.common.util.EmbabelObjectMapperHolder
+import tools.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.cache.CacheManager
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+import java.time.Instant
+import java.util.UUID
+
+// ─── Domain model ────────────────────────────────────────────────────────────
+// Identical to the in-memory and JDBC MVC test fixtures.
+// Extracted to a shared base in the planned refactor.
+
+private data class ChoiceRequest(val prompt: String, val options: List<String>)
+
+private data class UserChoice(val value: String, val request: ChoiceRequest? = null)
+
+private data class AdventureResult(val outcome: String)
+
+private class ChoiceAwaitable(
+    val choiceRequest: ChoiceRequest,
+    id: String = UUID.randomUUID().toString(),
+) : AbstractAwaitable<UserChoice, UserChoiceResponse>(
+    UserChoice("", choiceRequest),
+    id = id,
+) {
+    override fun onResponse(response: UserChoiceResponse, agentProcess: AgentProcess): ResponseImpact {
+        agentProcess.blackboard.addObject(UserChoice(response.choice, choiceRequest))
+        return ResponseImpact.UPDATED
+    }
+}
+
+private data class UserChoiceResponse(
+    override val id: String = UUID.randomUUID().toString(),
+    override val awaitableId: String,
+    val choice: String,
+    override val timestamp: Instant = Instant.now(),
+) : AwaitableResponse {
+    override fun persistent(): Boolean = false
+}
+
+@com.embabel.agent.api.annotation.Agent(description = "Cache adventure agent requiring user choices")
+private class AdventureAgent {
+    @Action
+    fun getChoice(input: UserInput, context: ActionContext): UserChoice =
+        waitFor(
+            ChoiceAwaitable(
+                ChoiceRequest(
+                    prompt = "Where do you want to go?",
+                    options = listOf("Castle", "Forest", "Cave"),
+                )
+            )
+        )
+
+    @Action
+    @AchievesGoal(description = "Complete the cache adventure")
+    fun processChoice(choice: UserChoice, context: ActionContext): AdventureResult =
+        AdventureResult("You chose: ${choice.value}")
+}
+
+// ─── DTOs ────────────────────────────────────────────────────────────────────
+
+private data class StartAdventureRequest(val playerName: String)
+
+private data class AwaitableResponseDto(
+    val processId: String,
+    val awaitableId: String,
+    val prompt: String,
+    val options: List<String>,
+)
+
+private data class ContinueAdventureRequest(val awaitableId: String, val choice: String)
+
+private data class AdventureResultDto(val outcome: String)
+
+// ─── Blackboard serializer ───────────────────────────────────────────────────
+// Required for snapshot/restore: ChoiceAwaitable cannot be round-tripped
+// by the Jackson fallback because AbstractAwaitable has no no-arg constructor.
+// Register one BlackboardEntrySerializer per custom Awaitable or domain type
+// that the fallback cannot handle.
+
+private data class ChoiceAwaitableSnapshot(val id: String, val choiceRequest: ChoiceRequest)
+
+private class ChoiceAwaitableSerializer(
+    private val objectMapper: ObjectMapper,
+) : BlackboardEntrySerializer {
+
+    override fun supportsSerialization(value: Any): Boolean = value is ChoiceAwaitable
+
+    override fun supportsDeserialization(value: SerializedBlackboardValue): Boolean =
+        value.typeName == ChoiceAwaitable::class.java.name
+
+    override fun serialize(value: Any, context: BlackboardEntrySerializationContext): SerializedBlackboardValue {
+        val awaitable = value as ChoiceAwaitable
+        return SerializedBlackboardValue(
+            typeName = ChoiceAwaitable::class.java.name,
+            contentType = MediaType.APPLICATION_JSON_VALUE,
+            payload = objectMapper.writeValueAsBytes(
+                ChoiceAwaitableSnapshot(id = awaitable.id, choiceRequest = awaitable.choiceRequest)
+            ),
+        )
+    }
+
+    override fun deserialize(value: SerializedBlackboardValue, context: BlackboardEntryDeserializationContext): Any {
+        val snapshot = objectMapper.readValue(value.payload, ChoiceAwaitableSnapshot::class.java)
+        return ChoiceAwaitable(choiceRequest = snapshot.choiceRequest, id = snapshot.id)
+    }
+}
+
+// ─── Controller ──────────────────────────────────────────────────────────────
+// Depends only on AgentProcessRepository — backend-agnostic by design.
+
+private val adventureLogger = LoggerFactory.getLogger("PersistentAdventureController")
+
+@ConditionalOnProperty(name = ["waitfor.persistent.cache.mvc.test.enabled"], havingValue = "true")
+@Profile("waitfor-persistent-cache")
+@RestController
+@RequestMapping("/cache-adventure")
+private class PersistentAdventureController(
+    @Qualifier("waitForCacheRepository")
+    private val processRepository: AgentProcessRepository,
+) {
+    @PostMapping("/start")
+    fun start(@RequestBody request: StartAdventureRequest): ResponseEntity<Any> {
+        val blackboard = InMemoryBlackboard()
+        blackboard.addObject(UserInput(request.playerName))
+        val agent = AgentMetadataReader().createAgentMetadata(AdventureAgent()) as Agent
+        val process = SimpleAgentProcess(
+            id = UUID.randomUUID().toString(),
+            parentId = null,
+            agent = agent,
+            processOptions = ProcessOptions.DEFAULT,
+            blackboard = blackboard,
+            platformServices = dummyPlatformServices(),
+            plannerFactory = DefaultPlannerFactory,
+            timestamp = Instant.now(),
+        )
+        val result = process.run()
+        processRepository.save(result)
+        adventureLogger.info("POST /cache-adventure/start processId={} status={}", result.id, result.status)
+        return when (result.status) {
+            AgentProcessStatusCode.WAITING -> {
+                val awaitable = result.blackboard.last(ChoiceAwaitable::class.java)
+                    ?: error("Expected ChoiceAwaitable in blackboard")
+                ResponseEntity.ok(
+                    AwaitableResponseDto(
+                        processId = result.id,
+                        awaitableId = awaitable.id,
+                        prompt = awaitable.choiceRequest.prompt,
+                        options = awaitable.choiceRequest.options,
+                    )
+                )
+            }
+            AgentProcessStatusCode.COMPLETED -> {
+                val finalResult = result.blackboard.last(AdventureResult::class.java)
+                    ?: error("No AdventureResult in blackboard")
+                ResponseEntity.ok(AdventureResultDto(outcome = finalResult.outcome))
+            }
+            else -> error("Unexpected process status: ${result.status}")
+        }
+    }
+
+    @PostMapping("/{processId}/continue")
+    fun continueProcess(
+        @PathVariable processId: String,
+        @RequestBody request: ContinueAdventureRequest,
+    ): ResponseEntity<Any> {
+        val agentProcess = processRepository.findById(processId)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Process not found: $processId")
+        require(agentProcess.status == AgentProcessStatusCode.WAITING) {
+            "Process is not waiting: ${agentProcess.status}"
+        }
+        val awaitable = agentProcess.blackboard.last(ChoiceAwaitable::class.java)
+            ?: error("Expected ChoiceAwaitable in blackboard")
+        require(awaitable.id == request.awaitableId) {
+            "Awaitable ID mismatch: expected ${awaitable.id}, got ${request.awaitableId}"
+        }
+        awaitable.onResponse(UserChoiceResponse(awaitableId = request.awaitableId, choice = request.choice), agentProcess)
+        val resumed = agentProcess.run()
+        processRepository.save(resumed)
+        adventureLogger.info("POST /cache-adventure/{}/continue status={}", processId, resumed.status)
+        return when (resumed.status) {
+            AgentProcessStatusCode.WAITING -> {
+                val next = resumed.blackboard.last(ChoiceAwaitable::class.java)
+                    ?: error("Expected ChoiceAwaitable in blackboard")
+                ResponseEntity.ok(
+                    AwaitableResponseDto(
+                        processId = resumed.id,
+                        awaitableId = next.id,
+                        prompt = next.choiceRequest.prompt,
+                        options = next.choiceRequest.options,
+                    )
+                )
+            }
+            AgentProcessStatusCode.COMPLETED -> {
+                val finalResult = resumed.blackboard.last(AdventureResult::class.java)
+                    ?: error("No AdventureResult in blackboard")
+                ResponseEntity.ok(AdventureResultDto(outcome = finalResult.outcome))
+            }
+            else -> error("Unexpected process status: ${resumed.status}")
+        }
+    }
+}
+
+// ─── Spring Boot application ──────────────────────────────────────────────────
+
+@Configuration
+@ComponentScan(basePackages = ["com.embabel.agent.cache.support"])
+@EnableAutoConfiguration
+@Profile("waitfor-persistent-cache")
+private class WaitForPersistentRepositoryCacheTestApplication
+
+// ─── Test ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Reference implementation: HITL agent flow backed by a Spring [CacheManager].
+ *
+ * ## What this proves
+ *
+ * 1. A process that reaches `WAITING` is durably checkpointed to the cache.
+ * 2. After the runtime repository is cleared (simulating a pod restart or
+ *    scale-out), a `/continue` call restores the process from the snapshot
+ *    and resumes it exactly where it paused.
+ * 3. The completed snapshot is written back at version 2.
+ *
+ * ## How to adapt this for production
+ *
+ * The [WaitForPersistentRepositoryCacheTestConfig] below is your starting
+ * point. Replace the [ConcurrentMapCacheManager] with the `CacheManager` for
+ * your chosen backend — everything else stays identical:
+ *
+ * ```
+ * // Redis ────────────────────────────────────────────────────────────────────
+ * @Bean
+ * fun cacheManager(factory: RedisConnectionFactory): CacheManager =
+ *     RedisCacheManager.builder(factory)
+ *         .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig()
+ *             .entryTtl(Duration.ofHours(1)))
+ *         .build()
+ *
+ * // Hazelcast ────────────────────────────────────────────────────────────────
+ * @Bean
+ * fun cacheManager(hz: HazelcastInstance): CacheManager =
+ *     HazelcastCacheManager(hz)
+ *
+ * // Ehcache 3 / JCache ───────────────────────────────────────────────────────
+ * @Bean
+ * fun cacheManager(): CacheManager =
+ *     JCacheCacheManager(Caching.getCachingProvider().cacheManager)
+ * ```
+ *
+ * The [agentCacheProvider], [cacheBackedSnapshotStore] and
+ * [agentProcessRepository] beans are backend-neutral and do not change.
+ *
+ * @see WaitForPersistentRepositoryJdbcMvcIntegrationTest for the JDBC
+ * equivalent using a hand-rolled SQL snapshot store.
+ */
+@SpringBootTest(classes = [WaitForPersistentRepositoryCacheTestApplication::class])
+@ActiveProfiles("test", "waitfor-persistent-cache")
+@TestPropertySource(properties = ["waitfor.persistent.cache.mvc.test.enabled=true"])
+@AutoConfigureMockMvc
+class WaitForPersistentRepositoryJCacheMvcIntegrationTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    @Qualifier("cacheRuntimeRepository")
+    private lateinit var runtimeRepository: InMemoryAgentProcessRepository
+
+    @Autowired
+    private lateinit var agentCacheProvider: AgentCacheProvider
+
+    private val objectMapper: ObjectMapper = EmbabelObjectMapperHolder.createDefault().get()
+
+    @BeforeEach
+    fun setUp() {
+        runtimeRepository.clear()
+        agentCacheProvider.getRegion(CacheRegionConfig(CacheRegions.AGENT_PROCESS_SNAPSHOTS)).clear()
+    }
+
+    @Test
+    fun `complete adventure flow resumes from cache snapshot after runtime repository loss`() {
+        // ── Step 1: start the adventure ───────────────────────────────────────
+        val startResult = mockMvc.perform(
+            MockMvcRequestBuilders.post("/cache-adventure/start")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(StartAdventureRequest("Player1")))
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.processId").exists())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.awaitableId").exists())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.prompt").value("Where do you want to go?"))
+            .andReturn()
+
+        val awaitableDto = objectMapper.readValue(
+            startResult.response.contentAsString,
+            AwaitableResponseDto::class.java,
+        )
+
+        // Process is in runtime repo and snapshot is in the cache at version 1.
+        assertThat(runtimeRepository.findById(awaitableDto.processId)?.status)
+            .isEqualTo(AgentProcessStatusCode.WAITING)
+        val snapshotStore = CacheBackedAgentProcessSnapshotStore(
+            agentCacheProvider.getRegion(CacheRegionConfig(CacheRegions.AGENT_PROCESS_SNAPSHOTS))
+        )
+        assertThat(snapshotStore.findLatestByProcessId(awaitableDto.processId)?.version).isEqualTo(1L)
+
+        // ── Step 2: simulate pod loss ─────────────────────────────────────────
+        runtimeRepository.clear()
+        assertThat(runtimeRepository.findById(awaitableDto.processId)).isNull()
+
+        // ── Step 3: continue — PersistentAgentProcessRepository restores from cache
+        mockMvc.perform(
+            MockMvcRequestBuilders.post("/cache-adventure/${awaitableDto.processId}/continue")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    objectMapper.writeValueAsString(
+                        ContinueAdventureRequest(
+                            awaitableId = awaitableDto.awaitableId,
+                            choice = "Castle",
+                        )
+                    )
+                )
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.jsonPath("$.outcome").value("You chose: Castle"))
+
+        // Completed process is back in the runtime repo and snapshot version is 2.
+        assertThat(runtimeRepository.findById(awaitableDto.processId)?.status)
+            .isEqualTo(AgentProcessStatusCode.COMPLETED)
+        assertThat(snapshotStore.findLatestByProcessId(awaitableDto.processId)?.version).isEqualTo(2L)
+        assertThat(snapshotStore.findLatestByProcessId(awaitableDto.processId)?.status)
+            .isEqualTo(AgentProcessStatusCode.COMPLETED)
+    }
+
+    // ─── Reference @Bean configuration ───────────────────────────────────────
+    /**
+     * Reference configuration for cache-backed agent process persistence.
+     *
+     * Copy these beans into your `@Configuration` class and swap the
+     * [cacheManager] bean for the backend of your choice. Every other bean
+     * is identical regardless of backend.
+     */
+    @TestConfiguration
+    @Profile("waitfor-persistent-cache")
+    class WaitForPersistentRepositoryCacheTestConfig {
+
+        // ── STEP 1: choose your backend ───────────────────────────────────────
+        //
+        // This is the ONLY bean that changes between backends.
+        //
+        // Redis (production distributed cache):
+        //   @Bean
+        //   fun cacheManager(factory: RedisConnectionFactory): CacheManager =
+        //       RedisCacheManager.builder(factory)
+        //           .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig()
+        //               .entryTtl(Duration.ofHours(1)))
+        //           .build()
+        //
+        // Hazelcast (distributed, JCache-compliant):
+        //   @Bean
+        //   fun cacheManager(hz: HazelcastInstance): CacheManager =
+        //       HazelcastCacheManager(hz)
+        //
+        // Ehcache 3 / JCache (local tiered, no infra required):
+        //   @Bean
+        //   fun cacheManager(): CacheManager =
+        //       JCacheCacheManager(Caching.getCachingProvider().cacheManager)
+        // ─────────────────────────────────────────────────────────────────────
+        @Bean
+        fun cacheManager(): CacheManager = ConcurrentMapCacheManager()
+
+        // ── STEP 2: wire Embabel's cache provider over your CacheManager ──────
+        @Bean
+        fun agentCacheProvider(cacheManager: CacheManager): AgentCacheProvider =
+            SpringCacheAgentCacheProvider(cacheManager)
+
+        // ── STEP 3: build the snapshot store ──────────────────────────────────
+        //
+        // CacheRegions.AGENT_PROCESS_SNAPSHOTS is the well-known region name.
+        // The region is created on first access; no up-front schema needed.
+        @Bean
+        fun cacheBackedSnapshotStore(agentCacheProvider: AgentCacheProvider): AgentProcessSnapshotStore =
+            CacheBackedAgentProcessSnapshotStore(
+                agentCacheProvider.getRegion(CacheRegionConfig(CacheRegions.AGENT_PROCESS_SNAPSHOTS))
+            )
+
+        // ── STEP 4: expose the runtime repository ─────────────────────────────
+        //
+        // Named so the test can inject and clear it to simulate a pod restart.
+        // In production you do not need a named qualifier; the repository is
+        // used only internally by PersistentAgentProcessRepository.
+        @Bean
+        fun cacheRuntimeRepository(): InMemoryAgentProcessRepository = InMemoryAgentProcessRepository()
+
+        // ── STEP 5: assemble the durable repository ───────────────────────────
+        //
+        // AgentProcessPersistence.persistentRepository() is the stable public
+        // factory. It hides the snapshot, serialisation and restore internals so
+        // they can evolve without affecting your configuration.
+        //
+        // blackboardEntrySerializers: supply one BlackboardEntrySerializer for
+        // each custom Awaitable or domain object that the Jackson fallback cannot
+        // round-trip (types with no no-arg constructor, sealed classes, etc.).
+        // Simple data classes are handled automatically by the Jackson fallback.
+        @Bean
+        @Qualifier("waitForCacheRepository")
+        fun agentProcessRepository(
+            @Qualifier("cacheRuntimeRepository") runtimeRepository: InMemoryAgentProcessRepository,
+            @Qualifier("cacheBackedSnapshotStore") snapshotStore: AgentProcessSnapshotStore,
+        ): AgentProcessRepository {
+            val objectMapper = EmbabelObjectMapperHolder.createDefault().get()
+            val agent = AgentMetadataReader().createAgentMetadata(AdventureAgent()) as Agent
+            return AgentProcessPersistence.persistentRepository(
+                runtimeRepository = runtimeRepository,
+                snapshotStore = snapshotStore,
+                objectMapper = objectMapper,
+                agents = { listOf(agent) },
+                platformServices = { dummyPlatformServices() },
+                blackboardEntrySerializers = listOf(ChoiceAwaitableSerializer(objectMapper)),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Overview

  - New: JCacheAgentCacheProvider / JCacheAgentCacheRegion — JSR-107 cache provider with true atomic CAS via
  javax.cache.Cache.replace(); SpringCacheAgentCacheProvider cannot guarantee this across JVM boundaries
  - New: WaitForPersistentRepositoryJCacheMvcIntegrationTest — Spring Boot MVC reference implementation for
  HITL agent persistence backed by a JCache CacheManager; 
- Documented how to configure a single cache provider```@Bean ', so the pattern can be used for Redis, Hazelcast, other backends
  - Renames: CacheBackedPersistenceIT → CacheBackedPersistenceIntegrationTest

### Tests

  - JCacheAgentProcessPersistenceTest — JCache unit test
  - WaitForPersistentRepositoryJCacheMvcIntegrationTest — full e2e test with REST Controller: start→wait→pod-loss→continue→complete flow

### Flow

The user only calls _processRepository.save(result)_. Everything below is transparent:
  
  controller:
    processRepository.save(result)                     // AgentProcessRepository interface
      └── PersistentAgentProcessRepository.save()
            ├── runtimeRepository.save(process)        // in-memory, for fast findById
            └── checkpointIfNeeded(process)
                  ├── checkpointPolicy.shouldStoreSnapshot(process)
                  │     └── LifecycleCheckpointPolicy: true if WAITING or COMPLETED
                  ├── snapshotStore.findLatestByProcessId(id)  // get current version
                  ├── snapshotFactory.snapshot(process)        // serialize blackboard
                  ├── snapshotSerializer.serialize(snapshot)   // to bytes
                  └── snapshotStore.save(snapshot, expectedVersion)
                        └── CacheBackedAgentProcessSnapshotStore.save()
                              └── region.replace(key, expectedVersion, cachedValue)

  The checkpoint policy - LifecycleCheckpointPolicy - fires on WAITING state and
  COMPLETED/FAILED (terminal state). Running processes are not checkpointed because mid-action state is unsafe
  to restore.

  On _/continue_, processRepository.findById() misses in the runtime repo (cleared), falls back to
  _snapshotStore.findLatestByProcessId(),_ deserializes the blackboard, and warms the runtime repo before
  returning — again all transparent to the controller.


Closes: #1965 