### PR TITLE
feat(persistence): event-driven snapshot checkpointing with policy safety net (#2005)

### DIFF
--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/AgentProcessEvent.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/api/event/AgentProcessEvent.kt
@@ -443,3 +443,17 @@ class ProgressUpdateEvent(
 class ProcessKilledEvent(
     agentProcess: AgentProcess,
 ) : AbstractAgentProcessEvent(agentProcess)
+
+/**
+ * Emitted when an agent process is terminated.
+ */
+class AgentProcessTerminatedEvent(
+    agentProcess: AgentProcess,
+) : AbstractAgentProcessEvent(agentProcess)
+
+/**
+ * Emitted after an agent process has been reconstructed from a snapshot.
+ */
+class AgentProcessRestoredEvent(
+    agentProcess: AgentProcess,
+) : AbstractAgentProcessEvent(agentProcess)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/core/support/AbstractAgentProcess.kt
@@ -123,6 +123,7 @@ abstract class AbstractAgentProcess(
                 // No guaranteed next tick - set status immediately
                 logger.info("Terminating process {} (was {}): {}", id, status, reason)
                 setStatus(AgentProcessStatusCode.TERMINATED)
+                platformServices.eventListener.onProcessEvent(AgentProcessTerminatedEvent(this))
             }
         }
     }
@@ -381,8 +382,12 @@ abstract class AbstractAgentProcess(
                 platformServices.eventListener.onProcessEvent(AgentProcessFailedEvent(this))
             }
 
-            AgentProcessStatusCode.TERMINATED, AgentProcessStatusCode.KILLED -> {
-                // Event will have been raised at the point of termination
+            AgentProcessStatusCode.TERMINATED -> {
+                platformServices.eventListener.onProcessEvent(AgentProcessTerminatedEvent(this))
+            }
+
+            AgentProcessStatusCode.KILLED -> {
+                // Event will have been raised at the point of termination (kill() returns ProcessKilledEvent)
             }
 
             AgentProcessStatusCode.WAITING -> {
@@ -420,6 +425,7 @@ abstract class AbstractAgentProcess(
             _failureInfo = signalTermination
             setStatus(AgentProcessStatusCode.TERMINATED)
             platformServices.eventListener.onProcessEvent(signalTermination)
+            platformServices.eventListener.onProcessEvent(AgentProcessTerminatedEvent(this))
             return signalTermination
         }
 
@@ -444,6 +450,7 @@ abstract class AbstractAgentProcess(
             _failureInfo = earlyTermination
             setStatus(AgentProcessStatusCode.TERMINATED)
             platformServices.eventListener.onProcessEvent(earlyTermination)
+            platformServices.eventListener.onProcessEvent(AgentProcessTerminatedEvent(this))
             return earlyTermination
         }
         return null
@@ -572,6 +579,7 @@ abstract class AbstractAgentProcess(
                 } catch (_: InterruptedException) {
                     Thread.currentThread().interrupt()
                     _status.set(AgentProcessStatusCode.TERMINATED)
+                    platformServices.eventListener.onProcessEvent(AgentProcessTerminatedEvent(this))
                     return ActionStatus(
                         runningTime = Duration.between(actionExecutionStartEvent.timestamp, Instant.now()),
                         status = ActionStatusCode.FAILED,

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/config/spring/AgentPlatformConfiguration.kt
@@ -189,6 +189,14 @@ class AgentPlatformConfiguration(
     }
 
     @Bean
+    fun agentProcessCheckpointListener(
+        agentProcessRepository: ObjectProvider<AgentProcessRepository>,
+    ): AgenticEventListener {
+        return (agentProcessRepository.getIfAvailable() as? AgenticEventListener)
+            ?: AgenticEventListener.DevNull
+    }
+
+    @Bean
     fun contextRepository(
         contextRepositoryProperties: ContextRepositoryProperties,
     ): ContextRepository = InMemoryContextRepository(contextRepositoryProperties)

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistence.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistence.kt
@@ -16,6 +16,7 @@
 package com.embabel.agent.spi.persistence
 
 import com.embabel.agent.api.common.PlatformServices
+import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.Agent
 import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.core.persistence.BlackboardEntrySerializer
@@ -104,4 +105,12 @@ object AgentProcessPersistence {
             platformServices = platformServices,
         )
     }
+
+    /**
+     * Return the [AgenticEventListener] that checkpoints processes reactively
+     * on lifecycle events for the given persistent repository.
+     */
+    fun checkpointListener(repository: AgentProcessRepository): AgenticEventListener =
+        repository as? AgenticEventListener
+            ?: error("Repository [${repository.javaClass.name}] does not implement AgenticEventListener")
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/PersistentAgentProcessRepository.kt
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/PersistentAgentProcessRepository.kt
@@ -16,12 +16,22 @@
 package com.embabel.agent.spi.support.persistence
 
 import com.embabel.agent.api.common.PlatformServices
+import com.embabel.agent.api.event.AgentProcessCompletedEvent
+import com.embabel.agent.api.event.AgentProcessEvent
+import com.embabel.agent.api.event.AgentProcessFailedEvent
+import com.embabel.agent.api.event.AgentProcessRestoredEvent
+import com.embabel.agent.api.event.AgentProcessTerminatedEvent
+import com.embabel.agent.api.event.AgentProcessWaitingEvent
+import com.embabel.agent.api.event.AgenticEventListener
+import com.embabel.agent.api.event.ProcessKilledEvent
 import com.embabel.agent.core.AbstractAgentProcessRepository
 import com.embabel.agent.core.Agent
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.spi.persistence.AgentProcessCheckpointPolicy
+import com.embabel.agent.core.persistence.AgentProcessPersistenceException
 import com.embabel.agent.spi.persistence.AgentProcessSnapshotStore
+import org.slf4j.LoggerFactory
 
 /**
  * Repository decorator that keeps active processes in a runtime repository and
@@ -45,7 +55,9 @@ internal class PersistentAgentProcessRepository(
     private val snapshotRestorer: AgentProcessSnapshotRestorer,
     private val agents: () -> Collection<Agent>,
     private val platformServices: () -> PlatformServices,
-) : AbstractAgentProcessRepository() {
+) : AbstractAgentProcessRepository(), AgenticEventListener {
+
+    private val logger = LoggerFactory.getLogger(javaClass)
 
     override fun findById(id: String): AgentProcess? =
         runtimeRepository.findById(id) ?: restore(snapshotStore.findLatestByProcessId(id))
@@ -80,7 +92,18 @@ internal class PersistentAgentProcessRepository(
         runtimeRepository.delete(agentProcess)
     }
 
-    private fun checkpointIfNeeded(agentProcess: AgentProcess) {
+    override fun onProcessEvent(event: AgentProcessEvent) {
+        when (event) {
+            is AgentProcessWaitingEvent -> checkpoint(event.agentProcess)
+            is AgentProcessCompletedEvent -> checkpoint(event.agentProcess)
+            is AgentProcessFailedEvent -> checkpoint(event.agentProcess)
+            is ProcessKilledEvent -> checkpoint(event.agentProcess)
+            is AgentProcessTerminatedEvent -> checkpoint(event.agentProcess)
+            else -> {}
+        }
+    }
+
+    fun checkpoint(agentProcess: AgentProcess) {
         if (!checkpointPolicy.shouldStoreSnapshot(agentProcess)) {
             return
         }
@@ -90,10 +113,28 @@ internal class PersistentAgentProcessRepository(
             agentProcess = agentProcess,
             version = nextVersion,
         )
-        snapshotStore.save(
-            snapshot = snapshotSerializer.serialize(snapshot),
-            expectedVersion = existing?.version,
-        )
+        try {
+            snapshotStore.save(
+                snapshot = snapshotSerializer.serialize(snapshot),
+                expectedVersion = existing?.version,
+            )
+        } catch (e: AgentProcessPersistenceException) {
+            val current = snapshotStore.findLatestByProcessId(agentProcess.id)
+            if (current != null && current.version >= nextVersion) {
+                logger.debug(
+                    "Deduplicated checkpoint for process {} at version {}: store already at version {}",
+                    agentProcess.id,
+                    nextVersion,
+                    current.version,
+                )
+                return
+            }
+            throw e
+        }
+    }
+
+    private fun checkpointIfNeeded(agentProcess: AgentProcess) {
+        checkpoint(agentProcess)
     }
 
     // After the first restore the process is cached in the runtime repository, so
@@ -108,5 +149,7 @@ internal class PersistentAgentProcessRepository(
                 platformServices = platformServices(),
             )
             runtimeRepository.save(restored)
+            platformServices().eventListener.onProcessEvent(AgentProcessRestoredEvent(restored))
+            restored
         }
 }

--- a/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/README.md
+++ b/embabel-agent-api/src/main/kotlin/com/embabel/agent/spi/support/persistence/README.md
@@ -6,11 +6,12 @@ through `AgentProcessSnapshotStore`, while this package owns snapshot creation,
 serialization, restoration, and decoration of an `InMemoryAgentProcessRepository`
 or another runtime `AgentProcessRepository`.
 
-The first supported lifecycle boundaries are:
+Checkpointing is primarily event-driven, with a policy-based safety net on repository operations:
 
-- `WAITING`: used as a recovery checkpoint for HITL flows parked by `waitFor`.
-- Finished states: used to advance durable state after resumed work completes,
-  fails, is killed, or is terminated.
+- **Event-Driven Checkpointing (Primary)**: `PersistentAgentProcessRepository` implements `AgenticEventListener` and checkpoints processes reactively on `AgentProcessWaitingEvent`, `AgentProcessCompletedEvent`, `AgentProcessFailedEvent`, `ProcessKilledEvent`, and `AgentProcessTerminatedEvent`.
+- **Policy-Based Safety Net**: `checkpointIfNeeded()` is called on repository `save()` and `update()` calls, ensuring persistence even when lifecycle events are not published.
+- **CAS Deduplication**: Redundant writes between the event layer and the safety net are deduplicated gracefully via optimistic versioning (CAS).
+- **Restore Notifications**: `AgentProcessRestoredEvent` is emitted whenever a process is reconstituted from durable snapshots.
 
 JDBC, cache, Redis, or other storage implementations are not shipped from this
 package. They should implement `AgentProcessSnapshotStore` outside the framework
@@ -19,6 +20,11 @@ or appear as test fixtures.
 ```mermaid
 classDiagram
     direction LR
+
+    class AgenticEventListener {
+        <<interface>>
+        +onProcessEvent(event)
+    }
 
     class AgentProcessRepository {
         <<interface>>
@@ -36,6 +42,8 @@ classDiagram
         -snapshotFactory
         -snapshotSerializer
         -snapshotRestorer
+        +onProcessEvent(event)
+        +checkpoint(process)
     }
 
     class AgentProcessCheckpointPolicy {
@@ -91,6 +99,7 @@ classDiagram
     }
 
     PersistentAgentProcessRepository ..|> AgentProcessRepository
+    PersistentAgentProcessRepository ..|> AgenticEventListener
     PersistentAgentProcessRepository --> AgentProcessSnapshotStore
     PersistentAgentProcessRepository --> AgentProcessCheckpointPolicy
     PersistentAgentProcessRepository --> AgentProcessSnapshotFactory

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/SimpleAgentProcessTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/core/support/SimpleAgentProcessTest.kt
@@ -24,6 +24,7 @@ import com.embabel.agent.api.common.StuckHandlingResultCode
 import com.embabel.agent.api.dsl.Frog
 import com.embabel.agent.api.dsl.agent
 import com.embabel.agent.api.dsl.evenMoreEvilWizard
+import com.embabel.agent.api.event.AgentProcessTerminatedEvent
 import com.embabel.agent.api.event.ObjectAddedEvent
 import com.embabel.agent.api.event.ObjectBoundEvent
 import com.embabel.agent.core.Agent
@@ -518,13 +519,26 @@ class SimpleAgentProcessTest {
 
         private fun createProcess(
             status: AgentProcessStatusCode = AgentProcessStatusCode.NOT_STARTED,
+            eventListener: com.embabel.agent.api.event.AgenticEventListener? = null,
         ): TestableAgentProcess {
-            val dummyPlatformServices = dummyPlatformServices()
+            val dummyPlatformServices = dummyPlatformServices(eventListener = eventListener)
             val process = TestableAgentProcess(dummyPlatformServices)
             if (status != AgentProcessStatusCode.NOT_STARTED) {
                 process.setStatusForTest(status)
             }
             return process
+        }
+
+        @Test
+        fun `immediate termination emits AgentProcessTerminatedEvent`() {
+            val eventListener = EventSavingAgenticEventListener()
+            val process = createProcess(AgentProcessStatusCode.WAITING, eventListener = eventListener)
+            process.terminateAgent("test reason")
+
+            assertEquals(AgentProcessStatusCode.TERMINATED, process.status)
+            val terminatedEvents = eventListener.processEvents.filterIsInstance<AgentProcessTerminatedEvent>()
+            assertEquals(1, terminatedEvents.size)
+            assertEquals("test-terminate", terminatedEvents.first().agentProcess.id)
         }
 
         @Test

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AgentProcessPersistenceWiringTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/config/spring/AgentProcessPersistenceWiringTest.kt
@@ -15,7 +15,10 @@
  */
 package com.embabel.agent.spi.config.spring
 
+import com.embabel.agent.api.event.AgentProcessWaitingEvent
+import com.embabel.agent.api.event.AgenticEventListener
 import com.embabel.agent.core.AgentPlatform
+import com.embabel.agent.core.AgentProcessRepository
 import com.embabel.agent.core.AgentProcessStatusCode
 import com.embabel.agent.core.ProcessOptions
 import com.embabel.agent.core.persistence.BlackboardEntryDeserializationContext
@@ -143,6 +146,27 @@ class AgentProcessPersistenceWiringTest {
         repository.save(waitingProcess("p1"))
 
         assertNotNull(store.findLatestByProcessId("p1"))
+    }
+
+    @Test
+    fun `registers checkpoint listener when repository implements AgenticEventListener`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = repository(store)
+        val listener = configuration.agentProcessCheckpointListener(
+            agentProcessRepository = providerOf(AgentProcessRepository::class.java, repository),
+        )
+        assertNotNull(listener)
+        val process = waitingProcess("p1")
+        listener.onProcessEvent(AgentProcessWaitingEvent(process))
+        assertNotNull(store.findLatestByProcessId("p1"))
+    }
+
+    @Test
+    fun `checkpoint listener returns DevNull when repository is missing or not an event listener`() {
+        val listener = configuration.agentProcessCheckpointListener(
+            agentProcessRepository = emptyProvider(),
+        )
+        assertEquals(AgenticEventListener.DevNull, listener)
     }
 
     private fun repository(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistenceTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/persistence/AgentProcessPersistenceTest.kt
@@ -27,6 +27,7 @@ import com.embabel.agent.core.support.DslWaitingAgent
 import com.embabel.agent.core.support.InMemoryBlackboard
 import com.embabel.agent.core.support.SimpleAgentProcess
 import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.api.event.AgentProcessWaitingEvent
 import com.embabel.agent.spi.support.DefaultPlannerFactory
 import com.embabel.agent.spi.support.InMemoryAgentProcessRepository
 import com.embabel.agent.spi.support.persistence.InMemoryAgentProcessSnapshotStore
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.http.MediaType
 
 /**
@@ -145,6 +147,28 @@ class AgentProcessPersistenceTest {
 
         assertNull(store.findLatestByProcessId("p1"))
         assertNull(runtime.findById("p1"))
+    }
+
+    @Test
+    fun `checkpointListener returns listener that checkpoints on lifecycle events`() {
+        val store = InMemoryAgentProcessSnapshotStore()
+        val repository = persistentRepository(snapshotStore = store)
+        val listener = AgentProcessPersistence.checkpointListener(repository)
+        assertNotNull(listener)
+
+        val process = waitingProcess("p1")
+        listener.onProcessEvent(AgentProcessWaitingEvent(process))
+        assertNotNull(store.findLatestByProcessId("p1"))
+        assertEquals(1L, store.findLatestByProcessId("p1")?.version)
+    }
+
+    @Test
+    fun `checkpointListener throws if repository does not implement AgenticEventListener`() {
+        val runtimeRepository = InMemoryAgentProcessRepository()
+        val exception = assertThrows<IllegalStateException> {
+            AgentProcessPersistence.checkpointListener(runtimeRepository)
+        }
+        assertTrue(exception.message!!.contains("does not implement AgenticEventListener"))
     }
 
     private fun persistentRepository(

--- a/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/PersistentAgentProcessRepositoryTest.kt
+++ b/embabel-agent-api/src/test/kotlin/com/embabel/agent/spi/support/persistence/PersistentAgentProcessRepositoryTest.kt
@@ -15,6 +15,13 @@
  */
 package com.embabel.agent.spi.support.persistence
 
+import com.embabel.agent.api.common.PlatformServices
+import com.embabel.agent.api.event.AgentProcessCompletedEvent
+import com.embabel.agent.api.event.AgentProcessFailedEvent
+import com.embabel.agent.api.event.AgentProcessRestoredEvent
+import com.embabel.agent.api.event.AgentProcessTerminatedEvent
+import com.embabel.agent.api.event.AgentProcessWaitingEvent
+import com.embabel.agent.api.event.ProcessKilledEvent
 import com.embabel.agent.core.AgentProcessStatusCode
 import com.embabel.agent.core.AgentProcess
 import com.embabel.agent.core.AgentProcessRepository
@@ -25,6 +32,7 @@ import com.embabel.agent.core.support.InMemoryBlackboard
 import com.embabel.agent.core.support.InternalAgentStateApi
 import com.embabel.agent.core.support.SimpleAgentProcess
 import com.embabel.agent.domain.io.UserInput
+import com.embabel.agent.test.common.EventSavingAgenticEventListener
 import com.embabel.agent.spi.persistence.AgentProcessCheckpointPolicy
 import com.embabel.agent.spi.persistence.SerializedAgentProcessSnapshot
 import com.embabel.agent.spi.persistence.StoredSnapshotMetadata
@@ -190,10 +198,99 @@ class PersistentAgentProcessRepositoryTest {
         )
     }
 
+    @Test
+    fun `emits AgentProcessRestoredEvent when restoring process from snapshot`() {
+        val snapshotStore = InMemoryAgentProcessSnapshotStore()
+        val originalRepository = repository(
+            runtimeRepository = InMemoryAgentProcessRepository(),
+            snapshotStore = snapshotStore,
+        )
+        val process = waitingProcess("p1")
+        originalRepository.save(process)
+
+        val eventListener = EventSavingAgenticEventListener()
+        val platformServices = dummyPlatformServices(eventListener = eventListener)
+        val restoringRepository = repository(
+            runtimeRepository = InMemoryAgentProcessRepository(),
+            snapshotStore = snapshotStore,
+            platformServices = { platformServices },
+        )
+
+        val restored = restoringRepository.findById("p1")
+        assertNotNull(restored)
+
+        val restoredEvents = eventListener.processEvents.filterIsInstance<AgentProcessRestoredEvent>()
+        assertEquals(1, restoredEvents.size)
+        assertEquals("p1", restoredEvents.first().agentProcess.id)
+    }
+
+    @Test
+    fun `checkpoints on lifecycle events via onProcessEvent`() {
+        val snapshotStore = InMemoryAgentProcessSnapshotStore()
+        val repository = repository(snapshotStore = snapshotStore)
+        val process = waitingProcess("p1")
+
+        repository.onProcessEvent(AgentProcessWaitingEvent(process))
+        assertEquals(1, snapshotStore.findLatestByProcessId("p1")?.version)
+
+        process.replaceRuntimeState(
+            status = AgentProcessStatusCode.COMPLETED,
+            history = emptyList(),
+        )
+        repository.onProcessEvent(AgentProcessCompletedEvent(process))
+        assertEquals(2, snapshotStore.findLatestByProcessId("p1")?.version)
+
+        process.replaceRuntimeState(
+            status = AgentProcessStatusCode.FAILED,
+            history = emptyList(),
+        )
+        repository.onProcessEvent(AgentProcessFailedEvent(process))
+        assertEquals(3, snapshotStore.findLatestByProcessId("p1")?.version)
+
+        process.replaceRuntimeState(
+            status = AgentProcessStatusCode.KILLED,
+            history = emptyList(),
+        )
+        repository.onProcessEvent(ProcessKilledEvent(process))
+        assertEquals(4, snapshotStore.findLatestByProcessId("p1")?.version)
+
+        process.replaceRuntimeState(
+            status = AgentProcessStatusCode.TERMINATED,
+            history = emptyList(),
+        )
+        repository.onProcessEvent(AgentProcessTerminatedEvent(process))
+        assertEquals(5, snapshotStore.findLatestByProcessId("p1")?.version)
+    }
+
+    @Test
+    fun `checkpoint deduplicates idempotently when snapshot store was concurrently advanced`() {
+        val underlyingStore = InMemoryAgentProcessSnapshotStore()
+        var saveCallCount = 0
+        val concurrentStore = object : AgentProcessSnapshotStore by underlyingStore {
+            override fun save(snapshot: SerializedAgentProcessSnapshot, expectedVersion: Long?): StoredSnapshotMetadata {
+                saveCallCount++
+                if (saveCallCount == 1) {
+                    // Simulate a concurrent writer successfully saving version 1
+                    underlyingStore.save(snapshot, expectedVersion)
+                    // Now attempt with the stale expectedVersion (throws AgentProcessPersistenceException)
+                    return underlyingStore.save(snapshot, expectedVersion)
+                }
+                return underlyingStore.save(snapshot, expectedVersion)
+            }
+        }
+        val repository = repository(snapshotStore = concurrentStore)
+        val process = waitingProcess("p1")
+
+        // Should not throw; CAS mismatch is caught and recognized as already at version 1
+        repository.checkpoint(process)
+        assertEquals(1, underlyingStore.findLatestByProcessId("p1")?.version)
+    }
+
     private fun repository(
         runtimeRepository: AgentProcessRepository = InMemoryAgentProcessRepository(),
-        snapshotStore: InMemoryAgentProcessSnapshotStore = InMemoryAgentProcessSnapshotStore(),
+        snapshotStore: AgentProcessSnapshotStore = InMemoryAgentProcessSnapshotStore(),
         checkpointPolicy: AgentProcessCheckpointPolicy = LifecycleCheckpointPolicy,
+        platformServices: () -> PlatformServices = { dummyPlatformServices() },
     ): PersistentAgentProcessRepository =
         PersistentAgentProcessRepository(
             runtimeRepository = runtimeRepository,
@@ -203,7 +300,7 @@ class PersistentAgentProcessRepositoryTest {
             snapshotSerializer = snapshotSerializer,
             snapshotRestorer = snapshotRestorer,
             agents = { listOf(DslWaitingAgent) },
-            platformServices = { dummyPlatformServices() },
+            platformServices = platformServices,
         )
 
     /**

--- a/embabel-agent-docs/src/main/asciidoc/reference/persistence/page.adoc
+++ b/embabel-agent-docs/src/main/asciidoc/reference/persistence/page.adoc
@@ -10,14 +10,20 @@ The framework keeps storage backend-neutral. Applications provide an
 them, restores process instances, and decorates an
 `InMemoryAgentProcessRepository` or another runtime `AgentProcessRepository`.
 
-==== Lifecycle Boundaries
+==== Lifecycle Boundaries and Event-Driven Checkpointing
 
-The initial persistence model supports two checkpoint boundaries:
+The persistence model supports event-driven snapshot checkpointing as the primary mechanism, backed by a policy-based safety net on repository operations:
 
-* `WAITING`: a process has called `waitFor` and can be restored by another
-  runtime after local process state is lost.
-* Finished states: a process has completed, failed, been killed, or been
-  terminated, and durable state should reflect that final lifecycle state.
+* *Event-Driven Checkpointing (Primary)*: `PersistentAgentProcessRepository` implements `AgenticEventListener` and listens for lifecycle events to trigger immediate, reactive snapshot saves. The subscribed events are:
+** `AgentProcessWaitingEvent`: a process has called `waitFor` and can be restored by another runtime after local process state is lost.
+** `AgentProcessCompletedEvent`: work completed successfully.
+** `AgentProcessFailedEvent`: execution failed.
+** `ProcessKilledEvent`: process was killed externally.
+** `AgentProcessTerminatedEvent`: process reached a termination condition (signal or policy termination).
+* *Policy-Based Safety Net*: `checkpointIfNeeded()` is retained during `save()` and `update()` repository operations to ensure processes are checkpointed even if lifecycle events are not published.
+* *CAS Deduplication*: Optimistic versioning (compare-and-set) naturally deduplicates writes when both layers attempt to write snapshots for the same version, treating redundant writes idempotently.
+
+Additionally, `AgentProcessRestoredEvent` is published whenever a process is restored from a durable snapshot in `PersistentAgentProcessRepository.restore()`.
 
 `WaitForCheckpointPolicy` checkpoints only `WAITING` processes. Use it when the
 snapshot store is only a recovery cache.
@@ -114,8 +120,8 @@ On lookup, `PersistentAgentProcessRepository` first checks the runtime
 repository. In the current tests this is an `InMemoryAgentProcessRepository`.
 If the in-memory process is missing, it loads the serialized snapshot, rebuilds
 the blackboard, reconstructs the process implementation, restores internal
-status and action history, then saves the restored process back into the
-in-memory repository.
+status and action history, saves the restored process back into the
+in-memory repository, and emits an `AgentProcessRestoredEvent`.
 
 This allows a HITL flow to resume after pod-local memory has been lost:
 


### PR DESCRIPTION
### Summary

Transitions process snapshot checkpointing from an invocation-only model (`save()` / `update()`) to an event-driven primary architecture, backed by repository policy checks as a safety net and CAS deduplication.

### Problem & Motivation

Previously, durable snapshots were only saved synchronously during `PersistentAgentProcessRepository.save()` and `update()`. This meant process state transitions triggered asynchronously or within agent turn execution (such as entering wait states, completing, or terminating) were not checkpointed until or unless an explicit repository write occurred.

### What's Changed

- **Event-Driven Checkpointing (Primary Layer)**: `PersistentAgentProcessRepository` now implements `AgenticEventListener`, reactively checkpointing snapshots on key lifecycle events (`AgentProcessWaitingEvent`, `AgentProcessCompletedEvent`, `AgentProcessFailedEvent`, `ProcessKilledEvent`, and `AgentProcessTerminatedEvent`).
- **Lifecycle Events**:
  - `AgentProcessTerminatedEvent`: emitted whenever a process transitions to `TERMINATED` (via early termination signals, policies, turn termination, or explicit termination).
  - `AgentProcessRestoredEvent`: emitted after snapshot reconstitution in `PersistentAgentProcessRepository.restore()`.
- **Policy Safety Net**: Retained `checkpointIfNeeded()` in `save()` and `update()` to ensure processes are persisted even if lifecycle events are bypassed or deferred.
- **CAS Deduplication**: Deduplicates duplicate writes between the event listener and the repository safety net using optimistic versioning (`current.version >= nextVersion`).
- **Platform Wiring & Docs**: Registered `agentProcessCheckpointListener` bean in `AgentPlatformConfiguration`, exposed SPI accessor `AgentProcessPersistence.checkpointListener()`, and updated reference documentation and architecture guides.

### Verification

```bash
mvn spotless:check -pl embabel-agent-api

mvn test -pl embabel-agent-api "-Dtest=PersistentAgentProcessRepositoryTest,SimpleAgentProcessTest,AgentProcessPersistenceTest,AgentProcessPersistenceWiringTest"
```

Closes #2005