### PR TITLE
feat: raise events when an LLM call is retried or fails (#555)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/AgentProcessEvent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/AgentProcessEvent.kt
@@ -301,6 +301,40 @@ class LlmRequestEvent<O>(
         )
     }
 
+    /**
+     * A failed attempt that is about to be retried.
+     * @param attempts round trips made to the model so far, including the one that just failed
+     */
+    fun retryEvent(
+        throwable: Throwable,
+        attempts: Int,
+        maxAttempts: Int,
+        runningTime: Duration,
+    ): LlmRetryEvent = LlmRetryEvent(
+        request = this,
+        throwable = throwable,
+        attempts = attempts,
+        maxAttempts = maxAttempts,
+        runningTime = runningTime,
+    )
+
+    /**
+     * The call as a whole failed, whether or not it was retried.
+     * @param attempts round trips made to the model before giving up
+     */
+    fun failureEvent(
+        throwable: Throwable,
+        attempts: Int,
+        maxAttempts: Int,
+        runningTime: Duration,
+    ): LlmCallFailedEvent = LlmCallFailedEvent(
+        request = this,
+        throwable = throwable,
+        attempts = attempts,
+        maxAttempts = maxAttempts,
+        runningTime = runningTime,
+    )
+
     override fun toString(): String {
         return "LlmRequestEvent(outputClass=$outputClass, interaction=$interaction, messages=$messages)"
     }
@@ -323,6 +357,52 @@ class LlmResponseEvent<O> internal constructor(
         return "LlmResponseEvent(outputClass=$outputClass, request=$request, response=$response, runningTime=$runningTime)"
     }
 }
+
+/**
+ * An LLM call attempt failed.
+ *
+ * [attempts] and [maxAttempts] both count the whole call, not one retry sequence within it.
+ * A call that binds and then re-prompts to fix a validation error runs two retry sequences,
+ * so it makes up to twice the configured attempts and both numbers say so.
+ *
+ * @param attempts round trips made to the model so far, including the one that failed
+ * @param maxAttempts round trips the retry policy allows this call
+ */
+sealed class LlmFailureEvent(
+    val request: LlmRequestEvent<*>,
+    val throwable: Throwable,
+    val attempts: Int,
+    val maxAttempts: Int,
+    override val runningTime: Duration,
+) : AbstractAgentProcessEvent(request.agentProcess), Timed {
+
+    override fun toString(): String =
+        "${javaClass.simpleName}(interaction=${request.interaction.id.value}, attempts=$attempts of $maxAttempts, throwable=$throwable)"
+}
+
+/**
+ * An attempt failed and another is about to be made.
+ * [runningTime] is that of the failed attempt.
+ */
+class LlmRetryEvent internal constructor(
+    request: LlmRequestEvent<*>,
+    throwable: Throwable,
+    attempts: Int,
+    maxAttempts: Int,
+    runningTime: Duration,
+) : LlmFailureEvent(request, throwable, attempts, maxAttempts, runningTime)
+
+/**
+ * The LLM call failed: attempts were exhausted, or the failure was not worth retrying.
+ * No [LlmResponseEvent] will follow. [runningTime] covers every attempt, as in [LlmResponseEvent].
+ */
+class LlmCallFailedEvent internal constructor(
+    request: LlmRequestEvent<*>,
+    throwable: Throwable,
+    attempts: Int,
+    maxAttempts: Int,
+    runningTime: Duration,
+) : LlmFailureEvent(request, throwable, attempts, maxAttempts, runningTime)
 
 /**
  * An object was bound to the process.

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/AbstractLlmOperations.kt
@@ -18,6 +18,7 @@ package com.embabel.agent.spi.support
 import com.embabel.agent.api.common.Asyncer
 import com.embabel.agent.api.event.LlmRequestEvent
 import com.embabel.agent.api.tool.Tool
+import com.embabel.agent.api.tool.ToolControlFlowSignal
 import com.embabel.agent.core.Action
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.internal.LlmOperations
@@ -46,6 +47,7 @@ import jakarta.validation.ConstraintViolation
 import jakarta.validation.Validator
 import java.lang.reflect.Field
 import java.time.Duration
+import java.time.Instant
 import java.util.Locale
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
@@ -138,6 +140,106 @@ abstract class AbstractLlmOperations(
         }
     }
 
+    /**
+     * The attempts made in one logical LLM call. Each runs under the data binding retry policy,
+     * which forgives transient failures such as malformed JSON, and the configured timeout.
+     * Publishes an [com.embabel.agent.api.event.LlmRetryEvent] as each retry begins.
+     *
+     * A retry is reported when it actually happens rather than when the attempt before it fails,
+     * so no event has to guess whether the policy will allow another attempt.
+     */
+    private inner class Attempts(
+        private val llmRequestEvent: LlmRequestEvent<*>,
+        private val interaction: LlmInteraction,
+    ) {
+        /** Round trips made to the model in this call, counted across every [attempt] block it runs. */
+        var made: Int = 0
+            private set
+
+        /**
+         * Round trips this call is allowed, counted the same way. Every [attempt] block runs its own
+         * retry sequence with its own budget, so the budget grows as blocks start. Counting both the
+         * same way keeps [made] and [maxAttempts] describing the same thing: the whole call.
+         */
+        var maxAttempts: Int = 0
+            private set
+
+        /** How long the last failed attempt took, excluding the backoff wait that follows it. */
+        private var lastFailure: Duration = Duration.ZERO
+
+        fun <O> attempt(operation: () -> O): O {
+            maxAttempts += dataBindingProperties.maxAttempts
+            return dataBindingProperties.retryTemplate(interaction.id.value)
+                .execute<O, Exception> { context ->
+                    // Null until an attempt has failed, so this fires only on a real retry
+                    context.lastThrowable?.let { lastThrowable ->
+                        llmRequestEvent.agentProcess.processContext.onProcessEvent(
+                            llmRequestEvent.retryEvent(
+                                throwable = lastThrowable,
+                                attempts = made,
+                                maxAttempts = maxAttempts,
+                                runningTime = lastFailure,
+                            )
+                        )
+                    }
+                    made++
+                    val attemptStarted = Instant.now()
+                    try {
+                        executeWithTimeout(
+                            interactionId = interaction.id.value,
+                            llmOptions = interaction.llm,
+                            attempt = made,
+                            operation = operation,
+                        )
+                    } catch (t: Throwable) {
+                        // Timed here, not at the next callback, which only runs after the backoff wait
+                        lastFailure = Duration.between(attemptStarted, Instant.now())
+                        throw t
+                    }
+                }
+        }
+    }
+
+    /**
+     * Run one logical LLM call, publishing an [com.embabel.agent.api.event.LlmCallFailedEvent] if it
+     * ends without a response. [call] makes each round trip through [Attempts.attempt], so a failure
+     * anywhere in the call - an exhausted retry, or a response that never passes validation - is
+     * reported once, counting every round trip the call made.
+     */
+    private fun <O> withFailureEvents(
+        llmRequestEvent: LlmRequestEvent<*>,
+        interaction: LlmInteraction,
+        call: Attempts.() -> O,
+    ): O {
+        val attempts = Attempts(llmRequestEvent, interaction)
+        return try {
+            attempts.call()
+        } catch (e: Exception) {
+            // Exception, not Throwable: an Error means the JVM is in trouble (out of memory, stack
+            // exhausted). Calling listeners then can turn a bad situation into a worse one, and the
+            // listener would have nothing useful to do with it anyway. Errors propagate untouched.
+            // Control flow signals such as ReplanRequestedException end the call without failing it
+            if (e !is ToolControlFlowSignal) {
+                llmRequestEvent.agentProcess.processContext.onProcessEvent(
+                    llmRequestEvent.failureEvent(
+                        throwable = e,
+                        attempts = attempts.made,
+                        maxAttempts = attempts.maxAttempts,
+                        runningTime = Duration.between(llmRequestEvent.timestamp, Instant.now()),
+                    )
+                )
+            }
+            throw e
+        }
+    }
+
+    /** A call that is a single round trip to the model. */
+    private fun <O> withRetry(
+        llmRequestEvent: LlmRequestEvent<*>,
+        interaction: LlmInteraction,
+        operation: () -> O,
+    ): O = withFailureEvents(llmRequestEvent, interaction) { attempt(operation) }
+
     final override fun <O> createObject(
         messages: List<Message>,
         interaction: LlmInteraction,
@@ -188,58 +290,48 @@ abstract class AbstractLlmOperations(
                     messages
                 }
 
-            // Wrap doTransform with retry for transient failures (e.g., malformed JSON)
-            // and timeout for operations that take too long
-            var candidate = dataBindingProperties.retryTemplate(interaction.id.value)
-                .execute<O, Exception> {
-                    executeWithTimeout(
-                        interactionId = interaction.id.value,
-                        llmOptions = interaction.llm,
-                    ) {
-                        doTransform(
-                            messages = initialMessages,
-                            interaction = interactionWithToolDecoration,
-                            outputClass = outputClass,
-                            llmRequestEvent = llmRequestEvent,
-                        )
-                    }
+            // Binding and validation are one LLM call: a response that never validates is a
+            // failure of that call, reported like an exhausted retry.
+            withFailureEvents(llmRequestEvent, interaction) {
+                var candidate = attempt {
+                    doTransform(
+                        messages = initialMessages,
+                        interaction = interactionWithToolDecoration,
+                        outputClass = outputClass,
+                        llmRequestEvent = llmRequestEvent,
+                    )
                 }
-            if (interaction.validation) {
-                var constraintViolations = validator.validate(candidate)
-                constraintViolations =
-                    filterConstraintViolations(constraintViolations, outputClass, interaction.fieldFilter)
-                if (constraintViolations.isNotEmpty()) {
-                    // If we had violations, try again, once, before throwing an exception
-                    candidate = dataBindingProperties.retryTemplate(interaction.id.value)
-                        .execute<O, Exception> {
-                            executeWithTimeout(
-                                interactionId = interaction.id.value,
-                                llmOptions = interaction.llm,
-                            ) {
-                                doTransform(
-                                    messages = messages + UserMessage(
-                                        validationPromptGenerator.generateViolationsReport(
-                                            constraintViolations
-                                        )
-                                    ),
-                                    interaction = interactionWithToolDecoration,
-                                    outputClass = outputClass,
-                                    llmRequestEvent = llmRequestEvent,
-                                )
-                            }
-                        }
-                    constraintViolations = validator.validate(candidate)
+                if (interaction.validation) {
+                    var constraintViolations = validator.validate(candidate)
                     constraintViolations =
                         filterConstraintViolations(constraintViolations, outputClass, interaction.fieldFilter)
                     if (constraintViolations.isNotEmpty()) {
-                        throw InvalidLlmReturnTypeException(
-                            returnedObject = candidate as Any,
-                            constraintViolations = constraintViolations,
-                        )
+                        // If we had violations, try again, once, before throwing an exception
+                        candidate = attempt {
+                            doTransform(
+                                messages = messages + UserMessage(
+                                    validationPromptGenerator.generateViolationsReport(
+                                        constraintViolations
+                                    )
+                                ),
+                                interaction = interactionWithToolDecoration,
+                                outputClass = outputClass,
+                                llmRequestEvent = llmRequestEvent,
+                            )
+                        }
+                        constraintViolations = validator.validate(candidate)
+                        constraintViolations =
+                            filterConstraintViolations(constraintViolations, outputClass, interaction.fieldFilter)
+                        if (constraintViolations.isNotEmpty()) {
+                            throw InvalidLlmReturnTypeException(
+                                returnedObject = candidate as Any,
+                                constraintViolations = constraintViolations,
+                            )
+                        }
                     }
                 }
+                candidate
             }
-            candidate
         }
         logger.debug("LLM createdObject response={}", createdObject)
         agentProcess.processContext.onProcessEvent(
@@ -297,20 +389,14 @@ abstract class AbstractLlmOperations(
         )
 
         val (response, ms) = time {
-            dataBindingProperties.retryTemplate(interaction.id.value)
-                .execute<Result<O>, Exception> {
-                    executeWithTimeout(
-                        interactionId = interaction.id.value,
-                        llmOptions = interaction.llm,
-                    ) {
-                        doTransformIfPossible(
-                            messages = messages,
-                            interaction = interactionWithToolDecoration,
-                            outputClass = outputClass,
-                            llmRequestEvent = llmRequestEvent,
-                        )
-                    }
-                }
+            withRetry(llmRequestEvent, interaction) {
+                doTransformIfPossible(
+                    messages = messages,
+                    interaction = interactionWithToolDecoration,
+                    outputClass = outputClass,
+                    llmRequestEvent = llmRequestEvent,
+                )
+            }
         }
         logger.debug("LLM createObjectIfPossible response={}", response)
         agentProcess.processContext.onProcessEvent(
@@ -357,20 +443,14 @@ abstract class AbstractLlmOperations(
         )
 
         val (thinkingResponse, ms) = time {
-            dataBindingProperties.retryTemplate(interaction.id.value)
-                .execute<ThinkingResponse<O>, Exception> {
-                    executeWithTimeout(
-                        interactionId = interaction.id.value,
-                        llmOptions = interaction.llm,
-                    ) {
-                        doTransformWithThinking(
-                            messages = messages,
-                            interaction = interactionWithToolDecoration,
-                            outputClass = outputClass,
-                            llmRequestEvent = llmRequestEvent,
-                        )
-                    }
-                }
+            withRetry(llmRequestEvent, interaction) {
+                doTransformWithThinking(
+                    messages = messages,
+                    interaction = interactionWithToolDecoration,
+                    outputClass = outputClass,
+                    llmRequestEvent = llmRequestEvent,
+                )
+            }
         }
         logger.debug("LLM thinking response={}", thinkingResponse)
         agentProcess.processContext.onProcessEvent(
@@ -417,20 +497,14 @@ abstract class AbstractLlmOperations(
         )
 
         val (response, ms) = time {
-            dataBindingProperties.retryTemplate(interaction.id.value)
-                .execute<Result<ThinkingResponse<O>>, Exception> {
-                    executeWithTimeout(
-                        interactionId = interaction.id.value,
-                        llmOptions = interaction.llm,
-                    ) {
-                        doTransformWithThinkingIfPossible(
-                            messages = messages,
-                            interaction = interactionWithToolDecoration,
-                            outputClass = outputClass,
-                            llmRequestEvent = llmRequestEvent,
-                        )
-                    }
-                }
+            withRetry(llmRequestEvent, interaction) {
+                doTransformWithThinkingIfPossible(
+                    messages = messages,
+                    interaction = interactionWithToolDecoration,
+                    outputClass = outputClass,
+                    llmRequestEvent = llmRequestEvent,
+                )
+            }
         }
         logger.debug("LLM createObjectIfPossibleWithThinking response={}", response)
         agentProcess.processContext.onProcessEvent(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/LlmFailureEventTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/LlmFailureEventTest.kt
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2024-2026 Embabel Pty Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.embabel.agent.spi.support
+
+import com.embabel.agent.api.common.InteractionId
+import com.embabel.agent.api.event.LlmCallFailedEvent
+import com.embabel.agent.api.event.LlmFailureEvent
+import com.embabel.agent.api.event.LlmRequestEvent
+import com.embabel.agent.api.event.LlmResponseEvent
+import com.embabel.agent.api.event.LlmRetryEvent
+import com.embabel.agent.core.AgentProcess
+import com.embabel.agent.core.ProcessContext
+import com.embabel.agent.core.ProcessOptions
+import com.embabel.agent.core.ReplanRequestedException
+import com.embabel.agent.core.support.InvalidLlmReturnTypeException
+import com.embabel.agent.core.support.LlmInteraction
+import com.embabel.agent.spi.AutoLlmSelectionCriteriaResolver
+import com.embabel.agent.spi.LlmService
+import com.embabel.agent.spi.validation.DefaultValidationPromptGenerator
+import com.embabel.agent.support.SimpleTestAgent
+import com.embabel.agent.test.common.EventSavingAgenticEventListener
+import com.embabel.chat.Message
+import com.embabel.chat.UserMessage
+import com.embabel.common.ai.model.LlmOptions
+import com.embabel.common.ai.model.ModelProvider
+import com.embabel.common.core.thinking.ThinkingResponse
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.validation.Validation
+import jakarta.validation.constraints.NotBlank
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import java.time.Duration
+import java.util.concurrent.Executors
+
+/**
+ * Failures of an LLM call must be visible to listeners, not only to the log.
+ */
+class LlmFailureEventTest {
+
+    private lateinit var eventListener: EventSavingAgenticEventListener
+    private lateinit var agentProcess: AgentProcess
+
+    @BeforeEach
+    fun setup() {
+        eventListener = EventSavingAgenticEventListener()
+        val processContext = mockk<ProcessContext>()
+        every { processContext.platformServices } returns mockk()
+        every { processContext.platformServices.agentPlatform } returns mockk()
+        every { processContext.platformServices.agentPlatform.toolGroupResolver } returns
+            RegistryToolGroupResolver("test", emptyList())
+        every { processContext.platformServices.eventListener } returns eventListener
+        every { processContext.onProcessEvent(any()) } answers { eventListener.onProcessEvent(firstArg()) }
+        every { processContext.processOptions } returns ProcessOptions()
+        agentProcess = mockk<AgentProcess>()
+        every { agentProcess.agent } returns SimpleTestAgent
+        every { agentProcess.processContext } returns processContext
+        every { processContext.agentProcess } returns agentProcess
+    }
+
+    private fun failuresBeforeSuccess(
+        failures: Int,
+        maxAttempts: Int,
+        backoffMillis: Long = 1L,
+        exception: () -> Throwable = { IllegalStateException("LLM is down") },
+    ): TestLlmOperations {
+        var attempt = 0
+        return TestLlmOperations(maxAttempts, backoffMillis) {
+            if (attempt++ < failures) throw exception()
+            "success"
+        }
+    }
+
+    private fun interaction(llm: LlmOptions = LlmOptions()) =
+        LlmInteraction(id = InteractionId("test-interaction"), llm = llm)
+
+    private fun <O> createObject(
+        operations: TestLlmOperations,
+        outputClass: Class<O>,
+        interaction: LlmInteraction = interaction(),
+    ): O =
+        operations.createObject(
+            messages = listOf(UserMessage("go")),
+            interaction = interaction,
+            outputClass = outputClass,
+            agentProcess = agentProcess,
+            action = null,
+        )
+
+    private fun createObject(operations: TestLlmOperations): String =
+        createObject(operations, String::class.java)
+
+    private fun failureEvents(): List<LlmFailureEvent> =
+        eventListener.processEvents.filterIsInstance<LlmFailureEvent>()
+
+    private fun retryEvents(): List<LlmRetryEvent> =
+        eventListener.processEvents.filterIsInstance<LlmRetryEvent>()
+
+    private fun failedEvent(): LlmCallFailedEvent =
+        eventListener.processEvents.filterIsInstance<LlmCallFailedEvent>().single()
+
+    @Nested
+    inner class Retrying {
+
+        @Test
+        fun `successful call raises no failure event`() {
+            createObject(failuresBeforeSuccess(failures = 0, maxAttempts = 5))
+
+            assertTrue(failureEvents().isEmpty(), "No failure expected: ${failureEvents()}")
+            assertEquals(1, eventListener.processEvents.filterIsInstance<LlmResponseEvent<*>>().size)
+        }
+
+        @Test
+        fun `each retry raises an event naming the attempt that failed`() {
+            createObject(failuresBeforeSuccess(failures = 2, maxAttempts = 5))
+
+            assertEquals(listOf(1, 2), retryEvents().map { it.attempts })
+            assertTrue(retryEvents().all { it.maxAttempts == 5 })
+            assertTrue(retryEvents().all { it.throwable.message == "LLM is down" })
+            assertEquals(1, eventListener.processEvents.filterIsInstance<LlmResponseEvent<*>>().size)
+        }
+
+        @Test
+        fun `exhausting attempts raises a failure event and no response event`() {
+            val operations = failuresBeforeSuccess(failures = Int.MAX_VALUE, maxAttempts = 3)
+
+            assertThrows<IllegalStateException> { createObject(operations) }
+
+            assertEquals(2, retryEvents().size)
+            assertEquals(3, failedEvent().attempts)
+            assertEquals(3, failedEvent().maxAttempts)
+            assertEquals("LLM is down", failedEvent().throwable.message)
+            assertTrue(eventListener.processEvents.filterIsInstance<LlmResponseEvent<*>>().isEmpty())
+        }
+
+        @Test
+        fun `a retry reports the time the failed attempt took, not the backoff wait`() {
+            val backoffMillis = 500L
+            createObject(failuresBeforeSuccess(failures = 1, maxAttempts = 2, backoffMillis = backoffMillis))
+
+            val retry = retryEvents().single()
+            assertTrue(
+                retry.runningTime.toMillis() < backoffMillis / 2,
+                "The attempt returns at once; only the wait that follows it is slow: ${retry.runningTime}",
+            )
+        }
+
+        @Test
+        fun `the failure event points back to its request`() {
+            val operations = failuresBeforeSuccess(failures = Int.MAX_VALUE, maxAttempts = 1)
+
+            assertThrows<IllegalStateException> { createObject(operations) }
+
+            val request = eventListener.processEvents.filterIsInstance<LlmRequestEvent<*>>().single()
+            assertEquals(request, failureEvents().single().request)
+        }
+
+        @Test
+        fun `a control flow signal is not a failure`() {
+            val operations = failuresBeforeSuccess(
+                failures = Int.MAX_VALUE,
+                maxAttempts = 3,
+                exception = { ReplanRequestedException("need to replan") },
+            )
+
+            assertThrows<ReplanRequestedException> { createObject(operations) }
+
+            assertTrue(failureEvents().isEmpty(), "Control flow signal is not a failure: ${failureEvents()}")
+        }
+    }
+
+    @Nested
+    inner class Validating {
+
+        @Test
+        fun `a response that never validates raises a failure event counting every round trip`() {
+            val operations = TestLlmOperations(maxAttempts = 3) { ValidatedPerson(name = "") }
+
+            assertThrows<InvalidLlmReturnTypeException> { createObject(operations, ValidatedPerson::class.java) }
+
+            assertTrue(
+                failedEvent().throwable is InvalidLlmReturnTypeException,
+                "Expected the validation failure to be reported: ${failedEvent().throwable}",
+            )
+            // The binding call and the relance that follows it are both round trips to the model
+            assertEquals(2, operations.calls)
+            assertEquals(operations.calls, failedEvent().attempts)
+            // The relance runs its own retry sequence, so it brings its own budget with it
+            assertEquals(6, failedEvent().maxAttempts)
+            assertTrue(retryEvents().isEmpty())
+            assertTrue(eventListener.processEvents.filterIsInstance<LlmResponseEvent<*>>().isEmpty())
+        }
+
+        @Test
+        fun `a retry inside the validation relance keeps counting up`() {
+            var call = 0
+            // Round trip 1 binds but does not validate; round trip 2 throws, so the relance retries
+            val operations = TestLlmOperations(maxAttempts = 3) {
+                if (call++ == 1) throw IllegalStateException("LLM is down")
+                ValidatedPerson(name = "")
+            }
+
+            assertThrows<InvalidLlmReturnTypeException> { createObject(operations, ValidatedPerson::class.java) }
+
+            assertEquals(3, operations.calls)
+            assertEquals(operations.calls, failedEvent().attempts)
+            assertEquals(6, failedEvent().maxAttempts)
+            // The retry is the third round trip, so two had been made when it was reported
+            assertEquals(listOf(2), retryEvents().map { it.attempts })
+            assertEquals(listOf(6), retryEvents().map { it.maxAttempts })
+        }
+    }
+
+    /**
+     * Every entry point runs its call through the same retry helper, so every one of them
+     * has to report a failure. Only [AbstractLlmOperations.createObject] also validates.
+     */
+    @Nested
+    inner class EveryEntryPoint {
+
+        private fun assertReportsFailure(call: (TestLlmOperations, LlmInteraction) -> Unit) {
+            val operations = failuresBeforeSuccess(failures = Int.MAX_VALUE, maxAttempts = 2)
+
+            assertThrows<IllegalStateException> { call(operations, interaction()) }
+
+            assertEquals(listOf(1), retryEvents().map { it.attempts })
+            assertEquals(2, failedEvent().attempts)
+            assertEquals(2, failedEvent().maxAttempts)
+            assertEquals(operations.calls, failedEvent().attempts)
+        }
+
+        @Test
+        fun `createObject reports a failure`() {
+            assertReportsFailure { operations, interaction ->
+                operations.createObject(listOf(UserMessage("go")), interaction, String::class.java, agentProcess, null)
+            }
+        }
+
+        @Test
+        fun `createObjectIfPossible reports a failure`() {
+            assertReportsFailure { operations, interaction ->
+                operations.createObjectIfPossible(
+                    listOf(UserMessage("go")), interaction, String::class.java, agentProcess, null,
+                )
+            }
+        }
+
+        @Test
+        fun `createObjectWithThinking reports a failure`() {
+            assertReportsFailure { operations, interaction ->
+                operations.createObjectWithThinking(
+                    listOf(UserMessage("go")), interaction, String::class.java, agentProcess, null,
+                )
+            }
+        }
+
+        @Test
+        fun `createObjectIfPossibleWithThinking reports a failure`() {
+            assertReportsFailure { operations, interaction ->
+                operations.createObjectIfPossibleWithThinking(
+                    listOf(UserMessage("go")), interaction, String::class.java, agentProcess, null,
+                )
+            }
+        }
+    }
+
+    /**
+     * A timed out call abandons its worker thread, so the failure event is the only place
+     * the timeout is reported to a listener.
+     */
+    @Nested
+    inner class TimingOut {
+
+        @Test
+        fun `a call that times out raises a failure event`() {
+            val operations = TestLlmOperations(maxAttempts = 1) {
+                Thread.sleep(2_000)
+                "too late"
+            }
+
+            val thrown = assertThrows<RuntimeException> {
+                createObject(operations, String::class.java, interaction(LlmOptions().withTimeout(Duration.ofMillis(50))))
+            }
+
+            assertTrue(thrown.message!!.contains("timed out"), "Expected a timeout: ${thrown.message}")
+            assertEquals(1, failedEvent().attempts)
+            assertTrue(failedEvent().throwable.message!!.contains("timed out"))
+            assertTrue(eventListener.processEvents.filterIsInstance<LlmResponseEvent<*>>().isEmpty())
+        }
+    }
+}
+
+/**
+ * Output class the LLM can only get wrong, so validation never passes.
+ */
+internal class ValidatedPerson(
+    @field:NotBlank
+    val name: String,
+)
+
+/**
+ * Minimal [AbstractLlmOperations] whose transforms are driven by [transform],
+ * so a test can decide when the LLM fails.
+ */
+private class TestLlmOperations(
+    maxAttempts: Int,
+    backoffMillis: Long = 1L,
+    private val transform: () -> Any,
+) : AbstractLlmOperations(
+    toolDecorator = DefaultToolDecorator(),
+    modelProvider = mockk<ModelProvider>().apply {
+        every { getLlm(any()) } returns mockk<LlmService<*>>(relaxed = true)
+    },
+    validator = Validation.buildDefaultValidatorFactory().validator,
+    validationPromptGenerator = DefaultValidationPromptGenerator(),
+    autoLlmSelectionCriteriaResolver = AutoLlmSelectionCriteriaResolver.DEFAULT,
+    dataBindingProperties = LlmDataBindingProperties(maxAttempts = maxAttempts, fixedBackoffMillis = backoffMillis),
+    promptsProperties = LlmOperationsPromptsProperties(),
+    asyncer = ExecutorAsyncer(Executors.newCachedThreadPool()),
+    objectMapper = jacksonObjectMapper(),
+) {
+
+    /** Round trips the LLM was actually asked to make, so a test can check the count reported. */
+    var calls: Int = 0
+        private set
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <O> doTransform(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>?,
+    ): O {
+        calls++
+        return transform() as O
+    }
+
+    // "If possible" lets the model decline to answer; it does not hide a failed call.
+    // The real implementation lets those propagate, so this one must too.
+    override fun <O> doTransformIfPossible(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>,
+    ): Result<O> = Result.success(doTransform(messages, interaction, outputClass, llmRequestEvent))
+
+    override fun <O> doTransformWithThinking(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>?,
+    ): ThinkingResponse<O> = ThinkingResponse(
+        result = doTransform(messages, interaction, outputClass, llmRequestEvent),
+        thinkingBlocks = emptyList(),
+    )
+
+    override fun <O> doTransformWithThinkingIfPossible(
+        messages: List<Message>,
+        interaction: LlmInteraction,
+        outputClass: Class<O>,
+        llmRequestEvent: LlmRequestEvent<O>?,
+    ): Result<ThinkingResponse<O>> =
+        Result.success(doTransformWithThinking(messages, interaction, outputClass, llmRequestEvent))
+}

--- a/embabel-agent-observability/README.md
+++ b/embabel-agent-observability/README.md
@@ -204,6 +204,7 @@ Your agents are now fully traced. No code changes required.
 | **Sub-agent Hierarchy** | Proper parent-child span relationships for sub-agents |
 | **Action Tracing** | Each action execution as a child span with duration, status, and `input.value`/`output.value` |
 | **LLM Call Spans** | A span per LLM interaction (`embabel.llm`) with model, operation, agent and action; plus an `embabel.llm.invocation` span per model round-trip carrying token usage and cost |
+| **LLM Failure Spans** | An `embabel.llm.retry` point span per replayed attempt and an `embabel.llm.error` point span when the call gives up, both with model, error type/message and `embabel.llm.attempt` / `embabel.llm.max_attempts`. Those two count round trips over the whole call, so a call that re-prompts to fix a validation error can exceed the configured `max-attempts`. A timed-out call leaves its `embabel.llm` span on the worker thread, so these are the nodes that mark the failure |
 | **Embedding Spans** | An `embabel.embedding` span per embedding invocation with model and token usage/cost — for in-agent embeddings and for **standalone** calls made outside an agent process (RAG/pgvector), which appear as root spans |
 | **Tool Loop Tracing** | An `embabel.tool_loop` span wrapping the tool loop (with the prompt `input.value` and result `output.value`), plus an `embabel.tool_loop.completed` point span with iteration count and replan flag |
 | **Input / Output Capture** | Agent, action and tool-loop spans carry `input.value`/`output.value` (OpenInference keys, rendered in Langfuse's input/output panels), truncated to `max-attribute-length` |
@@ -271,7 +272,7 @@ Your agents are now fully traced. No code changes required.
 | `embabel.agent.platform.observability.trace-tool-calls` | `true` | Trace tool invocations (`embabel.tool` span) |
 | `embabel.agent.platform.observability.trace-tool-loop` | `true` | Trace tool loop execution (`embabel.tool_loop` scoped span + `embabel.tool_loop.completed` point span) |
 | `embabel.agent.platform.observability.trace-tool-loop-completed` | `true` | Emit the `embabel.tool_loop.completed` point span (loop outcome: iterations, replan flag, duration). Set `false` to keep the scoped `embabel.tool_loop` span but drop the extra completion node. No effect when `trace-tool-loop` is `false` |
-| `embabel.agent.platform.observability.trace-llm-calls` | `true` | Trace LLM calls: the `embabel.llm` scoped span **and** the `embabel.llm.invocation` point span (model, tokens, cost), plus the Spring AI ChatModel filter |
+| `embabel.agent.platform.observability.trace-llm-calls` | `true` | Trace LLM calls: the `embabel.llm` scoped span **and** the `embabel.llm.invocation` point span (model, tokens, cost) and the `embabel.llm.retry` / `embabel.llm.error` failure point spans, plus the Spring AI ChatModel filter |
 | `embabel.agent.platform.observability.trace-embedding` | `true` | Trace embedding invocations (`embabel.embedding` span: model, tokens, cost) |
 | `embabel.agent.platform.observability.trace-planning` | `true` | Trace plan formulation (`embabel.planning`) and replan requests (`embabel.replan`) |
 | `embabel.agent.platform.observability.trace-state-transitions` | `true` | Trace state transitions (`embabel.state_transition` span) |
@@ -619,6 +620,7 @@ When a `MeterRegistry` is available (e.g. via `micrometer-registry-prometheus`),
 | `embabel.agent.stuck.total` | Counter | `agent` | Agent stuck events (unable to plan) |
 | `embabel.llm.requests.total` | Counter | `agent`, `model` | Total LLM requests |
 | `embabel.llm.duration` | Timer | `model`, `agent` | LLM call duration |
+| `embabel.llm.errors.total` | Counter | `model`, `agent`, `outcome` (retry/failed) | Failed LLM attempts: `retry` for an attempt the retry policy replayed, `failed` for the one that ended the call |
 | `embabel.llm.tokens.total` | Counter | `agent`, `direction` (input/output) | LLM tokens consumed |
 | `embabel.llm.cost.total` | Counter | `agent` | Estimated LLM cost in USD |
 | `embabel.tool.calls.total` | Counter | `tool`, `agent` | Total tool calls |

--- a/embabel-agent-observability/src/main/java/com/embabel/agent/observability/SpanAttributes.java
+++ b/embabel-agent-observability/src/main/java/com/embabel/agent/observability/SpanAttributes.java
@@ -85,9 +85,15 @@ public final class SpanAttributes {
     public static final String EMBABEL_LIFECYCLE = "embabel.lifecycle";
     public static final String EMBABEL_LIFECYCLE_STATE = "embabel.lifecycle.state";
     public static final String EMBABEL_LLM = "embabel.llm";
+    public static final String EMBABEL_LLM_ATTEMPT = "embabel.llm.attempt";
     public static final String EMBABEL_LLM_COST = "embabel.llm.cost";
+    public static final String EMBABEL_LLM_ERROR = "embabel.llm.error";
+    public static final String EMBABEL_LLM_ERROR_MESSAGE = "embabel.llm.error.message";
+    public static final String EMBABEL_LLM_ERROR_TYPE = "embabel.llm.error.type";
     public static final String EMBABEL_LLM_INVOCATION = "embabel.llm.invocation";
+    public static final String EMBABEL_LLM_MAX_ATTEMPTS = "embabel.llm.max_attempts";
     public static final String EMBABEL_LLM_MODEL = "embabel.llm.model";
+    public static final String EMBABEL_LLM_RETRY = "embabel.llm.retry";
     public static final String EMBABEL_PARENT_ID = "embabel.parent.id";
     public static final String EMBABEL_PLAN_ACTION_COUNT = "embabel.plan.action_count";
     public static final String EMBABEL_PLAN_GOAL = "embabel.plan.goal";

--- a/embabel-agent-observability/src/main/java/com/embabel/agent/observability/metrics/EmbabelMetricsEventListener.java
+++ b/embabel-agent-observability/src/main/java/com/embabel/agent/observability/metrics/EmbabelMetricsEventListener.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *   <li>{@code embabel.agent.active_duration} (timer) — agent process active duration (sum of action running times, excludes idle/wait time), tagged by {@code agent} and {@code status}</li>
  *   <li>{@code embabel.llm.requests.total} (counter) — LLM requests, tagged by {@code agent} and {@code model}</li>
  *   <li>{@code embabel.llm.duration} (timer) — LLM call duration, tagged by {@code model} and {@code agent}</li>
+ *   <li>{@code embabel.llm.errors.total} (counter) — failed LLM attempts, tagged by {@code model}, {@code agent} and {@code outcome} (retry or failed)</li>
  *   <li>{@code embabel.tool.duration} (timer) — tool call duration, tagged by {@code tool} and {@code agent}</li>
  *   <li>{@code embabel.tool.calls.total} (counter) — tool calls, tagged by {@code tool} and {@code agent}</li>
  *   <li>{@code embabel.agent.stuck.total} (counter) — agent stuck events, tagged by {@code agent}</li>
@@ -131,6 +132,7 @@ public class EmbabelMetricsEventListener implements AgenticEventListener {
             }
             case LlmRequestEvent e -> recordLlmRequest(e);
             case LlmResponseEvent e -> recordLlmDuration(e);
+            case LlmFailureEvent e -> recordLlmFailure(e);
             // WAITING/PAUSED/STUCK are NON-terminal: the process can resume via run() on the same
             // instance without re-emitting AgentProcessCreationEvent (the normal human-in-the-loop
             // case). Keep its id in the active set; only terminal events above remove it.
@@ -264,6 +266,21 @@ public class EmbabelMetricsEventListener implements AgenticEventListener {
                 .tag("agent", event.getAgentProcess().getAgent().getName())
                 .register(registry)
                 .record(event.getRunningTime());
+    }
+
+    /**
+     * Counts every failed LLM attempt. The {@code outcome} tag separates the attempts the retry
+     * policy replayed from the one that ended the call, so a noisy model shows up as retries
+     * long before it shows up as an agent failure.
+     */
+    private void recordLlmFailure(LlmFailureEvent event) {
+        Counter.builder("embabel.llm.errors.total")
+                .description("Failed LLM attempts")
+                .tag("model", event.getRequest().getLlmMetadata().getName())
+                .tag("agent", event.getAgentProcess().getAgent().getName())
+                .tag("outcome", event instanceof LlmRetryEvent ? "retry" : "failed")
+                .register(registry)
+                .increment();
     }
 
     private void recordToolCall(ToolCallRequestEvent event) {

--- a/embabel-agent-observability/src/main/java/com/embabel/agent/observability/tracing/EmbabelSpanEventListener.java
+++ b/embabel-agent-observability/src/main/java/com/embabel/agent/observability/tracing/EmbabelSpanEventListener.java
@@ -34,7 +34,9 @@ import com.embabel.agent.api.event.EmbeddingEventListener;
 import com.embabel.agent.api.event.EmbeddingInvocationEvent;
 import com.embabel.agent.api.event.EmbeddingResponseEvent;
 import com.embabel.agent.api.event.GoalAchievedEvent;
+import com.embabel.agent.api.event.LlmFailureEvent;
 import com.embabel.agent.api.event.LlmInvocationEvent;
+import com.embabel.agent.api.event.LlmRetryEvent;
 import com.embabel.agent.api.event.ProcessKilledEvent;
 import com.embabel.agent.api.event.RankingChoiceCouldNotBeMadeEvent;
 import com.embabel.agent.api.event.RankingChoiceMadeEvent;
@@ -98,6 +100,11 @@ public class EmbabelSpanEventListener implements AgenticEventListener, Embedding
             case LlmInvocationEvent e -> {
                 if (properties.isTraceLlmCalls()) {
                     recordLlmInvocation(e);
+                }
+            }
+            case LlmFailureEvent e -> {
+                if (properties.isTraceLlmCalls()) {
+                    recordLlmFailure(e);
                 }
             }
             case EmbeddingInvocationEvent e -> {
@@ -201,6 +208,37 @@ public class EmbabelSpanEventListener implements AgenticEventListener, Embedding
                 .highCardinalityKeyValue(SpanAttributes.EMBABEL_INTERACTION_ID, event.getInteractionId());
         addUsageAndCost(observation, invocation.getUsage(), invocation.cost());
         emit(observation);
+    }
+
+    /**
+     * A failed LLM attempt, as a point span. Retries produce sibling {@code embabel.llm} spans that
+     * look alike, so the attempt number lives here; and a timeout leaves its {@code embabel.llm} span
+     * behind on the worker thread, so for that case this is the only node marking the failure.
+     */
+    private void recordLlmFailure(LlmFailureEvent event) {
+        boolean retrying = event instanceof LlmRetryEvent;
+        String model = event.getRequest().getLlmMetadata().getName();
+        Throwable error = event.getThrowable();
+        Observation observation = point(
+                retrying ? SpanAttributes.EMBABEL_LLM_RETRY : SpanAttributes.EMBABEL_LLM_ERROR,
+                (retrying ? "llm.retry " : "llm.error ") + model)
+                .lowCardinalityKeyValue(SpanAttributes.EMBABEL_EVENT_TYPE, retrying ? "llm_retry" : "llm_error")
+                .lowCardinalityKeyValue(SpanAttributes.EMBABEL_LLM_MODEL, model)
+                // High, as the tool error path already classifies its own error type
+                .highCardinalityKeyValue(SpanAttributes.EMBABEL_LLM_ERROR_TYPE, error.getClass().getSimpleName())
+                .highCardinalityKeyValue(SpanAttributes.EMBABEL_INTERACTION_ID,
+                        event.getRequest().getInteraction().getId())
+                .highCardinalityKeyValue(SpanAttributes.EMBABEL_LLM_ATTEMPT, String.valueOf(event.getAttempts()))
+                .highCardinalityKeyValue(SpanAttributes.EMBABEL_LLM_MAX_ATTEMPTS,
+                        String.valueOf(event.getMaxAttempts()))
+                .highCardinalityKeyValue(SpanAttributes.EMBABEL_LLM_ERROR_MESSAGE, truncate(error.getMessage()));
+        // Pair start()/stop() so a throw from error() (e.g. a custom handler) can't leave the span open.
+        observation.start();
+        try {
+            observation.error(error);
+        } finally {
+            observation.stop();
+        }
     }
 
     private void recordEmbeddingInvocation(EmbeddingInvocationEvent event) {

--- a/embabel-agent-observability/src/test/java/com/embabel/agent/observability/metrics/EmbabelMetricsEventListenerTest.java
+++ b/embabel-agent-observability/src/test/java/com/embabel/agent/observability/metrics/EmbabelMetricsEventListenerTest.java
@@ -672,6 +672,45 @@ class EmbabelMetricsEventListenerTest {
     }
 
     // ================================================================================
+    // LLM FAILURE COUNTER TESTS
+    // ================================================================================
+
+    @Nested
+    @DisplayName("LLM Failure Counter Tests")
+    class LlmFailureCounterTests {
+
+        @Test
+        @DisplayName("Retried LLM attempt should increment counter with retry outcome")
+        void llmRetry_shouldIncrementCounterWithRetryOutcome() {
+            var registry = new SimpleMeterRegistry();
+            var listener = new EmbabelMetricsEventListener(registry, new ObservabilityProperties());
+            var process = createMockAgentProcess("run-1", "LlmAgent");
+
+            listener.onProcessEvent(createMockLlmFailureEvent(LlmRetryEvent.class, process, "gpt-4"));
+
+            Counter counter = registry.find("embabel.llm.errors.total")
+                    .tag("model", "gpt-4").tag("agent", "LlmAgent").tag("outcome", "retry").counter();
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("Failed LLM call should increment counter with failed outcome")
+        void llmCallFailed_shouldIncrementCounterWithFailedOutcome() {
+            var registry = new SimpleMeterRegistry();
+            var listener = new EmbabelMetricsEventListener(registry, new ObservabilityProperties());
+            var process = createMockAgentProcess("run-1", "LlmAgent");
+
+            listener.onProcessEvent(createMockLlmFailureEvent(LlmCallFailedEvent.class, process, "gpt-4"));
+
+            Counter counter = registry.find("embabel.llm.errors.total")
+                    .tag("model", "gpt-4").tag("agent", "LlmAgent").tag("outcome", "failed").counter();
+            assertThat(counter).isNotNull();
+            assertThat(counter.count()).isEqualTo(1.0);
+        }
+    }
+
+    // ================================================================================
     // METRICS DISABLED TESTS
     // ================================================================================
 
@@ -760,6 +799,15 @@ class EmbabelMetricsEventListenerTest {
         var request = createMockLlmRequestEvent(process, modelName);
         lenient().when(event.getRequest()).thenReturn(request);
         lenient().when(event.getRunningTime()).thenReturn(runningTime);
+        lenient().when(event.getAgentProcess()).thenReturn(process);
+        return event;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static <E extends LlmFailureEvent> E createMockLlmFailureEvent(Class<E> type, AgentProcess process, String modelName) {
+        E event = mock(type);
+        LlmRequestEvent request = createMockLlmRequestEvent(process, modelName);
+        lenient().when(event.getRequest()).thenReturn(request);
         lenient().when(event.getAgentProcess()).thenReturn(process);
         return event;
     }

--- a/embabel-agent-observability/src/test/java/com/embabel/agent/observability/tracing/EmbabelSpanEventListenerTest.java
+++ b/embabel-agent-observability/src/test/java/com/embabel/agent/observability/tracing/EmbabelSpanEventListenerTest.java
@@ -29,7 +29,11 @@ import com.embabel.agent.api.event.EmbeddingInvocationEvent;
 import com.embabel.agent.api.event.EmbeddingRequestEvent;
 import com.embabel.agent.api.event.EmbeddingResponseEvent;
 import com.embabel.agent.api.event.GoalAchievedEvent;
+import com.embabel.agent.api.event.LlmCallFailedEvent;
+import com.embabel.agent.api.event.LlmFailureEvent;
 import com.embabel.agent.api.event.LlmInvocationEvent;
+import com.embabel.agent.api.event.LlmRequestEvent;
+import com.embabel.agent.api.event.LlmRetryEvent;
 import com.embabel.agent.api.event.RankingChoiceCouldNotBeMadeEvent;
 import com.embabel.agent.api.event.RankingChoiceMadeEvent;
 import com.embabel.agent.api.event.ReplanRequestedEvent;
@@ -45,6 +49,7 @@ import com.embabel.agent.core.EarlyTermination;
 import com.embabel.agent.core.EarlyTerminationPolicy;
 import com.embabel.agent.core.EmbeddingInvocation;
 import com.embabel.agent.core.LlmInvocation;
+import com.embabel.agent.core.support.LlmInteraction;
 import com.embabel.agent.core.Usage;
 import com.embabel.agent.event.AgentProcessRagEvent;
 import com.embabel.agent.event.RagEvent;
@@ -159,6 +164,21 @@ class EmbabelSpanEventListenerTest {
                 new Usage(10, 20, null),
                 null, Instant.now(), Duration.ZERO);
         return new LlmInvocationEvent(process, invocation, "interaction-3");
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <E extends LlmFailureEvent> E llmFailureEvent(Class<E> type, int attempts) {
+        LlmInteraction interaction = mock(LlmInteraction.class);
+        lenient().when(interaction.getId()).thenReturn("interaction-9");
+        LlmRequestEvent request = mock(LlmRequestEvent.class);
+        lenient().when(request.getLlmMetadata()).thenReturn(LlmMetadata.create("gpt-4o", "openai"));
+        lenient().when(request.getInteraction()).thenReturn(interaction);
+        E event = mock(type);
+        lenient().when(event.getRequest()).thenReturn(request);
+        lenient().when(event.getThrowable()).thenReturn(new IllegalStateException("model timed out"));
+        lenient().when(event.getAttempts()).thenReturn(attempts);
+        lenient().when(event.getMaxAttempts()).thenReturn(3);
+        return event;
     }
 
     private EmbeddingInvocationEvent embeddingEvent() {
@@ -301,6 +321,62 @@ class EmbabelSpanEventListenerTest {
 
             Map<String, String> kv = kvOf("embabel.llm.invocation");
             assertNotNull(kv.get("embabel.llm.cost"), "cost tag present when pricing yields a positive cost");
+        }
+    }
+
+    @Nested
+    @DisplayName("LLM failures")
+    class LlmFailures {
+
+        @Test
+        @DisplayName("a retried attempt becomes a span carrying its attempt number")
+        void retrySpan() {
+            listener().onProcessEvent(llmFailureEvent(LlmRetryEvent.class, 2));
+
+            Map<String, String> kv = kvOf("embabel.llm.retry");
+            assertEquals("llm_retry", kv.get("embabel.event.type"));
+            assertEquals("gpt-4o", kv.get("embabel.llm.model"));
+            assertEquals("2", kv.get("embabel.llm.attempt"));
+            assertEquals("3", kv.get("embabel.llm.max_attempts"));
+            assertEquals("IllegalStateException", kv.get("embabel.llm.error.type"));
+            assertEquals("model timed out", kv.get("embabel.llm.error.message"));
+            assertEquals("interaction-9", kv.get("embabel.interaction.id"));
+        }
+
+        @Test
+        @DisplayName("a call that gives up becomes an error span")
+        void failedSpan() {
+            listener().onProcessEvent(llmFailureEvent(LlmCallFailedEvent.class, 3));
+
+            Map<String, String> kv = kvOf("embabel.llm.error");
+            assertEquals("llm_error", kv.get("embabel.event.type"));
+            assertEquals("3", kv.get("embabel.llm.attempt"));
+            Observation.Context ctx = handler.stopped.stream()
+                    .filter(c -> "embabel.llm.error".equals(c.getName()))
+                    .findFirst().orElseThrow();
+            assertNotNull(ctx.getError(), "the span is marked in error");
+        }
+
+        @Test
+        @DisplayName("failure span is closed even when error() throws between start() and stop()")
+        void failureSpanClosedWhenErrorThrows() {
+            // A custom handler failing in onError() must not leave the span open: stop() must still run.
+            registry.observationConfig().observationHandler(new ThrowingOnErrorHandler());
+            EmbabelSpanEventListener listener = listener();
+
+            assertThrows(RuntimeException.class,
+                    () -> listener.onProcessEvent(llmFailureEvent(LlmCallFailedEvent.class, 3)));
+
+            assertTrue(handler.stopped.stream().anyMatch(c -> "embabel.llm.error".equals(c.getName())),
+                    "failure span must be stopped even when error() throws after start()");
+        }
+
+        @Test
+        @DisplayName("trace-llm-calls=false suppresses the failure span")
+        void failureFlagDisabled() {
+            properties.setTraceLlmCalls(false);
+            listener().onProcessEvent(llmFailureEvent(LlmRetryEvent.class, 1));
+            assertTrue(handler.stopped.stream().noneMatch(c -> "embabel.llm.retry".equals(c.getName())));
         }
     }
 


### PR DESCRIPTION
## Problem

An LLM call emits `LlmRequestEvent`, then `LlmResponseEvent`. When the call fails the second one never comes, and nothing takes its place.

So a model that returns broken JSON four times before succeeding is invisible. From the outside everything worked. The four failures exist only in a log line: no listener can react, no metric counts them, no alert fires.

Closes #555.

## The events

```
LlmFailureEvent (sealed)
├── LlmRetryEvent       an attempt failed, another one is starting
└── LlmCallFailedEvent  the call gave up; no LlmResponseEvent will follow
```

Each carries the throwable, the attempts made, the retry budget, the running time and the originating request.

A listener that only wants "any LLM failure" subscribes to the parent and ignores the rest. Same shape as the existing `AgentProcessFinishedEvent` → `Completed` / `Failed`.

Additive only: no existing signature changes.

### What the two numbers mean

`attempts` and `maxAttempts` both count **round trips over the whole call**, not one retry sequence inside it.

This matters for `createObject`, which can run two retry sequences: one to bind the response, and one to re-prompt the model after a validation error. Each sequence gets its own budget from `max-attempts`, so a call that re-prompts may make up to twice the configured attempts - and both numbers say so. A call reporting "2 of 6" really made 2 round trips and was allowed 6.

Counting per sequence instead would report "1 of 3" for a call that made 2 round trips. Anyone building a dashboard on that number would be reading a wrong one.

## Where they are emitted

The retry block was copy-pasted five times in `AbstractLlmOperations`. It now lives in one place:

- `Attempts.attempt { }` -  one retry sequence, under the retry policy and the timeout. Publishes `LlmRetryEvent`.
- `withFailureEvents(...) { }` - one logical LLM call. Publishes `LlmCallFailedEvent` if it ends without a response.

The five call sites are shorter than they were.

Four decisions worth knowing:

**A retry is reported when it happens, not when an attempt fails.** At failure time the policy has not yet decided whether to replay - the error may not be replayable, or the budget may be spent. The event is published at the start of the next attempt, where `context.lastThrowable` is non-null. So it never guesses.

**`createObject` wraps binding and validation as one call.** A response that never validates ends the call without a response, so it raises `LlmCallFailedEvent` like an exhausted retry. Previously `InvalidLlmReturnTypeException` was thrown outside the retry block and emitted nothing at all - neither a response event nor a failure event.

**Control-flow signals are not failures.** `ReplanRequestedException`, waiting for a human answer, and anything else implementing `ToolControlFlowSignal` are exceptions, but the call did not fail. They are excluded.

**Errors are not reported either.** `withFailureEvents` catches `Exception`, not `Throwable`. An `Error` means the JVM itself is in trouble - out of memory, stack exhausted. Calling listeners at that point can turn a bad situation into a worse one, and a listener has nothing useful to do with it anyway. Errors propagate untouched.

## Metrics - Observability

One `case` on the parent, one counter:

`embabel.llm.errors.total`, tagged `model`, `agent`, and `outcome` - `retry` or `failed`.

One meter to declare, and the two outcomes read apart or together. A model going unstable climbs on `outcome="retry"` well before it takes an agent down; today those retries that end up succeeding are invisible.

## Tracing - Observability

Two point spans, gated by `trace-llm-calls`: `embabel.llm.retry` and `embabel.llm.error`, carrying model, attempt number, retry budget, error type and message, and marked in error.

They close three gaps:

- Retries produce sibling `embabel.llm` spans that look exactly like independent calls. The attempt number now tells them apart.
- `LlmInvocationEvent` returns early when there is no usage, so a failed round trip produced no point span at all, while every other notable thing has one.
- A timed-out call runs `doTransform` on a worker thread through `asyncer.async`, so its `embabel.llm` span stays over there. For that case these spans are the only node in the trace marking the failure - and a hanging provider is the case that matters most in production.

## Tests

**`LlmFailureEventTest.kt`** -13 tests, new file, covering: no failure event on
success; retries numbered; exhausted attempts raise `LlmCallFailedEvent` and no
response event; retry timing excludes the backoff wait; a control-flow signal is
not a failure; a response that never validates raises a failure event whose count
matches the round trips actually made; all four public entry points report a
failure; a timed-out call raises a failure event.

**`EmbabelSpanEventListenerTest.java` / `EmbabelMetricsEventListenerTest.java`** -
both outcomes on the counter; both spans with their attributes; the error span is
still closed when a handler throws from `onError`; `trace-llm-calls=false`
suppresses it.


4266 tests pass on `embabel-agent-api`, 199 on `embabel-agent-observability`.
